### PR TITLE
fix: Add cleanup for DiagnosticsPanel to prevent crash on exit

### DIFF
--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -576,9 +576,23 @@ class NetworkDiagnostics:
         """Register callback for real-time event notifications."""
         self._event_callbacks.append(callback)
 
+    def unregister_event_callback(self, callback: Callable[[DiagnosticEvent], None]):
+        """Unregister event callback."""
+        try:
+            self._event_callbacks.remove(callback)
+        except ValueError:
+            pass  # Already removed
+
     def register_health_callback(self, callback: Callable[[str, HealthCheck], None]):
         """Register callback for health status changes."""
         self._health_callbacks.append(callback)
+
+    def unregister_health_callback(self, callback: Callable[[str, HealthCheck], None]):
+        """Unregister health callback."""
+        try:
+            self._health_callbacks.remove(callback)
+        except ValueError:
+            pass  # Already removed
 
     # ==================== Report Generation ====================
 


### PR DESCRIPTION
- Add _is_destroyed flag and _update_timer_id tracking
- Add cleanup() method to unregister callbacks and stop timer
- Add unregister_event_callback() and unregister_health_callback() methods to NetworkDiagnostics singleton
- Timer callback now checks _is_destroyed to stop gracefully

This prevents callbacks from being invoked on destroyed widgets when the diagnostics panel or window is closed.