### PR TITLE
feat: Add SSH login message for MeshForge

### DIFF
--- a/scripts/install-desktop.sh
+++ b/scripts/install-desktop.sh
@@ -152,6 +152,14 @@ else
     echo "  Warning: Polkit not found, desktop launcher may not work"
 fi
 
+# Install SSH login message
+echo "Installing SSH login message..."
+if [ -d /etc/profile.d ]; then
+    cp "$PROJECT_DIR/scripts/meshforge-profile.sh" /etc/profile.d/meshforge.sh
+    chmod 644 /etc/profile.d/meshforge.sh
+    echo "  SSH users will see MeshForge prompt on login"
+fi
+
 echo
 echo "==========================================="
 echo "Installation complete!"
@@ -165,6 +173,7 @@ echo
 echo "Or search for 'MeshForge' in your application launcher."
 echo
 echo "To run from command line:"
-echo "  meshforge          # Uses pkexec for GUI"
-echo "  sudo meshforge tui # For terminal UI"
+echo "  meshforge        # TUI launcher (works over SSH)"
+echo "  meshforge gtk    # GTK desktop interface"
+echo "  meshforge cli    # Rich CLI menu"
 echo

--- a/scripts/meshforge-profile.sh
+++ b/scripts/meshforge-profile.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# MeshForge SSH Login Message
+# Installed to /etc/profile.d/meshforge.sh
+
+# Only show for interactive shells
+[ -z "$PS1" ] && return
+
+# Check if MeshForge is installed
+if [ -x /usr/local/bin/meshforge ] || [ -f /opt/meshforge/src/launcher_tui.py ]; then
+    # Show message on SSH login
+    if [ -n "$SSH_TTY" ] || [ -n "$SSH_CLIENT" ]; then
+        echo ""
+        echo "  ┌─────────────────────────────────────┐"
+        echo "  │  MeshForge NOC is installed         │"
+        echo "  │  Type 'meshforge' to launch         │"
+        echo "  └─────────────────────────────────────┘"
+        echo ""
+    fi
+fi


### PR DESCRIPTION
When users SSH into a machine with MeshForge installed, they see:
  ┌─────────────────────────────────────┐
  │  MeshForge NOC is installed         │
  │  Type 'meshforge' to launch         │
  └─────────────────────────────────────┘

- Created scripts/meshforge-profile.sh
- Installed to /etc/profile.d/meshforge.sh by install-desktop.sh
- Updated command help to reflect TUI as primary interface