### PR TITLE
fix: Add timer cleanup to prevent GTK panel crashes

### DIFF
--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -86,8 +86,34 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
         self.set_margin_bottom(20)
 
         self._component_status = {}
+
+        # Track timer IDs for cleanup (prevents crashes on panel destruction)
+        self._pending_timers = []
+
+        # Connect cleanup handler
+        self.connect("unrealize", self._on_unrealize)
+
         self._build_ui()
         self._refresh_all()
+
+    def _on_unrealize(self, widget):
+        """Clean up when panel is destroyed to prevent timer crashes."""
+        # Cancel all pending timers
+        for timer_id in self._pending_timers:
+            try:
+                GLib.source_remove(timer_id)
+            except Exception:
+                pass
+        self._pending_timers.clear()
+
+    def _schedule_timer(self, delay_ms: int, callback, *args):
+        """Schedule a timer and track it for cleanup."""
+        if args:
+            timer_id = GLib.timeout_add(delay_ms, callback, *args)
+        else:
+            timer_id = GLib.timeout_add(delay_ms, callback)
+        self._pending_timers.append(timer_id)
+        return timer_id
 
     def _build_ui(self):
         """Build the RNS panel UI"""

--- a/src/gtk_ui/panels/rns_mixins/components.py
+++ b/src/gtk_ui/panels/rns_mixins/components.py
@@ -393,7 +393,10 @@ class ComponentsMixin:
             self.main_window.set_status_message(msg)
 
         # Refresh status after a short delay to not overwrite the message
-        GLib.timeout_add(2000, self._refresh_all)
+        if hasattr(self, '_schedule_timer'):
+            self._schedule_timer(2000, self._refresh_all)
+        else:
+            GLib.timeout_add(2000, self._refresh_all)
         return False
 
     def _on_install_all(self, button):
@@ -464,7 +467,10 @@ class ComponentsMixin:
             self.main_window.set_status_message(msg)
 
         # Refresh status after a short delay to not overwrite the message
-        GLib.timeout_add(2000, self._refresh_all)
+        if hasattr(self, '_schedule_timer'):
+            self._schedule_timer(2000, self._refresh_all)
+        else:
+            GLib.timeout_add(2000, self._refresh_all)
         return False
 
     def _on_update_all(self, button):

--- a/src/gtk_ui/panels/rns_mixins/rnode.py
+++ b/src/gtk_ui/panels/rns_mixins/rnode.py
@@ -450,11 +450,14 @@ class RNodeMixin:
         config_frame.set_child(config_box)
         parent.append(config_frame)
 
-        # Load config preview after UI is built
-        GLib.timeout_add(2000, self._load_config_preview)
-
-        # Try to load current config
-        GLib.timeout_add(1500, self._load_rnode_config)
+        # Load config preview after UI is built (use tracked timer for cleanup)
+        if hasattr(self, '_schedule_timer'):
+            self._schedule_timer(2000, self._load_config_preview)
+            self._schedule_timer(1500, self._load_rnode_config)
+        else:
+            # Fallback for standalone use
+            GLib.timeout_add(2000, self._load_config_preview)
+            GLib.timeout_add(1500, self._load_rnode_config)
 
     def _load_rnode_config(self, button=None):
         """Load RNode config from ~/.reticulum/config"""


### PR DESCRIPTION
- Add _pending_timers tracking and _on_unrealize cleanup to RNSPanel
- Add _schedule_timer helper for tracked timer creation
- Update rnode.py mixin to use tracked timers for config preview/load
- Update components.py mixin to use tracked timers for refresh

Fixes crashes when switching away from RNS Radio Configuration panel while background timers are still pending.