### PR TITLE
fix: Use absolute imports in launcher_tui for direct script execution

### DIFF
--- a/scripts/meshforge-launcher.sh
+++ b/scripts/meshforge-launcher.sh
@@ -134,7 +134,7 @@ case "$1" in
         ;;
     tui)
         # raspi-config style whiptail/dialog TUI
-        cd "$MESHFORGE_DIR/src" && launch_terminal "python3 -m launcher_tui.main"
+        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
         ;;
     tui-textual)
         # Textual TUI (deprecated)
@@ -148,6 +148,6 @@ case "$1" in
         ;;
     *)
         # Default: raspi-config style TUI
-        cd "$MESHFORGE_DIR/src" && launch_terminal "python3 -m launcher_tui.main"
+        launch_terminal "$MESHFORGE_DIR/src/launcher_tui/main.py"
         ;;
 esac

--- a/scripts/meshforge-terminal.sh
+++ b/scripts/meshforge-terminal.sh
@@ -12,7 +12,7 @@
 MESHFORGE_DIR="/opt/meshforge"
 ICON_NAME="org.meshforge.app"
 TITLE="MeshForge"
-TUI_CMD="cd $MESHFORGE_DIR/src && sudo python3 -m launcher_tui.main"
+TUI_CMD="sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
 VTE_CMD="python3 $MESHFORGE_DIR/src/launcher_vte.py"
 
 # Log file for debugging launch issues
@@ -118,7 +118,7 @@ check_installation() {
         exit 1
     fi
 
-    if [ ! -d "$MESHFORGE_DIR/src/launcher_tui" ]; then
+    if [ ! -f "$MESHFORGE_DIR/src/launcher_tui/main.py" ]; then
         show_error "launcher_tui not found at $MESHFORGE_DIR/src/\n\nInstallation may be corrupted."
         exit 1
     fi
@@ -172,7 +172,7 @@ if has_display; then
 
     # Nothing worked - show error
     log_msg "No terminal emulator found!"
-    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  cd $MESHFORGE_DIR/src && sudo python3 -m launcher_tui.main"
+    show_error "No terminal emulator found!\n\nInstall one with:\n  sudo apt install xterm\n\nOr run directly:\n  sudo python3 $MESHFORGE_DIR/src/launcher_tui/main.py"
     exit 1
 else
     # No display (SSH session) - run TUI directly

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -17,6 +17,11 @@ import subprocess
 from pathlib import Path
 from typing import Optional, List
 
+# Ensure src directory is in path for imports when run directly
+_src_dir = Path(__file__).parent.parent
+if str(_src_dir) not in sys.path:
+    sys.path.insert(0, str(_src_dir))
+
 # Import version
 try:
     from __version__ import __version__
@@ -33,8 +38,8 @@ except ImportError:
             return Path(f'/home/{sudo_user}')
         return Path.home()
 
-# Import dialog backend from module
-from .backend import DialogBackend
+# Import dialog backend - use absolute import for direct script execution
+from launcher_tui.backend import DialogBackend
 
 
 class MeshForgeLauncher:


### PR DESCRIPTION
Add src directory to sys.path at startup so the module can be run directly as a script without relative import errors.