### PR TITLE
fix: Socket leak fixes in utility modules to prevent errno 24

### DIFF
--- a/src/utils/connections.py
+++ b/src/utils/connections.py
@@ -384,11 +384,11 @@ def detect_devices() -> List[dict]:
 
     # Check for meshtasticd
     import socket
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)
         result = sock.connect_ex(('127.0.0.1', 4403))
-        sock.close()
         if result == 0:
             devices.append({
                 'mode': ConnectionMode.TCP,
@@ -397,5 +397,11 @@ def detect_devices() -> List[dict]:
             })
     except Exception:
         pass
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     return devices

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -576,14 +576,20 @@ class GatewayDiagnostic:
 
     def check_tcp_port(self, host: str, port: int) -> bool:
         """Check if a TCP port is open."""
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(2)
             result = sock.connect_ex((host, port))
-            sock.close()
             return result == 0
         except Exception:
             return False
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     def check_rns_port_available(self, port: int = 29716) -> CheckResult:
         """Check if RNS AutoInterface UDP port is available for binding."""
@@ -714,12 +720,12 @@ def check_rns_port_available(port: int = 29716) -> Dict[str, any]:
     }
 
     # First try to bind to the port
+    sock = None
     try:
         # Try IPv6 first (covers IPv4 on most systems)
         sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         sock.bind(('::', port))
-        sock.close()
     except OSError as e:
         if e.errno == 98:  # Address already in use
             result['available'] = False
@@ -743,11 +749,19 @@ def check_rns_port_available(port: int = 29716) -> Dict[str, any]:
                 )
         else:
             # Try IPv4 fallback
+            # First close any existing socket
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+                sock = None
+
+            sock4 = None
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-                sock.bind(('0.0.0.0', port))
-                sock.close()
+                sock4 = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock4.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                sock4.bind(('0.0.0.0', port))
             except OSError as e2:
                 if e2.errno == 98:
                     result['available'] = False
@@ -757,6 +771,18 @@ def check_rns_port_available(port: int = 29716) -> Dict[str, any]:
                     result['fix_hint'] = (
                         f"Kill existing RNS process or stop rnsd: pkill -f rnsd"
                     )
+            finally:
+                if sock4:
+                    try:
+                        sock4.close()
+                    except Exception:
+                        pass
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     return result
 

--- a/src/utils/network_diag.py
+++ b/src/utils/network_diag.py
@@ -25,14 +25,20 @@ except ImportError:
         # Fallback implementation
         def check_port(port: int, host: str = 'localhost') -> bool:
             import socket
+            sock = None
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(1)
                 result = sock.connect_ex((host, port))
-                sock.close()
                 return result == 0
             except (socket.error, OSError):
                 return False
+            finally:
+                if sock:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
 
 # TCP state mapping (hex to name)
 TCP_STATES = {

--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -401,12 +401,12 @@ class NetworkDiagnostics:
 
     def _check_meshtasticd_health(self):
         """Check meshtasticd service health."""
+        sock = None
         try:
             # Check if port 4403 is open
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(2.0)
             result = sock.connect_ex(('localhost', 4403))
-            sock.close()
 
             if result == 0:
                 self.update_health(
@@ -424,6 +424,12 @@ class NetworkDiagnostics:
                 "meshtasticd", HealthStatus.UNKNOWN,
                 f"Check failed: {e}"
             )
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     def _check_rns_health(self):
         """Check RNS/Reticulum health."""
@@ -515,12 +521,12 @@ class NetworkDiagnostics:
 
     def _check_network_health(self):
         """Check network connectivity health."""
+        sock = None
         try:
             # Check internet connectivity
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(3.0)
             result = sock.connect_ex(('8.8.8.8', 53))
-            sock.close()
 
             if result == 0:
                 self.update_health(
@@ -538,6 +544,12 @@ class NetworkDiagnostics:
                 "internet", HealthStatus.UNKNOWN,
                 f"Check failed: {e}"
             )
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     # ==================== Event Queries ====================
 

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -98,15 +98,21 @@ def check_port(port: int, host: str = 'localhost', timeout: float = 2.0) -> bool
     Returns:
         True if port is open, False otherwise
     """
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(timeout)
         result = sock.connect_ex((host, port))
-        sock.close()
         return result == 0
     except (socket.error, OSError) as e:
         logger.debug(f"Port check failed for {host}:{port}: {e}")
         return False
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
 
 def check_systemd_service(service_name: str) -> Tuple[bool, bool]:


### PR DESCRIPTION
Fixed socket leaks in:
- service_check.py: check_port() now uses try/finally
- gateway_diagnostic.py: check_tcp_port() and check_rns_port_available()
- network_diag.py: fallback check_port() implementation
- network_diagnostics.py: _check_meshtasticd_health() and _check_network_health()
- connections.py: meshtasticd device discovery

These were causing "Too many open files" (errno 24) errors when sockets weren't closed on exception paths.