### PR TITLE
fix: Add cleanup() methods to RNS and RadioConfig panels

### DIFF
--- a/src/gtk_ui/panels/radio_config_simple.py
+++ b/src/gtk_ui/panels/radio_config_simple.py
@@ -108,6 +108,10 @@ class RadioConfigSimple(Gtk.Box):
 
     def _on_unrealize(self, widget):
         """Clean up when panel is destroyed."""
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources - called by main window on close."""
         for timer_id in self._pending_timers:
             try:
                 GLib.source_remove(timer_id)

--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -104,6 +104,10 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
 
     def _on_unrealize(self, widget):
         """Clean up when panel is destroyed to prevent timer crashes."""
+        self.cleanup()
+
+    def cleanup(self):
+        """Clean up resources - called by main window on close."""
         # Cancel all pending timers
         for timer_id in self._pending_timers:
             try:


### PR DESCRIPTION
Both panels had _on_unrealize handlers for timer cleanup, but the main window's _on_close_request calls cleanup() explicitly. Without cleanup() methods, timers could continue firing after window close, causing GTK to hang and prevent quitting.

- src/gtk_ui/panels/rns.py: Added cleanup() method
- src/gtk_ui/panels/radio_config_simple.py: Added cleanup() method

Both _on_unrealize handlers now delegate to cleanup() for consistency.