### PR TITLE
fix: Handle BaseException in GTK panels for RNS/meshtastic imports

### DIFF
--- a/src/gtk_ui/dialogs/gateway_wizard.py
+++ b/src/gtk_ui/dialogs/gateway_wizard.py
@@ -533,6 +533,10 @@ class GatewaySetupWizard(Adw.Window):
                 results.append("✓ RNS library - Available")
             except ImportError:
                 results.append("✗ RNS library - Not installed")
+            except (SystemExit, KeyboardInterrupt, GeneratorExit):
+                raise
+            except BaseException as e:
+                results.append(f"✗ RNS library - Error: {e}")
 
             GLib.idle_add(self._update_connection_result, results)
 

--- a/src/gtk_ui/panels/diagnostics.py
+++ b/src/gtk_ui/panels/diagnostics.py
@@ -773,6 +773,12 @@ class DiagnosticsPanel(Gtk.Box):
             results.append("[FAIL] RNS module not installed")
             results.append("  FIX: pip install rns")
             return results
+        except (SystemExit, KeyboardInterrupt, GeneratorExit):
+            raise
+        except BaseException as e:
+            results.append(f"[FAIL] RNS import error: {e}")
+            results.append("  FIX: pip install --upgrade rns cffi")
+            return results
 
         # Check rnsd
         try:

--- a/src/gtk_ui/panels/mesh_tools.py
+++ b/src/gtk_ui/panels/mesh_tools.py
@@ -1373,8 +1373,11 @@ class MeshToolsPanel(Gtk.Box):
                     except ImportError:
                         GLib.idle_add(self._log_message, "Meshtastic Python library not installed")
                         GLib.idle_add(self._log_message, "Install with: pip install meshtastic")
-                    except Exception as e:
-                        GLib.idle_add(self._log_message, f"TCP connection error: {e}")
+                    except (SystemExit, KeyboardInterrupt, GeneratorExit):
+                        raise
+                    except BaseException as e:
+                        # Catch pyo3 PanicException and other crashes
+                        GLib.idle_add(self._log_message, f"Meshtastic error: {e}")
                     finally:
                         # Always close interface and release lock
                         if interface:

--- a/src/gtk_ui/panels/rns_mixins/gateway.py
+++ b/src/gtk_ui/panels/rns_mixins/gateway.py
@@ -364,7 +364,10 @@ class GatewayMixin:
             except ImportError as e:
                 logger.debug(f"[RNS] Gateway start failed - missing module: {e}")
                 GLib.idle_add(self._gateway_start_complete, False, f"Missing module: {e}")
-            except Exception as e:
+            except (SystemExit, KeyboardInterrupt, GeneratorExit):
+                raise
+            except BaseException as e:
+                # Catch pyo3 PanicException and other crashes
                 logger.debug(f"[RNS] Gateway start exception: {e}")
                 GLib.idle_add(self._gateway_start_complete, False, str(e))
 


### PR DESCRIPTION
Added proper BaseException handling to prevent GTK crashes when:
- RNS import triggers pyo3 PanicException (cryptography issues)
- Meshtastic import fails with non-ImportError exceptions

Fixed crash points in:
- gateway_wizard.py: RNS availability test
- diagnostics.py: RNS connection test
- mesh_tools.py: Node list refresh via meshtastic
- rns_mixins/gateway.py: Gateway bridge startup

Pattern: catch ImportError first, re-raise critical exceptions (SystemExit, KeyboardInterrupt, GeneratorExit), then catch BaseException.