### PR TITLE
feat: Add .claude/rules/ directory with focused instruction files

### DIFF
--- a/.claude/rules/gtk_threading.md
+++ b/.claude/rules/gtk_threading.md
@@ -1,0 +1,99 @@
+# GTK Threading Rules
+
+## Golden Rule: UI updates ONLY from main thread
+
+GTK is NOT thread-safe. All widget modifications must happen on the main thread.
+
+---
+
+## Pattern: Background work with UI callback
+
+```python
+import threading
+from gi.repository import GLib
+
+def _on_button_clicked(self, button):
+    """Start background work when button clicked."""
+    button.set_sensitive(False)
+    self.status.set_text("Working...")
+
+    def do_work():
+        # This runs in background thread
+        result = slow_network_operation()
+
+        # Schedule UI update on main thread
+        GLib.idle_add(self._update_ui, result)
+
+    threading.Thread(target=do_work, daemon=True).start()
+
+def _update_ui(self, result):
+    """Called on main thread via GLib.idle_add."""
+    self.status.set_text(f"Done: {result}")
+    self.button.set_sensitive(True)
+    return False  # Don't repeat
+```
+
+---
+
+## Common Mistakes
+
+### WRONG: Direct UI update from thread
+```python
+def worker():
+    result = fetch_data()
+    self.label.set_text(result)  # CRASH or corruption
+```
+
+### WRONG: Blocking main thread
+```python
+def _on_button_clicked(self, button):
+    result = slow_operation()  # UI freezes!
+    self.label.set_text(result)
+```
+
+---
+
+## GLib.idle_add Patterns
+
+### Simple update
+```python
+GLib.idle_add(self.label.set_text, "New text")
+```
+
+### With lambda (for complex updates)
+```python
+GLib.idle_add(lambda: self._complex_update(data))
+```
+
+### Return False to run once
+```python
+def _update(self):
+    self.label.set_text("Updated")
+    return False  # Run once only
+```
+
+---
+
+## Opening URLs/Browsers
+
+Browser commands can block - always run in thread:
+
+```python
+def _open_url(self, url: str):
+    def do_open():
+        import subprocess
+        subprocess.run(["xdg-open", url], timeout=10)
+    threading.Thread(target=do_open, daemon=True).start()
+```
+
+---
+
+## Daemon Threads
+
+Always use `daemon=True` for background threads:
+
+```python
+threading.Thread(target=worker, daemon=True).start()
+```
+
+**Why**: Daemon threads are killed when main program exits. Non-daemon threads can prevent clean shutdown.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,79 @@
+# Security Rules
+
+## MF001: Path.home() - NEVER use directly
+
+```python
+# WRONG - returns /root when running with sudo
+config = Path.home() / ".config" / "meshforge"
+
+# CORRECT - works with sudo
+from utils.paths import get_real_user_home
+config = get_real_user_home() / ".config" / "meshforge"
+```
+
+**Why**: `Path.home()` returns effective user's home. With `sudo`, that's `/root`, breaking config persistence.
+
+**Linter**: `python3 scripts/lint.py` checks MF001
+
+---
+
+## MF002: shell=True - NEVER use in subprocess
+
+```python
+# WRONG - command injection risk
+subprocess.run(f"meshtastic --info {user_input}", shell=True)
+
+# CORRECT - safe argument list
+subprocess.run(["meshtastic", "--info", user_input], timeout=30)
+```
+
+**Why**: Shell injection allows arbitrary code execution.
+
+**Linter**: `python3 scripts/lint.py` checks MF002
+
+---
+
+## MF003: Bare except - Always specify exception type
+
+```python
+# WRONG - catches SystemExit, KeyboardInterrupt
+except:
+    pass
+
+# CORRECT - specific exceptions
+except Exception as e:
+    logger.error(f"Operation failed: {e}")
+```
+
+---
+
+## MF004: subprocess timeout - ALWAYS include
+
+```python
+# WRONG - can hang forever
+subprocess.run(["long", "command"])
+
+# CORRECT - bounded execution
+subprocess.run(["long", "command"], timeout=30)
+```
+
+---
+
+## Input Validation
+
+- Validate all user input before use
+- Sanitize file paths (no `..`, absolute paths only)
+- Validate URLs before fetch
+- Escape special characters in displayed text
+
+---
+
+## Secrets
+
+Never commit:
+- `.env` files
+- `credentials.json`
+- API keys in code
+- Private keys
+
+Use environment variables or secure config.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,109 @@
+# Testing Rules
+
+## Running Tests
+
+```bash
+# Run all tests
+python3 -m pytest tests/ -v
+
+# Run specific test file
+python3 -m pytest tests/test_rf.py -v
+
+# Run with coverage
+python3 -m pytest tests/ --cov=src --cov-report=term-missing
+
+# Quick syntax check
+python3 -m py_compile src/**/*.py
+```
+
+---
+
+## Test Locations
+
+```
+tests/
+├── test_rf.py       # RF calculations (well-tested)
+├── test_utils.py    # Utility functions
+└── conftest.py      # Shared fixtures
+```
+
+---
+
+## Writing Tests
+
+### Test pure functions first
+```python
+def test_haversine_distance():
+    """Test distance calculation between two points."""
+    # Known distance: SF to LA ~559 km
+    result = haversine_distance(37.7749, -122.4194, 34.0522, -118.2437)
+    assert 550 < result < 570
+```
+
+### Use fixtures for setup
+```python
+@pytest.fixture
+def sample_node():
+    return {"id": "!abc123", "lat": 37.7749, "lon": -122.4194}
+
+def test_node_processing(sample_node):
+    result = process_node(sample_node)
+    assert result.id == "!abc123"
+```
+
+### Test error conditions
+```python
+def test_invalid_coordinates():
+    with pytest.raises(ValueError):
+        haversine_distance(999, 999, 0, 0)
+```
+
+---
+
+## Test Patterns for MeshForge
+
+### Mocking external services
+```python
+from unittest.mock import patch, MagicMock
+
+@patch('requests.get')
+def test_hamclock_fetch(mock_get):
+    mock_get.return_value.json.return_value = {"sfi": 150}
+    result = fetch_space_weather()
+    assert result["sfi"] == 150
+```
+
+### Testing path utilities
+```python
+@patch.dict(os.environ, {"SUDO_USER": "testuser"})
+def test_get_real_user_home_with_sudo():
+    result = get_real_user_home()
+    assert result == Path("/home/testuser")
+```
+
+### Testing GTK (avoid where possible)
+```python
+# Prefer testing logic separately from UI
+def test_parse_node_data():
+    raw = '{"id": "!abc", "name": "Node1"}'
+    result = parse_node_data(raw)
+    assert result.name == "Node1"
+```
+
+---
+
+## When to Write Tests
+
+1. **RF calculations** - Always test (critical for HAMs)
+2. **Data parsing** - Test edge cases
+3. **Path utilities** - Test sudo compatibility
+4. **Business logic** - Test before GTK integration
+
+---
+
+## Linter as Pre-Test
+
+Run linter before tests:
+```bash
+python3 scripts/lint.py --all && python3 -m pytest tests/ -v
+```

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ htmlcov/
 # Local configuration
 .env
 config.local.yml
+CLAUDE.local.md
 
 # Distribution / packaging
 *.tar.gz

--- a/CLAUDE.local.md.template
+++ b/CLAUDE.local.md.template
@@ -1,0 +1,23 @@
+# CLAUDE.local.md - Machine-Specific Configuration
+# Copy this file to CLAUDE.local.md and customize for your machine.
+# CLAUDE.local.md is gitignored and won't be committed.
+
+## Machine Info
+- **Hostname**: your-machine-name
+- **User**: your-username
+- **Project Location**: /path/to/meshforge
+
+## Local Development Notes
+Add machine-specific notes, paths, or configurations here.
+
+## Connected Hardware
+- Meshtastic device: (none / USB / TCP)
+- RNS interface: (none / serial / TCP)
+
+## Local Services
+- meshtasticd: running on port 4403
+- rnsd: running
+- hamclock: running on port 8080
+
+## Custom Environment
+Any local environment variables or paths specific to this machine.


### PR DESCRIPTION
New rules files for Claude Code memory best practices:
- .claude/rules/security.md - Path.home(), shell=True, validation
- .claude/rules/gtk_threading.md - GLib.idle_add patterns
- .claude/rules/testing.md - pytest patterns and conventions

Also added:
- CLAUDE.local.md.template - Machine-specific config template
- .gitignore - Added CLAUDE.local.md (not committed)

This follows Claude Code memory best practices for organizing instructions into focused, maintainable files.