### PR TITLE
fix: Fix pip install and closure bugs in components mixin

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -464,4 +464,51 @@ except (subprocess.TimeoutExpired, OSError):
 
 ---
 
-*Last updated: 2026-01-11 - Added issues #7-9 from gateway bridge CLI session*
+---
+
+## Issue #10: Lambda Closure Bug in Loops
+
+### Symptom
+Clicking different buttons (like Install buttons for different RNS components) always triggers the action for the **last** item in the loop, not the intended one.
+
+### Root Cause
+When creating lambdas inside a `for` loop, the loop variable is captured **by reference**, not by value:
+
+```python
+# WRONG - classic closure bug
+for component in self.COMPONENTS:
+    btn = Gtk.Button(label=component['name'])
+    btn.connect("clicked", lambda b: self._install(component))  # All buttons install last component!
+```
+
+By the time any button is clicked, `component` has the value from the last iteration.
+
+### Impact
+- Wrong component gets installed
+- Wrong action gets triggered
+- Debugging is confusing because logs show wrong item being processed
+
+### Proper Fix
+Use a **default argument** to capture the value at iteration time:
+
+```python
+# CORRECT - capture by value using default argument
+for component in self.COMPONENTS:
+    btn = Gtk.Button(label=component['name'])
+    btn.connect("clicked", lambda b, c=component: self._install(c))  # Each button gets its own copy
+```
+
+The `c=component` creates a new binding at each iteration, capturing the current value.
+
+### Files Fixed (2026-01-12)
+- [x] `src/gtk_ui/panels/rns.py:288` - Component install buttons
+- [x] `src/gtk_ui/panels/rns_mixins/components.py:107` - Component install buttons (mixin)
+
+### Prevention
+- Search for `lambda.*for.*in` or `connect.*lambda` patterns before committing
+- When using lambdas in loops, ALWAYS use default argument pattern
+- Code review should flag any `lambda b: self._method(loop_var)` inside loops
+
+---
+
+*Last updated: 2026-01-12 - Added issue #10 (lambda closure bug in loops)*

--- a/src/gtk_ui/panels/rns_mixins/components.py
+++ b/src/gtk_ui/panels/rns_mixins/components.py
@@ -104,7 +104,8 @@ class ComponentsMixin:
 
         # Action button
         action_btn = Gtk.Button(label="Install")
-        action_btn.connect("clicked", lambda b: self._install_component(component))
+        # Use default arg to capture component by value, not reference (closure bug fix)
+        action_btn.connect("clicked", lambda b, c=component: self._install_component(c))
         row.append(action_btn)
 
         # Store references for updates
@@ -120,7 +121,7 @@ class ComponentsMixin:
         try:
             result = subprocess.run(
                 ['python3', '-c', 'import RNS'],
-                capture_output=True, text=True
+                capture_output=True, text=True, timeout=10
             )
             return result.returncode == 0
         except Exception:
@@ -132,7 +133,7 @@ class ComponentsMixin:
             # Check for rnsd process
             result = subprocess.run(
                 ['pgrep', '-f', 'rnsd'],
-                capture_output=True, text=True
+                capture_output=True, text=True, timeout=5
             )
             return result.returncode == 0
         except Exception:
@@ -143,7 +144,7 @@ class ComponentsMixin:
         try:
             result = subprocess.run(
                 ['pip3', 'show', package],
-                capture_output=True, text=True
+                capture_output=True, text=True, timeout=10
             )
             if result.returncode == 0:
                 for line in result.stdout.split('\n'):
@@ -285,18 +286,19 @@ class ComponentsMixin:
                 is_root = os.geteuid() == 0
                 real_user = self._get_real_username()
 
-                # Build pip install command
-                pip_args = ['pip', 'install', '--upgrade', '--user',
-                           '--no-cache-dir', '--break-system-packages', package]
+                # Build pip install command using python3 -m pip for reliability
+                pip_install_args = ['install', '--upgrade', '--user',
+                                   '--no-cache-dir', '--break-system-packages', package]
 
                 # When running as root, install as the real user
                 if is_root and real_user != 'root':
-                    # Use sudo -i -u to get user's environment and install to their home
-                    cmd = ['sudo', '-i', '-u', real_user] + pip_args
+                    # Use sudo -H -u to run as user with their HOME set
+                    # python3 -m pip ensures we use the right pip
+                    cmd = ['sudo', '-H', '-u', real_user, 'python3', '-m', 'pip'] + pip_install_args
                     logger.debug(f"[RNS] Installing as user {real_user}: {' '.join(cmd)}")
                 else:
                     # Running as normal user, use python -m pip
-                    cmd = [sys.executable, '-m'] + pip_args
+                    cmd = [sys.executable, '-m', 'pip'] + pip_install_args
                     logger.debug(f"[RNS] Running: {' '.join(cmd)}")
 
                 result = subprocess.run(
@@ -364,16 +366,17 @@ class ComponentsMixin:
                 is_root = os.geteuid() == 0
                 real_user = self._get_real_username()
 
-                # Build pip install command
-                pip_args = ['pip', 'install', '--upgrade', '--user',
-                           '--no-cache-dir', '--break-system-packages'] + packages
+                # Build pip install command using python3 -m pip for reliability
+                pip_install_args = ['install', '--upgrade', '--user',
+                                   '--no-cache-dir', '--break-system-packages'] + packages
 
                 # When running as root, install as the real user
                 if is_root and real_user != 'root':
-                    cmd = ['sudo', '-i', '-u', real_user] + pip_args
+                    # Use sudo -H -u to run as user with their HOME set
+                    cmd = ['sudo', '-H', '-u', real_user, 'python3', '-m', 'pip'] + pip_install_args
                     logger.debug(f"[RNS] Installing as user {real_user}: {' '.join(cmd)}")
                 else:
-                    cmd = [sys.executable, '-m'] + pip_args
+                    cmd = [sys.executable, '-m', 'pip'] + pip_install_args
                     logger.debug(f"[RNS] Running: {' '.join(cmd)}")
 
                 result = subprocess.run(


### PR DESCRIPTION
Components mixin had same issues as main rns.py:
- Lambda closure bug: Install buttons always installed last component
- Broken pip command: Used 'pip' instead of 'python3 -m pip'
- Missing timeouts on subprocess calls

Also added Issue #10 to persistent_issues.md documenting the lambda closure bug pattern for future prevention.