### PR TITLE
fix: Complete Path.home() remediation across codebase

### DIFF
--- a/src/amateur/ares_races.py
+++ b/src/amateur/ares_races.py
@@ -6,12 +6,23 @@ Radio Amateur Civil Emergency Service (RACES) functionality.
 """
 
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 from datetime import datetime
 from enum import Enum
 import json
 from pathlib import Path
+
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +258,7 @@ class ARESRACESTools:
 
     def __init__(self, config_dir: Optional[Path] = None):
         """Initialize ARES/RACES tools"""
-        self.config_dir = config_dir or Path.home() / '.config' / 'meshforge'
+        self.config_dir = config_dir or get_real_user_home() / '.config' / 'meshforge'
         self.data_dir = self.config_dir / 'ares_races'
         self.data_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/amateur/callsign.py
+++ b/src/amateur/callsign.py
@@ -5,12 +5,23 @@ Provides callsign lookup, validation, and management features.
 """
 
 import re
+import os
 import logging
 from dataclasses import dataclass, field
 from typing import Optional, Dict, List, Any
 from datetime import datetime
 from pathlib import Path
 import json
+
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 logger = logging.getLogger(__name__)
 
@@ -114,7 +125,7 @@ class CallsignManager:
 
     def __init__(self, config_dir: Optional[Path] = None):
         """Initialize callsign manager"""
-        self.config_dir = config_dir or Path.home() / '.config' / 'meshforge'
+        self.config_dir = config_dir or get_real_user_home() / '.config' / 'meshforge'
         self.cache_file = self.config_dir / 'callsign_cache.json'
         self.my_callsign: Optional[str] = None
         self.my_info: Optional[CallsignInfo] = None

--- a/src/config/channel_presets.py
+++ b/src/config/channel_presets.py
@@ -8,6 +8,16 @@ from rich.prompt import Prompt, Confirm
 from rich.table import Table
 from rich.panel import Panel
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 console = Console()
 
 
@@ -184,7 +194,7 @@ class ChannelPresetManager:
     }
 
     def __init__(self):
-        self.user_presets_dir = Path.home() / '.config' / 'meshtasticd' / 'presets'
+        self.user_presets_dir = get_real_user_home() / '.config' / 'meshtasticd' / 'presets'
         self.user_presets_dir.mkdir(parents=True, exist_ok=True)
 
     # Emoji icons for presets

--- a/src/core/edition.py
+++ b/src/core/edition.py
@@ -19,6 +19,16 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 
 class Edition(Enum):
     """MeshForge edition identifiers"""
@@ -173,7 +183,7 @@ def detect_edition() -> Edition:
         return _cached_edition
 
     # 2. Check config file
-    config_dir = Path.home() / ".config" / "meshforge"
+    config_dir = get_real_user_home() / ".config" / "meshforge"
     edition_file = config_dir / "edition.json"
 
     if edition_file.exists():
@@ -215,7 +225,7 @@ def set_edition(edition: Edition) -> None:
     """
     global _cached_edition
 
-    config_dir = Path.home() / ".config" / "meshforge"
+    config_dir = get_real_user_home() / ".config" / "meshforge"
     config_dir.mkdir(parents=True, exist_ok=True)
 
     edition_file = config_dir / "edition.json"

--- a/src/core/plugin_base.py
+++ b/src/core/plugin_base.py
@@ -13,6 +13,7 @@ Plugin Types:
 import json
 import logging
 import importlib.util
+import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,6 +22,16 @@ from enum import Enum
 from datetime import datetime
 
 logger = logging.getLogger(__name__)
+
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 
 class PluginType(Enum):
@@ -341,7 +352,7 @@ class PluginManager:
 
     def __init__(self, plugins_dir: Optional[Path] = None):
         if plugins_dir is None:
-            plugins_dir = Path.home() / ".config" / "meshforge" / "plugins"
+            plugins_dir = get_real_user_home() / ".config" / "meshforge" / "plugins"
         self.plugins_dir = plugins_dir
         self.plugins_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/gtk_ui/dialogs/gateway_config.py
+++ b/src/gtk_ui/dialogs/gateway_config.py
@@ -8,11 +8,22 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 import json
+import os
 from pathlib import Path
 import sys
 
 # Add parent path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 try:
     from gateway.config import GatewayConfig, MeshtasticConfig, RNSConfig, TelemetryConfig, RoutingRule
@@ -376,7 +387,7 @@ class GatewayConfigDialog(Adw.Window):
         box.append(self.anomaly_switch)
 
         # Config file location
-        config_path = Path.home() / ".config" / "meshforge" / "gateway.json"
+        config_path = get_real_user_home() / ".config" / "meshforge" / "gateway.json"
         path_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
         path_row.set_margin_top(10)
         path_label = Gtk.Label(label="Config File:")

--- a/src/gtk_ui/dialogs/rns_config.py
+++ b/src/gtk_ui/dialogs/rns_config.py
@@ -13,11 +13,21 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 
 class RNSConfigDialog(Adw.Window):
     """Dialog for editing RNS configuration file"""
 
-    DEFAULT_CONFIG_PATH = Path.home() / ".reticulum" / "config"
+    DEFAULT_CONFIG_PATH = get_real_user_home() / ".reticulum" / "config"
 
     # Default RNS configuration template
     DEFAULT_CONFIG = """# Reticulum Network Stack Configuration

--- a/src/gtk_ui/panels/diagnostics.py
+++ b/src/gtk_ui/panels/diagnostics.py
@@ -778,8 +778,17 @@ class DiagnosticsPanel(Gtk.Box):
         except Exception as e:
             results.append(f"[WARN] Could not check rnsd: {e}")
 
-        # Check config
-        rns_config = Path.home() / '.reticulum' / 'config'
+        # Check config - use real user home for sudo compatibility
+        try:
+            from utils.paths import get_real_user_home
+            rns_config = get_real_user_home() / '.reticulum' / 'config'
+        except ImportError:
+            import os as os_mod
+            sudo_user = os_mod.environ.get('SUDO_USER')
+            if sudo_user and sudo_user != 'root':
+                rns_config = Path(f'/home/{sudo_user}') / '.reticulum' / 'config'
+            else:
+                rns_config = Path.home() / '.reticulum' / 'config'
         if rns_config.exists():
             results.append(f"[PASS] RNS config exists: {rns_config}")
         else:

--- a/src/installer/uninstaller.py
+++ b/src/installer/uninstaller.py
@@ -11,6 +11,16 @@ from rich.panel import Panel
 from utils.system import run_command, is_service_running
 from utils.logger import log
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 console = Console()
 
 
@@ -20,7 +30,7 @@ class MeshtasticdUninstaller:
     def __init__(self):
         self.config_dir = Path('/etc/meshtasticd')
         self.installer_dir = Path('/opt/meshtasticd-installer')
-        self.user_config_dir = Path.home() / '.config' / 'meshtasticd-installer'
+        self.user_config_dir = get_real_user_home() / '.config' / 'meshtasticd-installer'
         self.log_files = [
             Path('/var/log/meshtasticd-installer.log'),
             Path('/var/log/meshtasticd-installer-error.log')

--- a/src/installer/update_notifier.py
+++ b/src/installer/update_notifier.py
@@ -9,6 +9,16 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 console = Console()
 
 
@@ -16,7 +26,7 @@ class UpdateNotifier:
     """Manages automatic update checking and notifications"""
 
     def __init__(self):
-        self.cache_dir = Path.home() / '.cache' / 'meshtasticd-installer'
+        self.cache_dir = get_real_user_home() / '.cache' / 'meshtasticd-installer'
         self.cache_file = self.cache_dir / 'update_cache.json'
         self.check_interval_hours = 24  # Check once per day
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -20,8 +20,18 @@ try:
 except ImportError:
     __version__ = "3.0.3"
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 # Config file location
-CONFIG_DIR = Path.home() / '.config' / 'meshtasticd-installer'
+CONFIG_DIR = get_real_user_home() / '.config' / 'meshtasticd-installer'
 CONFIG_FILE = CONFIG_DIR / 'preferences.json'
 
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -39,8 +39,18 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 # Config file location
-CONFIG_DIR = Path.home() / '.config' / 'meshtastic-monitor'
+CONFIG_DIR = get_real_user_home() / '.config' / 'meshtastic-monitor'
 CONFIG_FILE = CONFIG_DIR / 'config.json'
 
 def load_config() -> dict:

--- a/src/plugins/mqtt_bridge.py
+++ b/src/plugins/mqtt_bridge.py
@@ -27,6 +27,7 @@ Configuration (~/.config/meshforge/plugins/mqtt_bridge.json):
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Dict, Any, Optional
 
@@ -35,6 +36,16 @@ from utils.plugins import (
     PluginMetadata,
     PluginType,
 )
+
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +72,7 @@ class MQTTBridgePlugin(IntegrationPlugin):
 
     def _load_config(self) -> Dict[str, Any]:
         """Load plugin configuration."""
-        config_path = Path.home() / ".config" / "meshforge" / "plugins" / "mqtt_bridge.json"
+        config_path = get_real_user_home() / ".config" / "meshforge" / "plugins" / "mqtt_bridge.json"
         if config_path.exists():
             try:
                 return json.loads(config_path.read_text())

--- a/src/university/progress.py
+++ b/src/university/progress.py
@@ -5,10 +5,21 @@ Tracks user progress through courses and assessments.
 """
 
 import json
+import os
 from pathlib import Path
 from datetime import datetime
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
+
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 
 @dataclass
@@ -106,7 +117,7 @@ class ProgressTracker:
 
     def __init__(self, config_dir: Optional[Path] = None):
         if config_dir is None:
-            config_dir = Path.home() / '.config' / 'meshforge'
+            config_dir = get_real_user_home() / '.config' / 'meshforge'
         self.config_dir = config_dir
         self.progress_file = config_dir / 'university_progress.json'
         self.courses: Dict[str, CourseProgress] = {}

--- a/src/utils/env_config.py
+++ b/src/utils/env_config.py
@@ -6,6 +6,16 @@ from typing import Dict, Optional, Any
 from rich.console import Console
 from rich.table import Table
 
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 console = Console()
 
 # Default configuration values
@@ -46,7 +56,7 @@ def find_env_file() -> Optional[Path]:
     search_paths = [
         Path.cwd() / '.env',
         Path('/opt/meshtasticd-installer/.env'),
-        Path.home() / '.meshtasticd-installer.env',
+        get_real_user_home() / '.meshtasticd-installer.env',
         Path(__file__).parent.parent.parent / '.env',
     ]
 

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -14,6 +14,16 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Dict, Optional
 
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
 
 class CheckStatus(Enum):
     """Status of a diagnostic check."""
@@ -239,7 +249,7 @@ class GatewayDiagnostic:
 
     def check_rns_config(self) -> CheckResult:
         """Check RNS configuration file."""
-        config_path = Path.home() / ".reticulum" / "config"
+        config_path = get_real_user_home() / ".reticulum" / "config"
 
         if not config_path.exists():
             return CheckResult(
@@ -351,7 +361,7 @@ class GatewayDiagnostic:
 
     def check_meshtastic_interface(self) -> CheckResult:
         """Check Meshtastic_Interface.py for RNS."""
-        interface_path = Path.home() / ".reticulum" / "interfaces" / "Meshtastic_Interface.py"
+        interface_path = get_real_user_home() / ".reticulum" / "interfaces" / "Meshtastic_Interface.py"
 
         if interface_path.exists():
             # Check file size (should be > 10KB for real interface)

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -1,9 +1,20 @@
 """Logging utilities for the installer"""
 
 import logging
+import os
 import sys
 from datetime import datetime
 from pathlib import Path
+
+# Import centralized path utility for sudo compatibility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 
 # Global logger instance
@@ -50,7 +61,7 @@ def setup_logger(debug=False, log_file='/var/log/meshtasticd-installer.log'):
         logger.addHandler(file_handler)
     except PermissionError:
         # If we can't write to /var/log, try user directory
-        home_log = Path.home() / '.meshtasticd-installer.log'
+        home_log = get_real_user_home() / '.meshtasticd-installer.log'
         file_handler = logging.FileHandler(home_log)
         file_handler.setLevel(logging.DEBUG)
         file_handler.setFormatter(file_formatter)

--- a/src/utils/plugins.py
+++ b/src/utils/plugins.py
@@ -44,8 +44,19 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set, Type, Any
 import importlib.util
 import logging
+import os
 
 logger = logging.getLogger(__name__)
+
+# Import centralized path utility
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
 
 
 class PluginType(Enum):
@@ -235,7 +246,7 @@ class PluginManager:
             self.plugins_dir = Path(__file__).parent.parent / "plugins"
 
         # User plugins directory
-        self.user_plugins_dir = Path.home() / ".config" / "meshforge" / "plugins"
+        self.user_plugins_dir = get_real_user_home() / ".config" / "meshforge" / "plugins"
 
     def discover(self) -> List[str]:
         """Discover plugins in configured directories."""


### PR DESCRIPTION
Replace all Path.home() calls with get_real_user_home() to fix sudo compatibility issues. This ensures config files are written to the real user's home directory (/home/<user>) instead of /root when running with sudo.

Files fixed:
- core/edition.py, plugin_base.py: Edition detection
- university/progress.py: Learning progress tracking
- utils/plugins.py, gateway_diagnostic.py: Plugin and diagnostics
- gtk_ui/dialogs/: rns_config.py, gateway_config.py
- gtk_ui/panels/diagnostics.py: RNS config check in tests
- installer/: update_notifier.py, uninstaller.py
- launcher.py, monitor.py: Entry point configs
- cli/diagnose.py: CLI diagnostics
- amateur/: ares_races.py, callsign.py
- plugins/: mqtt_bridge.py, meshing_around.py
- config/channel_presets.py: User preset storage
- utils/: env_config.py, logger.py

All modules now use centralized get_real_user_home() with fallback import pattern for compatibility.