### PR TITLE
fix: Track all timers in RNS mixins to prevent GTK crashes

### DIFF
--- a/src/gtk_ui/panels/rns_mixins/config.py
+++ b/src/gtk_ui/panels/rns_mixins/config.py
@@ -254,8 +254,11 @@ loglevel = 4
             logger.debug(f"[RNS] Created default RNS config: {config_path}")
             self.main_window.set_status_message("Created default RNS config")
 
-            # Refresh the panel to show the config exists now
-            GLib.timeout_add(500, self._refresh_panel)
+            # Refresh the panel to show the config exists now (use tracked timer)
+            if hasattr(self, '_schedule_timer'):
+                self._schedule_timer(500, self._refresh_panel)
+            else:
+                GLib.timeout_add(500, self._refresh_panel)
 
         except Exception as e:
             logger.debug(f"[RNS] Failed to create default config: {e}")

--- a/src/gtk_ui/panels/rns_mixins/meshchat.py
+++ b/src/gtk_ui/panels/rns_mixins/meshchat.py
@@ -148,8 +148,11 @@ class MeshChatMixin:
         frame.set_child(box)
         parent.append(frame)
 
-        # Check status on load
-        GLib.timeout_add(600, self._check_meshchat_status)
+        # Check status on load (use tracked timer)
+        if hasattr(self, '_schedule_timer'):
+            self._schedule_timer(600, self._check_meshchat_status)
+        else:
+            GLib.timeout_add(600, self._check_meshchat_status)
 
     def _find_meshchat(self):
         """Find meshchat executable"""

--- a/src/gtk_ui/panels/rns_mixins/nomadnet.py
+++ b/src/gtk_ui/panels/rns_mixins/nomadnet.py
@@ -171,8 +171,11 @@ class NomadNetMixin:
         frame.set_child(box)
         parent.append(frame)
 
-        # Check status on load
-        GLib.timeout_add(500, self._check_nomadnet_status)
+        # Check status on load (use tracked timer for cleanup)
+        if hasattr(self, '_schedule_timer'):
+            self._schedule_timer(500, self._check_nomadnet_status)
+        else:
+            GLib.timeout_add(500, self._check_nomadnet_status)
 
     def _find_nomadnet(self):
         """Find nomadnet executable, checking user local bin if running as root"""
@@ -286,8 +289,15 @@ class NomadNetMixin:
         # Disable button immediately to prevent double-clicks
         if mode == "textui" and hasattr(self, 'nomadnet_textui_btn'):
             self.nomadnet_textui_btn.set_sensitive(False)
-            # Re-enable after 2 seconds
-            GLib.timeout_add(2000, lambda: self.nomadnet_textui_btn.set_sensitive(True) or False)
+            # Re-enable after 2 seconds (use tracked timer)
+            def re_enable_btn():
+                if hasattr(self, 'nomadnet_textui_btn'):
+                    self.nomadnet_textui_btn.set_sensitive(True)
+                return False
+            if hasattr(self, '_schedule_timer'):
+                self._schedule_timer(2000, re_enable_btn)
+            else:
+                GLib.timeout_add(2000, re_enable_btn)
 
         nomadnet_path = self._find_nomadnet()
         if not nomadnet_path:
@@ -347,7 +357,14 @@ class NomadNetMixin:
                 if stopped_something:
                     self.main_window.set_status_message("Releasing RNS ports...")
                     time.sleep(2.0)  # Wait for TIME_WAIT to clear
-                    GLib.timeout_add(3000, lambda: self._refresh_all() or False)
+                    # Use tracked timer for cleanup
+                    def do_refresh():
+                        self._refresh_all()
+                        return False
+                    if hasattr(self, '_schedule_timer'):
+                        self._schedule_timer(3000, do_refresh)
+                    else:
+                        GLib.timeout_add(3000, do_refresh)
 
                 # Build the terminal command - wrap in bash to keep terminal open on exit
                 # Check for ~/CONFIG first (custom RNS setup), fallback to ~/.nomadnetwork
@@ -417,8 +434,11 @@ class NomadNetMixin:
                 )
                 self.main_window.set_status_message("NomadNet daemon started")
                 logger.debug(f"[RNS] NomadNet daemon started (user: {real_user})")
-                # Refresh status after a moment
-                GLib.timeout_add(1000, self._check_nomadnet_status)
+                # Refresh status after a moment (use tracked timer)
+                if hasattr(self, '_schedule_timer'):
+                    self._schedule_timer(1000, self._check_nomadnet_status)
+                else:
+                    GLib.timeout_add(1000, self._check_nomadnet_status)
         except Exception as e:
             logger.debug(f"[RNS] Failed to launch NomadNet: {e}")
             self.main_window.set_status_message(f"Failed: {e}")
@@ -431,8 +451,11 @@ class NomadNetMixin:
             if result.returncode == 0:
                 self.main_window.set_status_message("NomadNet daemon stopped")
                 logger.debug("[RNS] NomadNet stopped")
-                # Refresh status
-                GLib.timeout_add(500, self._check_nomadnet_status)
+                # Refresh status (use tracked timer)
+                if hasattr(self, '_schedule_timer'):
+                    self._schedule_timer(500, self._check_nomadnet_status)
+                else:
+                    GLib.timeout_add(500, self._check_nomadnet_status)
             else:
                 self.main_window.set_status_message("NomadNet was not running")
         except Exception as e:


### PR DESCRIPTION
Fixed 7 untracked timers across RNS mixins:
- nomadnet.py: 5 timers now use _schedule_timer with fallback
- meshchat.py: 1 timer now uses _schedule_timer with fallback
- config.py: 1 timer now uses _schedule_timer with fallback

All timers now check for _schedule_timer (parent panel's tracked timer method) and fall back to GLib.timeout_add only if not available. This ensures timers are cancelled when the panel is destroyed, preventing crashes from callbacks firing on dead widgets.

Pattern used:
    if hasattr(self, '_schedule_timer'):
        self._schedule_timer(delay, callback)
    else:
        GLib.timeout_add(delay, callback)