### PR TITLE
fix: Move blocking operations to background threads

### DIFF
--- a/src/gtk_ui/app.py
+++ b/src/gtk_ui/app.py
@@ -1390,11 +1390,13 @@ class MeshForgeWindow(Adw.ApplicationWindow):
         )
 
     def _perform_reboot(self):
-        """Perform the actual reboot"""
-        try:
-            subprocess.run(['systemctl', 'reboot'], check=True, timeout=10)
-        except Exception as e:
-            self._show_error_dialog("Reboot Failed", str(e))
+        """Perform the actual reboot - runs in background thread"""
+        def do_reboot():
+            try:
+                subprocess.run(['systemctl', 'reboot'], check=True, timeout=10)
+            except Exception as e:
+                GLib.idle_add(self._show_error_dialog, "Reboot Failed", str(e))
+        threading.Thread(target=do_reboot, daemon=True).start()
         return False
 
     def _save_resume_state(self, reason):

--- a/src/gtk_ui/panels/eas_alerts.py
+++ b/src/gtk_ui/panels/eas_alerts.py
@@ -661,14 +661,17 @@ class EASAlertsPanel(Gtk.Box):
     def _on_settings_response(self, dialog, response):
         """Handle settings dialog response"""
         if response == "open":
-            # Open config file in default editor
+            # Open config file in default editor (runs in background thread)
             import subprocess
+            import threading
             # Use get_real_user_home to handle sudo properly
             config_path = str(get_real_user_home() / ".config/meshforge/plugins/eas_alerts.ini")
-            try:
-                subprocess.run(["xdg-open", config_path], check=False, timeout=10)
-            except Exception as e:
-                logger.error(f"Failed to open config: {e}")
+            def do_open():
+                try:
+                    subprocess.run(["xdg-open", config_path], check=False, timeout=10)
+                except Exception as e:
+                    logger.error(f"Failed to open config: {e}")
+            threading.Thread(target=do_open, daemon=True).start()
 
     def cleanup(self):
         """Clean up resources"""

--- a/src/gtk_ui/panels/rns_mixins/meshchat.py
+++ b/src/gtk_ui/panels/rns_mixins/meshchat.py
@@ -302,15 +302,17 @@ class MeshChatMixin:
         threading.Thread(target=stop, daemon=True).start()
 
     def _on_meshchat_browser(self, button):
-        """Open MeshChat in web browser"""
+        """Open MeshChat in web browser (runs in background thread)"""
         port = int(self.meshchat_port_entry.get_value())
         host_idx = self.meshchat_host_dropdown.get_selected()
 
         # Always use localhost for browser, even if bound to 0.0.0.0
         url = f"http://127.0.0.1:{port}"
 
-        try:
-            import webbrowser
-            webbrowser.open(url)
-        except Exception as e:
-            self._show_error(f"Failed to open browser: {e}")
+        def do_open():
+            try:
+                import webbrowser
+                webbrowser.open(url)
+            except Exception as e:
+                GLib.idle_add(self._show_error, f"Failed to open browser: {e}")
+        threading.Thread(target=do_open, daemon=True).start()

--- a/src/gtk_ui/panels/tools_mixins/hf_propagation.py
+++ b/src/gtk_ui/panels/tools_mixins/hf_propagation.py
@@ -128,10 +128,12 @@ class HFPropagationMixin:
         self._open_url_in_browser(url, "Contest Calendar")
 
     def _open_url_in_browser(self, url: str, description: str = ""):
-        """Open URL in default browser (helper method)"""
-        try:
-            webbrowser.open(url)
-            if description:
-                GLib.idle_add(self._log, f"Opened {description} in browser")
-        except Exception as e:
-            GLib.idle_add(self._log, f"Error opening browser: {e}")
+        """Open URL in default browser (runs in background thread)"""
+        def do_open():
+            try:
+                webbrowser.open(url)
+                if description:
+                    GLib.idle_add(self._log, f"Opened {description} in browser")
+            except Exception as e:
+                GLib.idle_add(self._log, f"Error opening browser: {e}")
+        threading.Thread(target=do_open, daemon=True).start()

--- a/src/gtk_ui/panels/tools_mixins/sdr_tools.py
+++ b/src/gtk_ui/panels/tools_mixins/sdr_tools.py
@@ -46,13 +46,15 @@ class SDRToolsMixin:
         return status
 
     def _on_open_webrx(self, button=None):
-        """Open OpenWebRX in browser"""
+        """Open OpenWebRX in browser (runs in background thread)"""
         url = "http://localhost:8073"
-        try:
-            webbrowser.open(url)
-            GLib.idle_add(self._log, "Opening OpenWebRX at http://localhost:8073")
-        except Exception as e:
-            GLib.idle_add(self._log, f"Error: {e}")
+        def do_open():
+            try:
+                webbrowser.open(url)
+                GLib.idle_add(self._log, "Opening OpenWebRX at http://localhost:8073")
+            except Exception as e:
+                GLib.idle_add(self._log, f"Error: {e}")
+        threading.Thread(target=do_open, daemon=True).start()
 
     def _on_install_openwebrx(self, button=None):
         """Show OpenWebRX installation instructions"""


### PR DESCRIPTION
Prevents GTK UI freezes by running these in background threads:
- app.py: systemctl reboot command
- eas_alerts.py: xdg-open for config file
- hf_propagation.py: webbrowser.open calls
- meshchat.py: webbrowser.open calls
- sdr_tools.py: webbrowser.open calls

All UI error callbacks now use GLib.idle_add for thread safety.