### PR TITLE
feat: Add Web Client Mode toggle to prevent meshtasticd interference

### DIFF
--- a/src/gtk_ui/app.py
+++ b/src/gtk_ui/app.py
@@ -913,6 +913,15 @@ class MeshForgeWindow(Adw.ApplicationWindow):
         import time as time_module
         import socket
 
+        # Check for web client mode - don't connect if enabled
+        try:
+            from utils.common import SettingsManager
+            settings = SettingsManager()
+            if settings.get("web_client_mode", False):
+                return "--"  # Return placeholder when web client mode is on
+        except Exception:
+            pass
+
         # Check cache first
         now = time_module.time()
         if now - self._node_count_timestamp < self._node_count_cache_ttl:

--- a/src/gtk_ui/panels/map.py
+++ b/src/gtk_ui/panels/map.py
@@ -108,6 +108,15 @@ class MapPanel(Gtk.Box):
         """Get or create persistent NodeMonitor"""
         import time
 
+        # Check for web client mode - don't connect if enabled
+        try:
+            from ...utils.common import SettingsManager
+            settings = SettingsManager()
+            if settings.get("web_client_mode", False):
+                return None, "Web Client Mode enabled - connections disabled"
+        except Exception:
+            pass
+
         with cls._monitor_lock:
             # Check if monitor exists and is connected
             if cls._monitor is not None:


### PR DESCRIPTION
When enabled:
- Map panel won't connect to meshtasticd
- Status bar won't query node count
- Disconnects any existing connections

Allows using Meshtastic web browser without GTK interference. Toggle in Settings > Dashboard > Web Client Mode