### PR TITLE
fix: Update CSS to target ScrollableContainer for dashboard

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -1623,13 +1623,17 @@ class MeshtasticdTUI(App):
         height: 100%;
     }
 
-    TabPane > Container {
+    TabPane > Container, TabPane > ScrollableContainer {
         height: 100%;
         overflow-y: auto;
     }
 
     TabbedContent {
         padding: 0;
+    }
+
+    DashboardPane {
+        height: 100%;
     }
     """
 


### PR DESCRIPTION
The CSS was targeting 'TabPane > Container' but DashboardPane was changed to ScrollableContainer, causing height: 0 and invisible content.

- Add ScrollableContainer to CSS selector
- Add explicit DashboardPane height rule