### PR TITLE
fix: Run launcher_tui as module to fix relative imports

### DIFF
--- a/scripts/meshforge-launcher.sh
+++ b/scripts/meshforge-launcher.sh
@@ -134,7 +134,7 @@ case "$1" in
         ;;
     tui)
         # raspi-config style whiptail/dialog TUI
-        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
+        cd "$MESHFORGE_DIR/src" && launch_terminal "python3 -m launcher_tui.main"
         ;;
     tui-textual)
         # Textual TUI (deprecated)
@@ -148,6 +148,6 @@ case "$1" in
         ;;
     *)
         # Default: raspi-config style TUI
-        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
+        cd "$MESHFORGE_DIR/src" && launch_terminal "python3 -m launcher_tui.main"
         ;;
 esac

--- a/scripts/meshforge-terminal.sh
+++ b/scripts/meshforge-terminal.sh
@@ -12,7 +12,7 @@
 MESHFORGE_DIR="/opt/meshforge"
 ICON_NAME="org.meshforge.app"
 TITLE="MeshForge"
-TUI_CMD="sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
+TUI_CMD="cd $MESHFORGE_DIR/src && sudo python3 -m launcher_tui.main"
 VTE_CMD="python3 $MESHFORGE_DIR/src/launcher_vte.py"
 
 # Log file for debugging launch issues
@@ -118,7 +118,7 @@ check_installation() {
         exit 1
     fi
 
-    if [ ! -f "$MESHFORGE_DIR/src/launcher_tui/main.py" ]; then
+    if [ ! -d "$MESHFORGE_DIR/src/launcher_tui" ]; then
         show_error "launcher_tui not found at $MESHFORGE_DIR/src/\n\nInstallation may be corrupted."
         exit 1
     fi
@@ -172,7 +172,7 @@ if has_display; then
 
     # Nothing worked - show error
     log_msg "No terminal emulator found!"
-    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
+    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  cd $MESHFORGE_DIR/src && sudo python3 -m launcher_tui.main"
     exit 1
 else
     # No display (SSH session) - run TUI directly


### PR DESCRIPTION
The launcher_tui module uses relative imports which fail when run directly as a script. Changed to run as module with:
  cd src && python3 -m launcher_tui.main