### PR TITLE
docs: Add release management with alpha/beta channels

### DIFF
--- a/.github/branch-protection.md
+++ b/.github/branch-protection.md
@@ -1,0 +1,70 @@
+# GitHub Branch Protection Setup
+
+Configure these rules in GitHub Settings > Branches > Branch protection rules.
+
+## Main Branch (Stable)
+
+**Branch name pattern:** `main`
+
+- [x] Require a pull request before merging
+  - [x] Require approvals: 1
+  - [x] Dismiss stale pull request approvals when new commits are pushed
+- [x] Require status checks to pass before merging
+  - [x] Require branches to be up to date before merging
+  - Status checks: `test` (if CI configured)
+- [x] Do not allow bypassing the above settings
+- [ ] Allow force pushes: NO
+- [ ] Allow deletions: NO
+
+## Beta Branch (Testing)
+
+**Branch name pattern:** `beta`
+
+- [x] Require a pull request before merging
+  - [x] Require approvals: 1
+- [x] Require status checks to pass before merging
+- [ ] Do not allow bypassing the above settings (maintainers can merge)
+- [ ] Allow force pushes: NO
+- [ ] Allow deletions: NO
+
+## Alpha Branch (Experimental)
+
+**Branch name pattern:** `alpha`
+
+- [ ] Require a pull request before merging (optional)
+- [ ] Require status checks (recommended but not required)
+- [x] Allow force pushes: Maintainers only
+- [ ] Allow deletions: NO
+
+## CLI Setup Commands
+
+If you have GitHub CLI installed, run these:
+
+```bash
+# Main branch protection
+gh api repos/Nursedude/meshforge/branches/main/protection -X PUT \
+  -F required_status_checks='{"strict":true,"contexts":[]}' \
+  -F enforce_admins=true \
+  -F required_pull_request_reviews='{"required_approving_review_count":1}' \
+  -F restrictions=null
+
+# Beta branch protection
+gh api repos/Nursedude/meshforge/branches/beta/protection -X PUT \
+  -F required_status_checks='{"strict":true,"contexts":[]}' \
+  -F enforce_admins=false \
+  -F required_pull_request_reviews='{"required_approving_review_count":1}' \
+  -F restrictions=null
+```
+
+## Why This Structure?
+
+After the errno 22/24 stability crisis (Jan 2026), we learned:
+
+1. **Socket leaks** accumulated over time causing crashes
+2. **Background monitors** created resource exhaustion
+3. **Large meshes** (250+ nodes) exposed edge cases
+
+The alpha/beta/stable structure ensures:
+- New features get tested in alpha first
+- Beta catches issues before production
+- Stable users get verified releases

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,190 @@
+# MeshForge Release Management
+
+## Release Channels
+
+MeshForge uses a three-channel release system to ensure stability:
+
+| Channel | Branch | Purpose | Stability |
+|---------|--------|---------|-----------|
+| **Alpha** | `alpha` | Experimental features, bleeding edge | May break |
+| **Beta** | `beta` | Testing before production | Should work |
+| **Stable** | `main` | Production releases | Verified stable |
+
+## Version Numbering
+
+```
+X.Y.Z-channel
+
+Examples:
+  0.4.7-alpha    # Experimental
+  0.4.7-beta     # Testing
+  0.4.7          # Stable release
+```
+
+## Development Workflow
+
+### For New Features
+
+```bash
+# 1. Create feature branch from alpha
+git checkout alpha
+git pull origin alpha
+git checkout -b feature/my-feature
+
+# 2. Develop and test
+# ... make changes ...
+python3 -m pytest tests/ -v
+
+# 3. Create PR to alpha branch
+gh pr create --base alpha --title "feat: My new feature"
+
+# 4. After testing in alpha, cherry-pick to beta
+git checkout beta
+git cherry-pick <commit-hash>
+
+# 5. After beta testing, merge to main
+git checkout main
+git merge beta
+```
+
+### For Bug Fixes
+
+```bash
+# Hotfixes go directly to main, then backport
+git checkout main
+git checkout -b fix/critical-bug
+# ... fix ...
+gh pr create --base main --title "fix: Critical bug"
+
+# Backport to beta and alpha
+git checkout beta && git cherry-pick <commit>
+git checkout alpha && git cherry-pick <commit>
+```
+
+## Release Process
+
+### Alpha Release
+1. Merge feature PRs to `alpha` branch
+2. Update `src/__version__.py`:
+   ```python
+   __version__ = "0.4.7-alpha"
+   __status__ = "alpha"
+   ```
+3. Tag: `git tag v0.4.7-alpha`
+4. Announce on GitHub Discussions (optional)
+
+### Beta Release
+1. Test alpha thoroughly (minimum 48 hours)
+2. Cherry-pick stable features to `beta`
+3. Update version:
+   ```python
+   __version__ = "0.4.7-beta"
+   __status__ = "beta"
+   ```
+4. Tag: `git tag v0.4.7-beta`
+5. Request community testing
+
+### Stable Release
+1. Beta must be stable for minimum 1 week
+2. Run full test suite: `python3 -m pytest tests/ -v`
+3. Run stability test: `sudo bash -c 'ulimit -n 65536 && timeout 3600 python3 src/launcher.py'`
+4. Merge `beta` to `main`
+5. Update version:
+   ```python
+   __version__ = "0.4.7"
+   __status__ = "stable"
+   ```
+6. Tag: `git tag v0.4.7`
+7. Create GitHub Release with changelog
+
+## Branch Protection Rules
+
+### main (Stable)
+- Require PR reviews (1 minimum)
+- Require status checks to pass
+- No direct pushes
+- Include administrators
+
+### beta (Testing)
+- Require PR reviews (1 minimum)
+- Require status checks to pass
+- No direct pushes
+
+### alpha (Experimental)
+- No required reviews (fast iteration)
+- Status checks recommended
+- Direct pushes allowed for maintainers
+
+## Stability Testing Checklist
+
+Before promoting to stable:
+
+- [ ] Clean startup (no errors in logs)
+- [ ] Connect to mesh network (250+ nodes)
+- [ ] Run for 1 hour without crashes
+- [ ] `ulimit -n 65536` verified
+- [ ] All panels open without crash
+- [ ] Log viewer works
+- [ ] RNS panel functional
+- [ ] No socket leaks (`ls /proc/PID/fd | wc -l` stable)
+
+## Quick Setup
+
+Run this to create the branch structure:
+
+```bash
+# Create branches from current stable (main)
+git checkout main
+git pull origin main
+
+# Create alpha branch
+git checkout -b alpha
+git push -u origin alpha
+
+# Create beta branch
+git checkout main
+git checkout -b beta
+git push -u origin beta
+
+# Return to main
+git checkout main
+```
+
+## Installing Specific Channels
+
+Users can install from specific channels:
+
+```bash
+# Stable (default)
+git clone https://github.com/Nursedude/meshforge.git
+cd meshforge && git checkout main
+
+# Beta testing
+git clone https://github.com/Nursedude/meshforge.git
+cd meshforge && git checkout beta
+
+# Alpha (bleeding edge)
+git clone https://github.com/Nursedude/meshforge.git
+cd meshforge && git checkout alpha
+```
+
+## Emergency Rollback
+
+If a release breaks production:
+
+```bash
+# Find last good version
+git log --oneline main | head -20
+
+# Create hotfix branch
+git checkout -b hotfix/rollback <last-good-commit>
+
+# Or revert specific commit
+git revert <bad-commit>
+
+# Push emergency fix
+gh pr create --base main --title "fix: Emergency rollback"
+```
+
+---
+*Release management added after errno 24/22 stability crisis (Jan 2026)*

--- a/scripts/setup-release-branches.sh
+++ b/scripts/setup-release-branches.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# MeshForge Release Branch Setup
+# Creates alpha and beta branches for staged releases
+
+set -e
+
+echo "MeshForge Release Branch Setup"
+echo "==============================="
+echo ""
+
+# Check we're in a git repo
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+    echo "Error: Not in a git repository"
+    exit 1
+fi
+
+# Get current branch
+CURRENT=$(git branch --show-current)
+echo "Current branch: $CURRENT"
+
+# Fetch latest
+echo ""
+echo "Fetching latest from origin..."
+git fetch origin main
+
+# Check if branches already exist
+ALPHA_EXISTS=$(git branch -a | grep -E "(^|\s)alpha$|origin/alpha" || true)
+BETA_EXISTS=$(git branch -a | grep -E "(^|\s)beta$|origin/beta" || true)
+
+if [ -n "$ALPHA_EXISTS" ]; then
+    echo "Alpha branch already exists"
+else
+    echo ""
+    echo "Creating alpha branch from main..."
+    git checkout main
+    git pull origin main
+    git checkout -b alpha
+    git push -u origin alpha
+    echo "Alpha branch created and pushed"
+fi
+
+if [ -n "$BETA_EXISTS" ]; then
+    echo "Beta branch already exists"
+else
+    echo ""
+    echo "Creating beta branch from main..."
+    git checkout main
+    git checkout -b beta
+    git push -u origin beta
+    echo "Beta branch created and pushed"
+fi
+
+# Return to original branch
+echo ""
+echo "Returning to $CURRENT..."
+git checkout "$CURRENT"
+
+echo ""
+echo "Done! Branch structure:"
+echo "  main  - Stable releases"
+echo "  beta  - Testing releases"
+echo "  alpha - Experimental releases"
+echo ""
+echo "See RELEASE.md for workflow documentation."

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -576,3 +576,75 @@ def show_version_history():
         table.add_row(entry['version'], entry['date'], changes)
 
     console.print(table)
+
+
+def get_release_channel():
+    """Get current release channel (alpha, beta, stable)"""
+    return __status__
+
+
+def is_stable():
+    """Check if this is a stable release"""
+    return __status__ == "stable"
+
+
+def is_beta():
+    """Check if this is a beta release"""
+    return __status__ == "beta"
+
+
+def is_alpha():
+    """Check if this is an alpha release"""
+    return __status__ == "alpha"
+
+
+def get_channel_warning():
+    """Get warning message for non-stable releases"""
+    if __status__ == "alpha":
+        return "ALPHA: Experimental build - may be unstable"
+    elif __status__ == "beta":
+        return "BETA: Testing build - report issues at github.com/Nursedude/meshforge"
+    return None
+
+
+def parse_version(version_str: str) -> tuple:
+    """
+    Parse version string into comparable tuple.
+
+    Examples:
+        '0.4.7' -> (0, 4, 7, 'stable', 0)
+        '0.4.7-beta' -> (0, 4, 7, 'beta', 0)
+        '0.4.7-alpha.2' -> (0, 4, 7, 'alpha', 2)
+    """
+    import re
+
+    # Handle pre-release suffixes
+    match = re.match(r'^(\d+)\.(\d+)\.(\d+)(?:-(\w+)(?:\.(\d+))?)?$', version_str)
+    if not match:
+        return (0, 0, 0, 'unknown', 0)
+
+    major, minor, patch = int(match.group(1)), int(match.group(2)), int(match.group(3))
+    channel = match.group(4) or 'stable'
+    build = int(match.group(5)) if match.group(5) else 0
+
+    # Channel ordering: stable > beta > alpha
+    channel_order = {'stable': 3, 'beta': 2, 'alpha': 1, 'unknown': 0}
+
+    return (major, minor, patch, channel_order.get(channel, 0), build)
+
+
+def compare_versions(v1: str, v2: str) -> int:
+    """
+    Compare two version strings.
+
+    Returns:
+        -1 if v1 < v2
+         0 if v1 == v2
+         1 if v1 > v2
+    """
+    t1, t2 = parse_version(v1), parse_version(v2)
+    if t1 < t2:
+        return -1
+    elif t1 > t2:
+        return 1
+    return 0


### PR DESCRIPTION
- RELEASE.md: Document three-channel release workflow (alpha/beta/stable)
- scripts/setup-release-branches.sh: Script to create branch structure
- .github/branch-protection.md: Branch protection configuration guide
- src/__version__.py: Add release channel helpers and version comparison

This structure prevents unstable code from reaching production by requiring features to progress through alpha -> beta -> stable testing.

Added after errno 22/24 stability crisis where socket leaks and background monitors caused crashes on large meshes (250+ nodes).