### PR TITLE
docs: Add session notes for auto-review findings

### DIFF
--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -4,8 +4,8 @@
 > *Build. Test. Deploy. Monitor.*
 
 ## Current Version: 0.4.3-beta
-## Last Updated: 2026-01-07
-## Branch: `claude/fix-address-in-use-qYem5`
+## Last Updated: 2026-01-15
+## Branch: `claude/review-and-report-rDUgX`
 
 ---
 
@@ -51,6 +51,38 @@ sudo ./scripts/install-desktop.sh
 ---
 
 ## Recent Work Summary
+
+### Session: 2026-01-15 - Auto-Review & Stability Milestone
+
+**Milestone: MeshForge GTK running stable for several hours**
+
+**Auto-Review Results:**
+- Files scanned: 197
+- Total issues: 2 (both false positives)
+- Security: 0, Redundancy: 0, Performance: 2 (FP), Reliability: 0
+
+**False Positives Identified:**
+
+1. `dashboard.py:43` - `GLib.timeout_add(500, self._initial_refresh)`
+   - Flagged as "timer may leak without cleanup"
+   - Reality: One-time startup timer, fires once then done
+   - No action needed
+
+2. `tools.py:846` - `GLib.timeout_add(50, self._scroll_to_end)`
+   - Flagged as "timer may leak without cleanup"
+   - Reality: Brief 50ms fire-and-forget with widget guards
+   - No action needed
+
+**Future Enhancement (auto_review.py):**
+
+The `glib_timeout_no_cleanup` pattern should be improved to recognize:
+- One-time timers (methods that return `False` or don't loop)
+- Very short timers (<100ms) used for UI scheduling/deferral
+- Timers with existing widget guards (hasattr checks)
+
+These are fire-and-forget patterns, not the long-running periodic timers the rule is designed to catch.
+
+---
 
 ### Session: 2026-01-06/07 - GTK Stabilization & HamClock
 


### PR DESCRIPTION
- Documented stability milestone (GTK running several hours)
- Recorded 2 false positives from glib_timeout_no_cleanup pattern
- Noted future enhancement for auto_review.py to recognize:
  - One-time startup timers
  - Brief UI scheduling timers (<100ms)
  - Timers with widget guards