### PR TITLE
chore: Bump version to 0.4.6-beta and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.4.5--beta-blue.svg" alt="Version"></a>
+  <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.4.6--beta-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-green.svg" alt="License"></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/python-3.9+-yellow.svg" alt="Python"></a>
   <a href="tests/"><img src="https://img.shields.io/badge/tests-779%20passing-brightgreen.svg" alt="Tests"></a>
@@ -51,10 +51,13 @@ The launcher auto-detects your environment and picks the best interface.
 | Interface | Command | Best For |
 |-----------|---------|----------|
 | Auto | `sudo python3 src/launcher.py` | Let MeshForge decide |
-| GTK Desktop | `sudo python3 src/main_gtk.py` | Desktop / VNC |
+| TUI (raspi-config style) | `sudo python3 src/launcher_tui.py` | SSH / headless (recommended) |
+| VTE Wrapper | `python3 src/launcher_vte.py` | Desktop with proper taskbar icon |
+| GTK Desktop | `sudo python3 src/main_gtk.py` | Full graphical interface |
 | Web UI | `sudo python3 src/main_web.py` | Browser access |
-| TUI | `sudo python3 src/main_tui.py` | SSH / headless |
 | Standalone | `python3 src/standalone.py` | Zero dependencies |
+
+**Desktop Integration**: After install, run `meshforge vte` for best taskbar icon support.
 
 ---
 
@@ -62,10 +65,23 @@ The launcher auto-detects your environment and picks the best interface.
 
 **Core Tools**
 - Service management for meshtasticd (start/stop/restart, logs)
+- Full radio configuration (presets, channels, hardware profiles)
 - YAML config editor with templates
 - Hardware detection (USB, SPI HAT, I2C)
 - Real-time node monitoring
 - RF calculations (Haversine, Fresnel, FSPL, earth bulge)
+
+**Radio Configuration (TUI)**
+- Radio presets (SHORT_TURBO → LONG_SLOW)
+- Full 8-channel configuration with individual editing
+- Frequency Slot Calculator (djb2 hash algorithm)
+- Gateway templates (Standard, Turbo, MtnMesh)
+- Hardware config selection from available.d/
+
+**Network & Diagnostics (TUI)**
+- System diagnostics (services, hardware, logs, resources)
+- Network tools (ping, port scan, device discovery)
+- Site planner (range estimator, antenna guidelines)
 
 **Gateway Bridge**
 - Bidirectional Meshtastic-to-RNS messaging
@@ -117,7 +133,8 @@ MeshForge follows a **configuration over installation** philosophy. It connects 
 # Raspberry Pi / Debian
 sudo apt update
 sudo apt install -y python3-pip python3-gi python3-gi-cairo \
-    gir1.2-gtk-4.0 libadwaita-1-0 gir1.2-adw-1
+    gir1.2-gtk-4.0 libadwaita-1-0 gir1.2-adw-1 \
+    gir1.2-vte-2.91 libvte-2.91-gtk4-0  # For VTE taskbar icon
 
 pip3 install rich textual flask meshtastic --break-system-packages
 
@@ -128,7 +145,13 @@ sudo raspi-config nonint do_i2c 0
 # Run
 git clone https://github.com/Nursedude/meshforge.git
 cd meshforge
-sudo python3 src/launcher.py
+sudo python3 src/launcher_tui.py  # Recommended: raspi-config style TUI
+```
+
+**Desktop Integration**
+```bash
+sudo ./scripts/install-desktop.sh  # Installs icons, menu entries, VTE dependencies
+meshforge vte  # Launch with proper taskbar icon
 ```
 
 ---

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -3,9 +3,9 @@ MeshForge - LoRa Mesh Network Development & Operations Suite
 Version information and changelog
 """
 
-__version__ = "0.4.5-beta"
-__version_info__ = (0, 4, 5, 'beta')
-__release_date__ = "2026-01-08"
+__version__ = "0.4.6-beta"
+__version_info__ = (0, 4, 6, 'beta')
+__release_date__ = "2026-01-11"
 __app_name__ = "MeshForge"
 __app_description__ = "LoRa Mesh Network Development & Operations Suite"
 __app_tagline__ = "Build. Test. Deploy. Monitor."
@@ -14,6 +14,25 @@ __status__ = "beta"  # alpha=experimental, beta=testing, stable=production
 
 # Version history
 VERSION_HISTORY = [
+    {
+        "version": "0.4.6-beta",
+        "date": "2026-01-11",
+        "status": "beta",
+        "changes": [
+            "NEW: GTK4 VTE wrapper (launcher_vte.py) for proper taskbar icon",
+            "NEW: Frequency Slot Calculator with djb2 hash algorithm (TUI)",
+            "NEW: Full meshtasticd config in TUI (presets, hardware, channels, templates)",
+            "NEW: System Diagnostics menu in TUI (services, network, hardware, logs)",
+            "NEW: Network Tools menu in TUI (ping, port scan, discovery, interfaces)",
+            "NEW: Site Planner menu in TUI (range estimator, presets, antenna guidelines)",
+            "NEW: Full 8-channel configuration with individual editing",
+            "FIX: CommandResult.raw attribute error (added .raw property alias)",
+            "FIX: get_nodes() function added to commands/meshtastic.py",
+            "FIX: GTK auto-loads channels and shows all 8 slots in radio config",
+            "IMPROVED: VTE launcher uses proper app_id for taskbar icon",
+            "IMPROVED: Terminal launcher tries VTE first when display available",
+        ]
+    },
     {
         "version": "0.4.5-beta",
         "date": "2026-01-08",


### PR DESCRIPTION
Version 0.4.6-beta changes:
- NEW: GTK4 VTE wrapper for proper taskbar icon
- NEW: Frequency Slot Calculator with djb2 hash algorithm
- NEW: Full meshtasticd config in TUI (presets, hardware, channels)
- NEW: System Diagnostics, Network Tools, Site Planner in TUI
- NEW: Full 8-channel configuration with individual editing
- FIX: CommandResult.raw attribute error
- FIX: get_nodes() function in commands/meshtastic.py
- FIX: GTK auto-loads channels and shows all 8 slots

README updates:
- Updated interface table with TUI and VTE options
- Added Radio Configuration and Network/Diagnostics features
- Added VTE installation instructions
- Updated version badge to 0.4.6-beta