### PR TITLE
fix: Desktop launcher uses terminal for sudo authentication

### DIFF
--- a/meshforge.desktop
+++ b/meshforge.desktop
@@ -4,27 +4,23 @@ Type=Application
 Name=MeshForge
 GenericName=Mesh Network Manager
 Comment=LoRa Mesh Network Development & Operations Suite
-Exec=pkexec /usr/local/bin/meshforge
+Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/launcher.py"
 Icon=meshforge
 Terminal=false
-Categories=Network;Utility;System;
+Categories=Network;System;
 Keywords=meshtastic;lora;mesh;radio;network;
 StartupNotify=true
 StartupWMClass=meshforge
-Actions=gtk;web;tui;cli;
+Actions=gtk;web;tui;
 
 [Desktop Action gtk]
 Name=Launch GTK Interface
-Exec=pkexec /usr/local/bin/meshforge gtk
+Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/main_gtk.py"
 
 [Desktop Action web]
 Name=Launch Web Interface
-Exec=pkexec /usr/local/bin/meshforge web
+Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/main_web.py"
 
 [Desktop Action tui]
 Name=Launch Terminal TUI
-Exec=x-terminal-emulator -e "sudo /usr/local/bin/meshforge tui"
-
-[Desktop Action cli]
-Name=Launch CLI
-Exec=x-terminal-emulator -e "sudo /usr/local/bin/meshforge cli"
+Exec=x-terminal-emulator -e "sudo python3 /opt/meshforge/src/main_tui.py"

--- a/scripts/meshforge-launcher.sh
+++ b/scripts/meshforge-launcher.sh
@@ -1,25 +1,67 @@
 #!/bin/bash
 # MeshForge Launcher Script
-# This script is called by pkexec to launch MeshForge with proper privileges
+# This script handles launching MeshForge with proper privileges
 
 MESHFORGE_DIR="/opt/meshforge"
+
+# For GUI apps, we need to preserve DISPLAY/WAYLAND environment
+# pkexec strips these, so we use a different approach
+
+# Function to launch with sudo in a way that preserves display
+launch_gui() {
+    local script="$1"
+
+    # If we're already root, just run
+    if [ "$EUID" -eq 0 ]; then
+        exec python3 "$script"
+    fi
+
+    # Try to run with preserved environment using sudo
+    # This works if user has NOPASSWD or enters password in terminal
+    if [ -n "$DISPLAY" ] || [ -n "$WAYLAND_DISPLAY" ]; then
+        # For Wayland
+        if [ -n "$WAYLAND_DISPLAY" ]; then
+            exec sudo -E python3 "$script"
+        fi
+        # For X11
+        if [ -n "$DISPLAY" ]; then
+            # Allow root to connect to X server
+            xhost +local:root 2>/dev/null || true
+            exec sudo -E python3 "$script"
+        fi
+    fi
+
+    # Fallback: run in terminal
+    exec x-terminal-emulator -e "sudo python3 $script"
+}
+
+# Function to launch terminal apps
+launch_terminal() {
+    local script="$1"
+    exec sudo python3 "$script"
+}
 
 # Determine which interface to launch
 case "$1" in
     gtk)
-        exec python3 "$MESHFORGE_DIR/src/main_gtk.py"
+        launch_gui "$MESHFORGE_DIR/src/main_gtk.py"
         ;;
     web)
-        exec python3 "$MESHFORGE_DIR/src/main_web.py"
+        # Web UI can run without GUI, just needs network
+        if [ "$EUID" -eq 0 ]; then
+            exec python3 "$MESHFORGE_DIR/src/main_web.py"
+        else
+            exec sudo python3 "$MESHFORGE_DIR/src/main_web.py"
+        fi
         ;;
     tui)
-        exec python3 "$MESHFORGE_DIR/src/main_tui.py"
+        launch_terminal "$MESHFORGE_DIR/src/main_tui.py"
         ;;
     cli)
-        exec python3 "$MESHFORGE_DIR/src/main.py"
+        launch_terminal "$MESHFORGE_DIR/src/main.py"
         ;;
     *)
-        # Default: use launcher
-        exec python3 "$MESHFORGE_DIR/src/launcher.py"
+        # Default: use launcher (GTK-based)
+        launch_gui "$MESHFORGE_DIR/src/launcher.py"
         ;;
 esac


### PR DESCRIPTION
- pkexec strips DISPLAY environment, breaking GTK apps
- Changed desktop file to use x-terminal-emulator for sudo prompt
- Updated launcher script with better environment handling
- Removed Utility category (user has Accessories instead)
- Terminal window shows password prompt and any errors