### PR TITLE
fix: Correct launcher_tui path in launch scripts

### DIFF
--- a/scripts/meshforge-launcher.sh
+++ b/scripts/meshforge-launcher.sh
@@ -134,7 +134,7 @@ case "$1" in
         ;;
     tui)
         # raspi-config style whiptail/dialog TUI
-        launch_terminal "$MESHFORGE_DIR/src/launcher_tui.py"
+        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
         ;;
     tui-textual)
         # Textual TUI (deprecated)
@@ -148,6 +148,6 @@ case "$1" in
         ;;
     *)
         # Default: raspi-config style TUI
-        launch_terminal "$MESHFORGE_DIR/src/launcher_tui.py"
+        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
         ;;
 esac

--- a/scripts/meshforge-terminal.sh
+++ b/scripts/meshforge-terminal.sh
@@ -12,7 +12,7 @@
 MESHFORGE_DIR="/opt/meshforge"
 ICON_NAME="org.meshforge.app"
 TITLE="MeshForge"
-TUI_CMD="sudo python3 $MESHFORGE_DIR/src/launcher_tui.py"
+TUI_CMD="sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
 VTE_CMD="python3 $MESHFORGE_DIR/src/launcher_vte.py"
 
 # Log file for debugging launch issues
@@ -118,8 +118,8 @@ check_installation() {
         exit 1
     fi
 
-    if [ ! -f "$MESHFORGE_DIR/src/launcher_tui.py" ]; then
-        show_error "launcher_tui.py not found at $MESHFORGE_DIR/src/\n\nInstallation may be corrupted."
+    if [ ! -f "$MESHFORGE_DIR/src/launcher_tui/main.py" ]; then
+        show_error "launcher_tui not found at $MESHFORGE_DIR/src/\n\nInstallation may be corrupted."
         exit 1
     fi
 }
@@ -172,7 +172,7 @@ if has_display; then
 
     # Nothing worked - show error
     log_msg "No terminal emulator found!"
-    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  sudo python3 $MESHFORGE_DIR/src/launcher_tui.py"
+    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
     exit 1
 else
     # No display (SSH session) - run TUI directly


### PR DESCRIPTION
The launcher scripts were referencing a non-existent `launcher_tui.py` file. The TUI launcher is actually a module at `launcher_tui/main.py`. Fixed all references in:
- meshforge-launcher.sh (2 occurrences)
- meshforge-terminal.sh (4 occurrences)