### PR TITLE
fix: Critical socket leak fixes causing errno 24 (too many open files)

### DIFF
--- a/src/commands/service.py
+++ b/src/commands/service.py
@@ -134,14 +134,20 @@ def check_status(name: str, port: Optional[int] = None) -> CommandResult:
     port_open = False
     if check_port:
         import socket
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(2.0)
             result = sock.connect_ex(('localhost', check_port))
-            sock.close()
             port_open = result == 0
         except (socket.error, OSError):
             pass
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     if not is_running:
         status_detail = "Stopped"

--- a/src/main_web.py
+++ b/src/main_web.py
@@ -379,15 +379,21 @@ def check_service_status():
 
     # Method 3: TCP port
     if not is_running:
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1.0)
             if sock.connect_ex(('localhost', 4403)) == 0:
                 is_running = True
                 status_detail = "Running (TCP 4403)"
-            sock.close()
         except Exception:
             pass
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     return is_running, status_detail
 
@@ -522,15 +528,21 @@ def get_radio_info(use_cache=True):
         return {'error': 'Meshtastic CLI not found. Install with: pipx install meshtastic'}
 
     # Check if port is reachable first (quick check)
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(3.0)
         result = sock.connect_ex(('localhost', 4403))
-        sock.close()
         if result != 0:
             return {'error': 'meshtasticd not running (port 4403 closed)'}
     except Exception:
         return {'error': 'Cannot check meshtasticd port 4403'}
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     try:
         # Increased timeout to 30 seconds - CLI can be slow
@@ -712,15 +724,20 @@ def get_nodes():
         return {'error': 'Meshtastic CLI not found', 'nodes': []}
 
     # Check if port is reachable
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(3.0)
         if sock.connect_ex(('localhost', 4403)) != 0:
-            sock.close()
             return {'error': 'meshtasticd not running (port 4403)', 'nodes': []}
-        sock.close()
     except Exception:
         return {'error': 'Cannot connect to meshtasticd', 'nodes': []}
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     try:
         result = run_subprocess(
@@ -793,15 +810,20 @@ def get_nodes_full():
     global _node_monitor
 
     # Check if port is reachable first
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(3.0)
         if sock.connect_ex(('localhost', 4403)) != 0:
-            sock.close()
             return {'error': 'meshtasticd not running (port 4403)'}
-        sock.close()
     except Exception:
         return {'error': 'Cannot connect to meshtasticd'}
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     try:
         with _node_monitor_lock:
@@ -959,15 +981,20 @@ def send_mesh_message(text, destination=None):
             return {'error': 'Invalid destination: must be hex node ID (e.g., !abc123 or abc123)'}
 
     # Check if port is reachable
+    sock = None
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(3.0)
         if sock.connect_ex(('localhost', 4403)) != 0:
-            sock.close()
             return {'error': 'meshtasticd not running'}
-        sock.close()
     except Exception:
         return {'error': 'Cannot connect to meshtasticd'}
+    finally:
+        if sock:
+            try:
+                sock.close()
+            except Exception:
+                pass
 
     try:
         cmd = [cli, '--host', 'localhost', '--sendtext', text]

--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -287,17 +287,23 @@ class DashboardPane(Container):
 
         # Check TCP port
         import socket
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(2)
             result = sock.connect_ex(('127.0.0.1', 4403))
-            sock.close()
             if result == 0:
                 log.write("[green][OK][/green] TCP port 4403 open")
             else:
                 log.write("[red][X][/red] TCP port 4403 closed")
         except Exception:
             log.write("[red][X][/red] Could not check port 4403")
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
         # Check RNS
         try:
@@ -1189,15 +1195,21 @@ class ToolsPane(Container):
         import socket
         output.write("\n[cyan]Testing port 4403...[/cyan]")
         for host in ['127.0.0.1', 'localhost']:
+            sock = None
             try:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(2)
                 result = sock.connect_ex((host, 4403))
-                sock.close()
                 status = "[green]OPEN[/green]" if result == 0 else "[red]CLOSED[/red]"
                 output.write(f"  {host}:4403 - {status}")
             except Exception as e:
                 output.write(f"  {host}:4403 - [red]Error: {e}[/red]")
+            finally:
+                if sock:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
 
     @work
     async def _show_interfaces(self, output: Log):
@@ -1362,6 +1374,7 @@ class ToolsPane(Container):
         import socket
         import struct
         output.write("\n[cyan]Testing multicast group 224.0.0.69...[/cyan]")
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
             sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -1370,7 +1383,6 @@ class ToolsPane(Container):
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
             output.write("  [green]Joined multicast group successfully[/green]")
             sock.setsockopt(socket.IPPROTO_IP, socket.IP_DROP_MEMBERSHIP, mreq)
-            sock.close()
             output.write("  [green]Left multicast group[/green]")
         except OSError as e:
             if "Address already in use" in str(e):
@@ -1379,6 +1391,12 @@ class ToolsPane(Container):
                 output.write(f"  [red]Error: {e}[/red]")
         except Exception as e:
             output.write(f"  [red]Error: {e}[/red]")
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
     # Network Diagnostics Methods
     def _parse_proc_net(self, protocol: str) -> list:

--- a/src/tui/panes/dashboard.py
+++ b/src/tui/panes/dashboard.py
@@ -212,17 +212,23 @@ class DashboardPane(Container):
             log.write("[red][X][/red] Could not check meshtasticd")
 
         # Check TCP port
+        sock = None
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(2)
             result = sock.connect_ex(('127.0.0.1', 4403))
-            sock.close()
             if result == 0:
                 log.write("[green][OK][/green] TCP port 4403 open")
             else:
                 log.write("[red][X][/red] TCP port 4403 closed")
         except Exception:
             log.write("[red][X][/red] Could not check port 4403")
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
         # Check RNS
         try:


### PR DESCRIPTION
Fixed socket leaks where sockets were not closed on exception paths:
- commands/service.py: check_port socket leaked on exception
- main_web.py: Multiple socket checks leaked FDs on early return/exception
- tui/app.py: Port check and multicast test sockets leaked on exceptions
- tui/panes/dashboard.py: Port check socket leaked on exception

All socket operations now use try/finally pattern:
  sock = None
  try:
      sock = socket.socket(...)
      ...
  except Exception:
      pass
  finally:
      if sock:
          try:
              sock.close()
          except Exception:
              pass

This ensures sockets are always closed regardless of success/failure.