### PR TITLE
fix: Device role parsing and desktop launcher integration

### DIFF
--- a/assets/org.meshforge.policy
+++ b/assets/org.meshforge.policy
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+ "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/PolicyKit/1/policyconfig.dtd">
+<policyconfig>
+  <vendor>MeshForge</vendor>
+  <vendor_url>https://github.com/Nursedude/meshforge</vendor_url>
+  <icon_name>meshforge</icon_name>
+
+  <action id="org.meshforge.run">
+    <description>Run MeshForge</description>
+    <message>Authentication is required to run MeshForge (requires access to network hardware)</message>
+    <defaults>
+      <allow_any>auth_admin</allow_any>
+      <allow_inactive>auth_admin</allow_inactive>
+      <allow_active>auth_admin_keep</allow_active>
+    </defaults>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/local/bin/meshforge</annotate>
+    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
+  </action>
+
+</policyconfig>

--- a/meshforge.desktop
+++ b/meshforge.desktop
@@ -4,8 +4,8 @@ Type=Application
 Name=MeshForge
 GenericName=Mesh Network Manager
 Comment=LoRa Mesh Network Development & Operations Suite
-Exec=sudo python3 /opt/meshforge/src/launcher.py
-Icon=/opt/meshforge/assets/meshforge-icon.png
+Exec=pkexec /usr/local/bin/meshforge
+Icon=meshforge
 Terminal=false
 Categories=Network;Utility;System;
 Keywords=meshtastic;lora;mesh;radio;network;
@@ -15,16 +15,16 @@ Actions=gtk;web;tui;cli;
 
 [Desktop Action gtk]
 Name=Launch GTK Interface
-Exec=sudo python3 /opt/meshforge/src/main_gtk.py
+Exec=pkexec /usr/local/bin/meshforge gtk
 
 [Desktop Action web]
 Name=Launch Web Interface
-Exec=sudo python3 /opt/meshforge/src/main_web.py
+Exec=pkexec /usr/local/bin/meshforge web
 
 [Desktop Action tui]
 Name=Launch Terminal TUI
-Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/main_tui.py"
+Exec=x-terminal-emulator -e "sudo /usr/local/bin/meshforge tui"
 
 [Desktop Action cli]
 Name=Launch CLI
-Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/main.py"
+Exec=x-terminal-emulator -e "sudo /usr/local/bin/meshforge cli"

--- a/scripts/install-desktop.sh
+++ b/scripts/install-desktop.sh
@@ -102,6 +102,22 @@ if command -v gtk-update-icon-cache &> /dev/null; then
     gtk-update-icon-cache -f /usr/share/icons/hicolor 2>/dev/null || true
 fi
 
+# Install launcher script
+echo "Installing launcher script..."
+cp "$PROJECT_DIR/scripts/meshforge-launcher.sh" /usr/local/bin/meshforge
+chmod 755 /usr/local/bin/meshforge
+
+# Install polkit policy (for pkexec authentication)
+echo "Installing polkit policy..."
+POLKIT_DIR="/usr/share/polkit-1/actions"
+if [ -d "$POLKIT_DIR" ]; then
+    cp "$PROJECT_DIR/assets/org.meshforge.policy" "$POLKIT_DIR/"
+    chmod 644 "$POLKIT_DIR/org.meshforge.policy"
+    echo "  Polkit policy installed - pkexec will prompt for password"
+else
+    echo "  Warning: Polkit not found, desktop launcher may not work"
+fi
+
 echo
 echo "==========================================="
 echo "Installation complete!"
@@ -116,5 +132,6 @@ echo
 echo "Or search for 'MeshForge' in your application launcher."
 echo
 echo "To run from command line:"
-echo "  sudo python3 /opt/meshforge/src/launcher.py"
+echo "  meshforge          # Uses pkexec for GUI"
+echo "  sudo meshforge tui # For terminal UI"
 echo

--- a/scripts/meshforge-launcher.sh
+++ b/scripts/meshforge-launcher.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# MeshForge Launcher Script
+# This script is called by pkexec to launch MeshForge with proper privileges
+
+MESHFORGE_DIR="/opt/meshforge"
+
+# Determine which interface to launch
+case "$1" in
+    gtk)
+        exec python3 "$MESHFORGE_DIR/src/main_gtk.py"
+        ;;
+    web)
+        exec python3 "$MESHFORGE_DIR/src/main_web.py"
+        ;;
+    tui)
+        exec python3 "$MESHFORGE_DIR/src/main_tui.py"
+        ;;
+    cli)
+        exec python3 "$MESHFORGE_DIR/src/main.py"
+        ;;
+    *)
+        # Default: use launcher
+        exec python3 "$MESHFORGE_DIR/src/launcher.py"
+        ;;
+esac

--- a/src/gtk_ui/panels/radio_config.py
+++ b/src/gtk_ui/panels/radio_config.py
@@ -1252,8 +1252,14 @@ class RadioConfigPanel(Gtk.Box):
         def set_dropdown_by_value(dropdown, options, value):
             """Set dropdown selection by matching value in options list"""
             value_upper = value.upper().strip()
+            # First try exact match
             for i, option in enumerate(options):
-                if option == value_upper or option in value_upper:
+                if option == value_upper:
+                    dropdown.set_selected(i)
+                    return True
+            # Fallback to partial match (for backwards compatibility)
+            for i, option in enumerate(options):
+                if option in value_upper:
                     dropdown.set_selected(i)
                     return True
             return False


### PR DESCRIPTION
- Fix device role dropdown to use exact match first, so CLIENT_MUTE is correctly detected instead of matching CLIENT
- Add polkit policy for pkexec authentication (org.meshforge.policy)
- Add meshforge-launcher.sh wrapper script for desktop integration
- Update .desktop file to use pkexec with proper launcher
- Update install script to install launcher and polkit policy