### PR TITLE
feat: Add tests for RNS bridge, network diagnostics, and AREDN modules

### DIFF
--- a/tests/test_aredn.py
+++ b/tests/test_aredn.py
@@ -1,0 +1,334 @@
+"""
+Tests for AREDN mesh network utilities.
+
+Run: python3 -m pytest tests/test_aredn.py -v
+"""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from src.utils.aredn import (
+    LinkType,
+    AREDNLink,
+    AREDNService,
+    AREDNNode,
+    AREDNClient,
+)
+
+
+class TestLinkType:
+    """Tests for LinkType enum."""
+
+    def test_all_types_exist(self):
+        """Test all expected link types exist."""
+        assert LinkType.RF.value == "RF"
+        assert LinkType.DTD.value == "DTD"
+        assert LinkType.TUN.value == "TUN"
+        assert LinkType.UNKNOWN.value == "Unknown"
+
+    def test_link_type_count(self):
+        """Test expected number of link types."""
+        assert len(LinkType) == 4
+
+
+class TestAREDNLink:
+    """Tests for AREDNLink dataclass."""
+
+    def test_creation(self):
+        """Test creating a link."""
+        link = AREDNLink(
+            ip="10.0.0.1",
+            hostname="KK6XXX-node",
+            link_type=LinkType.RF
+        )
+
+        assert link.ip == "10.0.0.1"
+        assert link.hostname == "KK6XXX-node"
+        assert link.link_type == LinkType.RF
+        assert link.link_quality == 0.0
+
+    def test_snr_calculation(self):
+        """Test SNR is calculated from signal and noise."""
+        link = AREDNLink(
+            ip="10.0.0.1",
+            hostname="test",
+            link_type=LinkType.RF,
+            signal=-60,
+            noise=-95
+        )
+
+        assert link.snr == 35  # -60 - (-95) = 35
+
+    def test_snr_zero_when_no_signal(self):
+        """Test SNR is 0 when no signal data."""
+        link = AREDNLink(
+            ip="10.0.0.1",
+            hostname="test",
+            link_type=LinkType.DTD
+        )
+
+        assert link.snr == 0
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        link = AREDNLink(
+            ip="10.0.0.1",
+            hostname="node1",
+            link_type=LinkType.TUN,
+            link_quality=0.95,
+            neighbor_link_quality=0.90,
+            tx_rate=300
+        )
+
+        d = link.to_dict()
+
+        assert d['ip'] == "10.0.0.1"
+        assert d['hostname'] == "node1"
+        assert d['link_type'] == "TUN"
+        assert d['link_quality'] == 0.95
+        assert d['tx_rate'] == 300
+
+
+class TestAREDNService:
+    """Tests for AREDNService dataclass."""
+
+    def test_creation(self):
+        """Test creating a service."""
+        svc = AREDNService(
+            name="MeshChat",
+            protocol="http",
+            host="10.0.0.5",
+            port=8080
+        )
+
+        assert svc.name == "MeshChat"
+        assert svc.protocol == "http"
+        assert svc.host == "10.0.0.5"
+        assert svc.port == 8080
+
+    def test_with_url(self):
+        """Test service with URL."""
+        svc = AREDNService(
+            name="Web",
+            protocol="http",
+            host="node",
+            port=80,
+            url="http://node.local.mesh/"
+        )
+
+        assert svc.url == "http://node.local.mesh/"
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        svc = AREDNService(
+            name="SSH",
+            protocol="tcp",
+            host="10.0.0.1",
+            port=22
+        )
+
+        d = svc.to_dict()
+
+        assert d['name'] == "SSH"
+        assert d['protocol'] == "tcp"
+        assert d['port'] == 22
+
+
+class TestAREDNNode:
+    """Tests for AREDNNode dataclass."""
+
+    def test_creation_minimal(self):
+        """Test creating a node with minimal data."""
+        node = AREDNNode(hostname="KK6XXX-node")
+
+        assert node.hostname == "KK6XXX-node"
+        assert node.ip == ""
+        assert node.links == []
+        assert node.services == []
+
+    def test_creation_full(self):
+        """Test creating a node with full data."""
+        node = AREDNNode(
+            hostname="WH6GXZ-router",
+            ip="10.0.0.1",
+            firmware_version="3.24.4.0",
+            model="MikroTik hAP ac lite",
+            ssid="AREDN-10-v3",
+            channel=177,
+            frequency="5.885 GHz",
+            mesh_status="active"
+        )
+
+        assert node.firmware_version == "3.24.4.0"
+        assert node.model == "MikroTik hAP ac lite"
+        assert node.channel == 177
+
+    def test_base_url_with_ip(self):
+        """Test base_url uses IP when available."""
+        node = AREDNNode(hostname="test", ip="10.0.0.5")
+
+        assert node.base_url == "http://10.0.0.5"
+
+    def test_base_url_without_ip(self):
+        """Test base_url uses hostname when no IP."""
+        node = AREDNNode(hostname="mynode")
+
+        assert node.base_url == "http://mynode.local.mesh"
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        link = AREDNLink(
+            ip="10.0.0.2",
+            hostname="neighbor",
+            link_type=LinkType.RF
+        )
+        service = AREDNService(
+            name="Web",
+            protocol="http",
+            host="10.0.0.1",
+            port=80
+        )
+        node = AREDNNode(
+            hostname="test",
+            ip="10.0.0.1",
+            links=[link],
+            services=[service]
+        )
+
+        d = node.to_dict()
+
+        assert d['hostname'] == "test"
+        assert len(d['links']) == 1
+        assert len(d['services']) == 1
+        assert d['links'][0]['hostname'] == "neighbor"
+
+
+class TestAREDNClient:
+    """Tests for AREDNClient class."""
+
+    def test_init_with_hostname(self):
+        """Test initialization with hostname."""
+        client = AREDNClient("KK6XXX-node")
+
+        assert "KK6XXX-node" in client.base_url
+
+    def test_init_with_ip(self):
+        """Test initialization with IP address."""
+        client = AREDNClient("10.0.0.1")
+
+        assert "10.0.0.1" in client.base_url
+
+    def test_default_timeout(self):
+        """Test default timeout is set."""
+        client = AREDNClient("test")
+
+        assert client.timeout == 5
+
+    def test_custom_timeout(self):
+        """Test custom timeout."""
+        client = AREDNClient("test", timeout=30)
+
+        assert client.timeout == 30
+
+    def test_get_sysinfo_no_connection(self):
+        """Test get_sysinfo returns None on connection error."""
+        client = AREDNClient("nonexistent.local.mesh", timeout=1)
+
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            mock_urlopen.side_effect = Exception("Connection refused")
+
+            result = client.get_sysinfo()
+
+            assert result is None
+
+    def test_get_sysinfo_success(self):
+        """Test get_sysinfo returns dict response."""
+        client = AREDNClient("10.0.0.1")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'''{
+            "node": "KK6XXX-node",
+            "api_version": "1.12",
+            "model": "MikroTik hAP ac lite",
+            "firmware_version": "3.24.4.0",
+            "node_details": {
+                "description": "Test node"
+            }
+        }'''
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch('urllib.request.urlopen', return_value=mock_response):
+            result = client.get_sysinfo()
+
+            assert result is not None
+            assert isinstance(result, dict)
+            assert result['node'] == "KK6XXX-node"
+            assert result['api_version'] == "1.12"
+
+    def test_get_neighbors_no_connection(self):
+        """Test get_neighbors returns empty list on error."""
+        client = AREDNClient("nonexistent", timeout=1)
+
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            mock_urlopen.side_effect = Exception("Timeout")
+
+            result = client.get_neighbors()
+
+            assert result == []
+
+    def test_check_connectivity_true(self):
+        """Test check_connectivity returns True when node responds."""
+        client = AREDNClient("10.0.0.1")
+
+        mock_response = MagicMock()
+        mock_response.read.return_value = b'{"node": "test"}'
+        mock_response.__enter__ = MagicMock(return_value=mock_response)
+        mock_response.__exit__ = MagicMock(return_value=False)
+
+        with patch('urllib.request.urlopen', return_value=mock_response):
+            result = client.check_connectivity()
+
+            assert result is True
+
+    def test_check_connectivity_false(self):
+        """Test check_connectivity returns False when node doesn't respond."""
+        client = AREDNClient("10.0.0.1")
+
+        with patch('urllib.request.urlopen') as mock_urlopen:
+            mock_urlopen.side_effect = Exception("Connection refused")
+
+            result = client.check_connectivity()
+
+            assert result is False
+
+
+class TestLinkQuality:
+    """Tests for link quality calculations."""
+
+    def test_rf_link_quality(self):
+        """Test RF link with signal/noise data."""
+        link = AREDNLink(
+            ip="10.0.0.1",
+            hostname="test",
+            link_type=LinkType.RF,
+            link_quality=0.85,
+            signal=-65,
+            noise=-95
+        )
+
+        assert link.link_quality == 0.85
+        assert link.snr == 30
+
+    def test_tunnel_link_no_rf_metrics(self):
+        """Test tunnel link has no RF metrics."""
+        link = AREDNLink(
+            ip="172.16.0.1",
+            hostname="tunnel-node",
+            link_type=LinkType.TUN,
+            link_quality=1.0
+        )
+
+        assert link.signal == 0
+        assert link.noise == 0
+        assert link.snr == 0

--- a/tests/test_network_diagnostics.py
+++ b/tests/test_network_diagnostics.py
@@ -1,0 +1,426 @@
+"""
+Tests for network diagnostics system.
+
+Run: python3 -m pytest tests/test_network_diagnostics.py -v
+"""
+
+import pytest
+import threading
+import time
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+from src.utils.network_diagnostics import (
+    EventCategory,
+    EventSeverity,
+    HealthStatus,
+    DiagnosticEvent,
+    HealthCheck,
+    NetworkDiagnostics,
+)
+
+
+class TestEventCategory:
+    """Tests for EventCategory enum."""
+
+    def test_all_categories_exist(self):
+        """Test all expected categories exist."""
+        assert EventCategory.NETWORK.value == "network"
+        assert EventCategory.SECURITY.value == "security"
+        assert EventCategory.PERFORMANCE.value == "perf"
+        assert EventCategory.SYSTEM.value == "system"
+        assert EventCategory.ERROR.value == "error"
+        assert EventCategory.AUDIT.value == "audit"
+
+    def test_category_count(self):
+        """Test expected number of categories."""
+        assert len(EventCategory) == 6
+
+
+class TestEventSeverity:
+    """Tests for EventSeverity enum."""
+
+    def test_all_severities_exist(self):
+        """Test all expected severities exist."""
+        assert EventSeverity.DEBUG.value == "debug"
+        assert EventSeverity.INFO.value == "info"
+        assert EventSeverity.WARNING.value == "warning"
+        assert EventSeverity.ERROR.value == "error"
+        assert EventSeverity.CRITICAL.value == "critical"
+
+    def test_severity_count(self):
+        """Test expected number of severities."""
+        assert len(EventSeverity) == 5
+
+
+class TestHealthStatus:
+    """Tests for HealthStatus enum."""
+
+    def test_all_statuses_exist(self):
+        """Test all expected statuses exist."""
+        assert HealthStatus.HEALTHY.value == "healthy"
+        assert HealthStatus.DEGRADED.value == "degraded"
+        assert HealthStatus.UNHEALTHY.value == "unhealthy"
+        assert HealthStatus.UNKNOWN.value == "unknown"
+
+
+class TestDiagnosticEvent:
+    """Tests for DiagnosticEvent dataclass."""
+
+    def test_creation(self):
+        """Test creating a diagnostic event."""
+        event = DiagnosticEvent(
+            timestamp=datetime(2026, 1, 9, 12, 0, 0),
+            category=EventCategory.NETWORK,
+            severity=EventSeverity.INFO,
+            source="meshtastic",
+            message="Connected to device"
+        )
+
+        assert event.category == EventCategory.NETWORK
+        assert event.severity == EventSeverity.INFO
+        assert event.source == "meshtastic"
+        assert event.message == "Connected to device"
+        assert event.details is None
+        assert event.fix_hint is None
+
+    def test_with_details(self):
+        """Test event with details and fix hint."""
+        event = DiagnosticEvent(
+            timestamp=datetime.now(),
+            category=EventCategory.ERROR,
+            severity=EventSeverity.ERROR,
+            source="rns",
+            message="Connection failed",
+            details={"port": 4403, "error_code": 111},
+            fix_hint="Check if rnsd is running"
+        )
+
+        assert event.details == {"port": 4403, "error_code": 111}
+        assert event.fix_hint == "Check if rnsd is running"
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        ts = datetime(2026, 1, 9, 12, 0, 0)
+        event = DiagnosticEvent(
+            timestamp=ts,
+            category=EventCategory.SECURITY,
+            severity=EventSeverity.WARNING,
+            source="auth",
+            message="Login attempt",
+            details={"user": "admin"}
+        )
+
+        d = event.to_dict()
+
+        assert d['timestamp'] == ts.isoformat()
+        assert d['category'] == "security"
+        assert d['severity'] == "warning"
+        assert d['source'] == "auth"
+        assert d['message'] == "Login attempt"
+        assert d['details'] == {"user": "admin"}
+
+    def test_to_log_line(self):
+        """Test formatting as log line."""
+        ts = datetime(2026, 1, 9, 12, 30, 45)
+        event = DiagnosticEvent(
+            timestamp=ts,
+            category=EventCategory.NETWORK,
+            severity=EventSeverity.INFO,
+            source="mesh",
+            message="Node discovered"
+        )
+
+        line = event.to_log_line()
+
+        assert "2026-01-09 12:30:45" in line
+        assert "INFO" in line
+        assert "NETW" in line
+        assert "mesh" in line
+        assert "Node discovered" in line
+
+
+class TestHealthCheck:
+    """Tests for HealthCheck dataclass."""
+
+    def test_creation(self):
+        """Test creating a health check."""
+        check = HealthCheck(
+            name="meshtasticd",
+            status=HealthStatus.HEALTHY,
+            message="Service running",
+            last_check=datetime.now()
+        )
+
+        assert check.name == "meshtasticd"
+        assert check.status == HealthStatus.HEALTHY
+        assert check.message == "Service running"
+
+    def test_with_fix_hint(self):
+        """Test health check with fix hint."""
+        check = HealthCheck(
+            name="rnsd",
+            status=HealthStatus.UNHEALTHY,
+            message="Service not running",
+            last_check=datetime.now(),
+            fix_hint="Run: sudo systemctl start rnsd"
+        )
+
+        assert check.fix_hint == "Run: sudo systemctl start rnsd"
+
+    def test_to_dict(self):
+        """Test serialization to dict."""
+        ts = datetime(2026, 1, 9, 12, 0, 0)
+        check = HealthCheck(
+            name="test",
+            status=HealthStatus.DEGRADED,
+            message="High latency",
+            last_check=ts,
+            details={"latency_ms": 500}
+        )
+
+        d = check.to_dict()
+
+        assert d['name'] == "test"
+        assert d['status'] == "degraded"
+        assert d['message'] == "High latency"
+        assert d['last_check'] == ts.isoformat()
+        assert d['details'] == {"latency_ms": 500}
+
+
+class TestNetworkDiagnostics:
+    """Tests for NetworkDiagnostics singleton."""
+
+    @pytest.fixture
+    def diag(self):
+        """Create a fresh diagnostics instance for testing."""
+        # Reset singleton for testing
+        NetworkDiagnostics._instance = None
+
+        with patch.object(NetworkDiagnostics, '_ensure_dirs'):
+            with patch.object(NetworkDiagnostics, '_health_monitor_loop'):
+                instance = NetworkDiagnostics()
+                instance._monitor_running = False
+                yield instance
+
+                # Cleanup
+                instance._monitor_running = False
+                NetworkDiagnostics._instance = None
+
+    def test_singleton(self):
+        """Test that NetworkDiagnostics is a singleton."""
+        NetworkDiagnostics._instance = None
+
+        with patch.object(NetworkDiagnostics, '_ensure_dirs'):
+            with patch.object(NetworkDiagnostics, '_health_monitor_loop'):
+                diag1 = NetworkDiagnostics()
+                diag2 = NetworkDiagnostics()
+
+                assert diag1 is diag2
+
+                NetworkDiagnostics._instance = None
+
+    def test_log_event(self, diag):
+        """Test logging an event."""
+        with patch.object(diag, '_write_event_to_file'):
+            event = diag.log_event(
+                EventCategory.NETWORK,
+                EventSeverity.INFO,
+                "test",
+                "Test message"
+            )
+
+            assert event.category == EventCategory.NETWORK
+            assert event.source == "test"
+            assert len(diag._events) == 1
+
+    def test_log_event_with_callback(self, diag):
+        """Test that event logging triggers callbacks."""
+        callback = MagicMock()
+        diag._event_callbacks.append(callback)
+
+        with patch.object(diag, '_write_event_to_file'):
+            event = diag.log_event(
+                EventCategory.SYSTEM,
+                EventSeverity.WARNING,
+                "test",
+                "Test warning"
+            )
+
+        callback.assert_called_once_with(event)
+
+    def test_log_connection_success(self, diag):
+        """Test logging successful connection."""
+        with patch.object(diag, 'log_event') as mock_log:
+            diag.log_connection("meshtastic", "localhost:4403", True)
+
+            mock_log.assert_called_once()
+            args = mock_log.call_args
+            assert args[0][0] == EventCategory.NETWORK
+            assert args[0][1] == EventSeverity.INFO
+
+    def test_log_connection_failure(self, diag):
+        """Test logging connection failure."""
+        with patch.object(diag, 'log_event') as mock_log:
+            with patch.object(diag, '_get_connection_fix_hint', return_value="Fix hint"):
+                diag.log_connection("rns", "localhost", False, "Connection refused")
+
+                mock_log.assert_called_once()
+                args = mock_log.call_args
+                assert args[0][0] == EventCategory.NETWORK
+                assert args[0][1] == EventSeverity.ERROR
+
+    def test_log_disconnection(self, diag):
+        """Test logging disconnection."""
+        with patch.object(diag, 'log_event') as mock_log:
+            diag.log_disconnection("mesh", "device", "timeout")
+
+            mock_log.assert_called_once()
+            args = mock_log.call_args
+            assert args[0][1] == EventSeverity.WARNING
+
+    def test_log_security_event(self, diag):
+        """Test logging security event."""
+        with patch.object(diag, 'log_event') as mock_log:
+            diag.log_security_event("auth", "Failed login attempt")
+
+            mock_log.assert_called_once()
+            args = mock_log.call_args
+            assert args[0][0] == EventCategory.SECURITY
+
+    def test_log_performance(self, diag):
+        """Test logging performance metric."""
+        with patch.object(diag, 'log_event') as mock_log:
+            diag.log_performance("network", "latency", 50, "ms")
+
+            mock_log.assert_called_once()
+            args = mock_log.call_args
+            assert args[0][0] == EventCategory.PERFORMANCE
+            assert "latency" in args[0][3]
+
+    def test_log_config_change(self, diag):
+        """Test logging config change for audit."""
+        with patch.object(diag, 'log_event') as mock_log:
+            diag.log_config_change("gateway", "enabled", False, True)
+
+            mock_log.assert_called_once()
+            args = mock_log.call_args
+            assert args[0][0] == EventCategory.AUDIT
+
+    def test_events_limited_to_maxlen(self, diag):
+        """Test that events are limited by maxlen."""
+        with patch.object(diag, '_write_event_to_file'):
+            # Add more than maxlen events
+            for i in range(1100):
+                diag.log_event(
+                    EventCategory.SYSTEM,
+                    EventSeverity.DEBUG,
+                    "test",
+                    f"Event {i}"
+                )
+
+            # Should be capped at 1000
+            assert len(diag._events) == 1000
+
+    def test_callback_error_handling(self, diag):
+        """Test that callback errors don't break logging."""
+        bad_callback = MagicMock(side_effect=Exception("Callback error"))
+        good_callback = MagicMock()
+
+        diag._event_callbacks = [bad_callback, good_callback]
+
+        with patch.object(diag, '_write_event_to_file'):
+            # Should not raise
+            diag.log_event(
+                EventCategory.SYSTEM,
+                EventSeverity.INFO,
+                "test",
+                "Test"
+            )
+
+        # Good callback should still be called
+        good_callback.assert_called_once()
+
+
+class TestHealthCheckMethods:
+    """Tests for health check functionality."""
+
+    @pytest.fixture
+    def diag(self):
+        """Create diagnostics instance."""
+        NetworkDiagnostics._instance = None
+
+        with patch.object(NetworkDiagnostics, '_ensure_dirs'):
+            with patch.object(NetworkDiagnostics, '_health_monitor_loop'):
+                instance = NetworkDiagnostics()
+                instance._monitor_running = False
+                yield instance
+
+                instance._monitor_running = False
+                NetworkDiagnostics._instance = None
+
+    def test_update_health(self, diag):
+        """Test updating health status."""
+        with patch.object(diag, '_write_event_to_file'):
+            diag.update_health(
+                "test_service",
+                HealthStatus.HEALTHY,
+                "Running"
+            )
+
+        assert "test_service" in diag._health
+        assert diag._health["test_service"].status == HealthStatus.HEALTHY
+
+    def test_update_health_with_details(self, diag):
+        """Test updating health with details and fix hint."""
+        with patch.object(diag, '_write_event_to_file'):
+            diag.update_health(
+                "test",
+                HealthStatus.UNHEALTHY,
+                "Service down",
+                details={"error": "timeout"},
+                fix_hint="Restart service"
+            )
+
+        check = diag._health["test"]
+        assert check.details == {"error": "timeout"}
+        assert check.fix_hint == "Restart service"
+
+    def test_get_health_single(self, diag):
+        """Test getting single health status."""
+        check = HealthCheck(
+            name="test",
+            status=HealthStatus.DEGRADED,
+            message="High load",
+            last_check=datetime.now()
+        )
+        diag._health["test"] = check
+
+        result = diag.get_health("test")
+
+        assert "test" in result
+        assert result["test"] == check
+
+    def test_get_health_unknown(self, diag):
+        """Test getting health for unknown service returns empty dict."""
+        result = diag.get_health("unknown_service")
+
+        assert result == {}
+
+    def test_get_health_all(self, diag):
+        """Test getting all health statuses."""
+        diag._health["svc1"] = HealthCheck(
+            name="svc1", status=HealthStatus.HEALTHY,
+            message="OK", last_check=datetime.now()
+        )
+        diag._health["svc2"] = HealthCheck(
+            name="svc2", status=HealthStatus.UNHEALTHY,
+            message="Down", last_check=datetime.now()
+        )
+
+        all_health = diag.get_health()  # No name = get all
+
+        assert len(all_health) == 2
+        assert "svc1" in all_health
+        assert "svc2" in all_health

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -1,0 +1,355 @@
+"""
+Tests for RNS-Meshtastic bridge service.
+
+Run: python3 -m pytest tests/test_rns_bridge.py -v
+"""
+
+import pytest
+import threading
+import time
+from datetime import datetime, timedelta
+from unittest.mock import patch, MagicMock, PropertyMock
+from queue import Queue
+
+from src.gateway.rns_bridge import (
+    BridgedMessage,
+    RNSMeshtasticBridge,
+)
+from src.gateway.config import GatewayConfig
+
+
+class TestBridgedMessage:
+    """Tests for BridgedMessage dataclass."""
+
+    def test_defaults(self):
+        """Test default message values."""
+        msg = BridgedMessage(
+            source_network="meshtastic",
+            source_id="!abcd1234",
+            destination_id=None,
+            content="Hello"
+        )
+
+        assert msg.source_network == "meshtastic"
+        assert msg.source_id == "!abcd1234"
+        assert msg.content == "Hello"
+        assert msg.title is None
+        assert msg.is_broadcast is False
+        assert msg.timestamp is not None
+        assert msg.metadata == {}
+
+    def test_with_all_fields(self):
+        """Test message with all fields."""
+        ts = datetime(2026, 1, 9, 12, 0, 0)
+        msg = BridgedMessage(
+            source_network="rns",
+            source_id="abc123",
+            destination_id="def456",
+            content="Test message",
+            title="Test Title",
+            timestamp=ts,
+            is_broadcast=True,
+            metadata={"priority": "high"}
+        )
+
+        assert msg.source_network == "rns"
+        assert msg.title == "Test Title"
+        assert msg.timestamp == ts
+        assert msg.is_broadcast is True
+        assert msg.metadata == {"priority": "high"}
+
+    def test_auto_timestamp(self):
+        """Test automatic timestamp on creation."""
+        before = datetime.now()
+        msg = BridgedMessage(
+            source_network="meshtastic",
+            source_id="test",
+            destination_id=None,
+            content="Test"
+        )
+        after = datetime.now()
+
+        assert before <= msg.timestamp <= after
+
+    def test_auto_metadata(self):
+        """Test automatic empty metadata dict."""
+        msg = BridgedMessage(
+            source_network="meshtastic",
+            source_id="test",
+            destination_id=None,
+            content="Test"
+        )
+
+        # Should be a new dict, not None
+        assert msg.metadata is not None
+        assert isinstance(msg.metadata, dict)
+
+
+class TestRNSMeshtasticBridge:
+    """Tests for RNSMeshtasticBridge class."""
+
+    @pytest.fixture
+    def mock_config(self):
+        """Create a mock config for testing."""
+        config = GatewayConfig()
+        config.enabled = True
+        return config
+
+    @pytest.fixture
+    def bridge(self, mock_config):
+        """Create a bridge instance with mocked dependencies."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker'):
+            with patch.object(GatewayConfig, 'load', return_value=mock_config):
+                bridge = RNSMeshtasticBridge(config=mock_config)
+                yield bridge
+                # Cleanup
+                if bridge._running:
+                    bridge._running = False
+
+    def test_init(self, bridge):
+        """Test bridge initialization."""
+        assert bridge._running is False
+        assert bridge._connected_mesh is False
+        assert bridge._connected_rns is False
+        assert bridge.stats['messages_mesh_to_rns'] == 0
+        assert bridge.stats['messages_rns_to_mesh'] == 0
+
+    def test_is_running_property(self, bridge):
+        """Test is_running property."""
+        assert bridge.is_running is False
+
+        bridge._running = True
+        assert bridge.is_running is True
+
+    def test_is_connected_property(self, bridge):
+        """Test is_connected property."""
+        assert bridge.is_connected is False
+
+        bridge._connected_mesh = True
+        assert bridge.is_connected is True
+
+        bridge._connected_mesh = False
+        bridge._connected_rns = True
+        assert bridge.is_connected is True
+
+    def test_get_status(self, bridge):
+        """Test get_status returns correct structure."""
+        status = bridge.get_status()
+
+        assert 'running' in status
+        assert 'enabled' in status
+        assert 'meshtastic_connected' in status
+        assert 'rns_connected' in status
+        assert 'statistics' in status
+        assert 'node_stats' in status
+
+    def test_get_status_with_uptime(self, bridge):
+        """Test get_status calculates uptime."""
+        bridge.stats['start_time'] = datetime.now() - timedelta(seconds=60)
+
+        status = bridge.get_status()
+
+        assert status['uptime_seconds'] is not None
+        assert status['uptime_seconds'] >= 60
+
+    def test_register_message_callback(self, bridge):
+        """Test registering message callbacks."""
+        callback = MagicMock()
+
+        bridge.register_message_callback(callback)
+
+        assert callback in bridge._message_callbacks
+
+    def test_register_status_callback(self, bridge):
+        """Test registering status callbacks."""
+        callback = MagicMock()
+
+        bridge.register_status_callback(callback)
+
+        assert callback in bridge._status_callbacks
+
+    def test_send_to_meshtastic_not_connected(self, bridge):
+        """Test send fails when not connected."""
+        bridge._connected_mesh = False
+
+        result = bridge.send_to_meshtastic("Test message")
+
+        assert result is False
+
+    def test_send_to_rns_not_connected(self, bridge):
+        """Test send fails when not connected."""
+        bridge._connected_rns = False
+
+        result = bridge.send_to_rns("Test message")
+
+        assert result is False
+
+    def test_send_to_meshtastic_with_interface(self, bridge):
+        """Test send uses interface when available."""
+        bridge._connected_mesh = True
+        mock_interface = MagicMock()
+        bridge._mesh_interface = mock_interface
+
+        result = bridge.send_to_meshtastic("Hello", destination="!12345678", channel=1)
+
+        assert result is True
+        mock_interface.sendText.assert_called_once_with(
+            "Hello",
+            destinationId="!12345678",
+            channelIndex=1
+        )
+
+    def test_send_to_meshtastic_error_handling(self, bridge):
+        """Test send handles errors gracefully."""
+        bridge._connected_mesh = True
+        mock_interface = MagicMock()
+        mock_interface.sendText.side_effect = Exception("Send failed")
+        bridge._mesh_interface = mock_interface
+
+        result = bridge.send_to_meshtastic("Hello")
+
+        assert result is False
+        assert bridge.stats['errors'] == 1
+
+    def test_test_connection_structure(self, bridge):
+        """Test test_connection returns correct structure."""
+        with patch.object(bridge, '_test_meshtastic', return_value=False):
+            with patch.object(bridge, '_test_rns', return_value=False):
+                result = bridge.test_connection()
+
+        assert 'meshtastic' in result
+        assert 'rns' in result
+        assert 'connected' in result['meshtastic']
+        assert 'error' in result['meshtastic']
+
+    def test_stop_when_not_running(self, bridge):
+        """Test stop does nothing when not running."""
+        bridge._running = False
+
+        # Should not raise
+        bridge.stop()
+
+    def test_message_queues_initialized(self, bridge):
+        """Test message queues are initialized."""
+        assert isinstance(bridge._mesh_to_rns_queue, Queue)
+        assert isinstance(bridge._rns_to_mesh_queue, Queue)
+
+    def test_stats_initialization(self, bridge):
+        """Test statistics are properly initialized."""
+        assert bridge.stats['messages_mesh_to_rns'] == 0
+        assert bridge.stats['messages_rns_to_mesh'] == 0
+        assert bridge.stats['errors'] == 0
+        assert bridge.stats['start_time'] is None
+
+
+class TestBridgeStartStop:
+    """Tests for bridge start/stop lifecycle."""
+
+    def test_start_sets_running(self):
+        """Test start sets running flag."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker') as mock_tracker:
+            mock_tracker_instance = MagicMock()
+            mock_tracker.return_value = mock_tracker_instance
+
+            config = GatewayConfig()
+            config.enabled = False  # Disable to avoid thread spawning
+
+            bridge = RNSMeshtasticBridge(config=config)
+            result = bridge.start()
+
+            assert result is True
+            assert bridge._running is True
+            assert bridge.stats['start_time'] is not None
+            mock_tracker_instance.start.assert_called_once()
+
+            bridge._running = False  # Cleanup
+
+    def test_start_when_already_running(self):
+        """Test start returns True if already running."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker'):
+            config = GatewayConfig()
+            config.enabled = False
+
+            bridge = RNSMeshtasticBridge(config=config)
+            bridge._running = True
+
+            result = bridge.start()
+
+            assert result is True
+
+    def test_stop_clears_running(self):
+        """Test stop clears running flag."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker') as mock_tracker:
+            mock_tracker_instance = MagicMock()
+            mock_tracker.return_value = mock_tracker_instance
+
+            config = GatewayConfig()
+            config.enabled = False
+
+            bridge = RNSMeshtasticBridge(config=config)
+            bridge._running = True
+
+            bridge.stop()
+
+            assert bridge._running is False
+            mock_tracker_instance.stop.assert_called_once()
+
+
+class TestBridgeCallbacks:
+    """Tests for callback notification."""
+
+    def test_notify_status_calls_callbacks(self):
+        """Test _notify_status calls all registered callbacks."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker'):
+            config = GatewayConfig()
+            bridge = RNSMeshtasticBridge(config=config)
+
+            callback1 = MagicMock()
+            callback2 = MagicMock()
+            bridge.register_status_callback(callback1)
+            bridge.register_status_callback(callback2)
+
+            bridge._notify_status("test_event")
+
+            # Callbacks receive event and status dict
+            assert callback1.call_count == 1
+            assert callback2.call_count == 1
+            assert callback1.call_args[0][0] == "test_event"
+            assert callback2.call_args[0][0] == "test_event"
+
+    def test_notify_message_calls_callbacks(self):
+        """Test _notify_message calls all registered callbacks."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker'):
+            config = GatewayConfig()
+            bridge = RNSMeshtasticBridge(config=config)
+
+            callback = MagicMock()
+            bridge.register_message_callback(callback)
+
+            msg = BridgedMessage(
+                source_network="meshtastic",
+                source_id="test",
+                destination_id=None,
+                content="Hello"
+            )
+            bridge._notify_message(msg)
+
+            callback.assert_called_once_with(msg)
+
+    def test_callback_error_handling(self):
+        """Test callbacks don't break on error."""
+        with patch('src.gateway.rns_bridge.UnifiedNodeTracker'):
+            config = GatewayConfig()
+            bridge = RNSMeshtasticBridge(config=config)
+
+            bad_callback = MagicMock(side_effect=Exception("Callback error"))
+            good_callback = MagicMock()
+
+            bridge.register_status_callback(bad_callback)
+            bridge.register_status_callback(good_callback)
+
+            # Should not raise
+            bridge._notify_status("test")
+
+            # Good callback should still be called
+            good_callback.assert_called_once()


### PR DESCRIPTION
Comprehensive test coverage for:
- rns_bridge.py: BridgedMessage serialization, RNSMeshtasticBridge lifecycle and callbacks (25 tests)
- network_diagnostics.py: EventCategory, EventSeverity, DiagnosticEvent, HealthCheck tracking, NetworkDiagnostics manager (28 tests)
- aredn.py: LinkType, AREDNLink with SNR calculations, AREDNService, AREDNNode with base_url generation, AREDNClient API methods (25 tests)

Total test count now at 500 tests, all passing.