### PR TITLE
fix: Handle 'Address already in use' error during RNS initialization

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -401,6 +401,25 @@ class RNSMeshtasticBridge:
             config_dir = self.config.rns.config_dir or None
             try:
                 self._reticulum = RNS.Reticulum(configdir=config_dir)
+            except OSError as e:
+                # Handle "Address already in use" error (errno 98)
+                from utils.gateway_diagnostic import handle_address_in_use_error
+                error_info = handle_address_in_use_error(e, logger)
+
+                if error_info['is_address_in_use']:
+                    if error_info['can_use_shared']:
+                        # An RNS daemon is running, use shared transport
+                        logger.info("RNS already running (rnsd), using shared instance")
+                        self._reticulum = None  # Use shared transport
+                    else:
+                        # Port in use but no rnsd - likely a stale process
+                        logger.error(f"Cannot initialize RNS: {error_info['message']}")
+                        for fix in error_info['fix_options']:
+                            logger.info(f"  Fix: {fix}")
+                        self._connected_rns = False
+                        return
+                else:
+                    raise
             except Exception as e:
                 if "reinitialise" in str(e).lower() or "already running" in str(e).lower():
                     logger.info("RNS already running, using shared instance")


### PR DESCRIPTION
When a previous RNS instance (rnsd or another MeshForge instance) is still running, RNS.Reticulum() would fail with OSError errno 98. This change:

- Adds utility functions to gateway_diagnostic.py:
  - check_rns_port_available() - Check if UDP port 29716 is available
  - find_rns_processes() - Find running rnsd/RNS processes
  - handle_address_in_use_error() - Analyze error and suggest fixes
  - kill_rns_processes() - Clean up stale RNS processes

- Updates node_tracker.py and rns_bridge.py to catch OSError and:
  - Detect if rnsd is running and use shared transport instead
  - Provide actionable fix suggestions to the user
  - Gracefully degrade if the port is blocked by unknown process