### PR TITLE
feat: Add consolidated Mesh Tools and Ham Tools panels

### DIFF
--- a/src/gtk_ui/app.py
+++ b/src/gtk_ui/app.py
@@ -340,6 +340,10 @@ class MeshForgeWindow(Adw.ApplicationWindow):
             ("config", self._add_config_page),
             ("radio_config", self._add_radio_config_page),
             ("rns", self._add_rns_page),
+            # Consolidated tool panels
+            ("mesh_tools", self._add_mesh_tools_page),
+            ("ham_tools", self._add_ham_tools_page),
+            # Legacy panels (still available)
             ("map", self._add_map_page),
             ("hamclock", self._add_hamclock_page),
             ("cli", self._add_cli_page),
@@ -487,25 +491,26 @@ class MeshForgeWindow(Adw.ApplicationWindow):
         listbox.connect("row-selected", self._on_nav_selected)
         scrolled.set_child(listbox)
 
-        # Navigation items
         # Navigation items with feature requirements
         # Format: (page_name, label, icon, required_feature or None)
+        # Reorganized into: Core, Consolidated Tools, Legacy/Advanced, Settings
         all_nav_items = [
+            # Core functionality
             ("dashboard", "Dashboard", "utilities-system-monitor-symbolic", None),
             ("service", "Service Management", "system-run-symbolic", None),
             ("install", "Install / Update", "system-software-install-symbolic", None),
             ("config", "Config File Manager", "document-edit-symbolic", None),
             ("radio_config", "Radio Configuration", "network-wireless-symbolic", None),
             ("rns", "Reticulum (RNS)", "network-transmit-receive-symbolic", "rns_integration"),
-            ("map", "Node Map", "mark-location-symbolic", None),
-            ("hamclock", "HamClock", "weather-clear-symbolic", "hamclock"),
+            # Consolidated tool panels (new)
+            ("mesh_tools", "Mesh Tools", "network-workgroup-symbolic", None),
+            ("ham_tools", "Ham Tools", "audio-speakers-symbolic", None),
+            # Advanced/Legacy panels
             ("cli", "Meshtastic CLI", "utilities-terminal-symbolic", None),
             ("hardware", "Hardware Detection", "drive-harddisk-symbolic", None),
             ("tools", "System Tools", "applications-utilities-symbolic", None),
-            ("diagnostics", "Network Diagnostics", "dialog-information-symbolic", None),
             ("aredn", "AREDN Mesh", "network-server-symbolic", "aredn_integration"),
-            ("amateur", "Amateur Radio", "audio-speakers-symbolic", "amateur_radio"),
-            ("meshbot", "MeshBot", "mail-send-symbolic", None),
+            # Settings
             ("settings", "Settings", "preferences-system-symbolic", None),
         ]
 
@@ -669,6 +674,20 @@ class MeshForgeWindow(Adw.ApplicationWindow):
         panel = MeshBotPanel(self)
         self.content_stack.add_named(panel, "meshbot")
         self.meshbot_panel = panel
+
+    def _add_mesh_tools_page(self):
+        """Add the consolidated Mesh Tools page (MeshBot, Map, Diagnostics)"""
+        from .panels.mesh_tools import MeshToolsPanel
+        panel = MeshToolsPanel(self)
+        self.content_stack.add_named(panel, "mesh_tools")
+        self.mesh_tools_panel = panel
+
+    def _add_ham_tools_page(self):
+        """Add the consolidated Ham Tools page (HamClock, Propagation, Callsign)"""
+        from .panels.ham_tools import HamToolsPanel
+        panel = HamToolsPanel(self)
+        self.content_stack.add_named(panel, "ham_tools")
+        self.ham_tools_panel = panel
 
     def _add_settings_page(self):
         """Add the settings page"""

--- a/src/gtk_ui/panels/ham_tools.py
+++ b/src/gtk_ui/panels/ham_tools.py
@@ -1,0 +1,827 @@
+"""
+Ham Tools Panel - Consolidated amateur radio tools
+
+Combines:
+- HamClock (space weather, propagation)
+- Propagation (band conditions, forecasts)
+- Callsign Lookup (QRZ, callook)
+
+With shared resizable output at bottom.
+"""
+
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw, GLib
+import threading
+import subprocess
+import urllib.request
+import urllib.error
+import json
+import os
+from pathlib import Path
+from datetime import datetime
+
+# Import UI standards
+try:
+    from utils.gtk_helpers import (
+        UI, create_panel_header, create_standard_frame,
+        ResizableLogViewer, StatusIndicator
+    )
+    HAS_UI_HELPERS = True
+except ImportError:
+    HAS_UI_HELPERS = False
+
+# Import logging
+try:
+    from utils.logging_utils import get_logger
+    logger = get_logger(__name__)
+except ImportError:
+    import logging
+    logger = logging.getLogger(__name__)
+
+# Import path utilities
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
+# Import settings manager
+try:
+    from utils.common import SettingsManager
+    HAS_SETTINGS = True
+except ImportError:
+    HAS_SETTINGS = False
+
+
+class HamToolsPanel(Gtk.Box):
+    """
+    Consolidated amateur radio tools panel.
+
+    Provides sub-tabs for HamClock, Propagation, and Callsign Lookup
+    with a shared resizable output at the bottom.
+    """
+
+    SETTINGS_DEFAULTS = {
+        "hamclock_url": "http://localhost",
+        "hamclock_api_port": 8082,
+        "hamclock_live_port": 8081,
+        "qrz_username": "",
+        "output_position": 350,
+    }
+
+    def __init__(self, main_window):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self.main_window = main_window
+
+        # Apply standard margins
+        margin = UI.MARGIN_PANEL if HAS_UI_HELPERS else 20
+        self.set_margin_start(margin)
+        self.set_margin_end(margin)
+        self.set_margin_top(margin)
+        self.set_margin_bottom(margin)
+
+        # Load settings
+        if HAS_SETTINGS:
+            self._settings_mgr = SettingsManager("ham_tools", defaults=self.SETTINGS_DEFAULTS)
+            self._settings = self._settings_mgr.all()
+        else:
+            self._settings = self.SETTINGS_DEFAULTS.copy()
+
+        self._build_ui()
+
+        # Initial checks
+        GLib.timeout_add(500, self._check_hamclock_status)
+
+    def _save_settings(self):
+        """Save settings"""
+        if HAS_SETTINGS:
+            self._settings_mgr.update(self._settings)
+            self._settings_mgr.save()
+
+    def _build_ui(self):
+        """Build the main UI with paned layout"""
+        # Header
+        if HAS_UI_HELPERS:
+            header = create_panel_header(
+                "Ham Tools",
+                "HamClock, Propagation, and Callsign Lookup",
+                "audio-speakers-symbolic"
+            )
+        else:
+            header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+            title = Gtk.Label(label="Ham Tools")
+            title.add_css_class("title-1")
+            title.set_xalign(0)
+            header.append(title)
+
+        self.append(header)
+        self.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # Main paned layout
+        self._paned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
+        self._paned.set_wide_handle(True)
+        self._paned.set_vexpand(True)
+
+        # Top: Notebook with tabs
+        self._notebook = Gtk.Notebook()
+        self._notebook.set_tab_pos(Gtk.PositionType.TOP)
+
+        # Add tabs
+        self._add_hamclock_tab()
+        self._add_propagation_tab()
+        self._add_callsign_tab()
+
+        self._paned.set_start_child(self._notebook)
+
+        # Bottom: Output viewer
+        self._build_output_viewer()
+        self._paned.set_end_child(self._output_frame)
+
+        # Restore position
+        self._paned.set_position(self._settings.get("output_position", 350))
+        self._paned.connect("notify::position", self._on_paned_moved)
+
+        self.append(self._paned)
+
+    def _build_output_viewer(self):
+        """Build the shared output viewer"""
+        self._output_frame = Gtk.Frame()
+        self._output_frame.set_label("Data Output")
+
+        output_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        # Controls
+        controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        controls.set_margin_start(10)
+        controls.set_margin_end(10)
+        controls.set_margin_top(5)
+        controls.set_margin_bottom(5)
+
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        controls.append(spacer)
+
+        clear_btn = Gtk.Button(label="Clear")
+        clear_btn.connect("clicked", lambda b: self._clear_output())
+        controls.append(clear_btn)
+
+        copy_btn = Gtk.Button(label="Copy")
+        copy_btn.connect("clicked", self._on_copy_output)
+        controls.append(copy_btn)
+
+        output_box.append(controls)
+        output_box.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # Text view
+        self._output_text = Gtk.TextView()
+        self._output_text.set_editable(False)
+        self._output_text.set_monospace(True)
+        self._output_text.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+
+        output_scroll = Gtk.ScrolledWindow()
+        output_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        output_scroll.set_vexpand(True)
+        output_scroll.set_min_content_height(100)
+        output_scroll.set_child(self._output_text)
+
+        output_box.append(output_scroll)
+        self._output_frame.set_child(output_box)
+
+    def _on_paned_moved(self, paned, param):
+        """Save paned position"""
+        self._settings["output_position"] = paned.get_position()
+        self._save_settings()
+
+    # =========================================================================
+    # HamClock Tab
+    # =========================================================================
+
+    def _add_hamclock_tab(self):
+        """Add HamClock integration tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Connection section
+        conn_frame = Gtk.Frame()
+        conn_frame.set_label("HamClock Connection")
+        conn_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        conn_box.set_margin_start(15)
+        conn_box.set_margin_end(15)
+        conn_box.set_margin_top(10)
+        conn_box.set_margin_bottom(10)
+
+        # Status row
+        status_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=15)
+        self._hc_status_icon = Gtk.Image.new_from_icon_name("emblem-question-symbolic")
+        self._hc_status_icon.set_pixel_size(24)
+        status_row.append(self._hc_status_icon)
+
+        self._hc_status_label = Gtk.Label(label="Not connected")
+        self._hc_status_label.set_xalign(0)
+        status_row.append(self._hc_status_label)
+
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        status_row.append(spacer)
+
+        connect_btn = Gtk.Button(label="Connect")
+        connect_btn.add_css_class("suggested-action")
+        connect_btn.connect("clicked", self._on_connect_hamclock)
+        status_row.append(connect_btn)
+
+        conn_box.append(status_row)
+
+        # URL entry
+        url_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        url_row.append(Gtk.Label(label="URL:"))
+        self._hc_url_entry = Gtk.Entry()
+        self._hc_url_entry.set_text(self._settings.get("hamclock_url", "http://localhost"))
+        self._hc_url_entry.set_hexpand(True)
+        self._hc_url_entry.set_placeholder_text("http://hamclock.local")
+        url_row.append(self._hc_url_entry)
+
+        url_row.append(Gtk.Label(label="API Port:"))
+        self._hc_api_port = Gtk.SpinButton()
+        self._hc_api_port.set_range(1, 65535)
+        self._hc_api_port.set_value(self._settings.get("hamclock_api_port", 8082))
+        self._hc_api_port.set_increments(1, 10)
+        url_row.append(self._hc_api_port)
+
+        conn_box.append(url_row)
+
+        conn_frame.set_child(conn_box)
+        box.append(conn_frame)
+
+        # Space Weather section
+        wx_frame = Gtk.Frame()
+        wx_frame.set_label("Space Weather")
+        wx_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        wx_box.set_margin_start(15)
+        wx_box.set_margin_end(15)
+        wx_box.set_margin_top(10)
+        wx_box.set_margin_bottom(10)
+
+        # Weather data grid
+        wx_grid = Gtk.Grid()
+        wx_grid.set_column_spacing(20)
+        wx_grid.set_row_spacing(5)
+
+        self._wx_labels = {}
+        wx_items = [
+            ("sfi", "Solar Flux (SFI)"),
+            ("kp", "Kp Index"),
+            ("a", "A Index"),
+            ("xray", "X-Ray Flux"),
+            ("sunspots", "Sunspot Number"),
+        ]
+
+        for i, (key, label) in enumerate(wx_items):
+            name_lbl = Gtk.Label(label=f"{label}:")
+            name_lbl.set_xalign(0)
+            wx_grid.attach(name_lbl, 0, i, 1, 1)
+
+            value_lbl = Gtk.Label(label="--")
+            value_lbl.set_xalign(0)
+            value_lbl.add_css_class("heading")
+            wx_grid.attach(value_lbl, 1, i, 1, 1)
+            self._wx_labels[key] = value_lbl
+
+        wx_box.append(wx_grid)
+
+        # Fetch buttons
+        fetch_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        fetch_hc_btn = Gtk.Button(label="Fetch from HamClock")
+        fetch_hc_btn.add_css_class("suggested-action")
+        fetch_hc_btn.connect("clicked", self._on_fetch_hamclock_wx)
+        fetch_row.append(fetch_hc_btn)
+
+        fetch_noaa_btn = Gtk.Button(label="Fetch from NOAA")
+        fetch_noaa_btn.connect("clicked", self._on_fetch_noaa_wx)
+        fetch_row.append(fetch_noaa_btn)
+
+        wx_box.append(fetch_row)
+
+        wx_frame.set_child(wx_box)
+        box.append(wx_frame)
+
+        # Service section
+        svc_frame = Gtk.Frame()
+        svc_frame.set_label("HamClock Service")
+        svc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        svc_box.set_margin_start(15)
+        svc_box.set_margin_end(15)
+        svc_box.set_margin_top(10)
+        svc_box.set_margin_bottom(10)
+
+        start_btn = Gtk.Button(label="Start Service")
+        start_btn.connect("clicked", lambda b: self._hamclock_service("start"))
+        svc_box.append(start_btn)
+
+        stop_btn = Gtk.Button(label="Stop Service")
+        stop_btn.connect("clicked", lambda b: self._hamclock_service("stop"))
+        svc_box.append(stop_btn)
+
+        open_btn = Gtk.Button(label="Open in Browser")
+        open_btn.connect("clicked", self._on_open_hamclock_browser)
+        svc_box.append(open_btn)
+
+        install_btn = Gtk.Button(label="Install HamClock")
+        install_btn.connect("clicked", self._on_install_hamclock)
+        svc_box.append(install_btn)
+
+        svc_frame.set_child(svc_box)
+        box.append(svc_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("weather-clear-symbolic"))
+        tab_box.append(Gtk.Label(label="HamClock"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    # =========================================================================
+    # Propagation Tab
+    # =========================================================================
+
+    def _add_propagation_tab(self):
+        """Add Propagation predictions tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Band Conditions
+        bands_frame = Gtk.Frame()
+        bands_frame.set_label("HF Band Conditions")
+        bands_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        bands_box.set_margin_start(15)
+        bands_box.set_margin_end(15)
+        bands_box.set_margin_top(10)
+        bands_box.set_margin_bottom(10)
+
+        # Band grid
+        bands_grid = Gtk.Grid()
+        bands_grid.set_column_spacing(20)
+        bands_grid.set_row_spacing(5)
+
+        # Headers
+        for i, header in enumerate(["Band", "Day", "Night"]):
+            lbl = Gtk.Label(label=header)
+            lbl.add_css_class("heading")
+            bands_grid.attach(lbl, i, 0, 1, 1)
+
+        self._band_labels = {}
+        bands = ["80m-40m", "30m-20m", "17m-15m", "12m-10m"]
+
+        for row, band in enumerate(bands, start=1):
+            band_lbl = Gtk.Label(label=band)
+            band_lbl.set_xalign(0)
+            bands_grid.attach(band_lbl, 0, row, 1, 1)
+
+            day_lbl = Gtk.Label(label="--")
+            bands_grid.attach(day_lbl, 1, row, 1, 1)
+
+            night_lbl = Gtk.Label(label="--")
+            bands_grid.attach(night_lbl, 2, row, 1, 1)
+
+            self._band_labels[band] = {"day": day_lbl, "night": night_lbl}
+
+        bands_box.append(bands_grid)
+
+        refresh_bands_btn = Gtk.Button(label="Refresh Band Conditions")
+        refresh_bands_btn.connect("clicked", self._on_refresh_bands)
+        bands_box.append(refresh_bands_btn)
+
+        bands_frame.set_child(bands_box)
+        box.append(bands_frame)
+
+        # External Resources
+        resources_frame = Gtk.Frame()
+        resources_frame.set_label("Propagation Resources")
+        resources_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        resources_box.set_margin_start(15)
+        resources_box.set_margin_end(15)
+        resources_box.set_margin_top(10)
+        resources_box.set_margin_bottom(10)
+
+        resources = [
+            ("VOACAP Online", "https://www.voacap.com/hf/", "Detailed HF propagation predictions"),
+            ("Solar Ham", "https://www.solarham.net/", "Real-time solar activity"),
+            ("DX Heat", "https://dxheat.com/", "DX cluster and propagation"),
+            ("PSK Reporter", "https://pskreporter.info/pskmap.html", "Live propagation map"),
+        ]
+
+        for name, url, desc in resources:
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+            btn = Gtk.Button(label=name)
+            btn.connect("clicked", lambda b, u=url: self._open_url(u))
+            btn.set_tooltip_text(url)
+            row.append(btn)
+
+            desc_lbl = Gtk.Label(label=desc)
+            desc_lbl.add_css_class("dim-label")
+            desc_lbl.set_xalign(0)
+            row.append(desc_lbl)
+
+            resources_box.append(row)
+
+        resources_frame.set_child(resources_box)
+        box.append(resources_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("network-transmit-symbolic"))
+        tab_box.append(Gtk.Label(label="Propagation"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    # =========================================================================
+    # Callsign Tab
+    # =========================================================================
+
+    def _add_callsign_tab(self):
+        """Add Callsign Lookup tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Lookup section
+        lookup_frame = Gtk.Frame()
+        lookup_frame.set_label("Callsign Lookup")
+        lookup_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        lookup_box.set_margin_start(15)
+        lookup_box.set_margin_end(15)
+        lookup_box.set_margin_top(10)
+        lookup_box.set_margin_bottom(10)
+
+        # Search row
+        search_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        search_row.append(Gtk.Label(label="Callsign:"))
+
+        self._callsign_entry = Gtk.Entry()
+        self._callsign_entry.set_placeholder_text("W1AW")
+        self._callsign_entry.set_width_chars(12)
+        self._callsign_entry.connect("activate", self._on_lookup_callsign)
+        search_row.append(self._callsign_entry)
+
+        lookup_btn = Gtk.Button(label="Lookup")
+        lookup_btn.add_css_class("suggested-action")
+        lookup_btn.connect("clicked", self._on_lookup_callsign)
+        search_row.append(lookup_btn)
+
+        # Source selector
+        search_row.append(Gtk.Label(label="Source:"))
+        self._lookup_source = Gtk.ComboBoxText()
+        self._lookup_source.append("callook", "Callook.info (FCC)")
+        self._lookup_source.append("hamqth", "HamQTH")
+        self._lookup_source.append("qrz", "QRZ.com")
+        self._lookup_source.set_active_id("callook")
+        search_row.append(self._lookup_source)
+
+        lookup_box.append(search_row)
+
+        # Results area
+        self._callsign_results = Gtk.TextView()
+        self._callsign_results.set_editable(False)
+        self._callsign_results.set_wrap_mode(Gtk.WrapMode.WORD)
+
+        results_scroll = Gtk.ScrolledWindow()
+        results_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        results_scroll.set_min_content_height(150)
+        results_scroll.set_child(self._callsign_results)
+
+        lookup_box.append(results_scroll)
+
+        lookup_frame.set_child(lookup_box)
+        box.append(lookup_frame)
+
+        # Recent lookups
+        recent_frame = Gtk.Frame()
+        recent_frame.set_label("Recent Lookups")
+        recent_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+        recent_box.set_margin_start(15)
+        recent_box.set_margin_end(15)
+        recent_box.set_margin_top(10)
+        recent_box.set_margin_bottom(10)
+
+        self._recent_store = Gtk.ListStore(str, str, str)  # callsign, name, location
+
+        recent_tree = Gtk.TreeView(model=self._recent_store)
+        for i, title in enumerate(["Callsign", "Name", "Location"]):
+            renderer = Gtk.CellRendererText()
+            column = Gtk.TreeViewColumn(title, renderer, text=i)
+            column.set_resizable(True)
+            recent_tree.append_column(column)
+
+        recent_scroll = Gtk.ScrolledWindow()
+        recent_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        recent_scroll.set_min_content_height(100)
+        recent_scroll.set_child(recent_tree)
+
+        recent_box.append(recent_scroll)
+
+        recent_frame.set_child(recent_box)
+        box.append(recent_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("system-users-symbolic"))
+        tab_box.append(Gtk.Label(label="Callsign"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    # =========================================================================
+    # Event Handlers
+    # =========================================================================
+
+    def _check_hamclock_status(self):
+        """Check HamClock connection status"""
+        url = self._settings.get("hamclock_url", "http://localhost")
+        port = self._settings.get("hamclock_api_port", 8082)
+
+        def check():
+            try:
+                test_url = f"{url}:{port}/get_sys.txt"
+                req = urllib.request.Request(test_url, method='GET')
+                req.add_header('User-Agent', 'MeshForge/1.0')
+                with urllib.request.urlopen(req, timeout=3) as response:
+                    GLib.idle_add(self._update_hc_status, True, "Connected")
+            except Exception:
+                GLib.idle_add(self._update_hc_status, False, "Not connected")
+
+        threading.Thread(target=check, daemon=True).start()
+        return False
+
+    def _update_hc_status(self, connected: bool, message: str):
+        """Update HamClock status display"""
+        if connected:
+            self._hc_status_icon.set_from_icon_name("emblem-default-symbolic")
+            self._hc_status_label.set_label(message)
+        else:
+            self._hc_status_icon.set_from_icon_name("dialog-warning-symbolic")
+            self._hc_status_label.set_label(message)
+
+    def _on_connect_hamclock(self, button):
+        """Connect to HamClock"""
+        url = self._hc_url_entry.get_text().strip()
+        port = int(self._hc_api_port.get_value())
+
+        self._settings["hamclock_url"] = url
+        self._settings["hamclock_api_port"] = port
+        self._save_settings()
+
+        self._output_message(f"Connecting to HamClock at {url}:{port}...")
+        self._check_hamclock_status()
+
+    def _on_fetch_hamclock_wx(self, button):
+        """Fetch space weather from HamClock"""
+        url = self._settings.get("hamclock_url", "http://localhost")
+        port = self._settings.get("hamclock_api_port", 8082)
+
+        self._output_message("Fetching space weather from HamClock...")
+
+        def fetch():
+            try:
+                api_url = f"{url}:{port}/get_spacewx.txt"
+                req = urllib.request.Request(api_url)
+                req.add_header('User-Agent', 'MeshForge/1.0')
+
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    data = response.read().decode('utf-8')
+                    GLib.idle_add(self._parse_hamclock_wx, data)
+
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"Error: {e}")
+
+        threading.Thread(target=fetch, daemon=True).start()
+
+    def _parse_hamclock_wx(self, data: str):
+        """Parse HamClock space weather response"""
+        self._output_message(f"Raw data:\n{data}")
+
+        for line in data.strip().split('\n'):
+            if '=' in line:
+                key, value = line.split('=', 1)
+                key = key.strip().lower()
+                value = value.strip()
+
+                if key == 'sfi' and 'sfi' in self._wx_labels:
+                    self._wx_labels['sfi'].set_label(value)
+                elif key == 'kp' and 'kp' in self._wx_labels:
+                    self._wx_labels['kp'].set_label(value)
+                elif key == 'a' and 'a' in self._wx_labels:
+                    self._wx_labels['a'].set_label(value)
+                elif key == 'xray' and 'xray' in self._wx_labels:
+                    self._wx_labels['xray'].set_label(value)
+                elif key == 'ssn' and 'sunspots' in self._wx_labels:
+                    self._wx_labels['sunspots'].set_label(value)
+
+    def _on_fetch_noaa_wx(self, button):
+        """Fetch space weather from NOAA"""
+        self._output_message("Fetching space weather from NOAA...")
+
+        def fetch():
+            try:
+                url = "https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json"
+                req = urllib.request.Request(url)
+                req.add_header('User-Agent', 'MeshForge/1.0')
+
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    data = json.loads(response.read().decode('utf-8'))
+
+                if data:
+                    latest = data[-1]
+                    GLib.idle_add(self._apply_noaa_wx, latest)
+
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"Error: {e}")
+
+        threading.Thread(target=fetch, daemon=True).start()
+
+    def _apply_noaa_wx(self, data: dict):
+        """Apply NOAA weather data"""
+        self._output_message(f"NOAA data: {json.dumps(data, indent=2)}")
+
+        if 'f10.7' in data:
+            self._wx_labels['sfi'].set_label(str(data['f10.7']))
+        if 'ssn' in data:
+            self._wx_labels['sunspots'].set_label(str(data['ssn']))
+
+    def _hamclock_service(self, action: str):
+        """Control HamClock service"""
+        self._output_message(f"{action.capitalize()}ing HamClock service...")
+
+        def do_action():
+            services = ['hamclock', 'hamclock-web', 'hamclock-systemd']
+            for name in services:
+                try:
+                    result = subprocess.run(
+                        ['sudo', 'systemctl', action, name],
+                        capture_output=True, text=True, timeout=30
+                    )
+                    if result.returncode == 0:
+                        GLib.idle_add(self._output_message, f"Service {name} {action}ed")
+                        GLib.idle_add(self._check_hamclock_status)
+                        return
+                except Exception:
+                    continue
+
+            GLib.idle_add(self._output_message, "No HamClock service found")
+
+        threading.Thread(target=do_action, daemon=True).start()
+
+    def _on_open_hamclock_browser(self, button):
+        """Open HamClock in browser"""
+        url = self._settings.get("hamclock_url", "http://localhost")
+        port = self._settings.get("hamclock_live_port", 8081)
+        live_url = f"{url}:{port}/live.html"
+        self._open_url(live_url)
+
+    def _on_install_hamclock(self, button):
+        """Install HamClock"""
+        self._output_message("Installing HamClock...")
+        # TODO: Implement installation
+
+    def _on_refresh_bands(self, button):
+        """Refresh band conditions"""
+        self._output_message("Fetching band conditions...")
+
+        def fetch():
+            try:
+                # Try N0NBH widget data
+                url = "https://www.hamqsl.com/solarxml.php"
+                req = urllib.request.Request(url)
+                req.add_header('User-Agent', 'MeshForge/1.0')
+
+                with urllib.request.urlopen(req, timeout=10) as response:
+                    data = response.read().decode('utf-8')
+                    GLib.idle_add(self._output_message, f"Band data fetched")
+                    # TODO: Parse XML
+
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"Error: {e}")
+
+        threading.Thread(target=fetch, daemon=True).start()
+
+    def _on_lookup_callsign(self, widget):
+        """Lookup callsign"""
+        callsign = self._callsign_entry.get_text().strip().upper()
+        if not callsign:
+            return
+
+        source = self._lookup_source.get_active_id()
+        self._output_message(f"Looking up {callsign} via {source}...")
+
+        def do_lookup():
+            try:
+                if source == "callook":
+                    url = f"https://callook.info/{callsign}/json"
+                    req = urllib.request.Request(url)
+                    req.add_header('User-Agent', 'MeshForge/1.0')
+
+                    with urllib.request.urlopen(req, timeout=10) as response:
+                        data = json.loads(response.read().decode('utf-8'))
+                        GLib.idle_add(self._display_callsign_result, callsign, data)
+
+                else:
+                    GLib.idle_add(self._output_message, f"Source {source} not yet implemented")
+
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"Lookup error: {e}")
+
+        threading.Thread(target=do_lookup, daemon=True).start()
+
+    def _display_callsign_result(self, callsign: str, data: dict):
+        """Display callsign lookup result"""
+        if data.get('status') == 'VALID':
+            name = data.get('name', 'Unknown')
+            addr = data.get('address', {})
+            location = f"{addr.get('city', '')}, {addr.get('state', '')}"
+            lic_class = data.get('current', {}).get('operClass', 'Unknown')
+            grant_date = data.get('current', {}).get('grantDate', 'Unknown')
+
+            result = f"""Callsign: {callsign}
+Name: {name}
+Location: {location}
+Class: {lic_class}
+Grant Date: {grant_date}
+"""
+            buffer = self._callsign_results.get_buffer()
+            buffer.set_text(result)
+
+            # Add to recent
+            self._recent_store.insert(0, [callsign, name, location])
+
+            self._output_message(f"Found: {callsign} - {name}")
+        else:
+            buffer = self._callsign_results.get_buffer()
+            buffer.set_text(f"Callsign {callsign} not found")
+            self._output_message(f"Callsign {callsign} not found")
+
+    def _output_message(self, message: str):
+        """Add message to output"""
+        buffer = self._output_text.get_buffer()
+        end_iter = buffer.get_end_iter()
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        buffer.insert(end_iter, f"[{timestamp}] {message}\n")
+
+    def _clear_output(self):
+        """Clear output"""
+        buffer = self._output_text.get_buffer()
+        buffer.set_text("")
+
+    def _on_copy_output(self, button):
+        """Copy output to clipboard"""
+        buffer = self._output_text.get_buffer()
+        start, end = buffer.get_bounds()
+        text = buffer.get_text(start, end, False)
+
+        clipboard = self.get_clipboard()
+        clipboard.set(text)
+        self._output_message("Copied to clipboard")
+
+    def _open_url(self, url: str):
+        """Open URL in browser"""
+        real_user = os.environ.get('SUDO_USER', os.environ.get('USER', 'pi'))
+        try:
+            subprocess.Popen(
+                ['sudo', '-u', real_user, 'xdg-open', url],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True
+            )
+            self._output_message(f"Opening {url}")
+        except Exception as e:
+            self._output_message(f"Error opening URL: {e}")
+
+    def cleanup(self):
+        """Clean up resources"""
+        pass

--- a/src/gtk_ui/panels/mesh_tools.py
+++ b/src/gtk_ui/panels/mesh_tools.py
@@ -1,0 +1,990 @@
+"""
+Mesh Tools Panel - Consolidated mesh network tools
+
+Combines:
+- MeshBot (BBS, games, inventory, weather)
+- Node Map (network visualization)
+- Diagnostics (health monitoring, event log)
+
+With shared resizable log output at bottom.
+"""
+
+import gi
+gi.require_version('Gtk', '4.0')
+gi.require_version('Adw', '1')
+from gi.repository import Gtk, Adw, GLib
+import threading
+import subprocess
+import os
+import json
+from pathlib import Path
+from datetime import datetime
+
+# Import UI standards
+try:
+    from utils.gtk_helpers import (
+        UI, create_panel_header, create_standard_frame,
+        ResizableLogViewer, ResizablePanedLayout, StatusIndicator
+    )
+    HAS_UI_HELPERS = True
+except ImportError:
+    HAS_UI_HELPERS = False
+
+# Import logging
+try:
+    from utils.logging_utils import get_logger
+    logger = get_logger(__name__)
+except ImportError:
+    import logging
+    logger = logging.getLogger(__name__)
+
+# Import path utilities
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            return Path(f'/home/{sudo_user}')
+        return Path.home()
+
+# Import settings manager
+try:
+    from utils.common import SettingsManager
+    HAS_SETTINGS = True
+except ImportError:
+    HAS_SETTINGS = False
+
+# Import diagnostics
+try:
+    from utils.network_diagnostics import (
+        get_diagnostics, EventCategory, EventSeverity, HealthStatus
+    )
+    HAS_DIAGNOSTICS = True
+except ImportError:
+    HAS_DIAGNOSTICS = False
+
+
+class MeshToolsPanel(Gtk.Box):
+    """
+    Consolidated mesh network tools panel.
+
+    Provides sub-tabs for MeshBot, Node Map, and Diagnostics
+    with a shared resizable log output at the bottom.
+    """
+
+    SETTINGS_DEFAULTS = {
+        "meshbot_path": "/opt/meshing-around",
+        "log_position": 300,  # Paned position
+        "active_tab": 0,
+    }
+
+    def __init__(self, main_window):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self.main_window = main_window
+
+        # Apply standard margins
+        margin = UI.MARGIN_PANEL if HAS_UI_HELPERS else 20
+        self.set_margin_start(margin)
+        self.set_margin_end(margin)
+        self.set_margin_top(margin)
+        self.set_margin_bottom(margin)
+
+        # Load settings
+        if HAS_SETTINGS:
+            self._settings_mgr = SettingsManager("mesh_tools", defaults=self.SETTINGS_DEFAULTS)
+            self._settings = self._settings_mgr.all()
+        else:
+            self._settings = self.SETTINGS_DEFAULTS.copy()
+
+        # Bot process tracking
+        self._bot_process = None
+        self._log_timer_id = None
+
+        self._build_ui()
+
+        # Initial status check
+        GLib.timeout_add(500, self._check_all_status)
+
+    def _save_settings(self):
+        """Save settings"""
+        if HAS_SETTINGS:
+            self._settings_mgr.update(self._settings)
+            self._settings_mgr.save()
+
+    def _build_ui(self):
+        """Build the main UI with paned layout"""
+        # Header
+        if HAS_UI_HELPERS:
+            header = create_panel_header(
+                "Mesh Tools",
+                "MeshBot, Node Map, and Network Diagnostics",
+                "network-workgroup-symbolic"
+            )
+        else:
+            header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+            title = Gtk.Label(label="Mesh Tools")
+            title.add_css_class("title-1")
+            title.set_xalign(0)
+            header.append(title)
+
+        self.append(header)
+        self.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # Main paned layout: tabs on top, log on bottom
+        self._paned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
+        self._paned.set_wide_handle(True)
+        self._paned.set_vexpand(True)
+
+        # Top: Notebook with tabs
+        self._notebook = Gtk.Notebook()
+        self._notebook.set_tab_pos(Gtk.PositionType.TOP)
+
+        # Add tabs
+        self._add_meshbot_tab()
+        self._add_map_tab()
+        self._add_diagnostics_tab()
+
+        self._paned.set_start_child(self._notebook)
+
+        # Bottom: Shared log viewer
+        self._build_log_viewer()
+        self._paned.set_end_child(self._log_frame)
+
+        # Restore paned position
+        self._paned.set_position(self._settings.get("log_position", 300))
+        self._paned.connect("notify::position", self._on_paned_moved)
+
+        self.append(self._paned)
+
+    def _build_log_viewer(self):
+        """Build the shared log viewer at the bottom"""
+        self._log_frame = Gtk.Frame()
+        self._log_frame.set_label("Output Log")
+
+        log_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+
+        # Controls bar
+        controls = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        controls.set_margin_start(10)
+        controls.set_margin_end(10)
+        controls.set_margin_top(5)
+        controls.set_margin_bottom(5)
+
+        # Source selector
+        controls.append(Gtk.Label(label="Source:"))
+        self._log_source = Gtk.ComboBoxText()
+        self._log_source.append("meshbot", "MeshBot Output")
+        self._log_source.append("diagnostics", "Diagnostics Events")
+        self._log_source.append("system", "System Log")
+        self._log_source.set_active_id("meshbot")
+        self._log_source.connect("changed", self._on_log_source_changed)
+        controls.append(self._log_source)
+
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        controls.append(spacer)
+
+        # Auto-scroll toggle
+        self._auto_scroll = Gtk.CheckButton(label="Auto-scroll")
+        self._auto_scroll.set_active(True)
+        controls.append(self._auto_scroll)
+
+        # Refresh button
+        refresh_btn = Gtk.Button()
+        refresh_btn.set_icon_name("view-refresh-symbolic")
+        refresh_btn.set_tooltip_text("Refresh Log")
+        refresh_btn.connect("clicked", self._on_refresh_log)
+        controls.append(refresh_btn)
+
+        # Clear button
+        clear_btn = Gtk.Button(label="Clear")
+        clear_btn.connect("clicked", self._on_clear_log)
+        controls.append(clear_btn)
+
+        log_box.append(controls)
+        log_box.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # Log text view
+        self._log_text = Gtk.TextView()
+        self._log_text.set_editable(False)
+        self._log_text.set_monospace(True)
+        self._log_text.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self._log_text.set_cursor_visible(False)
+
+        log_scroll = Gtk.ScrolledWindow()
+        log_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        log_scroll.set_vexpand(True)
+        log_scroll.set_min_content_height(100)
+        log_scroll.set_child(self._log_text)
+        self._log_scroll = log_scroll
+
+        log_box.append(log_scroll)
+        self._log_frame.set_child(log_box)
+
+    def _on_paned_moved(self, paned, param):
+        """Save paned position when moved"""
+        self._settings["log_position"] = paned.get_position()
+        self._save_settings()
+
+    # =========================================================================
+    # MeshBot Tab
+    # =========================================================================
+
+    def _add_meshbot_tab(self):
+        """Add MeshBot management tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Status section
+        status_frame = Gtk.Frame()
+        status_frame.set_label("MeshBot Status")
+        status_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        status_box.set_margin_start(15)
+        status_box.set_margin_end(15)
+        status_box.set_margin_top(10)
+        status_box.set_margin_bottom(10)
+
+        # Status row
+        status_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=15)
+
+        self._meshbot_status_icon = Gtk.Image.new_from_icon_name("emblem-question-symbolic")
+        self._meshbot_status_icon.set_pixel_size(32)
+        status_row.append(self._meshbot_status_icon)
+
+        status_info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+        self._meshbot_status_label = Gtk.Label(label="Checking...")
+        self._meshbot_status_label.set_xalign(0)
+        self._meshbot_status_label.add_css_class("heading")
+        status_info.append(self._meshbot_status_label)
+
+        self._meshbot_detail_label = Gtk.Label(label="")
+        self._meshbot_detail_label.set_xalign(0)
+        self._meshbot_detail_label.add_css_class("dim-label")
+        status_info.append(self._meshbot_detail_label)
+
+        status_row.append(status_info)
+
+        spacer = Gtk.Box()
+        spacer.set_hexpand(True)
+        status_row.append(spacer)
+
+        # Control buttons
+        btn_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+
+        self._start_btn = Gtk.Button(label="Start")
+        self._start_btn.add_css_class("suggested-action")
+        self._start_btn.connect("clicked", self._on_start_bot)
+        btn_box.append(self._start_btn)
+
+        self._stop_btn = Gtk.Button(label="Stop")
+        self._stop_btn.add_css_class("destructive-action")
+        self._stop_btn.connect("clicked", self._on_stop_bot)
+        btn_box.append(self._stop_btn)
+
+        install_btn = Gtk.Button(label="Install")
+        install_btn.connect("clicked", self._on_install_bot)
+        btn_box.append(install_btn)
+
+        status_row.append(btn_box)
+        status_box.append(status_row)
+
+        status_frame.set_child(status_box)
+        box.append(status_frame)
+
+        # Config section
+        config_frame = Gtk.Frame()
+        config_frame.set_label("Configuration")
+        config_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        config_box.set_margin_start(15)
+        config_box.set_margin_end(15)
+        config_box.set_margin_top(10)
+        config_box.set_margin_bottom(10)
+
+        # Path entry
+        path_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        path_row.append(Gtk.Label(label="Install Path:"))
+        self._path_entry = Gtk.Entry()
+        self._path_entry.set_text(self._settings.get("meshbot_path", "/opt/meshing-around"))
+        self._path_entry.set_hexpand(True)
+        path_row.append(self._path_entry)
+        config_box.append(path_row)
+
+        # Config file buttons
+        config_btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        edit_config_btn = Gtk.Button(label="Edit Config")
+        edit_config_btn.connect("clicked", self._on_edit_config)
+        edit_config_btn.set_tooltip_text("Edit config.ini in text editor")
+        config_btn_row.append(edit_config_btn)
+
+        view_config_btn = Gtk.Button(label="View Config")
+        view_config_btn.connect("clicked", self._on_view_config)
+        view_config_btn.set_tooltip_text("View config.ini in log viewer below")
+        config_btn_row.append(view_config_btn)
+
+        open_folder_btn = Gtk.Button(label="Open Folder")
+        open_folder_btn.connect("clicked", self._on_open_meshbot_folder)
+        config_btn_row.append(open_folder_btn)
+
+        config_box.append(config_btn_row)
+
+        config_frame.set_child(config_box)
+        box.append(config_frame)
+
+        # Features overview
+        features_frame = Gtk.Frame()
+        features_frame.set_label("MeshBot Features")
+        features_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
+        features_box.set_margin_start(15)
+        features_box.set_margin_end(15)
+        features_box.set_margin_top(10)
+        features_box.set_margin_bottom(10)
+
+        features = [
+            ("BBS Messaging", "Store-and-forward bulletin board"),
+            ("Weather/Alerts", "NOAA, USGS, FEMA emergency data"),
+            ("Games", "DopeWars, BlackJack, Poker"),
+            ("Inventory/POS", "Point-of-sale with cart system"),
+        ]
+
+        for title, desc in features:
+            row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+            title_lbl = Gtk.Label(label=f"{title}:")
+            title_lbl.set_xalign(0)
+            title_lbl.add_css_class("heading")
+            title_lbl.set_width_chars(15)
+            row.append(title_lbl)
+
+            desc_lbl = Gtk.Label(label=desc)
+            desc_lbl.set_xalign(0)
+            desc_lbl.add_css_class("dim-label")
+            row.append(desc_lbl)
+            features_box.append(row)
+
+        features_frame.set_child(features_box)
+        box.append(features_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label with icon
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("mail-send-symbolic"))
+        tab_box.append(Gtk.Label(label="MeshBot"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    # =========================================================================
+    # Node Map Tab
+    # =========================================================================
+
+    def _add_map_tab(self):
+        """Add Node Map tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Map controls
+        controls_frame = Gtk.Frame()
+        controls_frame.set_label("Node Map Controls")
+        controls_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        controls_box.set_margin_start(15)
+        controls_box.set_margin_end(15)
+        controls_box.set_margin_top(10)
+        controls_box.set_margin_bottom(10)
+
+        btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        refresh_map_btn = Gtk.Button(label="Refresh Nodes")
+        refresh_map_btn.add_css_class("suggested-action")
+        refresh_map_btn.connect("clicked", self._on_refresh_map)
+        btn_row.append(refresh_map_btn)
+
+        open_map_btn = Gtk.Button(label="Open Full Map")
+        open_map_btn.connect("clicked", self._on_open_full_map)
+        open_map_btn.set_tooltip_text("Open node map in browser")
+        btn_row.append(open_map_btn)
+
+        export_btn = Gtk.Button(label="Export GeoJSON")
+        export_btn.connect("clicked", self._on_export_geojson)
+        btn_row.append(export_btn)
+
+        controls_box.append(btn_row)
+        controls_frame.set_child(controls_box)
+        box.append(controls_frame)
+
+        # Node list
+        nodes_frame = Gtk.Frame()
+        nodes_frame.set_label("Discovered Nodes")
+        nodes_frame.set_vexpand(True)
+        nodes_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        nodes_box.set_margin_start(15)
+        nodes_box.set_margin_end(15)
+        nodes_box.set_margin_top(10)
+        nodes_box.set_margin_bottom(10)
+
+        # Node list store
+        self._node_store = Gtk.ListStore(str, str, str, str)  # ID, Name, Type, Last Seen
+
+        self._node_tree = Gtk.TreeView(model=self._node_store)
+        self._node_tree.set_headers_visible(True)
+
+        for i, title in enumerate(["Node ID", "Name", "Type", "Last Seen"]):
+            renderer = Gtk.CellRendererText()
+            column = Gtk.TreeViewColumn(title, renderer, text=i)
+            column.set_resizable(True)
+            column.set_min_width(80)
+            self._node_tree.append_column(column)
+
+        node_scroll = Gtk.ScrolledWindow()
+        node_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        node_scroll.set_min_content_height(150)
+        node_scroll.set_vexpand(True)
+        node_scroll.set_child(self._node_tree)
+
+        nodes_box.append(node_scroll)
+
+        # Stats row
+        self._node_stats_label = Gtk.Label(label="Nodes: 0 | Last update: Never")
+        self._node_stats_label.set_xalign(0)
+        self._node_stats_label.add_css_class("dim-label")
+        nodes_box.append(self._node_stats_label)
+
+        nodes_frame.set_child(nodes_box)
+        box.append(nodes_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("mark-location-symbolic"))
+        tab_box.append(Gtk.Label(label="Node Map"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    # =========================================================================
+    # Diagnostics Tab
+    # =========================================================================
+
+    def _add_diagnostics_tab(self):
+        """Add Diagnostics tab"""
+        scrolled = Gtk.ScrolledWindow()
+        scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+        box.set_margin_start(15)
+        box.set_margin_end(15)
+        box.set_margin_top(15)
+        box.set_margin_bottom(15)
+
+        # Health status
+        health_frame = Gtk.Frame()
+        health_frame.set_label("System Health")
+        health_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        health_box.set_margin_start(15)
+        health_box.set_margin_end(15)
+        health_box.set_margin_top(10)
+        health_box.set_margin_bottom(10)
+
+        # Health cards grid
+        health_grid = Gtk.Grid()
+        health_grid.set_column_spacing(15)
+        health_grid.set_row_spacing(10)
+
+        self._health_cards = {}
+        checks = [
+            ("meshtastic", "Meshtastic", "network-wireless-symbolic"),
+            ("reticulum", "Reticulum", "network-transmit-receive-symbolic"),
+            ("meshbot", "MeshBot", "mail-send-symbolic"),
+            ("network", "Network", "network-wired-symbolic"),
+        ]
+
+        for i, (key, label, icon) in enumerate(checks):
+            card = self._create_health_card(label, icon)
+            health_grid.attach(card, i % 2, i // 2, 1, 1)
+            self._health_cards[key] = card
+
+        health_box.append(health_grid)
+
+        # Refresh button
+        refresh_health_btn = Gtk.Button(label="Run Health Check")
+        refresh_health_btn.connect("clicked", self._on_run_health_check)
+        health_box.append(refresh_health_btn)
+
+        health_frame.set_child(health_box)
+        box.append(health_frame)
+
+        # Quick tests
+        tests_frame = Gtk.Frame()
+        tests_frame.set_label("Network Tests")
+        tests_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
+        tests_box.set_margin_start(15)
+        tests_box.set_margin_end(15)
+        tests_box.set_margin_top(10)
+        tests_box.set_margin_bottom(10)
+
+        tests_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+
+        ping_btn = Gtk.Button(label="Ping Test")
+        ping_btn.connect("clicked", self._on_ping_test)
+        tests_row.append(ping_btn)
+
+        traceroute_btn = Gtk.Button(label="Traceroute")
+        traceroute_btn.connect("clicked", self._on_traceroute_test)
+        tests_row.append(traceroute_btn)
+
+        dns_btn = Gtk.Button(label="DNS Check")
+        dns_btn.connect("clicked", self._on_dns_test)
+        tests_row.append(dns_btn)
+
+        port_btn = Gtk.Button(label="Port Scan")
+        port_btn.connect("clicked", self._on_port_scan)
+        tests_row.append(port_btn)
+
+        tests_box.append(tests_row)
+        tests_frame.set_child(tests_box)
+        box.append(tests_frame)
+
+        # Report generation
+        report_frame = Gtk.Frame()
+        report_frame.set_label("Diagnostic Reports")
+        report_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        report_box.set_margin_start(15)
+        report_box.set_margin_end(15)
+        report_box.set_margin_top(10)
+        report_box.set_margin_bottom(10)
+
+        gen_report_btn = Gtk.Button(label="Generate Full Report")
+        gen_report_btn.add_css_class("suggested-action")
+        gen_report_btn.connect("clicked", self._on_generate_report)
+        report_box.append(gen_report_btn)
+
+        open_reports_btn = Gtk.Button(label="Open Reports Folder")
+        open_reports_btn.connect("clicked", self._on_open_reports_folder)
+        report_box.append(open_reports_btn)
+
+        report_frame.set_child(report_box)
+        box.append(report_frame)
+
+        scrolled.set_child(box)
+
+        # Tab label
+        tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+        tab_box.append(Gtk.Image.new_from_icon_name("dialog-information-symbolic"))
+        tab_box.append(Gtk.Label(label="Diagnostics"))
+
+        self._notebook.append_page(scrolled, tab_box)
+
+    def _create_health_card(self, label: str, icon_name: str) -> Gtk.Box:
+        """Create a health status card"""
+        card = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        card.add_css_class("card")
+        card.set_margin_start(10)
+        card.set_margin_end(10)
+        card.set_margin_top(5)
+        card.set_margin_bottom(5)
+
+        icon = Gtk.Image.new_from_icon_name(icon_name)
+        icon.set_pixel_size(24)
+        card.append(icon)
+
+        info = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        name = Gtk.Label(label=label)
+        name.set_xalign(0)
+        name.add_css_class("heading")
+        info.append(name)
+
+        status = Gtk.Label(label="Unknown")
+        status.set_xalign(0)
+        status.add_css_class("dim-label")
+        status.set_name("status")
+        info.append(status)
+
+        card.append(info)
+
+        # Store reference to status label
+        card._status_label = status
+        return card
+
+    # =========================================================================
+    # Event Handlers
+    # =========================================================================
+
+    def _check_all_status(self):
+        """Check status of all services"""
+        self._check_meshbot_status()
+        self._update_health_cards()
+        return False  # Don't repeat
+
+    def _check_meshbot_status(self):
+        """Check MeshBot installation and running status"""
+        def check():
+            status = {"installed": False, "running": False, "path": None}
+
+            meshbot_path = self._path_entry.get_text().strip() or "/opt/meshing-around"
+
+            if Path(meshbot_path).exists() and (Path(meshbot_path) / "mesh_bot.py").exists():
+                status["installed"] = True
+                status["path"] = meshbot_path
+
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'mesh_bot.py'],
+                    capture_output=True, text=True, timeout=5
+                )
+                if result.returncode == 0 and result.stdout.strip():
+                    status["running"] = True
+            except Exception:
+                pass
+
+            GLib.idle_add(self._update_meshbot_status, status)
+
+        threading.Thread(target=check, daemon=True).start()
+
+    def _update_meshbot_status(self, status):
+        """Update MeshBot status display"""
+        if status["running"]:
+            self._meshbot_status_icon.set_from_icon_name("emblem-default-symbolic")
+            self._meshbot_status_label.set_label("MeshBot Running")
+            self._meshbot_detail_label.set_label(f"Path: {status['path']}")
+            self._start_btn.set_sensitive(False)
+            self._stop_btn.set_sensitive(True)
+        elif status["installed"]:
+            self._meshbot_status_icon.set_from_icon_name("media-playback-stop-symbolic")
+            self._meshbot_status_label.set_label("MeshBot Stopped")
+            self._meshbot_detail_label.set_label(f"Path: {status['path']}")
+            self._start_btn.set_sensitive(True)
+            self._stop_btn.set_sensitive(False)
+        else:
+            self._meshbot_status_icon.set_from_icon_name("dialog-warning-symbolic")
+            self._meshbot_status_label.set_label("MeshBot Not Installed")
+            self._meshbot_detail_label.set_label("Click Install to set up")
+            self._start_btn.set_sensitive(False)
+            self._stop_btn.set_sensitive(False)
+
+    def _update_health_cards(self):
+        """Update health status cards"""
+        for key, card in self._health_cards.items():
+            # Default to unknown
+            card._status_label.set_label("Checking...")
+
+        # Check each service
+        def check_health():
+            results = {}
+
+            # Check Meshtastic
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'meshtasticd'],
+                    capture_output=True, timeout=5
+                )
+                results["meshtastic"] = "Running" if result.returncode == 0 else "Not Running"
+            except Exception:
+                results["meshtastic"] = "Unknown"
+
+            # Check Reticulum
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, timeout=5
+                )
+                results["reticulum"] = "Running" if result.returncode == 0 else "Not Running"
+            except Exception:
+                results["reticulum"] = "Unknown"
+
+            # Check MeshBot
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'mesh_bot.py'],
+                    capture_output=True, timeout=5
+                )
+                results["meshbot"] = "Running" if result.returncode == 0 else "Not Running"
+            except Exception:
+                results["meshbot"] = "Unknown"
+
+            # Check Network
+            try:
+                result = subprocess.run(
+                    ['ping', '-c', '1', '-W', '2', '8.8.8.8'],
+                    capture_output=True, timeout=5
+                )
+                results["network"] = "Connected" if result.returncode == 0 else "No Internet"
+            except Exception:
+                results["network"] = "Unknown"
+
+            GLib.idle_add(self._apply_health_results, results)
+
+        threading.Thread(target=check_health, daemon=True).start()
+
+    def _apply_health_results(self, results):
+        """Apply health check results to cards"""
+        for key, status in results.items():
+            if key in self._health_cards:
+                card = self._health_cards[key]
+                card._status_label.set_label(status)
+
+                # Color code
+                if "Running" in status or "Connected" in status:
+                    card._status_label.remove_css_class("error")
+                    card._status_label.add_css_class("success")
+                elif "Not" in status or "No " in status:
+                    card._status_label.remove_css_class("success")
+                    card._status_label.add_css_class("error")
+
+    def _on_start_bot(self, button):
+        """Start MeshBot"""
+        meshbot_path = self._path_entry.get_text().strip()
+        script_path = Path(meshbot_path) / "mesh_bot.py"
+
+        if not script_path.exists():
+            self._log_message("Error: mesh_bot.py not found")
+            return
+
+        self._log_message("Starting MeshBot...")
+
+        def do_start():
+            try:
+                launch_script = Path(meshbot_path) / "launch.sh"
+                if launch_script.exists():
+                    cmd = ['bash', str(launch_script)]
+                else:
+                    cmd = ['python3', str(script_path)]
+
+                process = subprocess.Popen(
+                    cmd,
+                    cwd=meshbot_path,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    start_new_session=True
+                )
+
+                import time
+                time.sleep(2)
+
+                if process.poll() is None:
+                    GLib.idle_add(self._log_message, "MeshBot started successfully")
+                    GLib.idle_add(self._check_meshbot_status)
+                else:
+                    GLib.idle_add(self._log_message, "MeshBot failed to start")
+
+            except Exception as e:
+                GLib.idle_add(self._log_message, f"Start error: {e}")
+
+        threading.Thread(target=do_start, daemon=True).start()
+
+    def _on_stop_bot(self, button):
+        """Stop MeshBot"""
+        self._log_message("Stopping MeshBot...")
+
+        def do_stop():
+            try:
+                subprocess.run(['pkill', '-f', 'mesh_bot.py'], timeout=10)
+                import time
+                time.sleep(1)
+                GLib.idle_add(self._log_message, "MeshBot stopped")
+                GLib.idle_add(self._check_meshbot_status)
+            except Exception as e:
+                GLib.idle_add(self._log_message, f"Stop error: {e}")
+
+        threading.Thread(target=do_stop, daemon=True).start()
+
+    def _on_install_bot(self, button):
+        """Install MeshBot"""
+        install_path = self._path_entry.get_text().strip() or "/opt/meshing-around"
+        self._log_message(f"Installing MeshBot to {install_path}...")
+
+        def do_install():
+            try:
+                install_dir = Path(install_path)
+
+                if install_dir.exists():
+                    GLib.idle_add(self._log_message, "Updating existing installation...")
+                    result = subprocess.run(
+                        ['git', '-C', str(install_dir), 'pull'],
+                        capture_output=True, text=True, timeout=120
+                    )
+                else:
+                    GLib.idle_add(self._log_message, "Cloning repository...")
+                    result = subprocess.run(
+                        ['sudo', 'git', 'clone',
+                         'https://github.com/SpudGunMan/meshing-around.git',
+                         str(install_dir)],
+                        capture_output=True, text=True, timeout=300
+                    )
+
+                if result.returncode == 0:
+                    GLib.idle_add(self._log_message, "Installation complete!")
+                    GLib.idle_add(self._check_meshbot_status)
+                else:
+                    GLib.idle_add(self._log_message, f"Install failed: {result.stderr}")
+
+            except Exception as e:
+                GLib.idle_add(self._log_message, f"Install error: {e}")
+
+        threading.Thread(target=do_install, daemon=True).start()
+
+    def _on_edit_config(self, button):
+        """Open config file in editor"""
+        meshbot_path = self._path_entry.get_text().strip()
+        config_path = Path(meshbot_path) / "config.ini"
+
+        if not config_path.exists():
+            template = Path(meshbot_path) / "config.template"
+            if template.exists():
+                subprocess.run(['cp', str(template), str(config_path)])
+            else:
+                self._log_message("No config file found")
+                return
+
+        # Open in default editor
+        real_user = os.environ.get('SUDO_USER', os.environ.get('USER', 'pi'))
+        try:
+            subprocess.Popen(
+                ['sudo', '-u', real_user, 'xdg-open', str(config_path)],
+                start_new_session=True
+            )
+            self._log_message(f"Opening {config_path} in editor")
+        except Exception as e:
+            self._log_message(f"Error opening editor: {e}")
+
+    def _on_view_config(self, button):
+        """View config in log viewer"""
+        meshbot_path = self._path_entry.get_text().strip()
+        config_path = Path(meshbot_path) / "config.ini"
+
+        if config_path.exists():
+            content = config_path.read_text()
+            self._set_log_text(f"=== {config_path} ===\n\n{content}")
+        else:
+            self._log_message("Config file not found")
+
+    def _on_open_meshbot_folder(self, button):
+        """Open MeshBot folder"""
+        meshbot_path = self._path_entry.get_text().strip()
+        self._open_folder(meshbot_path)
+
+    def _on_refresh_map(self, button):
+        """Refresh node list"""
+        self._log_message("Refreshing node list...")
+        # TODO: Integrate with actual node tracking
+        self._node_store.clear()
+        self._node_stats_label.set_label(f"Nodes: 0 | Last update: {datetime.now().strftime('%H:%M:%S')}")
+
+    def _on_open_full_map(self, button):
+        """Open full map view"""
+        self._log_message("Opening map in browser...")
+        # TODO: Launch map view
+
+    def _on_export_geojson(self, button):
+        """Export nodes as GeoJSON"""
+        self._log_message("Exporting GeoJSON...")
+        # TODO: Export functionality
+
+    def _on_run_health_check(self, button):
+        """Run full health check"""
+        self._log_message("Running health check...")
+        self._update_health_cards()
+
+    def _on_ping_test(self, button):
+        """Run ping test"""
+        self._run_network_test("Ping Test", ['ping', '-c', '4', '8.8.8.8'])
+
+    def _on_traceroute_test(self, button):
+        """Run traceroute"""
+        self._run_network_test("Traceroute", ['traceroute', '-m', '10', '8.8.8.8'])
+
+    def _on_dns_test(self, button):
+        """Run DNS check"""
+        self._run_network_test("DNS Check", ['nslookup', 'google.com'])
+
+    def _on_port_scan(self, button):
+        """Run port scan on localhost"""
+        self._run_network_test("Port Scan", ['ss', '-tuln'])
+
+    def _run_network_test(self, name: str, cmd: list):
+        """Run a network test and show output"""
+        self._log_message(f"Running {name}...")
+
+        def do_test():
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                output = result.stdout if result.stdout else result.stderr
+                GLib.idle_add(self._log_message, f"\n=== {name} ===\n{output}")
+            except subprocess.TimeoutExpired:
+                GLib.idle_add(self._log_message, f"{name}: Timed out")
+            except Exception as e:
+                GLib.idle_add(self._log_message, f"{name} error: {e}")
+
+        threading.Thread(target=do_test, daemon=True).start()
+
+    def _on_generate_report(self, button):
+        """Generate diagnostic report"""
+        self._log_message("Generating diagnostic report...")
+        # TODO: Generate comprehensive report
+
+    def _on_open_reports_folder(self, button):
+        """Open reports folder"""
+        reports_dir = get_real_user_home() / ".local" / "share" / "meshforge" / "diagnostics"
+        reports_dir.mkdir(parents=True, exist_ok=True)
+        self._open_folder(str(reports_dir))
+
+    def _on_log_source_changed(self, combo):
+        """Handle log source change"""
+        source = combo.get_active_id()
+        self._log_message(f"Switched to {source} log source")
+
+    def _on_refresh_log(self, button):
+        """Refresh current log"""
+        source = self._log_source.get_active_id()
+        self._log_message(f"Refreshing {source} log...")
+        # TODO: Implement per-source refresh
+
+    def _on_clear_log(self, button):
+        """Clear log output"""
+        buffer = self._log_text.get_buffer()
+        buffer.set_text("")
+
+    def _log_message(self, message: str):
+        """Add message to log output"""
+        buffer = self._log_text.get_buffer()
+        end_iter = buffer.get_end_iter()
+        timestamp = datetime.now().strftime("%H:%M:%S")
+        buffer.insert(end_iter, f"[{timestamp}] {message}\n")
+
+        if self._auto_scroll.get_active():
+            end_iter = buffer.get_end_iter()
+            self._log_text.scroll_to_iter(end_iter, 0, False, 0, 0)
+
+    def _set_log_text(self, text: str):
+        """Set log text (replace all)"""
+        buffer = self._log_text.get_buffer()
+        buffer.set_text(text)
+
+    def _open_folder(self, path: str):
+        """Open folder in file manager"""
+        real_user = os.environ.get('SUDO_USER', os.environ.get('USER', 'pi'))
+        try:
+            subprocess.Popen(
+                ['sudo', '-u', real_user, 'xdg-open', path],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True
+            )
+        except Exception as e:
+            self._log_message(f"Error opening folder: {e}")
+
+    def cleanup(self):
+        """Clean up resources"""
+        if self._log_timer_id:
+            GLib.source_remove(self._log_timer_id)


### PR DESCRIPTION
UI Reorganization:
- New "Mesh Tools" panel combining MeshBot, Node Map, Diagnostics
- New "Ham Tools" panel combining HamClock, Propagation, Callsign Lookup
- Both panels feature resizable log/output at bottom (Gtk.Paned)
- Streamlined sidebar navigation

UI Standards (gtk_helpers.py):
- UIStandards class with consistent margins, spacing, CSS constants
- ResizableLogViewer component with auto-scroll and controls
- ResizablePanedLayout for content + output layouts
- StatusIndicator widget for consistent status display
- create_panel_header() and create_standard_frame() helpers

Features:
- All config files editable in-place
- Live bot output visible in resizable bottom pane
- Drag handle to resize log output area
- Health status cards for service monitoring
- Callsign lookup via Callook.info API
- Space weather from HamClock or NOAA

Navigation changes:
- Core: Dashboard, Service, Install, Config, Radio, RNS
- Tools: Mesh Tools, Ham Tools
- Advanced: CLI, Hardware, System Tools, AREDN
- Settings