### PR TITLE
feat: Add resilient Meshtastic TCP connection manager

### DIFF
--- a/src/utils/meshtastic_connection.py
+++ b/src/utils/meshtastic_connection.py
@@ -1,0 +1,307 @@
+"""
+Meshtastic TCP Connection Manager
+
+Provides resilient connection handling for meshtasticd which only supports
+one TCP client connection at a time. Features:
+- Connection locking to prevent concurrent access
+- Retry logic for transient failures (Connection reset by peer)
+- Timeout handling
+- Graceful cleanup
+"""
+
+import socket
+import threading
+import time
+import logging
+from contextlib import contextmanager
+from typing import Optional, List, Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Singleton instance
+_connection_manager: Optional['MeshtasticConnectionManager'] = None
+_manager_lock = threading.Lock()
+
+
+class ConnectionError(Exception):
+    """Exception raised when connection to meshtasticd fails"""
+    pass
+
+
+def get_connection_manager(host: str = 'localhost', port: int = 4403) -> 'MeshtasticConnectionManager':
+    """Get the singleton connection manager instance"""
+    global _connection_manager
+    with _manager_lock:
+        if _connection_manager is None:
+            _connection_manager = MeshtasticConnectionManager(host, port)
+        return _connection_manager
+
+
+def reset_connection_manager():
+    """Reset the singleton (for testing)"""
+    global _connection_manager
+    with _manager_lock:
+        _connection_manager = None
+
+
+class MeshtasticConnectionManager:
+    """
+    Manages TCP connections to meshtasticd.
+
+    meshtasticd only supports one TCP client at a time, so this manager:
+    - Uses a lock to prevent concurrent connection attempts
+    - Retries on transient failures like "Connection reset by peer"
+    - Provides convenience methods for common operations
+    """
+
+    def __init__(self, host: str = 'localhost', port: int = 4403):
+        """
+        Initialize the connection manager.
+
+        Args:
+            host: meshtasticd host (default: localhost)
+            port: meshtasticd TCP port (default: 4403)
+        """
+        self.host = host
+        self.port = port
+        self._lock = threading.Lock()
+        self._interface = None
+
+    def is_available(self, timeout: float = 2.0) -> bool:
+        """
+        Check if meshtasticd is reachable.
+
+        Args:
+            timeout: Connection timeout in seconds
+
+        Returns:
+            True if port is reachable, False otherwise
+        """
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(timeout)
+                sock.connect((self.host, self.port))
+                return True
+        except (socket.error, socket.timeout, OSError):
+            return False
+
+    def acquire_lock(self, timeout: float = 30.0) -> bool:
+        """
+        Acquire the connection lock.
+
+        Args:
+            timeout: How long to wait for lock (seconds)
+
+        Returns:
+            True if lock acquired, False if timeout
+        """
+        return self._lock.acquire(timeout=timeout)
+
+    def release_lock(self):
+        """Release the connection lock"""
+        try:
+            self._lock.release()
+        except RuntimeError:
+            pass  # Lock not held
+
+    def _create_interface(self):
+        """
+        Create a new meshtastic TCP interface.
+
+        Returns:
+            TCPInterface instance
+
+        Raises:
+            ConnectionError: If connection fails
+        """
+        try:
+            import meshtastic.tcp_interface
+            return meshtastic.tcp_interface.TCPInterface(hostname=self.host)
+        except ImportError:
+            raise ConnectionError("meshtastic library not installed")
+        except Exception as e:
+            raise ConnectionError(f"Failed to connect: {e}")
+
+    @contextmanager
+    def with_connection(self, max_retries: int = 3, retry_delay: float = 1.0, lock_timeout: float = 30.0):
+        """
+        Context manager for safe connection handling.
+
+        Acquires lock, creates connection, and ensures cleanup.
+        Retries on transient connection failures.
+
+        Args:
+            max_retries: Maximum number of connection attempts
+            retry_delay: Delay between retries (seconds)
+            lock_timeout: How long to wait for connection lock
+
+        Yields:
+            TCPInterface instance
+
+        Raises:
+            ConnectionError: If connection fails after all retries
+        """
+        if not self.acquire_lock(timeout=lock_timeout):
+            raise ConnectionError("Could not acquire connection lock (another operation in progress)")
+
+        interface = None
+        last_error = None
+
+        try:
+            for attempt in range(max_retries):
+                try:
+                    interface = self._create_interface()
+                    yield interface
+                    return
+                except (ConnectionResetError, BrokenPipeError, OSError) as e:
+                    last_error = e
+                    logger.warning(f"Connection attempt {attempt + 1}/{max_retries} failed: {e}")
+                    if attempt < max_retries - 1:
+                        time.sleep(retry_delay)
+                        # Exponential backoff
+                        retry_delay *= 1.5
+                except ConnectionError:
+                    raise
+                finally:
+                    if interface is not None:
+                        try:
+                            interface.close()
+                        except Exception:
+                            pass
+                        interface = None
+
+            raise ConnectionError(f"Connection failed after max retries: {last_error}")
+
+        finally:
+            self.release_lock()
+
+    def get_nodes(self, max_retries: int = 2) -> List[Dict[str, Any]]:
+        """
+        Get list of nodes from meshtasticd.
+
+        Args:
+            max_retries: Number of connection retries
+
+        Returns:
+            List of node dictionaries, empty list on error
+        """
+        try:
+            with self.with_connection(max_retries=max_retries) as iface:
+                nodes = []
+                if hasattr(iface, 'nodes') and iface.nodes:
+                    for node_id, node in iface.nodes.items():
+                        node_info = {
+                            'id': node_id,
+                            'name': '',
+                            'short': '',
+                        }
+                        if hasattr(node, 'user') and node.user:
+                            node_info['name'] = getattr(node.user, 'longName', '') or ''
+                            node_info['short'] = getattr(node.user, 'shortName', '') or ''
+                            if hasattr(node.user, 'id'):
+                                node_info['id'] = node.user.id
+                        nodes.append(node_info)
+                return nodes
+        except Exception as e:
+            logger.warning(f"Failed to get nodes: {e}")
+            return []
+
+    def get_channels(self, max_retries: int = 2) -> List[Dict[str, Any]]:
+        """
+        Get list of channels from meshtasticd.
+
+        Args:
+            max_retries: Number of connection retries
+
+        Returns:
+            List of channel dictionaries, empty list on error
+        """
+        try:
+            with self.with_connection(max_retries=max_retries) as iface:
+                channels = []
+                if hasattr(iface, 'localNode') and iface.localNode:
+                    local_node = iface.localNode
+                    if hasattr(local_node, 'channels'):
+                        for idx, ch in enumerate(local_node.channels):
+                            channel_info = {
+                                'index': idx,
+                                'role': 'DISABLED',
+                                'name': '',
+                                'psk': False
+                            }
+
+                            if hasattr(ch, 'role'):
+                                role_map = {0: 'DISABLED', 1: 'PRIMARY', 2: 'SECONDARY'}
+                                try:
+                                    role_int = int(ch.role)
+                                    channel_info['role'] = role_map.get(role_int, str(role_int))
+                                except (ValueError, TypeError):
+                                    channel_info['role'] = str(ch.role)
+
+                            if hasattr(ch, 'settings'):
+                                settings = ch.settings
+                                if hasattr(settings, 'name'):
+                                    channel_info['name'] = settings.name or f"Channel {idx}"
+                                if hasattr(settings, 'psk'):
+                                    channel_info['psk'] = bool(settings.psk)
+
+                            channels.append(channel_info)
+                return channels
+        except Exception as e:
+            logger.warning(f"Failed to get channels: {e}")
+            return []
+
+    def get_radio_info(self, max_retries: int = 2) -> Dict[str, Any]:
+        """
+        Get radio information from meshtasticd.
+
+        Args:
+            max_retries: Number of connection retries
+
+        Returns:
+            Dictionary with radio info, or error dict on failure
+        """
+        try:
+            with self.with_connection(max_retries=max_retries) as iface:
+                info = {}
+                if hasattr(iface, 'localNode') and iface.localNode:
+                    local_node = iface.localNode
+                    if hasattr(local_node, 'nodeNum'):
+                        info['node_num'] = local_node.nodeNum
+                    if hasattr(local_node, 'user'):
+                        user = local_node.user
+                        if hasattr(user, 'longName'):
+                            info['long_name'] = user.longName
+                        if hasattr(user, 'shortName'):
+                            info['short_name'] = user.shortName
+                        if hasattr(user, 'id'):
+                            info['node_id'] = user.id
+                        if hasattr(user, 'hwModel'):
+                            info['hardware'] = str(user.hwModel)
+                return info
+        except Exception as e:
+            logger.warning(f"Failed to get radio info: {e}")
+            return {'error': str(e)}
+
+    def send_message(self, text: str, destination: str = '^all', max_retries: int = 2) -> bool:
+        """
+        Send a message via meshtasticd.
+
+        Args:
+            text: Message text
+            destination: Destination node ID or ^all for broadcast
+            max_retries: Number of connection retries
+
+        Returns:
+            True if sent successfully, False on error
+        """
+        try:
+            with self.with_connection(max_retries=max_retries) as iface:
+                if destination == '^all':
+                    iface.sendText(text)
+                else:
+                    iface.sendText(text, destinationId=destination)
+                return True
+        except Exception as e:
+            logger.warning(f"Failed to send message: {e}")
+            return False

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -1,0 +1,300 @@
+"""
+Tests for Meshtastic TCP Connection Manager
+
+Tests resilient connection handling for meshtasticd which only supports
+one TCP client connection at a time.
+"""
+
+import pytest
+import threading
+import time
+from unittest.mock import Mock, patch, MagicMock
+import socket
+import sys
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+class TestMeshtasticConnectionManager:
+    """Tests for the connection manager"""
+
+    def test_import_connection_manager(self):
+        """Connection manager module can be imported"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        assert MeshtasticConnectionManager is not None
+
+    def test_singleton_pattern(self):
+        """Connection manager uses singleton pattern"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager, get_connection_manager
+        mgr1 = get_connection_manager()
+        mgr2 = get_connection_manager()
+        assert mgr1 is mgr2
+
+    def test_default_host_port(self):
+        """Connection manager has correct default host/port"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        mgr = MeshtasticConnectionManager()
+        assert mgr.host == 'localhost'
+        assert mgr.port == 4403
+
+    def test_custom_host_port(self):
+        """Connection manager accepts custom host/port"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        mgr = MeshtasticConnectionManager(host='192.168.1.100', port=4404)
+        assert mgr.host == '192.168.1.100'
+        assert mgr.port == 4404
+
+
+class TestConnectionStatus:
+    """Tests for connection status checking"""
+
+    def test_is_available_when_port_open(self):
+        """is_available returns True when port is reachable"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        with patch('socket.socket') as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value.__enter__ = Mock(return_value=mock_sock)
+            mock_socket.return_value.__exit__ = Mock(return_value=False)
+            mock_sock.connect.return_value = None
+
+            mgr = MeshtasticConnectionManager()
+            assert mgr.is_available() is True
+
+    def test_is_available_when_port_closed(self):
+        """is_available returns False when port is not reachable"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        with patch('socket.socket') as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value.__enter__ = Mock(return_value=mock_sock)
+            mock_socket.return_value.__exit__ = Mock(return_value=False)
+            mock_sock.connect.side_effect = socket.error("Connection refused")
+
+            mgr = MeshtasticConnectionManager()
+            assert mgr.is_available() is False
+
+    def test_is_available_timeout(self):
+        """is_available returns False on timeout"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        with patch('socket.socket') as mock_socket:
+            mock_sock = MagicMock()
+            mock_socket.return_value.__enter__ = Mock(return_value=mock_sock)
+            mock_socket.return_value.__exit__ = Mock(return_value=False)
+            mock_sock.connect.side_effect = socket.timeout("Connection timed out")
+
+            mgr = MeshtasticConnectionManager()
+            assert mgr.is_available() is False
+
+
+class TestConnectionLocking:
+    """Tests for connection locking to prevent concurrent access"""
+
+    def test_acquire_lock(self):
+        """Can acquire connection lock"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        mgr = MeshtasticConnectionManager()
+
+        assert mgr.acquire_lock(timeout=1.0) is True
+        mgr.release_lock()
+
+    def test_lock_prevents_concurrent_access(self):
+        """Lock prevents multiple concurrent acquisitions"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        mgr = MeshtasticConnectionManager()
+
+        # First acquisition should succeed
+        assert mgr.acquire_lock(timeout=1.0) is True
+
+        # Second acquisition should fail (non-blocking)
+        assert mgr.acquire_lock(timeout=0.1) is False
+
+        mgr.release_lock()
+
+    def test_lock_released_after_use(self):
+        """Lock can be reacquired after release"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+        mgr = MeshtasticConnectionManager()
+
+        assert mgr.acquire_lock(timeout=1.0) is True
+        mgr.release_lock()
+
+        # Should be able to acquire again
+        assert mgr.acquire_lock(timeout=1.0) is True
+        mgr.release_lock()
+
+
+class TestWithConnection:
+    """Tests for the with_connection context manager"""
+
+    def test_with_connection_success(self):
+        """with_connection yields interface on success"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.return_value = mock_interface
+
+            mgr = MeshtasticConnectionManager()
+            with mgr.with_connection() as iface:
+                assert iface is mock_interface
+
+    def test_with_connection_closes_interface(self):
+        """with_connection closes interface after use"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.return_value = mock_interface
+
+            mgr = MeshtasticConnectionManager()
+            with mgr.with_connection() as iface:
+                pass
+
+            # Interface should be closed
+            mock_interface.close.assert_called_once()
+
+    def test_with_connection_releases_lock_on_exception(self):
+        """with_connection releases lock even on exception"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.return_value = mock_interface
+
+            mgr = MeshtasticConnectionManager()
+
+            try:
+                with mgr.with_connection() as iface:
+                    raise ValueError("Test error")
+            except ValueError:
+                pass
+
+            # Lock should be released - we can acquire it again
+            assert mgr.acquire_lock(timeout=0.1) is True
+            mgr.release_lock()
+
+
+class TestRetryLogic:
+    """Tests for connection retry logic"""
+
+    def test_retry_on_connection_reset(self):
+        """Retries connection on ConnectionResetError"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+        call_count = 0
+
+        def create_with_failure(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 2:
+                raise ConnectionResetError("Connection reset by peer")
+            return mock_interface
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.side_effect = create_with_failure
+
+            mgr = MeshtasticConnectionManager()
+            with mgr.with_connection(max_retries=3) as iface:
+                assert iface is mock_interface
+
+            assert call_count == 2  # Failed once, succeeded on retry
+
+    def test_max_retries_exceeded(self):
+        """Raises exception when max retries exceeded"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager, ConnectionError
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.side_effect = ConnectionResetError("Connection reset by peer")
+
+            mgr = MeshtasticConnectionManager()
+
+            with pytest.raises(ConnectionError) as exc_info:
+                with mgr.with_connection(max_retries=2) as iface:
+                    pass
+
+            assert "max retries" in str(exc_info.value).lower()
+
+
+class TestGetNodes:
+    """Tests for the get_nodes convenience method"""
+
+    def test_get_nodes_returns_list(self):
+        """get_nodes returns a list of node dictionaries"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+        mock_node = MagicMock()
+        mock_node.user = MagicMock()
+        mock_node.user.id = '!12345678'
+        mock_node.user.longName = 'Test Node'
+        mock_node.user.shortName = 'TST'
+        mock_interface.nodes = {'!12345678': mock_node}
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.return_value = mock_interface
+
+            mgr = MeshtasticConnectionManager()
+            nodes = mgr.get_nodes()
+
+            assert isinstance(nodes, list)
+            assert len(nodes) == 1
+            assert nodes[0]['id'] == '!12345678'
+
+    def test_get_nodes_returns_empty_on_error(self):
+        """get_nodes returns empty list on connection error"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.side_effect = ConnectionResetError("Connection failed")
+
+            mgr = MeshtasticConnectionManager()
+            nodes = mgr.get_nodes()
+
+            assert nodes == []
+
+
+class TestGetChannels:
+    """Tests for the get_channels convenience method"""
+
+    def test_get_channels_returns_list(self):
+        """get_channels returns a list of channel dictionaries"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        mock_interface = MagicMock()
+        mock_channel = MagicMock()
+        mock_channel.role = 1  # PRIMARY
+        mock_channel.settings = MagicMock()
+        mock_channel.settings.name = 'TestChannel'
+        mock_channel.settings.psk = b'test'
+        mock_interface.localNode = MagicMock()
+        mock_interface.localNode.channels = [mock_channel]
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.return_value = mock_interface
+
+            mgr = MeshtasticConnectionManager()
+            channels = mgr.get_channels()
+
+            assert isinstance(channels, list)
+            assert len(channels) == 1
+            assert channels[0]['name'] == 'TestChannel'
+
+    def test_get_channels_returns_empty_on_error(self):
+        """get_channels returns empty list on connection error"""
+        from utils.meshtastic_connection import MeshtasticConnectionManager
+
+        with patch('utils.meshtastic_connection.MeshtasticConnectionManager._create_interface') as mock_create:
+            mock_create.side_effect = ConnectionResetError("Connection failed")
+
+            mgr = MeshtasticConnectionManager()
+            channels = mgr.get_channels()
+
+            assert channels == []


### PR DESCRIPTION
meshtasticd only supports one TCP client at a time, causing "Connection reset by peer" errors when multiple clients connect.

New MeshtasticConnectionManager:
- Connection locking to prevent concurrent access
- Retry logic with exponential backoff for transient failures
- Graceful handling of BrokenPipeError and ConnectionResetError
- Convenience methods: get_nodes(), get_channels(), get_radio_info()
- Singleton pattern for shared access

Web API integration:
- get_nodes() now tries connection manager first
- Falls back to CLI method if needed
- Always returns 'nodes' array (prevents JS filter errors)

Tests: 19 new tests, 676 total passing