### PR TITLE
fix: Gateway reliability improvements

### DIFF
--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -218,8 +218,8 @@ class UnifiedNode:
                     # First byte might be display name length
                     # This varies by application
                     pass
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Could not parse RNS app_data: {e}")
 
         node.last_seen = datetime.now()
         return node
@@ -682,8 +682,8 @@ class UnifiedNodeTracker:
                     display_name = app_data.decode('utf-8', errors='ignore').strip()
                     # Clean up - remove non-printable characters
                     display_name = ''.join(c for c in display_name if c.isprintable())
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Could not decode RNS display name: {e}")
 
             # Create node from announce
             node = UnifiedNode.from_rns(dest_hash, name=display_name, app_data=app_data)

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -72,9 +72,9 @@ class RNSMeshtasticBridge:
         self._connected_rns = False
         self._rns_init_failed_permanently = False  # True if RNS can't be initialized from this thread
 
-        # Message queues
-        self._mesh_to_rns_queue = Queue()
-        self._rns_to_mesh_queue = Queue()
+        # Message queues (bounded to prevent memory exhaustion)
+        self._mesh_to_rns_queue = Queue(maxsize=1000)
+        self._rns_to_mesh_queue = Queue(maxsize=1000)
 
         # Threads
         self._mesh_thread = None
@@ -869,8 +869,8 @@ class RNSMeshtasticBridge:
             if sock:
                 try:
                     sock.close()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"Socket close during cleanup: {e}")
 
     def _test_meshtastic_cli(self) -> bool:
         """Test Meshtastic CLI availability"""
@@ -909,16 +909,18 @@ class RNSMeshtasticBridge:
             return False
 
     def _notify_message(self, msg: BridgedMessage):
-        """Notify message callbacks"""
-        for callback in self._message_callbacks:
+        """Notify message callbacks (thread-safe snapshot)"""
+        callbacks = list(self._message_callbacks)  # Snapshot to avoid race condition
+        for callback in callbacks:
             try:
                 callback(msg)
             except Exception as e:
                 logger.error(f"Message callback error: {e}")
 
     def _notify_status(self, status: str):
-        """Notify status callbacks"""
-        for callback in self._status_callbacks:
+        """Notify status callbacks (thread-safe snapshot)"""
+        callbacks = list(self._status_callbacks)  # Snapshot to avoid race condition
+        for callback in callbacks:
             try:
                 callback(status, self.get_status())
             except Exception as e:


### PR DESCRIPTION
- Add logging to bare except handlers in node_tracker.py (lines 221, 685)
- Add logging to socket cleanup in rns_bridge.py (line 872)
- Fix race condition: use list snapshot for callback iteration
- Add bounds to message queues (maxsize=1000) to prevent memory exhaustion

These changes improve observability and prevent potential crashes under load.