### PR TITLE
fix: Add missing emojis to EMOJI_MAP and simplify banners

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -125,12 +125,10 @@ def run_setup_wizard():
 def print_banner():
     """Print the welcome banner"""
     print(f"""{Colors.CYAN}
-+---------------------------------------------------------------+
-|     Meshtasticd Interactive Manager - v{__version__:<21}|
-|     For Raspberry Pi OS & Linux                               |
-+---------------------------------------------------------------+
-|     Choose your interface to get started                      |
-+---------------------------------------------------------------+
+    MeshForge - Meshtasticd Manager v{__version__}
+    For Raspberry Pi OS & Linux
+
+    Choose your interface to get started
 {Colors.NC}""")
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -40,12 +40,8 @@ def get_banner():
     mesh = em.get('🌐', '[MESH]')
     ant = em.get('📡', '[ANT]')
     return f"""
-+-----------------------------------------------------------+
-|   {mesh} Meshtasticd Interactive Installer & Manager          |
-|   For Raspberry Pi OS                          v{__version__}   |
-+-----------------------------------------------------------+
-|   {ant} Install - Configure - Monitor - Update               |
-+-----------------------------------------------------------+
+    {mesh} MeshForge - Meshtasticd Manager v{__version__}
+    {ant} Install - Configure - Monitor - Update
 """
 
 BANNER = get_banner()

--- a/src/utils/emoji.py
+++ b/src/utils/emoji.py
@@ -223,6 +223,8 @@ class EmojiHelper:
         '🗺️': '[MAP]',      # Map
         '🤙': '[SHAKA]',    # Shaka/Hang loose
         '📁': '[FOLDER]',   # Folder
+        '📶': '[SIG]',      # Signal/Bars
+        '🛠️': '[TOOL]',     # Tools/Wrench
     }
 
     def get(self, emoji, fallback=None):


### PR DESCRIPTION
- Add 📶 (signal) and 🛠️ (tools) to emoji fallback map
- Remove all border characters from banners for cleaner display
- Simpler, cleaner interface that works on any terminal

All 705 tests pass.