### PR TITLE
fix: Fix closure bug causing wrong component install

### DIFF
--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -285,7 +285,8 @@ class RNSPanel(Gtk.Box):
 
         # Action button
         action_btn = Gtk.Button(label="Install")
-        action_btn.connect("clicked", lambda b: self._install_component(component))
+        # Use default arg to capture component by value, not reference (closure bug fix)
+        action_btn.connect("clicked", lambda b, c=component: self._install_component(c))
         row.append(action_btn)
 
         # Store references for updates


### PR DESCRIPTION
The lambda in _create_component_row captured `component` by reference, not by value. This meant clicking ANY install button would always install the last component (meshchat) instead of the intended one.

Fix: Use default argument to capture component by value:
  lambda b, c=component: self._install_component(c)

This is a classic Python closure-in-loop bug.