### PR TITLE
fix: Add missing SETTINGS_FILE constant to SettingsPanel

### DIFF
--- a/src/gtk_ui/panels/settings.py
+++ b/src/gtk_ui/panels/settings.py
@@ -19,6 +19,9 @@ except ImportError:
 class SettingsPanel(Gtk.Box):
     """Settings panel with theme, preferences, and simulation options"""
 
+    # Settings file location
+    SETTINGS_FILE = Path.home() / ".config" / "meshforge" / "settings.json"
+
     # Settings defaults
     SETTINGS_DEFAULTS = {
         "theme": "dark",        # "system", "dark", "light"


### PR DESCRIPTION
The settings panel was crashing because SETTINGS_FILE class constant was referenced but never defined. Added the path constant.