### PR TITLE
fix: Sync inline status labels with mixin update methods

### DIFF
--- a/src/gtk_ui/panels/tools_mixins/hf_propagation.py
+++ b/src/gtk_ui/panels/tools_mixins/hf_propagation.py
@@ -51,6 +51,19 @@ class HFPropagationMixin:
                     'protonflux': solar.findtext('protonflux', '--'),
                     'updated': solar.findtext('updated', '--'),
                 }
+
+                # Get band conditions (day/night)
+                calc = root.find('.//calculatedconditions')
+                if calc is not None:
+                    bands = calc.findall('band')
+                    for band in bands:
+                        name = band.get('name', '')
+                        time_attr = band.get('time', 'day')
+                        condition = band.text or '--'
+                        # Only use day conditions for simplicity
+                        if time_attr == 'day' and name:
+                            data[f'band_{name}'] = condition
+
                 GLib.idle_add(self._update_solar_display, data)
             else:
                 GLib.idle_add(self._log, "Could not parse solar data")
@@ -86,11 +99,29 @@ class HFPropagationMixin:
         except ValueError:
             pass
 
-        # Update labels if they exist
-        if hasattr(self, 'sfi_label'):
-            GLib.idle_add(self.sfi_label.set_label, str(data['sfi']))
-        if hasattr(self, 'kindex_label'):
-            GLib.idle_add(self.kindex_label.set_label, str(data['kindex']))
+        # Update inline labels if they exist (names must match tools.py UI)
+        if hasattr(self, 'solar_sfi_label'):
+            self.solar_sfi_label.set_label(str(data['sfi']))
+        if hasattr(self, 'solar_sn_label'):
+            self.solar_sn_label.set_label(str(data['sunspots']))
+        if hasattr(self, 'solar_a_label'):
+            self.solar_a_label.set_label(str(data['aindex']))
+        if hasattr(self, 'solar_k_label'):
+            self.solar_k_label.set_label(str(data['kindex']))
+        if hasattr(self, 'solar_status_label'):
+            self.solar_status_label.set_label(f"Updated: {data['updated']}")
+
+        # Update band condition labels
+        band_mapping = {
+            'band_80m-40m': 'band_80m_label',
+            'band_30m-20m': 'band_20m_label',
+            'band_17m-15m': 'band_15m_label',
+            'band_12m-10m': 'band_10m_label',
+        }
+        for xml_key, label_attr in band_mapping.items():
+            if xml_key in data and hasattr(self, label_attr):
+                band_name = xml_key.replace('band_', '').split('-')[0]
+                getattr(self, label_attr).set_label(f"{band_name}: {data[xml_key]}")
 
     def _on_voacap_online(self, button=None):
         """Open VOACAP Online propagation predictor"""

--- a/src/gtk_ui/panels/tools_mixins/network_tools.py
+++ b/src/gtk_ui/panels/tools_mixins/network_tools.py
@@ -172,15 +172,16 @@ class NetworkToolsMixin:
 
     def _refresh_status_thread(self):
         """Check network status in background"""
-        # Check meshtasticd port
+        # Get local IP address
+        local_ip = "--"
         sock = None
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.settimeout(2)
-            result = sock.connect_ex(('localhost', 4403))
-            meshtastic_status = "Connected" if result == 0 else "Not Connected"
+            sock.connect(("8.8.8.8", 80))
+            local_ip = sock.getsockname()[0]
         except Exception:
-            meshtastic_status = "Error"
+            local_ip = "No network"
         finally:
             if sock:
                 try:
@@ -188,5 +189,45 @@ class NetworkToolsMixin:
                 except Exception:
                     pass
 
-        if hasattr(self, 'mesh_status_label'):
-            GLib.idle_add(self.mesh_status_label.set_label, meshtastic_status)
+        if hasattr(self, 'local_ip_label'):
+            GLib.idle_add(self.local_ip_label.set_label, local_ip)
+
+        # Check meshtasticd port 4403
+        sock = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(2)
+            result = sock.connect_ex(('localhost', 4403))
+            port_status = "Open ✓" if result == 0 else "Closed"
+        except Exception:
+            port_status = "Error"
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+
+        if hasattr(self, 'port_status_label'):
+            GLib.idle_add(self.port_status_label.set_label, port_status)
+
+        # Check MUDP package status
+        try:
+            import importlib.util
+            mudp_installed = importlib.util.find_spec('mudp') is not None
+            mudp_status = "Installed ✓" if mudp_installed else "Not installed"
+        except Exception:
+            mudp_status = "Unknown"
+
+        if hasattr(self, 'mudp_status_label'):
+            GLib.idle_add(self.mudp_status_label.set_label, mudp_status)
+
+        # Check SDR tools status
+        import shutil
+        openwebrx_status = "Installed ✓" if shutil.which('openwebrx') else "Not installed"
+        rtlsdr_status = "Installed ✓" if shutil.which('rtl_test') else "Not installed"
+
+        if hasattr(self, 'openwebrx_status'):
+            GLib.idle_add(self.openwebrx_status.set_label, openwebrx_status)
+        if hasattr(self, 'rtlsdr_status'):
+            GLib.idle_add(self.rtlsdr_status.set_label, rtlsdr_status)


### PR DESCRIPTION
Root cause: Label names in UI (tools.py) didn't match what mixins expected, so status updates were failing silently.

Fixed mismatches:
- Network Tools: mesh_status_label → port_status_label
- HF Propagation: sfi_label → solar_sfi_label (and others)

Added missing status updates to _refresh_status_thread:
- Local IP address (was created but never updated)
- Port 4403 status with visual indicator (Open ✓ / Closed)
- MUDP package installation status
- OpenWebRX/RTL-SDR tool availability

HF Propagation now updates:
- All solar data labels (SFI, Sunspots, A-Index, K-Index)
- Status label with last update timestamp
- Band condition labels from HamQSL XML data

This follows systematic debugging - audit all labels, match names, verify update paths. No more silent failures.