### PR TITLE
fix: Multiple crash prevention fixes across GTK panels

### DIFF
--- a/src/gtk_ui/panels/mesh_tools.py
+++ b/src/gtk_ui/panels/mesh_tools.py
@@ -751,14 +751,21 @@ class MeshToolsPanel(Gtk.Box):
 
     def _update_meshtasticd_status(self, running: bool):
         """Update meshtasticd status display"""
-        if running:
-            self._meshtasticd_status.set_label("Running (TCP available)")
-            self._meshtasticd_status.remove_css_class("error")
-            self._meshtasticd_status.add_css_class("success")
-        else:
-            self._meshtasticd_status.set_label("Not Running")
-            self._meshtasticd_status.remove_css_class("success")
-            self._meshtasticd_status.add_css_class("error")
+        # Guard: Panel might have been destroyed
+        if not hasattr(self, '_meshtasticd_status') or self._meshtasticd_status is None:
+            return False
+        try:
+            if running:
+                self._meshtasticd_status.set_label("Running (TCP available)")
+                self._meshtasticd_status.remove_css_class("error")
+                self._meshtasticd_status.add_css_class("success")
+            else:
+                self._meshtasticd_status.set_label("Not Running")
+                self._meshtasticd_status.remove_css_class("success")
+                self._meshtasticd_status.add_css_class("error")
+        except Exception:
+            pass
+        return False
 
     def _on_start_meshtasticd(self, button):
         """Start meshtasticd service"""

--- a/src/gtk_ui/panels/meshbot.py
+++ b/src/gtk_ui/panels/meshbot.py
@@ -699,6 +699,17 @@ class MeshBotPanel(Gtk.Box):
 
     def _update_status_ui(self, status):
         """Update the status UI"""
+        # Guard: Panel might have been destroyed
+        if not hasattr(self, 'status_label') or self.status_label is None:
+            return False
+        try:
+            self._do_update_status_ui(status)
+        except Exception:
+            pass
+        return False
+
+    def _do_update_status_ui(self, status):
+        """Actually update the status UI (called by _update_status_ui)"""
         if status['installed']:
             self.install_status_icon.set_from_icon_name("emblem-default-symbolic")
             self.install_status_label.set_label("MeshBot Installed")

--- a/src/gtk_ui/panels/radio_config_simple.py
+++ b/src/gtk_ui/panels/radio_config_simple.py
@@ -1001,18 +1001,27 @@ class RadioConfigSimple(Gtk.Box):
     def _apply_preset(self, button):
         """Apply modem preset."""
         preset_idx = self.preset_dropdown.get_selected()
+        if preset_idx < 0 or preset_idx >= len(PRESET_NAMES):
+            self.main_window.set_status_message("Please select a preset first")
+            return
         preset_name = PRESET_NAMES[preset_idx]
         self._apply_setting("lora.modem_preset", preset_name, f"Preset: {preset_name}")
 
     def _apply_region(self, button):
         """Apply LoRa region. WARNING: Must comply with local regulations!"""
         region_idx = self.region_dropdown.get_selected()
+        if region_idx < 0 or region_idx >= len(REGIONS):
+            self.main_window.set_status_message("Please select a region first")
+            return
         region_name = REGIONS[region_idx]
         self._apply_setting("lora.region", region_name, f"Region: {region_name}")
 
     def _apply_role(self, button):
         """Apply device role."""
         role_idx = self.role_dropdown.get_selected()
+        if role_idx < 0 or role_idx >= len(ROLE_NAMES):
+            self.main_window.set_status_message("Please select a role first")
+            return
         role_name = ROLE_NAMES[role_idx]
         self._apply_setting("device.role", role_name, f"Role: {role_name}")
 
@@ -1029,6 +1038,9 @@ class RadioConfigSimple(Gtk.Box):
     def _apply_rebroadcast(self, button):
         """Apply rebroadcast mode."""
         idx = self.rebroadcast_dropdown.get_selected()
+        if idx < 0 or idx >= len(REBROADCAST_MODES):
+            self.main_window.set_status_message("Please select a rebroadcast mode first")
+            return
         mode = REBROADCAST_MODES[idx]
         self._apply_setting("device.rebroadcast_mode", mode, f"Rebroadcast: {mode}")
 

--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -93,8 +93,14 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
         # Connect cleanup handler
         self.connect("unrealize", self._on_unrealize)
 
+        # Track last known service state
+        self._last_rnsd_running = None
+
         self._build_ui()
         self._refresh_all()
+
+        # Start periodic service status monitoring
+        self._start_status_monitor()
 
     def _on_unrealize(self, widget):
         """Clean up when panel is destroyed to prevent timer crashes."""
@@ -114,6 +120,66 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
             timer_id = GLib.timeout_add(delay_ms, callback)
         self._pending_timers.append(timer_id)
         return timer_id
+
+    def _start_status_monitor(self):
+        """Start periodic monitoring of rnsd service status."""
+        # Check every 5 seconds
+        self._schedule_timer(5000, self._check_service_status_periodic)
+
+    def _check_service_status_periodic(self):
+        """Lightweight periodic check of rnsd service status.
+
+        Only updates UI if status changed to avoid unnecessary redraws.
+        """
+        def do_check():
+            try:
+                is_running = self._check_rns_service()
+                # Only update UI if status changed
+                if is_running != self._last_rnsd_running:
+                    self._last_rnsd_running = is_running
+                    GLib.idle_add(self._update_service_status_only, is_running)
+            except Exception:
+                pass
+
+        thread = threading.Thread(target=do_check, daemon=True)
+        thread.start()
+
+        # Return True to keep the timer running
+        return True
+
+    def _update_service_status_only(self, is_running):
+        """Update just the service status UI (lightweight update)."""
+        try:
+            if is_running:
+                self.rns_status_icon.set_from_icon_name("emblem-default")
+                self.rns_status_label.set_label("Running")
+                service_status = self._get_systemd_service_status()
+                if service_status == 'active':
+                    self.rns_status_detail.set_label("rnsd running (systemd service)")
+                else:
+                    self.rns_status_detail.set_label("rnsd running (process)")
+                self.rns_install_note.set_label("")
+                self.rns_start_btn.set_sensitive(False)
+                self.rns_stop_btn.set_sensitive(True)
+                self.rns_restart_btn.set_sensitive(True)
+            else:
+                self.rns_status_icon.set_from_icon_name("dialog-warning")
+                self.rns_status_label.set_label("Stopped")
+                service_status = self._get_systemd_service_status()
+                if service_status == 'inactive':
+                    self.rns_status_detail.set_label("rnsd stopped (systemd service installed)")
+                elif service_status == 'not-found':
+                    self.rns_status_detail.set_label("rnsd not running (no systemd service)")
+                else:
+                    self.rns_status_detail.set_label("Reticulum daemon is not running")
+                self.rns_install_note.set_label("Start with: rnsd")
+                self.rns_start_btn.set_sensitive(True)
+                self.rns_stop_btn.set_sensitive(False)
+                self.rns_restart_btn.set_sensitive(True)
+            logger.debug(f"RNS service status changed: running={is_running}")
+        except Exception as e:
+            logger.warning(f"Error updating service status UI: {e}")
+        return False
 
     def _build_ui(self):
         """Build the RNS panel UI"""

--- a/src/gtk_ui/panels/service.py
+++ b/src/gtk_ui/panels/service.py
@@ -49,6 +49,15 @@ class ServicePanel(Gtk.Box):
         self._build_ui()
         self._refresh_status()
 
+    def _safe_status_message(self, message):
+        """Safely set status message - handles case where main_window may be destroyed."""
+        try:
+            if hasattr(self, 'main_window') and self.main_window:
+                self.main_window.set_status_message(message)
+        except Exception:
+            pass
+        return False
+
     def _build_ui(self):
         """Build the service panel UI"""
         # Title
@@ -349,9 +358,9 @@ class ServicePanel(Gtk.Box):
             def do_reload():
                 try:
                     subprocess.run(['sudo', 'systemctl', 'daemon-reload'], check=True, timeout=15)
-                    GLib.idle_add(self.main_window.set_status_message, "Daemon reloaded successfully")
+                    GLib.idle_add(self._safe_status_message, "Daemon reloaded successfully")
                 except Exception as e:
-                    GLib.idle_add(self.main_window.set_status_message, f"Failed to reload daemon: {e}")
+                    GLib.idle_add(self._safe_status_message, f"Failed to reload daemon: {e}")
 
             thread = threading.Thread(target=do_reload, daemon=True)
             thread.start()
@@ -374,9 +383,9 @@ class ServicePanel(Gtk.Box):
                 try:
                     subprocess.run(['sudo', 'systemctl', action, 'meshtasticd'], check=True, timeout=30)
                     GLib.idle_add(self._refresh_status)
-                    GLib.idle_add(self.main_window.set_status_message, f"Service {action}d on boot")
+                    GLib.idle_add(self._safe_status_message, f"Service {action}d on boot")
                 except Exception as e:
-                    GLib.idle_add(self.main_window.set_status_message, f"Failed to {action} service: {e}")
+                    GLib.idle_add(self._safe_status_message, f"Failed to {action} service: {e}")
 
             thread = threading.Thread(target=do_toggle, daemon=True)
             thread.start()


### PR DESCRIPTION
RNS Panel:
- Added periodic service status monitoring (5 second interval)
- Panel now detects when rnsd stops externally and updates UI

Radio Config Panel:
- Fixed dropdown bounds checking for preset, region, role, and rebroadcast dropdowns (prevents IndexError when get_selected() returns -1)

Mesh Tools Panel:
- Added guard to _update_meshtasticd_status to handle destroyed widgets

Service Panel:
- Added _safe_status_message helper for protected callback execution
- Fixed GLib.idle_add callbacks that access main_window from threads

MeshBot Panel:
- Added guard to _update_status_ui to prevent crashes on destroyed widgets