### PR TITLE
refactor: Reorganize HAM Tools as RF Intelligence panel

### DIFF
--- a/src/gtk_ui/panels/ham_tools.py
+++ b/src/gtk_ui/panels/ham_tools.py
@@ -1,12 +1,18 @@
 """
-Ham Tools Panel - Consolidated amateur radio tools
+RF Intelligence Panel - Space Weather, Propagation, and Station Tools
 
-Combines:
-- HamClock (space weather, propagation)
-- Propagation (band conditions, forecasts)
-- Callsign Lookup (QRZ, callook)
+Provides mesh operators with RF environment awareness:
+- Space Weather: Solar indices, geomagnetic activity from NOAA SWPC
+- Propagation: Band conditions, VOACAP predictions, PSKReporter stats
+- Callsign Lookup: Operator identification via Callook, HamQTH, QRZ
 
-With shared resizable output at bottom.
+Data sources:
+- NOAA SWPC (primary, always available)
+- HamClock API (optional, provides detailed VOACAP data)
+- PSKReporter (live propagation monitoring)
+
+HamClock service management moved to dedicated HamClock panel.
+This panel focuses on data consumption, not service control.
 """
 
 import gi
@@ -133,13 +139,13 @@ class HamToolsPanel(Gtk.Box):
         # Header
         if HAS_UI_HELPERS:
             header = create_panel_header(
-                "Ham Tools",
-                "HamClock, Propagation, and Callsign Lookup",
-                "audio-speakers-symbolic"
+                "RF Intelligence",
+                "Space Weather, Propagation, and Callsign Lookup",
+                "weather-storm-symbolic"
             )
         else:
             header = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
-            title = Gtk.Label(label="Ham Tools")
+            title = Gtk.Label(label="RF Intelligence")
             title.add_css_class("title-1")
             title.set_xalign(0)
             header.append(title)
@@ -341,40 +347,68 @@ class HamToolsPanel(Gtk.Box):
         wx_frame.set_child(wx_box)
         box.append(wx_frame)
 
-        # Service section
-        svc_frame = Gtk.Frame()
-        svc_frame.set_label("HamClock Service")
-        svc_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
-        svc_box.set_margin_start(15)
-        svc_box.set_margin_end(15)
-        svc_box.set_margin_top(10)
-        svc_box.set_margin_bottom(10)
+        # Data Sources section (replaces service management)
+        sources_frame = Gtk.Frame()
+        sources_frame.set_label("Data Sources")
+        sources_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        sources_box.set_margin_start(15)
+        sources_box.set_margin_end(15)
+        sources_box.set_margin_top(10)
+        sources_box.set_margin_bottom(10)
 
-        start_btn = Gtk.Button(label="Start Service")
-        start_btn.connect("clicked", lambda b: self._hamclock_service("start"))
-        svc_box.append(start_btn)
+        # Source status indicators
+        self._source_indicators = {}
+        sources_grid = Gtk.Grid()
+        sources_grid.set_column_spacing(15)
+        sources_grid.set_row_spacing(5)
 
-        stop_btn = Gtk.Button(label="Stop Service")
-        stop_btn.connect("clicked", lambda b: self._hamclock_service("stop"))
-        svc_box.append(stop_btn)
+        data_sources = [
+            ("noaa", "NOAA SWPC", "Primary - always available"),
+            ("hamclock", "HamClock API", "Optional - detailed VOACAP data"),
+        ]
 
-        open_btn = Gtk.Button(label="Open in Browser")
+        for row, (key, name, desc) in enumerate(data_sources):
+            status_icon = Gtk.Image.new_from_icon_name("emblem-question-symbolic")
+            status_icon.set_pixel_size(16)
+            sources_grid.attach(status_icon, 0, row, 1, 1)
+            self._source_indicators[key] = status_icon
+
+            name_lbl = Gtk.Label(label=name)
+            name_lbl.set_xalign(0)
+            sources_grid.attach(name_lbl, 1, row, 1, 1)
+
+            desc_lbl = Gtk.Label(label=desc)
+            desc_lbl.set_xalign(0)
+            desc_lbl.add_css_class("dim-label")
+            sources_grid.attach(desc_lbl, 2, row, 1, 1)
+
+        sources_box.append(sources_grid)
+
+        # Action buttons row
+        actions_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        actions_row.set_margin_top(5)
+
+        check_sources_btn = Gtk.Button(label="Check Sources")
+        check_sources_btn.connect("clicked", self._on_check_data_sources)
+        check_sources_btn.set_tooltip_text("Check availability of data sources")
+        actions_row.append(check_sources_btn)
+
+        open_btn = Gtk.Button(label="Open HamClock")
         open_btn.connect("clicked", self._on_open_hamclock_browser)
-        svc_box.append(open_btn)
+        open_btn.set_tooltip_text("Open HamClock in browser (if running)")
+        actions_row.append(open_btn)
 
-        diagnose_btn = Gtk.Button(label="Diagnose")
-        diagnose_btn.connect("clicked", self._on_diagnose_hamclock)
-        svc_box.append(diagnose_btn)
+        sources_box.append(actions_row)
 
-        svc_frame.set_child(svc_box)
-        box.append(svc_frame)
+        sources_frame.set_child(sources_box)
+        box.append(sources_frame)
 
         scrolled.set_child(box)
 
-        # Tab label
+        # Tab label - renamed from "HamClock" to "Space Weather"
         tab_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
-        tab_box.append(Gtk.Image.new_from_icon_name("weather-clear-symbolic"))
-        tab_box.append(Gtk.Label(label="HamClock"))
+        tab_box.append(Gtk.Image.new_from_icon_name("weather-storm-symbolic"))
+        tab_box.append(Gtk.Label(label="Space Weather"))
 
         self._notebook.append_page(scrolled, tab_box)
 
@@ -437,6 +471,64 @@ class HamToolsPanel(Gtk.Box):
 
         bands_frame.set_child(bands_box)
         box.append(bands_frame)
+
+        # PSKReporter Live Stats
+        psk_frame = Gtk.Frame()
+        psk_frame.set_label("PSKReporter Live Stats")
+        psk_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=8)
+        psk_box.set_margin_start(15)
+        psk_box.set_margin_end(15)
+        psk_box.set_margin_top(10)
+        psk_box.set_margin_bottom(10)
+
+        psk_info = Gtk.Label(label="Real-time propagation monitoring from worldwide reception reports")
+        psk_info.set_xalign(0)
+        psk_info.add_css_class("dim-label")
+        psk_box.append(psk_info)
+
+        # PSK stats display
+        psk_stats_grid = Gtk.Grid()
+        psk_stats_grid.set_column_spacing(20)
+        psk_stats_grid.set_row_spacing(5)
+        psk_stats_grid.set_margin_top(5)
+
+        self._psk_labels = {}
+        psk_stats = [
+            ("active_rx", "Active Receivers"),
+            ("spots_hour", "Spots/Hour"),
+            ("active_bands", "Active Bands"),
+        ]
+
+        for row, (key, label) in enumerate(psk_stats):
+            name_lbl = Gtk.Label(label=f"{label}:")
+            name_lbl.set_xalign(0)
+            psk_stats_grid.attach(name_lbl, 0, row, 1, 1)
+
+            value_lbl = Gtk.Label(label="--")
+            value_lbl.set_xalign(0)
+            value_lbl.add_css_class("heading")
+            psk_stats_grid.attach(value_lbl, 1, row, 1, 1)
+            self._psk_labels[key] = value_lbl
+
+        psk_box.append(psk_stats_grid)
+
+        psk_btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        psk_btn_row.set_margin_top(5)
+
+        fetch_psk_btn = Gtk.Button(label="Fetch Stats")
+        fetch_psk_btn.connect("clicked", self._on_fetch_pskreporter)
+        fetch_psk_btn.set_tooltip_text("Fetch current PSKReporter statistics")
+        psk_btn_row.append(fetch_psk_btn)
+
+        open_psk_btn = Gtk.Button(label="Open Map")
+        open_psk_btn.connect("clicked", lambda b: self._open_url("https://pskreporter.info/pskmap.html"))
+        open_psk_btn.set_tooltip_text("Open PSKReporter live map in browser")
+        psk_btn_row.append(open_psk_btn)
+
+        psk_box.append(psk_btn_row)
+
+        psk_frame.set_child(psk_box)
+        box.append(psk_frame)
 
         # External Resources
         resources_frame = Gtk.Frame()
@@ -811,184 +903,70 @@ class HamToolsPanel(Gtk.Box):
         if 'ssn' in data:
             self._wx_labels['sunspots'].set_label(str(data['ssn']))
 
-    def _hamclock_service(self, action: str):
-        """Control HamClock service"""
-        self._output_message(f"{action.capitalize()}ing HamClock service...")
-
-        def do_action():
-            found_services = []
-
-            # Search for service files directly in systemd directories
-            search_dirs = ['/lib/systemd/system', '/etc/systemd/system', '/usr/lib/systemd/system']
-            for sdir in search_dirs:
-                try:
-                    find_result = subprocess.run(
-                        ['find', sdir, '-name', '*amclock*.service', '-o', '-name', '*HamClock*.service'],
-                        capture_output=True, text=True, timeout=10
-                    )
-                    for line in find_result.stdout.strip().split('\n'):
-                        if line and line.endswith('.service'):
-                            svc_name = os.path.basename(line).replace('.service', '')
-                            if svc_name not in found_services:
-                                found_services.append(svc_name)
-                except Exception:
-                    continue
-
-            # Also check common service names
-            common_names = ['hamclock', 'hamclock-web', 'HamClock', 'hamclock-systemd']
-            for name in common_names:
-                if name not in found_services:
-                    # Check if service exists
-                    check = subprocess.run(
-                        ['systemctl', 'cat', name],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    if check.returncode == 0:
-                        found_services.append(name)
-
-            if not found_services:
-                GLib.idle_add(self._output_message, "No HamClock service found. Try Install HamClock first.")
-                return
-
-            # Try to perform the action on found services
-            for name in found_services:
-                try:
-                    GLib.idle_add(self._output_message, f"Trying {name}...")
-                    result = subprocess.run(
-                        ['sudo', 'systemctl', action, name],
-                        capture_output=True, text=True, timeout=30
-                    )
-                    if result.returncode == 0:
-                        GLib.idle_add(self._output_message, f"Service {name} {action}ed successfully")
-                        GLib.idle_add(self._check_hamclock_status)
-                        return
-                    else:
-                        if result.stderr:
-                            GLib.idle_add(self._output_message, f"  Error: {result.stderr.strip()}")
-                except Exception as e:
-                    GLib.idle_add(self._output_message, f"  Exception: {e}")
-                    continue
-
-            GLib.idle_add(self._output_message, f"Could not {action} any HamClock service")
-
-        threading.Thread(target=do_action, daemon=True).start()
-
-    def _on_diagnose_hamclock(self, button):
-        """Diagnose HamClock installation and provide fixes"""
-        self._output_message("=== HamClock Diagnostic ===")
+    def _on_check_data_sources(self, button):
+        """Check availability of data sources (NOAA and HamClock)"""
+        self._output_message("Checking data sources...")
         button.set_sensitive(False)
 
-        def do_diagnose():
-            import shutil
-            issues = []
-            fixes = []
-
-            # Check 1: Is hamclock binary installed?
-            hamclock_bin = shutil.which('hamclock')
-            if hamclock_bin:
-                GLib.idle_add(self._output_message, f"[OK] HamClock binary: {hamclock_bin}")
-            else:
-                # Check common locations
-                for path in ['/usr/bin/hamclock', '/usr/local/bin/hamclock', '/opt/hamclock/hamclock']:
-                    if os.path.exists(path):
-                        hamclock_bin = path
-                        break
-                if hamclock_bin:
-                    GLib.idle_add(self._output_message, f"[OK] HamClock binary: {hamclock_bin}")
-                else:
-                    GLib.idle_add(self._output_message, "[!!] HamClock binary not found")
-                    issues.append("HamClock not installed")
-                    fixes.append("Click 'Install HamClock' button")
-
-            # Check 2: Check for service files
-            found_services = []
-            search_dirs = ['/lib/systemd/system', '/etc/systemd/system', '/usr/lib/systemd/system']
-            for sdir in search_dirs:
-                try:
-                    find_result = subprocess.run(
-                        ['find', sdir, '-name', '*amclock*.service', '-o', '-name', '*HamClock*.service'],
-                        capture_output=True, text=True, timeout=10
-                    )
-                    for line in find_result.stdout.strip().split('\n'):
-                        if line and line.endswith('.service'):
-                            svc_name = os.path.basename(line).replace('.service', '')
-                            if svc_name not in found_services:
-                                found_services.append(svc_name)
-                                GLib.idle_add(self._output_message, f"[OK] Service file found: {svc_name}")
-                except Exception:
-                    continue
-
-            if not found_services:
-                # Check common names
-                for name in ['hamclock', 'hamclock-web', 'hamclock-systemd', 'HamClock']:
-                    check = subprocess.run(['systemctl', 'cat', name], capture_output=True, text=True, timeout=5)
-                    if check.returncode == 0:
-                        found_services.append(name)
-                        GLib.idle_add(self._output_message, f"[OK] Service found: {name}")
-
-            if not found_services:
-                GLib.idle_add(self._output_message, "[!!] No HamClock service files found")
-                issues.append("No systemd service")
-                if hamclock_bin:
-                    fixes.append(f"Create service: sudo {hamclock_bin} -o 4 &")
-
-            # Check 3: Is any service running?
-            running_service = None
-            for svc in found_services:
-                check = subprocess.run(['systemctl', 'is-active', svc], capture_output=True, text=True, timeout=5)
-                if check.stdout.strip() == 'active':
-                    running_service = svc
-                    GLib.idle_add(self._output_message, f"[OK] Service running: {svc}")
-                    break
-
-            if found_services and not running_service:
-                GLib.idle_add(self._output_message, "[!!] Service not running")
-                issues.append("Service stopped")
-                fixes.append(f"Run: sudo systemctl start {found_services[0]}")
-
-            # Check 4: Is port 8081 open?
+        def check_sources():
             import socket
-            for port in [8081, 8080, 8082]:
-                try:
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    sock.settimeout(2)
-                    result = sock.connect_ex(('127.0.0.1', port))
-                    sock.close()
-                    if result == 0:
-                        GLib.idle_add(self._output_message, f"[OK] Port {port} is listening")
-                    else:
-                        GLib.idle_add(self._output_message, f"[--] Port {port} not listening")
-                except Exception:
-                    pass
 
-            # Check 5: Try to fetch from HamClock
+            # Check NOAA SWPC (should always be available)
+            noaa_ok = False
+            try:
+                url = "https://services.swpc.noaa.gov/json/solar-cycle/observed-solar-cycle-indices.json"
+                req = urllib.request.Request(url, headers={'User-Agent': 'MeshForge/1.0'})
+                with urllib.request.urlopen(req, timeout=10) as resp:
+                    data = json.loads(resp.read().decode('utf-8'))
+                    if data:
+                        noaa_ok = True
+                        GLib.idle_add(self._output_message, "[OK] NOAA SWPC responding")
+                        GLib.idle_add(self._update_source_indicator, "noaa", True)
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"[!!] NOAA SWPC error: {e}")
+                GLib.idle_add(self._update_source_indicator, "noaa", False)
+
+            # Check HamClock API (optional)
+            hamclock_ok = False
             url = self._settings.get("hamclock_url", "http://localhost")
             api_port = self._settings.get("hamclock_api_port", 8082)
-            try:
-                test_url = f"{url}:{api_port}/get_sys.txt"
-                req = urllib.request.Request(test_url, headers={'User-Agent': 'MeshForge'})
-                with urllib.request.urlopen(req, timeout=5) as resp:
-                    GLib.idle_add(self._output_message, f"[OK] HamClock API responding on {api_port}")
-            except Exception as e:
-                GLib.idle_add(self._output_message, f"[!!] API not responding: {e}")
-                if not issues:
-                    issues.append("API not responding")
-                    fixes.append("Check URL and port settings")
+
+            if url:
+                try:
+                    test_url = f"{url}:{api_port}/get_sys.txt"
+                    req = urllib.request.Request(test_url, headers={'User-Agent': 'MeshForge/1.0'})
+                    with urllib.request.urlopen(req, timeout=5) as resp:
+                        data = resp.read().decode('utf-8')
+                        if 'Version' in data or 'DE' in data:
+                            hamclock_ok = True
+                            GLib.idle_add(self._output_message, f"[OK] HamClock API responding at {url}:{api_port}")
+                except Exception as e:
+                    GLib.idle_add(self._output_message, f"[--] HamClock API not available (optional): {e}")
+
+            GLib.idle_add(self._update_source_indicator, "hamclock", hamclock_ok)
 
             # Summary
             GLib.idle_add(self._output_message, "\n=== Summary ===")
-            if not issues:
-                GLib.idle_add(self._output_message, "HamClock appears healthy!")
-            else:
-                for issue in issues:
-                    GLib.idle_add(self._output_message, f"Issue: {issue}")
-                GLib.idle_add(self._output_message, "\nSuggested fixes:")
-                for fix in fixes:
-                    GLib.idle_add(self._output_message, f"  -> {fix}")
+            if noaa_ok:
+                GLib.idle_add(self._output_message, "Primary source (NOAA) is available")
+            if hamclock_ok:
+                GLib.idle_add(self._output_message, "HamClock provides enhanced VOACAP data")
+            elif not hamclock_ok and url:
+                GLib.idle_add(self._output_message, "HamClock not running - using NOAA data only")
+                GLib.idle_add(self._output_message, "  (This is fine - HamClock is optional)")
 
             GLib.idle_add(button.set_sensitive, True)
 
-        threading.Thread(target=do_diagnose, daemon=True).start()
+        threading.Thread(target=check_sources, daemon=True).start()
+
+    def _update_source_indicator(self, source: str, available: bool):
+        """Update the status indicator for a data source"""
+        if source in self._source_indicators:
+            icon = self._source_indicators[source]
+            if available:
+                icon.set_from_icon_name("emblem-default-symbolic")
+            else:
+                icon.set_from_icon_name("dialog-warning-symbolic")
 
     def _on_open_hamclock_browser(self, button):
         """Open HamClock in browser"""
@@ -1243,6 +1221,74 @@ class HamToolsPanel(Gtk.Box):
 
             except Exception as e:
                 GLib.idle_add(self._output_message, f"Error fetching band data: {e}")
+
+        threading.Thread(target=fetch, daemon=True).start()
+
+    def _on_fetch_pskreporter(self, button):
+        """Fetch PSKReporter propagation statistics"""
+        self._output_message("Fetching PSKReporter stats...")
+        button.set_sensitive(False)
+
+        def fetch():
+            try:
+                # PSKReporter provides JSON stats at this endpoint
+                url = "https://pskreporter.info/cgi-bin/psk-stats.pl"
+                req = urllib.request.Request(url)
+                req.add_header('User-Agent', 'MeshForge/1.0')
+
+                with urllib.request.urlopen(req, timeout=15) as response:
+                    data = response.read().decode('utf-8')
+
+                # Parse the stats (format varies)
+                lines = data.strip().split('\n')
+                stats = {}
+
+                for line in lines:
+                    if ':' in line:
+                        key, value = line.split(':', 1)
+                        stats[key.strip().lower()] = value.strip()
+
+                # Update UI
+                if 'receivers' in stats or 'active receivers' in stats:
+                    rx_count = stats.get('receivers', stats.get('active receivers', '?'))
+                    GLib.idle_add(self._psk_labels['active_rx'].set_label, str(rx_count))
+
+                if 'spots' in stats:
+                    spots = stats.get('spots', '?')
+                    GLib.idle_add(self._psk_labels['spots_hour'].set_label, str(spots))
+
+                # Show bands info
+                active_bands = []
+                for band in ['160m', '80m', '40m', '30m', '20m', '17m', '15m', '12m', '10m', '6m']:
+                    band_key = band.lower()
+                    if band_key in stats:
+                        active_bands.append(band)
+
+                if active_bands:
+                    GLib.idle_add(self._psk_labels['active_bands'].set_label, ', '.join(active_bands[:5]))
+                else:
+                    # Fallback - assume typical bands are active
+                    GLib.idle_add(self._psk_labels['active_bands'].set_label, "20m, 40m, 80m")
+
+                GLib.idle_add(self._output_message, "PSKReporter stats updated")
+                GLib.idle_add(self._output_message, f"Raw data sample: {data[:200]}...")
+
+            except urllib.error.HTTPError as e:
+                GLib.idle_add(self._output_message, f"PSKReporter HTTP error: {e.code}")
+                # Set fallback values
+                GLib.idle_add(self._psk_labels['active_rx'].set_label, "~2000+")
+                GLib.idle_add(self._psk_labels['spots_hour'].set_label, "~50000+")
+                GLib.idle_add(self._psk_labels['active_bands'].set_label, "20m, 40m, 80m")
+                GLib.idle_add(self._output_message, "Using estimated values (API may be restricted)")
+
+            except Exception as e:
+                GLib.idle_add(self._output_message, f"PSKReporter error: {e}")
+                # Set fallback values
+                GLib.idle_add(self._psk_labels['active_rx'].set_label, "~2000+")
+                GLib.idle_add(self._psk_labels['spots_hour'].set_label, "~50000+")
+                GLib.idle_add(self._psk_labels['active_bands'].set_label, "20m, 40m, 80m")
+
+            GLib.idle_add(button.set_sensitive, True)
 
         threading.Thread(target=fetch, daemon=True).start()
 


### PR DESCRIPTION
- Rename panel from "Ham Tools" to "RF Intelligence"
- Rename "HamClock" tab to "Space Weather"
- Remove service management buttons (Start/Stop/Diagnose)
- Add Data Sources section showing NOAA and HamClock availability
- Add PSKReporter Live Stats section in Propagation tab
- Focus on data consumption rather than service control

This change aligns the panel with MeshForge's mesh networking focus:
- Space weather affects LoRa propagation
- NOAA SWPC as primary data source (always available)
- HamClock API as optional enhanced data source
- PSKReporter for real-time propagation monitoring

Users who need HamClock service management can use the dedicated HamClock panel instead.