### PR TITLE
feat: Add gateway device profiles and hardware detection

### DIFF
--- a/src/config/hardware.py
+++ b/src/config/hardware.py
@@ -32,10 +32,12 @@ class HardwareDetector:
         },
         '10c4:ea60': {
             'name': 'CP2102 USB-Serial',
-            'common_devices': ['Various LoRa modules'],
+            'common_devices': ['Station G2', 'Various LoRa modules'],
             'meshtastic_compatible': True,
-            'power_requirement': 'Standard USB',
-            'notes': 'Silicon Labs chipset'
+            'power_requirement': 'Standard USB (5V DC or PoE for Station G2)',
+            'notes': 'Silicon Labs chipset. Station G2 variant has Ethernet.',
+            'gateway_capable': True,
+            'flash_method': 'esptool'
         },
         '0403:6001': {
             'name': 'FT232 USB-Serial',
@@ -50,6 +52,54 @@ class HardwareDetector:
             'meshtastic_compatible': True,
             'power_requirement': 'Standard USB',
             'notes': 'Official Meshtastic USB device'
+        },
+        # Heltec devices (ESP32-S3 based)
+        '303a:1001': {
+            'name': 'Heltec ESP32-S3 (CDC)',
+            'common_devices': ['Heltec V3', 'Heltec V4', 'Station G2'],
+            'meshtastic_compatible': True,
+            'power_requirement': '500mA typical, 1A peak (V4 at max TX)',
+            'notes': 'ESP32-S3 native USB CDC. V4 supports 28dBm TX.',
+            'gateway_capable': True,
+            'flash_method': 'esptool'
+        },
+        '303a:4001': {
+            'name': 'Heltec ESP32-S3 (JTAG)',
+            'common_devices': ['Heltec V3', 'Heltec V4'],
+            'meshtastic_compatible': True,
+            'power_requirement': '500mA typical',
+            'notes': 'ESP32-S3 JTAG interface for debugging',
+            'gateway_capable': True,
+            'flash_method': 'esptool'
+        },
+        # RAK WisBlock devices (nRF52840 based)
+        '239a:8029': {
+            'name': 'RAK4631 (Adafruit nRF52840)',
+            'common_devices': ['RAK4631', 'RAK WisBlock Meshtastic Kit'],
+            'meshtastic_compatible': True,
+            'power_requirement': '100mA typical',
+            'notes': 'nRF52840 + SX1262. Low power, excellent for solar nodes.',
+            'gateway_capable': True,
+            'flash_method': 'uf2'
+        },
+        '239a:0029': {
+            'name': 'RAK4631 Bootloader',
+            'common_devices': ['RAK4631 in bootloader mode'],
+            'meshtastic_compatible': True,
+            'power_requirement': '100mA',
+            'notes': 'RAK4631 in UF2 bootloader mode - ready for flashing',
+            'gateway_capable': True,
+            'flash_method': 'uf2'
+        },
+        # LILYGO T-Beam
+        '1a86:55d3': {
+            'name': 'CH9102 USB-Serial',
+            'common_devices': ['LILYGO T-Beam S3', 'T-Beam Supreme'],
+            'meshtastic_compatible': True,
+            'power_requirement': '500mA typical',
+            'notes': 'ESP32-S3 based T-Beam with GPS',
+            'gateway_capable': True,
+            'flash_method': 'esptool'
         }
     }
 

--- a/src/gateway/profiles/README.md
+++ b/src/gateway/profiles/README.md
@@ -1,0 +1,165 @@
+# MeshForge Gateway Profiles
+
+Pre-configured profiles for optimizing Meshtastic devices as MeshForge gateways.
+
+## Available Profiles
+
+| Profile | Device | TX Power | Features |
+|---------|--------|----------|----------|
+| `rak4631_gateway` | RAK4631 (nRF52840) | 22dBm | GPS, Low power |
+| `heltec_v3_gateway` | Heltec V3 (ESP32-S3) | 20dBm | WiFi |
+| `heltec_v4_gateway` | Heltec V4 (ESP32-S3) | 27dBm | WiFi, High power |
+| `station_g2_gateway` | Station G2 | 22dBm | Ethernet, PoE |
+
+## Quick Start
+
+### 1. Apply a Profile
+
+```bash
+# Via serial port
+meshtastic --port /dev/ttyUSB0 --configure rak4631_gateway.yaml
+
+# Via meshtasticd (TCP)
+meshtastic --host localhost --configure heltec_v4_gateway.yaml
+```
+
+### 2. Via Python
+
+```python
+from gateway.profiles import ProfileManager
+
+manager = ProfileManager()
+
+# List profiles
+for profile in manager.list_profiles():
+    print(f"{profile.name}: {profile.device} ({profile.tx_power}dBm)")
+
+# Apply profile
+result = manager.apply_profile('heltec_v4_gateway', port='/dev/ttyUSB0')
+print(result['message'])
+```
+
+## Gateway Optimizations
+
+All profiles include these gateway optimizations:
+
+### Always Enabled
+- **Router role**: Forward messages for other nodes
+- **Store & Forward**: Buffer messages for offline nodes
+- **Neighbor info**: Track nearby nodes
+- **Serial API**: For meshtasticd connection
+- **Maximum hop limit**: Wide network coverage
+
+### Always Disabled
+- **Bluetooth**: Not needed for headless gateway
+- **Display**: Power saving, headless operation
+- **Power saving**: Always listening for messages
+- **Canned messages**: Not needed for gateway
+- **Range test**: Disable unless actively testing
+
+## Customization
+
+### Change LoRa Region
+
+Edit the profile and change the region:
+
+```yaml
+lora:
+  region: EU_868  # Options: US, EU_868, AU_915, etc.
+```
+
+### Set Fixed Position
+
+For fixed gateways, set your coordinates:
+
+```yaml
+position:
+  fixed_position: true
+  fixed_lat: 37.7749    # Your latitude
+  fixed_lng: -122.4194  # Your longitude
+  fixed_alt: 10         # Altitude in meters
+```
+
+### Configure WiFi (ESP32 devices)
+
+```yaml
+network:
+  wifi_enabled: true
+  wifi_ssid: "YourNetworkName"
+  wifi_psk: "YourPassword"
+```
+
+### Enable MQTT Bridge
+
+```yaml
+modules:
+  mqtt:
+    enabled: true
+    address: "mqtt.example.com"
+    username: "meshforge"
+    password: "secret"
+    json_enabled: true
+```
+
+## Profile Selection Guide
+
+| Use Case | Recommended Profile |
+|----------|-------------------|
+| Solar-powered remote node | `rak4631_gateway` |
+| WiFi-connected indoor gateway | `heltec_v3_gateway` |
+| Maximum range outdoor gateway | `heltec_v4_gateway` |
+| Fixed infrastructure/base station | `station_g2_gateway` |
+
+## Troubleshooting
+
+### Profile Won't Apply
+
+1. Check device connection:
+   ```bash
+   meshtastic --info
+   ```
+
+2. Verify serial port:
+   ```bash
+   ls -la /dev/ttyUSB* /dev/ttyACM*
+   ```
+
+3. Check meshtasticd is running:
+   ```bash
+   systemctl status meshtasticd
+   ```
+
+### Device Not Detected
+
+1. Install meshtastic CLI:
+   ```bash
+   pip install meshtastic
+   ```
+
+2. Add user to dialout group:
+   ```bash
+   sudo usermod -a -G dialout $USER
+   # Logout and login again
+   ```
+
+### Wrong Region Error
+
+If you see "Invalid region" errors, the device firmware may not support your region. Check supported regions:
+
+```bash
+meshtastic --info | grep region
+```
+
+## Creating Custom Profiles
+
+Copy an existing profile and modify:
+
+```bash
+cp heltec_v4_gateway.yaml my_custom_gateway.yaml
+# Edit my_custom_gateway.yaml
+meshtastic --configure my_custom_gateway.yaml
+```
+
+---
+
+*Made with aloha for the mesh community*

--- a/src/gateway/profiles/__init__.py
+++ b/src/gateway/profiles/__init__.py
@@ -1,0 +1,348 @@
+"""
+MeshForge Gateway Profiles
+
+Pre-configured profiles for optimizing Meshtastic devices as gateways.
+These profiles configure official Meshtastic firmware for gateway operation.
+
+Usage:
+    from gateway.profiles import ProfileManager
+
+    # List available profiles
+    manager = ProfileManager()
+    profiles = manager.list_profiles()
+
+    # Get profile details
+    info = manager.get_profile_info('rak4631_gateway')
+
+    # Apply profile to device
+    result = manager.apply_profile('heltec_v4_gateway', port='/dev/ttyUSB0')
+
+    # Or via CLI:
+    # meshtastic --configure /path/to/profile.yaml
+"""
+
+import os
+import subprocess
+import logging
+from pathlib import Path
+from typing import Dict, List, Optional, Any
+from dataclasses import dataclass
+
+try:
+    import yaml
+    YAML_AVAILABLE = True
+except ImportError:
+    YAML_AVAILABLE = False
+
+logger = logging.getLogger(__name__)
+
+# Profile directory
+PROFILES_DIR = Path(__file__).parent
+
+
+@dataclass
+class ProfileInfo:
+    """Information about a gateway profile"""
+    name: str
+    path: Path
+    device: str
+    description: str
+    tx_power: int
+    has_wifi: bool
+    has_ethernet: bool
+    has_gps: bool
+    flash_method: str
+
+
+# Profile metadata (extracted from YAML comments)
+PROFILE_METADATA = {
+    'rak4631_gateway': {
+        'device': 'RAK4631 (nRF52840)',
+        'description': 'Low-power gateway with excellent battery life',
+        'tx_power': 22,
+        'has_wifi': False,
+        'has_ethernet': False,
+        'has_gps': True,
+        'flash_method': 'uf2',
+    },
+    'heltec_v3_gateway': {
+        'device': 'Heltec V3 (ESP32-S3)',
+        'description': 'WiFi-enabled gateway with standard TX power',
+        'tx_power': 20,
+        'has_wifi': True,
+        'has_ethernet': False,
+        'has_gps': False,
+        'flash_method': 'esptool',
+    },
+    'heltec_v4_gateway': {
+        'device': 'Heltec V4 (ESP32-S3 High Power)',
+        'description': 'High-power gateway with 28dBm TX for maximum range',
+        'tx_power': 27,
+        'has_wifi': True,
+        'has_ethernet': False,
+        'has_gps': False,
+        'flash_method': 'esptool',
+    },
+    'station_g2_gateway': {
+        'device': 'Heltec Station G2',
+        'description': 'Ethernet-enabled base station for fixed deployment',
+        'tx_power': 22,
+        'has_wifi': False,
+        'has_ethernet': True,
+        'has_gps': False,
+        'flash_method': 'esptool',
+    },
+}
+
+
+class ProfileManager:
+    """
+    Manage gateway configuration profiles.
+
+    Profiles are YAML files that can be applied to Meshtastic devices
+    using the `meshtastic --configure` command.
+    """
+
+    def __init__(self, profiles_dir: Optional[Path] = None):
+        self.profiles_dir = profiles_dir or PROFILES_DIR
+
+    def list_profiles(self) -> List[ProfileInfo]:
+        """List all available gateway profiles"""
+        profiles = []
+
+        for yaml_file in self.profiles_dir.glob('*.yaml'):
+            name = yaml_file.stem
+            meta = PROFILE_METADATA.get(name, {})
+
+            profiles.append(ProfileInfo(
+                name=name,
+                path=yaml_file,
+                device=meta.get('device', 'Unknown'),
+                description=meta.get('description', ''),
+                tx_power=meta.get('tx_power', 0),
+                has_wifi=meta.get('has_wifi', False),
+                has_ethernet=meta.get('has_ethernet', False),
+                has_gps=meta.get('has_gps', False),
+                flash_method=meta.get('flash_method', 'unknown'),
+            ))
+
+        return sorted(profiles, key=lambda p: p.name)
+
+    def get_profile_path(self, profile_name: str) -> Optional[Path]:
+        """Get the path to a profile file"""
+        # Add .yaml extension if not present
+        if not profile_name.endswith('.yaml'):
+            profile_name = f"{profile_name}.yaml"
+
+        profile_path = self.profiles_dir / profile_name
+
+        if profile_path.exists():
+            return profile_path
+
+        return None
+
+    def get_profile_info(self, profile_name: str) -> Optional[ProfileInfo]:
+        """Get detailed information about a profile"""
+        path = self.get_profile_path(profile_name)
+        if not path:
+            return None
+
+        name = path.stem
+        meta = PROFILE_METADATA.get(name, {})
+
+        return ProfileInfo(
+            name=name,
+            path=path,
+            device=meta.get('device', 'Unknown'),
+            description=meta.get('description', ''),
+            tx_power=meta.get('tx_power', 0),
+            has_wifi=meta.get('has_wifi', False),
+            has_ethernet=meta.get('has_ethernet', False),
+            has_gps=meta.get('has_gps', False),
+            flash_method=meta.get('flash_method', 'unknown'),
+        )
+
+    def load_profile(self, profile_name: str) -> Optional[Dict[str, Any]]:
+        """Load and parse a profile YAML file"""
+        if not YAML_AVAILABLE:
+            logger.error("PyYAML not installed. Install with: pip install pyyaml")
+            return None
+
+        path = self.get_profile_path(profile_name)
+        if not path:
+            logger.error(f"Profile not found: {profile_name}")
+            return None
+
+        try:
+            with open(path, 'r') as f:
+                return yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            logger.error(f"Failed to parse profile {profile_name}: {e}")
+            return None
+
+    def validate_profile(self, profile_name: str) -> tuple:
+        """
+        Validate a profile for common issues.
+
+        Returns:
+            (is_valid, list_of_warnings)
+        """
+        warnings = []
+        profile = self.load_profile(profile_name)
+
+        if not profile:
+            return False, ["Profile could not be loaded"]
+
+        # Check for placeholder values that need to be changed
+        network = profile.get('network', {})
+        if network.get('wifi_enabled'):
+            ssid = network.get('wifi_ssid', '')
+            if 'YOUR_WIFI' in ssid or not ssid:
+                warnings.append("WiFi SSID needs to be configured")
+            psk = network.get('wifi_psk', '')
+            if 'YOUR_WIFI' in psk or not psk:
+                warnings.append("WiFi password needs to be configured")
+
+        # Check fixed position
+        position = profile.get('position', {})
+        if position.get('fixed_position'):
+            if not position.get('fixed_lat') and not position.get('fixed_lng'):
+                warnings.append("Fixed position enabled but coordinates not set")
+
+        # Check region
+        lora = profile.get('lora', {})
+        region = lora.get('region', 'US')
+        if region == 'US':
+            warnings.append("LoRa region set to US - verify this is correct for your location")
+
+        return len(warnings) == 0 or all('verify' in w.lower() for w in warnings), warnings
+
+    def apply_profile(
+        self,
+        profile_name: str,
+        port: Optional[str] = None,
+        host: Optional[str] = None,
+        dry_run: bool = False
+    ) -> dict:
+        """
+        Apply a profile to a connected Meshtastic device.
+
+        Args:
+            profile_name: Name of the profile to apply
+            port: Serial port (e.g., /dev/ttyUSB0)
+            host: TCP host (e.g., localhost for meshtasticd)
+            dry_run: If True, show command but don't execute
+
+        Returns:
+            dict with 'success', 'message', and 'command' keys
+        """
+        path = self.get_profile_path(profile_name)
+        if not path:
+            return {
+                'success': False,
+                'message': f"Profile not found: {profile_name}",
+                'command': None
+            }
+
+        # Build command
+        cmd = ['meshtastic', '--configure', str(path)]
+
+        if port:
+            cmd.extend(['--port', port])
+        elif host:
+            cmd.extend(['--host', host])
+
+        if dry_run:
+            return {
+                'success': True,
+                'message': f"Dry run - would execute: {' '.join(cmd)}",
+                'command': cmd
+            }
+
+        # Execute
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=60
+            )
+
+            if result.returncode == 0:
+                return {
+                    'success': True,
+                    'message': f"Profile {profile_name} applied successfully",
+                    'command': cmd,
+                    'stdout': result.stdout
+                }
+            else:
+                return {
+                    'success': False,
+                    'message': f"Failed to apply profile: {result.stderr}",
+                    'command': cmd,
+                    'stderr': result.stderr
+                }
+
+        except subprocess.TimeoutExpired:
+            return {
+                'success': False,
+                'message': "Command timed out after 60 seconds",
+                'command': cmd
+            }
+        except FileNotFoundError:
+            return {
+                'success': False,
+                'message': "meshtastic CLI not found. Install with: pip install meshtastic",
+                'command': cmd
+            }
+        except (subprocess.SubprocessError, OSError) as e:
+            return {
+                'success': False,
+                'message': f"Error executing command: {e}",
+                'command': cmd
+            }
+
+    def recommend_profile(self, device_info: dict) -> Optional[str]:
+        """
+        Recommend a profile based on detected device.
+
+        Args:
+            device_info: Dict from HardwareDetector with 'common_devices' or 'name'
+
+        Returns:
+            Recommended profile name or None
+        """
+        devices = device_info.get('common_devices', [])
+        name = device_info.get('name', '')
+
+        # Check for specific devices
+        device_str = ' '.join(devices).lower() + ' ' + name.lower()
+
+        if 'rak4631' in device_str or 'wisblock' in device_str:
+            return 'rak4631_gateway'
+        elif 'station g2' in device_str:
+            return 'station_g2_gateway'
+        elif 'heltec v4' in device_str:
+            return 'heltec_v4_gateway'
+        elif 'heltec v3' in device_str or 'heltec' in device_str:
+            return 'heltec_v3_gateway'
+        elif 't-beam' in device_str:
+            return 'heltec_v3_gateway'  # Similar ESP32-S3 config
+
+        return None
+
+
+def get_profile_manager() -> ProfileManager:
+    """Get a ProfileManager instance"""
+    return ProfileManager()
+
+
+# Convenience functions
+def list_profiles() -> List[ProfileInfo]:
+    """List all available gateway profiles"""
+    return ProfileManager().list_profiles()
+
+
+def apply_profile(profile_name: str, port: str = None, host: str = None) -> dict:
+    """Apply a profile to a device"""
+    return ProfileManager().apply_profile(profile_name, port=port, host=host)

--- a/src/gateway/profiles/heltec_v3_gateway.yaml
+++ b/src/gateway/profiles/heltec_v3_gateway.yaml
@@ -1,0 +1,94 @@
+# MeshForge Gateway Profile: Heltec V3 (ESP32-S3)
+# Optimized for gateway/router operation
+# Apply with: meshtastic --configure heltec_v3_gateway.yaml
+#
+# Features enabled:
+# - Router role for message forwarding
+# - WiFi enabled for API access
+# - Bluetooth disabled (headless operation)
+# - Power saving disabled (always listening)
+# - JSON API enabled for MeshForge
+# - Display disabled (headless)
+# - Store & Forward for offline message delivery
+
+device:
+  role: ROUTER_CLIENT
+  rebroadcast_mode: ALL
+  node_info_broadcast_secs: 900
+  serial_enabled: true
+
+lora:
+  region: US  # Change: US, EU_868, AU_915, etc.
+  modem_preset: LONG_FAST
+  hop_limit: 5
+  tx_enabled: true
+  tx_power: 20  # Heltec V3 max: 20dBm
+
+bluetooth:
+  enabled: false
+  fixed_pin: 123456
+
+power:
+  ls_secs: 0
+  min_wake_secs: 10
+  wait_bluetooth_secs: 0
+  mesh_sds_timeout_secs: 0
+  sds_secs: 0
+  on_battery_shutdown_after_secs: 0
+
+display:
+  screen_on_secs: 0  # Display off for headless
+  auto_screen_carousel_secs: 0
+  flip_screen: false
+  oled_type: OLED_AUTO
+  wake_on_tap_or_motion: false
+
+position:
+  gps_enabled: false  # V3 has no GPS, set true if external GPS
+  gps_update_interval: 120
+  position_broadcast_secs: 900
+  position_broadcast_smart_enabled: true
+  fixed_position: false  # Set true for fixed gateway location
+
+telemetry:
+  device_update_interval: 900
+  environment_update_interval: 900
+  environment_measurement_enabled: true
+  power_measurement_enabled: true
+
+modules:
+  serial:
+    enabled: true
+    echo: false
+    mode: PROTO
+    baud: BAUD_DEFAULT
+
+  store_forward:
+    enabled: true
+    heartbeat: false
+    records: 100
+    history_return_max: 50
+    history_return_window: 3600
+
+  neighbor_info:
+    enabled: true
+    update_interval: 900
+
+  range_test:
+    enabled: false
+
+  canned_message:
+    enabled: false
+
+  external_notification:
+    enabled: false
+
+# WiFi Configuration (ESP32-S3 has WiFi)
+network:
+  wifi_enabled: true
+  wifi_ssid: "YOUR_WIFI_SSID"  # CHANGE THIS
+  wifi_psk: "YOUR_WIFI_PASSWORD"  # CHANGE THIS
+  ntp_server: "pool.ntp.org"
+  eth_enabled: false
+  # API access settings
+  api_server_enabled: true  # Enable TCP API for meshtasticd

--- a/src/gateway/profiles/heltec_v4_gateway.yaml
+++ b/src/gateway/profiles/heltec_v4_gateway.yaml
@@ -1,0 +1,105 @@
+# MeshForge Gateway Profile: Heltec V4 (ESP32-S3 High Power)
+# Optimized for gateway/router operation with maximum TX power
+# Apply with: meshtastic --configure heltec_v4_gateway.yaml
+#
+# Heltec V4 Features:
+# - 28dBm TX power (vs 20dBm on V3)
+# - Same pinout as V3
+# - Built-in WiFi/Bluetooth antenna
+# - ESP32-S3 + SX1262
+#
+# Gateway optimizations:
+# - Maximum TX power for range
+# - WiFi enabled for API access
+# - Display disabled (headless)
+# - Store & Forward enabled
+# - Longer packet queues via store_forward
+
+device:
+  role: ROUTER_CLIENT
+  rebroadcast_mode: ALL
+  node_info_broadcast_secs: 900
+  serial_enabled: true
+
+lora:
+  region: US  # Change: US, EU_868, AU_915, etc.
+  modem_preset: LONG_FAST
+  hop_limit: 5
+  tx_enabled: true
+  tx_power: 27  # Heltec V4 max: 28dBm (use 27 for safety margin)
+  # For maximum range gateway:
+  # modem_preset: LONG_SLOW  # Slower but longer range
+
+bluetooth:
+  enabled: false
+  fixed_pin: 123456
+
+power:
+  ls_secs: 0  # No sleep - always listening
+  min_wake_secs: 10
+  wait_bluetooth_secs: 0
+  mesh_sds_timeout_secs: 0
+  sds_secs: 0
+  on_battery_shutdown_after_secs: 0
+
+display:
+  screen_on_secs: 0
+  auto_screen_carousel_secs: 0
+  flip_screen: false
+  oled_type: OLED_AUTO
+  wake_on_tap_or_motion: false
+
+position:
+  gps_enabled: false  # Set true if external GPS connected
+  gps_update_interval: 120
+  position_broadcast_secs: 900
+  position_broadcast_smart_enabled: true
+  fixed_position: false  # Recommended: set true with lat/lon for fixed gateway
+
+telemetry:
+  device_update_interval: 900
+  environment_update_interval: 900
+  environment_measurement_enabled: true
+  power_measurement_enabled: true
+
+modules:
+  serial:
+    enabled: true
+    echo: false
+    mode: PROTO
+    baud: BAUD_DEFAULT
+
+  store_forward:
+    enabled: true
+    heartbeat: false
+    records: 150  # More records for high-traffic gateway
+    history_return_max: 75
+    history_return_window: 7200  # 2 hour window
+
+  neighbor_info:
+    enabled: true
+    update_interval: 900
+
+  range_test:
+    enabled: false
+
+  canned_message:
+    enabled: false
+
+  external_notification:
+    enabled: false
+
+# WiFi Configuration
+network:
+  wifi_enabled: true
+  wifi_ssid: "YOUR_WIFI_SSID"  # CHANGE THIS
+  wifi_psk: "YOUR_WIFI_PASSWORD"  # CHANGE THIS
+  ntp_server: "pool.ntp.org"
+  eth_enabled: false
+  api_server_enabled: true
+
+# Note: V4's higher TX power means:
+# - Better range as a gateway
+# - Higher power consumption
+# - Ensure adequate power supply (5V 2A recommended)
+# - Good antenna is essential

--- a/src/gateway/profiles/rak4631_gateway.yaml
+++ b/src/gateway/profiles/rak4631_gateway.yaml
@@ -1,0 +1,105 @@
+# MeshForge Gateway Profile: RAK4631 (nRF52840)
+# Optimized for gateway/router operation
+# Apply with: meshtastic --configure rak4631_gateway.yaml
+#
+# Features enabled:
+# - Router role for message forwarding
+# - Bluetooth disabled (headless operation)
+# - Power saving disabled (always listening)
+# - Maximum hop limit for network reach
+# - JSON API for MeshForge integration
+
+device:
+  role: ROUTER_CLIENT  # Forward messages, also receive
+  rebroadcast_mode: ALL  # Rebroadcast all messages
+  node_info_broadcast_secs: 900  # Announce every 15 min
+  serial_enabled: true  # Keep serial for meshtasticd
+
+lora:
+  region: US  # Change to your region: US, EU_868, AU_915, etc.
+  modem_preset: LONG_FAST  # Good balance of range/speed
+  hop_limit: 5  # Maximum hops for wide coverage
+  tx_enabled: true
+  tx_power: 22  # Max for RAK4631 (+22dBm)
+  # Override for specific channel if needed:
+  # channel_num: 0
+  # frequency_offset: 0
+
+bluetooth:
+  enabled: false  # Disable for headless gateway
+  fixed_pin: 123456
+
+power:
+  ls_secs: 0  # Disable light sleep (always listening)
+  min_wake_secs: 10
+  wait_bluetooth_secs: 0  # Don't wait for BT connection
+  mesh_sds_timeout_secs: 0  # Disable sleep
+  sds_secs: 0
+  on_battery_shutdown_after_secs: 0  # Never shutdown
+
+display:
+  screen_on_secs: 0  # Display always off (save power)
+  auto_screen_carousel_secs: 0
+  compass_north_top: false
+  flip_screen: false
+  oled_type: OLED_AUTO
+  wake_on_tap_or_motion: false
+
+position:
+  gps_enabled: true  # Enable if GPS module present
+  gps_update_interval: 120  # Position update every 2 min
+  position_broadcast_secs: 900  # Broadcast position every 15 min
+  position_broadcast_smart_enabled: true
+  fixed_position: false  # Set true and configure lat/lon for fixed gateway
+
+telemetry:
+  device_update_interval: 900  # Device telemetry every 15 min
+  environment_update_interval: 900
+  environment_measurement_enabled: true
+  environment_screen_enabled: false
+  power_measurement_enabled: true
+  power_screen_enabled: false
+
+# Module-specific settings
+modules:
+  serial:
+    enabled: true
+    echo: false
+    mode: PROTO  # Protocol buffer mode for meshtasticd
+    rxd: 0
+    txd: 0
+    baud: BAUD_DEFAULT
+    timeout: 0
+    override_console_serial_port: false
+
+  range_test:
+    enabled: false  # Disable unless testing
+
+  store_forward:
+    enabled: true  # Enable for gateway
+    heartbeat: false
+    records: 100  # Store up to 100 messages
+    history_return_max: 50
+    history_return_window: 3600  # 1 hour window
+
+  neighbor_info:
+    enabled: true
+    update_interval: 900  # Update every 15 min
+
+  detection_sensor:
+    enabled: false
+
+  ambient_lighting:
+    enabled: false
+
+  canned_message:
+    enabled: false
+
+  external_notification:
+    enabled: false
+
+# Network/WiFi (if using WiFi variant)
+# network:
+#   wifi_enabled: false  # RAK4631 doesn't have WiFi
+#   wifi_ssid: ""
+#   wifi_psk: ""

--- a/src/gateway/profiles/station_g2_gateway.yaml
+++ b/src/gateway/profiles/station_g2_gateway.yaml
@@ -1,0 +1,119 @@
+# MeshForge Gateway Profile: Heltec Station G2
+# Optimized for fixed gateway/base station operation
+# Apply with: meshtastic --configure station_g2_gateway.yaml
+#
+# Station G2 Features:
+# - ESP32 + SX1262
+# - Ethernet support (ideal for fixed gateway)
+# - PoE capable
+# - External antenna connector
+# - No display (headless by design)
+#
+# Perfect for:
+# - Fixed location gateways
+# - MeshForge bridge nodes
+# - MQTT integration
+# - High-reliability deployments
+
+device:
+  role: ROUTER  # Pure router - maximum forwarding
+  rebroadcast_mode: ALL
+  node_info_broadcast_secs: 900
+  serial_enabled: true
+
+lora:
+  region: US  # Change: US, EU_868, AU_915, etc.
+  modem_preset: LONG_FAST
+  hop_limit: 7  # Maximum hops for base station
+  tx_enabled: true
+  tx_power: 22  # Station G2 typical max
+  # For infrastructure gateway, consider:
+  # modem_preset: MEDIUM_FAST  # Balance speed/reliability
+
+bluetooth:
+  enabled: false  # Not needed for fixed station
+  fixed_pin: 123456
+
+power:
+  ls_secs: 0  # Never sleep
+  min_wake_secs: 10
+  wait_bluetooth_secs: 0
+  mesh_sds_timeout_secs: 0
+  sds_secs: 0
+  on_battery_shutdown_after_secs: 0  # PoE powered, no battery concern
+
+display:
+  # Station G2 has no display
+  screen_on_secs: 0
+  auto_screen_carousel_secs: 0
+
+position:
+  gps_enabled: false  # Station G2 has no GPS
+  fixed_position: true  # REQUIRED: Set your gateway location
+  # Uncomment and set your coordinates:
+  # fixed_lat: 0.0
+  # fixed_lng: 0.0
+  # fixed_alt: 0
+  position_broadcast_secs: 3600  # Broadcast position hourly
+  position_broadcast_smart_enabled: false  # Fixed position, no smart needed
+
+telemetry:
+  device_update_interval: 900
+  environment_update_interval: 0  # No sensors
+  environment_measurement_enabled: false
+  power_measurement_enabled: true
+
+modules:
+  serial:
+    enabled: true
+    echo: false
+    mode: PROTO
+    baud: BAUD_DEFAULT
+
+  store_forward:
+    enabled: true
+    heartbeat: true  # Enable for base station
+    records: 200  # Large buffer for base station
+    history_return_max: 100
+    history_return_window: 14400  # 4 hour window
+
+  neighbor_info:
+    enabled: true
+    update_interval: 600  # More frequent for base station
+
+  mqtt:
+    enabled: false  # Enable if using MQTT bridge
+    # address: "mqtt.example.com"
+    # username: ""
+    # password: ""
+    # encryption_enabled: true
+    # json_enabled: true  # JSON for easy integration
+    # tls_enabled: true
+    # root_topic: "msh"
+
+  range_test:
+    enabled: false
+
+  canned_message:
+    enabled: false
+
+# Network Configuration (Ethernet primary)
+network:
+  wifi_enabled: false  # Use Ethernet instead
+  eth_enabled: true  # Primary connection method
+  # Static IP recommended for gateway:
+  # eth_mode: STATIC
+  # eth_config:
+  #   ip: 192.168.1.100
+  #   gateway: 192.168.1.1
+  #   subnet: 255.255.255.0
+  #   dns: 8.8.8.8
+  ntp_server: "pool.ntp.org"
+  api_server_enabled: true  # Enable API for meshtasticd
+
+# Note: Station G2 deployment tips:
+# - Use PoE for reliable power
+# - Mount with good antenna line-of-sight
+# - Set fixed_position with accurate coordinates
+# - Enable MQTT if bridging to home automation
+# - Consider MEDIUM_FAST preset for better reliability


### PR DESCRIPTION
Phase 1 firmware integration (safe, no custom builds):

Hardware detection updates:
- Add Heltec V3/V4 (ESP32-S3) USB IDs
- Add RAK4631 (nRF52840) USB IDs
- Add Station G2 detection via CP2102
- Add LILYGO T-Beam S3
- Add gateway_capable and flash_method flags

Gateway profiles (src/gateway/profiles/):
- rak4631_gateway.yaml: Low-power nRF52 gateway
- heltec_v3_gateway.yaml: WiFi-enabled ESP32-S3
- heltec_v4_gateway.yaml: High-power 27dBm gateway
- station_g2_gateway.yaml: Ethernet base station

Profile features:
- Router role for message forwarding
- Store & Forward enabled
- Display/Bluetooth disabled (headless)
- Power saving disabled (always listening)
- Maximum hop limits for coverage
- WiFi/Ethernet configuration where applicable

ProfileManager utility:
- List available profiles
- Validate profile configuration
- Apply profiles via meshtastic CLI
- Device-to-profile recommendation