### PR TITLE
fix: Update CSP to allow Leaflet maps and external resources

### DIFF
--- a/src/main_web.py
+++ b/src/main_web.py
@@ -85,13 +85,14 @@ def add_security_headers(response):
     response.headers['X-Frame-Options'] = 'SAMEORIGIN'
     response.headers['X-XSS-Protection'] = '1; mode=block'
     response.headers['Referrer-Policy'] = 'strict-origin-when-cross-origin'
-    # CSP - allow inline styles/scripts for single-file app, but restrict sources
+    # CSP - allow Leaflet maps and external resources needed for the app
     response.headers['Content-Security-Policy'] = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline'; "
-        "style-src 'self' 'unsafe-inline'; "
-        "img-src 'self' data:; "
-        "connect-src 'self'"
+        "script-src 'self' 'unsafe-inline' https://unpkg.com; "
+        "style-src 'self' 'unsafe-inline' https://unpkg.com; "
+        "img-src 'self' data: https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org; "
+        "connect-src 'self' https://*.basemaps.cartocdn.com https://*.tile.openstreetmap.org; "
+        "font-src 'self' data:"
     )
     return response
 


### PR DESCRIPTION
The Content-Security-Policy was blocking:
- Leaflet JS/CSS from unpkg.com
- Map tiles from basemaps.cartocdn.com
- OpenStreetMap tiles

Updated CSP to allow these resources for map functionality.