### PR TITLE
feat: Add native space weather API with auto-fallback

### DIFF
--- a/src/commands/hamclock.py
+++ b/src/commands/hamclock.py
@@ -692,3 +692,295 @@ def get_all_data() -> CommandResult:
             "Could not retrieve HamClock data",
             data=all_data
         )
+
+
+# ==================== Enhanced NOAA Native API ====================
+# These functions work without HamClock installed
+
+def get_noaa_kp_index() -> CommandResult:
+    """
+    Get current Kp index from NOAA.
+
+    Kp indicates geomagnetic activity (0-9 scale):
+    - 0-3: Quiet (good HF conditions)
+    - 4-5: Unsettled to Active
+    - 6-7: Minor to Major Storm
+    - 8-9: Severe Storm
+    """
+    url = "https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=_timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if len(data) < 2:
+            return CommandResult.fail("No Kp data available")
+
+        # Latest entry (skip header row)
+        latest = data[-1]
+        kp_value = latest[1] if len(latest) > 1 else "0"
+        timestamp = latest[0] if len(latest) > 0 else ""
+
+        return CommandResult.ok(
+            f"Kp Index: {kp_value}",
+            data={'kp': kp_value, 'timestamp': timestamp, 'source': 'NOAA SWPC'}
+        )
+    except Exception as e:
+        return CommandResult.fail(f"Kp fetch failed: {e}")
+
+
+def get_noaa_xray_flux() -> CommandResult:
+    """
+    Get current X-ray flux from NOAA GOES satellite.
+
+    X-ray classification:
+    - A, B, C: Quiet
+    - M: Moderate flare
+    - X: Major flare (HF radio blackout possible)
+    """
+    url = "https://services.swpc.noaa.gov/json/goes/primary/xray-flares-latest.json"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=_timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if not data:
+            # Try alternate endpoint for current flux
+            url2 = "https://services.swpc.noaa.gov/json/goes/primary/xrays-6-hour.json"
+            req2 = urllib.request.Request(url2)
+            req2.add_header('User-Agent', 'MeshForge/1.0')
+            with urllib.request.urlopen(req2, timeout=_timeout) as response:
+                data = json.loads(response.read().decode('utf-8'))
+                if data:
+                    latest = data[-1]
+                    flux = latest.get('flux', 0)
+                    # Convert flux to class
+                    if flux < 1e-7:
+                        xray_class = "A"
+                    elif flux < 1e-6:
+                        xray_class = "B"
+                    elif flux < 1e-5:
+                        xray_class = "C"
+                    elif flux < 1e-4:
+                        xray_class = "M"
+                    else:
+                        xray_class = "X"
+                    return CommandResult.ok(
+                        f"X-ray: {xray_class}",
+                        data={'xray': xray_class, 'flux': flux, 'source': 'NOAA GOES'}
+                    )
+            return CommandResult.fail("No X-ray data available")
+
+        latest = data[0] if isinstance(data, list) else data
+        xray_class = latest.get('max_class', 'Unknown')
+
+        return CommandResult.ok(
+            f"X-ray flux: {xray_class}",
+            data={'xray': xray_class, 'source': 'NOAA GOES'}
+        )
+    except Exception as e:
+        return CommandResult.fail(f"X-ray fetch failed: {e}")
+
+
+def get_noaa_alerts() -> CommandResult:
+    """
+    Get active space weather alerts from NOAA.
+    """
+    url = "https://services.swpc.noaa.gov/products/alerts.json"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=_timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        # Filter recent alerts (last 24h)
+        alerts = []
+        for alert in data[:10]:  # Limit to 10 most recent
+            alerts.append({
+                'message': alert.get('message', ''),
+                'issue_datetime': alert.get('issue_datetime', ''),
+            })
+
+        return CommandResult.ok(
+            f"{len(alerts)} space weather alerts",
+            data={'alerts': alerts, 'count': len(alerts), 'source': 'NOAA SWPC'}
+        )
+    except Exception as e:
+        return CommandResult.fail(f"Alerts fetch failed: {e}")
+
+
+def get_native_space_weather() -> CommandResult:
+    """
+    Get comprehensive space weather from NOAA (no HamClock required).
+
+    Combines multiple NOAA endpoints to provide:
+    - Solar Flux Index (SFI)
+    - Sunspot Number (SSN)
+    - Kp Index
+    - X-ray flux class
+    - Band conditions estimate
+    """
+    weather = {
+        'source': 'NOAA SWPC (native)',
+        'hamclock_available': False
+    }
+    errors = []
+
+    # Get solar indices
+    result = get_noaa_solar_data()
+    if result.success:
+        weather.update(result.data)
+    else:
+        errors.append(f"Solar: {result.message}")
+
+    # Get Kp index
+    result = get_noaa_kp_index()
+    if result.success:
+        weather['kp'] = result.data.get('kp', '')
+        weather['kp_timestamp'] = result.data.get('timestamp', '')
+    else:
+        errors.append(f"Kp: {result.message}")
+
+    # Get X-ray flux
+    result = get_noaa_xray_flux()
+    if result.success:
+        weather['xray'] = result.data.get('xray', '')
+    else:
+        errors.append(f"X-ray: {result.message}")
+
+    # Derive overall conditions from Kp
+    kp_str = weather.get('kp', '0')
+    try:
+        kp = float(kp_str)
+        if kp < 3:
+            weather['geomagnetic'] = 'Quiet'
+        elif kp < 5:
+            weather['geomagnetic'] = 'Unsettled'
+        elif kp < 7:
+            weather['geomagnetic'] = 'Storm'
+        else:
+            weather['geomagnetic'] = 'Severe Storm'
+    except (ValueError, TypeError):
+        weather['geomagnetic'] = 'Unknown'
+
+    if errors:
+        weather['errors'] = errors
+
+    return CommandResult.ok(
+        f"Space weather: SFI={weather.get('sfi', '?')}, Kp={weather.get('kp', '?')}, X-ray={weather.get('xray', '?')}",
+        data=weather
+    )
+
+
+# ==================== Unified API (Auto-Fallback) ====================
+
+def get_space_weather_auto() -> CommandResult:
+    """
+    Get space weather with automatic fallback.
+
+    Tries HamClock first, falls back to NOAA if unavailable.
+    This is the recommended function to use.
+    """
+    # Try HamClock first
+    if is_available():
+        result = get_space_weather()
+        if result.success:
+            result.data['source'] = 'HamClock'
+            result.data['hamclock_available'] = True
+            return result
+
+    # Fall back to native NOAA
+    logger.info("HamClock not available, using native NOAA API")
+    return get_native_space_weather()
+
+
+def get_band_conditions_auto() -> CommandResult:
+    """
+    Get band conditions with automatic fallback.
+
+    Tries HamClock first, derives from NOAA SFI if unavailable.
+    """
+    # Try HamClock first
+    if is_available():
+        result = get_band_conditions()
+        if result.success:
+            return result
+
+    # Fall back to NOAA-based estimate
+    result = get_noaa_solar_data()
+    if result.success:
+        data = result.data
+        data['source'] = 'NOAA estimate'
+        data['note'] = 'Band conditions estimated from Solar Flux Index'
+        return CommandResult.ok(
+            f"Band conditions: {data.get('conditions', 'Unknown')} (SFI-based estimate)",
+            data=data
+        )
+    return result
+
+
+def get_propagation_summary() -> CommandResult:
+    """
+    Get a summary of current propagation conditions.
+
+    Works with or without HamClock installed.
+    """
+    summary = {
+        'timestamp': '',
+        'overall': 'Unknown',
+        'hf_conditions': {},
+        'alerts': [],
+        'source': 'NOAA SWPC'
+    }
+
+    # Get space weather
+    result = get_space_weather_auto()
+    if result.success:
+        data = result.data
+        summary['sfi'] = data.get('sfi', '')
+        summary['kp'] = data.get('kp', '')
+        summary['xray'] = data.get('xray', '')
+        summary['ssn'] = data.get('ssn', '')
+        summary['geomagnetic'] = data.get('geomagnetic', data.get('conditions', ''))
+        summary['source'] = data.get('source', 'NOAA')
+
+        # Determine overall conditions
+        try:
+            sfi = float(summary['sfi']) if summary['sfi'] else 0
+            kp = float(summary['kp']) if summary['kp'] else 0
+
+            if kp >= 5:
+                summary['overall'] = 'Disturbed'
+            elif sfi >= 120 and kp < 3:
+                summary['overall'] = 'Excellent'
+            elif sfi >= 90:
+                summary['overall'] = 'Good'
+            elif sfi >= 70:
+                summary['overall'] = 'Fair'
+            else:
+                summary['overall'] = 'Poor'
+        except (ValueError, TypeError):
+            summary['overall'] = 'Unknown'
+
+        # Get band conditions
+        bands = data.get('bands_estimate', {})
+        if bands:
+            summary['hf_conditions'] = bands
+
+    # Get alerts
+    alerts_result = get_noaa_alerts()
+    if alerts_result.success:
+        summary['alerts'] = alerts_result.data.get('alerts', [])[:3]  # Top 3
+
+    return CommandResult.ok(
+        f"Propagation: {summary['overall']} (SFI={summary.get('sfi', '?')}, Kp={summary.get('kp', '?')})",
+        data=summary
+    )


### PR DESCRIPTION
HamClock features now work without HamClock installed:

Native NOAA APIs added:
- get_noaa_kp_index() - Geomagnetic activity (0-9 scale)
- get_noaa_xray_flux() - Solar flare classification (A-X)
- get_noaa_alerts() - Active space weather alerts
- get_native_space_weather() - Comprehensive NOAA data

Unified auto-fallback APIs:
- get_space_weather_auto() - Tries HamClock, falls back to NOAA
- get_band_conditions_auto() - Band conditions from either source
- get_propagation_summary() - Full propagation report

Updated launcher_tui.py to use get_propagation_summary() for richer space weather display with alerts and band conditions.