### PR TITLE
fix: Correct src_dir path in launcher_tui for GTK launch

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -53,7 +53,7 @@ class MeshForgeLauncher:
 
     def __init__(self):
         self.dialog = DialogBackend()
-        self.src_dir = Path(__file__).parent
+        self.src_dir = Path(__file__).parent.parent  # src/ directory
         self.env = self._detect_environment()
 
     def _detect_environment(self) -> dict:


### PR DESCRIPTION
src_dir pointed to launcher_tui/ instead of src/, causing GTK launch to fail when looking for main_gtk.py in wrong directory.