### PR TITLE
fix: Address code review issues in RNODE detection

### DIFF
--- a/src/commands/rnode.py
+++ b/src/commands/rnode.py
@@ -14,7 +14,6 @@ Usage:
 """
 
 import os
-import subprocess
 import logging
 import re
 from pathlib import Path
@@ -321,7 +320,12 @@ def check_rns_config(port: str) -> bool:
         from utils.paths import get_real_user_home
         config_path = get_real_user_home() / '.reticulum' / 'config'
     except ImportError:
-        config_path = Path.home() / '.reticulum' / 'config'
+        # Fallback: use SUDO_USER to avoid Path.home() returning /root
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user and sudo_user != 'root':
+            config_path = Path(f'/home/{sudo_user}') / '.reticulum' / 'config'
+        else:
+            config_path = Path.home() / '.reticulum' / 'config'
 
     if not config_path.exists():
         return False
@@ -329,7 +333,8 @@ def check_rns_config(port: str) -> bool:
     try:
         content = config_path.read_text()
         return port in content
-    except Exception:
+    except Exception as e:
+        logger.debug(f"Could not read RNS config at {config_path}: {e}")
         return False
 
 

--- a/tests/test_rnode_detection.py
+++ b/tests/test_rnode_detection.py
@@ -190,6 +190,28 @@ class TestCheckRnsConfig:
 
         assert result is False
 
+    def test_sudo_user_fallback(self):
+        """Use SUDO_USER when utils.paths import fails."""
+        # This test verifies the code doesn't crash when SUDO_USER is set
+        # The fallback path construction is tested implicitly
+        import os
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == 'utils.paths':
+                raise ImportError("Simulated import error")
+            return original_import(name, *args, **kwargs)
+
+        with patch.dict(os.environ, {'SUDO_USER': 'testuser'}):
+            with patch.object(builtins, '__import__', mock_import):
+                with patch('pathlib.Path.exists', return_value=False):
+                    # The function should not crash and should use SUDO_USER fallback
+                    result = check_rns_config('/dev/ttyUSB0')
+
+        assert result is False  # No config exists, but it didn't crash
+
 
 class TestDetectDevices:
     """Tests for detect_devices function."""


### PR DESCRIPTION
- Remove unused subprocess import
- Fix Path.home() bug: add SUDO_USER fallback when utils.paths unavailable
- Add debug logging for config read exceptions
- Add test for SUDO_USER fallback path