### PR TITLE
docs: Add meshtastic bug report and icon fix instructions

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -548,9 +548,33 @@ GTK4/libadwaita has strict requirements for taskbar icons:
 3. **Try GResource**: Bundle icon as GResource instead of file system installation
 4. **Desktop-specific**: Test on different DEs to isolate if it's environment-specific
 
-### Workaround
-Currently none - icon shows as generic in taskbar.
+### Fix (2026-01-13)
+
+Run the desktop integration installer:
+
+```bash
+cd /opt/meshforge
+sudo ./scripts/install-desktop.sh
+```
+
+This installs icons to:
+- `/usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
+- `/usr/share/icons/hicolor/{48,64,128,256}x{48,64,128,256}/apps/`
+- `/usr/share/pixmaps/`
+
+Then clear the icon cache:
+
+```bash
+gtk-update-icon-cache -f /usr/share/icons/hicolor
+# Log out and back in, or restart desktop environment
+```
+
+### If Still Not Working
+
+1. Verify icon installed: `ls /usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
+2. Check WM_CLASS: `xprop WM_CLASS` → click MeshForge window → should show `org.meshforge.app`
+3. Clear DE cache: Some DEs (GNOME, KDE) cache icons aggressively
 
 ---
 
-*Last updated: 2026-01-12 - Added issue #11 (taskbar icon persistent issue)*
+*Last updated: 2026-01-13 - Added fix instructions for taskbar icon*

--- a/.claude/research/meshtastic_broken_pipe_bug.md
+++ b/.claude/research/meshtastic_broken_pipe_bug.md
@@ -1,0 +1,74 @@
+# Meshtastic Python Library - Broken Pipe Bug Report
+
+**Date**: 2026-01-13
+**Affects**: meshtastic Python package (all versions using TCP interface)
+**Severity**: Low (cosmetic - command still succeeds)
+
+## Description
+
+When using the meshtastic CLI with `--host localhost` (TCP interface to meshtasticd), commands complete successfully but produce a "Broken pipe" error on exit.
+
+## Error Output
+
+```
+Aborting due to: [Errno 32] Broken pipe
+
+STDERR:
+Traceback (most recent call last):
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/__main__.py", line 1090, in onConnected
+    interface.close()
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/tcp_interface.py", line 80, in close
+    super().close()
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/stream_interface.py", line 134, in close
+    MeshInterface.close(self)
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/mesh_interface.py", line 148, in close
+    self._sendDisconnect()
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/mesh_interface.py", line 1193, in _sendDisconnect
+    self._sendToRadio(m)
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/mesh_interface.py", line 1218, in _sendToRadio
+    self._sendToRadioImpl(toRadio)
+  File "/usr/local/lib/python3.13/dist-packages/meshtastic/stream_interface.py", line 129, in _sendToRadioImpl
+    self._writeBytes(header + b)
+```
+
+## Root Cause
+
+In `mesh_interface.py:_sendDisconnect()`, the code attempts to send a disconnect message after the command completes. However, `meshtasticd` has already closed the TCP connection, resulting in `EPIPE` (broken pipe).
+
+## Impact
+
+- **Commands succeed** - the actual operation completes before the error
+- **User confusion** - error message suggests failure when there was none
+- **Log noise** - fills logs with stack traces
+
+## Suggested Fix
+
+In `/usr/local/lib/python3.13/dist-packages/meshtastic/mesh_interface.py`, modify `_sendDisconnect()` to catch `BrokenPipeError`:
+
+```python
+def _sendDisconnect(self):
+    """Send disconnect message to radio"""
+    try:
+        # ... existing code ...
+        self._sendToRadio(m)
+    except (BrokenPipeError, OSError) as e:
+        # Connection already closed by peer - this is expected
+        logging.debug(f"Disconnect send skipped (connection closed): {e}")
+```
+
+## Workaround for Users
+
+Suppress stderr when running meshtastic CLI:
+
+```bash
+meshtastic --host localhost --info 2>/dev/null
+```
+
+## MeshForge Mitigation
+
+MeshForge already uses `capture_output=True` in subprocess calls, which hides this error from the GUI. Direct CLI users will see it.
+
+## References
+
+- meshtastic-python: https://github.com/meshtastic/python
+- Issue to file: https://github.com/meshtastic/python/issues


### PR DESCRIPTION
- Created research doc for meshtastic broken pipe upstream bug
- Updated persistent_issues.md with clear icon fix instructions
- Icon fix: run sudo ./scripts/install-desktop.sh

The broken pipe error in meshtastic CLI is an upstream bug (commands succeed but show error on disconnect). MeshForge already mitigates this with capture_output=True.