### PR TITLE
fix: Properly shut down RNS Transport to release ports

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -504,7 +504,17 @@ class RNSMeshtasticBridge:
             self._connected_rns = False
 
     def _disconnect_rns(self):
-        """Disconnect from RNS"""
+        """Disconnect from RNS and release ports"""
+        # Properly shut down RNS to release ports
+        if self._reticulum:
+            try:
+                import RNS
+                # RNS.Transport.exithandler() closes all interfaces and releases ports
+                RNS.Transport.exithandler()
+                logger.debug("RNS Transport shut down")
+            except Exception as e:
+                logger.debug(f"Error shutting down RNS Transport: {e}")
+
         self._lxmf_router = None
         self._lxmf_source = None
         self._identity = None

--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -1289,7 +1289,7 @@ class RNSPanel(Gtk.Box):
                     self._gateway_bridge.stop()
                     self._gateway_bridge = None
                     import time
-                    time.sleep(0.5)  # Wait for port to be released
+                    time.sleep(1.0)  # Wait for RNS to release ports
                     self.main_window.set_status_message("Stopped gateway for NomadNet")
                     GLib.idle_add(self._update_gateway_status)
 
@@ -1342,7 +1342,7 @@ class RNSPanel(Gtk.Box):
                     self._gateway_bridge.stop()
                     self._gateway_bridge = None
                     import time
-                    time.sleep(0.5)
+                    time.sleep(1.0)  # Wait for RNS to release ports
                     GLib.idle_add(self._update_gateway_status)
 
                 # Stop rnsd if running - NomadNet manages its own RNS instance
@@ -1350,7 +1350,7 @@ class RNSPanel(Gtk.Box):
                     logger.debug("[RNS] rnsd running - stopping it before NomadNet daemon")
                     subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
                     import time
-                    time.sleep(0.5)  # Wait for port to be released
+                    time.sleep(1.0)  # Wait for port to be released
 
                 # Run as daemon using full path
                 # When running as root, run as real user


### PR DESCRIPTION
- Call RNS.Transport.exithandler() in _disconnect_rns() to properly close interfaces and release UDP ports
- Increase wait time from 0.5s to 1.0s after stopping bridge/rnsd to ensure ports are fully released before NomadNet starts