### PR TITLE
fix: Critical file handle and process pipe leaks causing errno 24

### DIFF
--- a/src/main_gtk.py
+++ b/src/main_gtk.py
@@ -338,14 +338,21 @@ def daemonize():
     env['MESHTASTICD_DAEMON'] = '1'  # Mark as daemon
 
     # Start new process detached from terminal
-    proc = subprocess.Popen(
-        [sys.executable, script_path],
-        stdin=subprocess.DEVNULL,
-        stdout=open('/tmp/meshtasticd-manager.log', 'a'),
-        stderr=subprocess.STDOUT,
-        start_new_session=True,
-        env=env
-    )
+    # Open log file and ensure it's closed in parent after fork
+    log_file = open('/tmp/meshtasticd-manager.log', 'a')
+    try:
+        proc = subprocess.Popen(
+            [sys.executable, script_path],
+            stdin=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=env
+        )
+    finally:
+        # Close the file handle in the parent process
+        # The child process inherits and keeps its own copy
+        log_file.close()
 
     print(f"MeshForge started in background (PID: {proc.pid})")
     print(f"Log: /tmp/meshtasticd-manager.log")

--- a/src/utils/progress.py
+++ b/src/utils/progress.py
@@ -103,6 +103,7 @@ def run_with_live_progress(command, description, shell=False, timeout=600):
     ) as progress:
         task = progress.add_task(description, total=100)
 
+        process = None
         try:
             process = subprocess.Popen(
                 command,
@@ -153,7 +154,9 @@ def run_with_live_progress(command, description, shell=False, timeout=600):
             }
 
         except subprocess.TimeoutExpired:
-            process.kill()
+            if process:
+                process.kill()
+                process.wait()  # Reap the process
             return {
                 'success': False,
                 'stdout': ''.join(stdout_lines),
@@ -161,6 +164,12 @@ def run_with_live_progress(command, description, shell=False, timeout=600):
                 'returncode': -1
             }
         except Exception as e:
+            if process:
+                try:
+                    process.kill()
+                    process.wait()
+                except Exception:
+                    pass
             return {
                 'success': False,
                 'stdout': ''.join(stdout_lines),

--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -424,30 +424,55 @@ def run_command(command, shell=False, capture_output=True, stream_output=False, 
 
         if stream_output:
             # Stream output in real-time for better user feedback
-            process = subprocess.Popen(
-                command,
-                shell=shell,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-                bufsize=1,
-                universal_newlines=True
-            )
-
+            process = None
             stdout_lines = []
-            for line in process.stdout:
-                print(line, end='')
-                stdout_lines.append(line)
+            try:
+                process = subprocess.Popen(
+                    command,
+                    shell=shell,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                    bufsize=1,
+                    universal_newlines=True
+                )
 
-            process.wait(timeout=300)
-            stdout = ''.join(stdout_lines)
+                for line in process.stdout:
+                    print(line, end='')
+                    stdout_lines.append(line)
 
-            return {
-                'returncode': process.returncode,
-                'stdout': stdout,
-                'stderr': '',
-                'success': process.returncode == 0
-            }
+                process.wait(timeout=300)
+                stdout = ''.join(stdout_lines)
+
+                return {
+                    'returncode': process.returncode,
+                    'stdout': stdout,
+                    'stderr': '',
+                    'success': process.returncode == 0
+                }
+            except subprocess.TimeoutExpired:
+                if process:
+                    process.kill()
+                    process.wait()
+                return {
+                    'returncode': -1,
+                    'stdout': ''.join(stdout_lines),
+                    'stderr': 'Command timed out',
+                    'success': False
+                }
+            except Exception as e:
+                if process:
+                    try:
+                        process.kill()
+                        process.wait()
+                    except Exception:
+                        pass
+                return {
+                    'returncode': -1,
+                    'stdout': ''.join(stdout_lines),
+                    'stderr': str(e),
+                    'success': False
+                }
         else:
             # Build subprocess arguments
             run_kwargs = {


### PR DESCRIPTION
ROOT CAUSE IDENTIFIED:
- main_gtk.py line 344: open() file handle passed to Popen was never closed in parent process, leaking one FD per daemon spawn

FIXES:
1. main_gtk.py: Close log file handle in parent after Popen fork
2. utils/progress.py: Add process cleanup in exception handlers
3. utils/system.py: Add try/finally for streaming subprocess output
4. rns_mixins/*: Restore hasattr checks for _schedule_timer safety

These leaks accumulated over time, eventually hitting the file descriptor limit and causing errno 24 "too many open files".