### PR TITLE
fix(gateway): Register bridge with commands module for messaging

### DIFF
--- a/src/commands/gateway.py
+++ b/src/commands/gateway.py
@@ -19,6 +19,13 @@ logger = logging.getLogger(__name__)
 _bridge_instance = None
 
 
+def set_bridge(bridge):
+    """Register an external bridge instance (e.g., from GTK UI)."""
+    global _bridge_instance
+    _bridge_instance = bridge
+    logger.info("Gateway bridge registered from external source")
+
+
 def _get_bridge():
     """Get or create the bridge instance."""
     global _bridge_instance

--- a/src/gtk_ui/panels/rns_mixins/gateway.py
+++ b/src/gtk_ui/panels/rns_mixins/gateway.py
@@ -422,6 +422,14 @@ class GatewayMixin:
                 success = self._gateway_bridge.start()
                 logger.debug(f"[RNS] Gateway start: {'OK' if success else 'FAILED'}")
 
+                # Register bridge with commands module so messaging can use it
+                if success:
+                    try:
+                        from commands import gateway as gateway_cmd
+                        gateway_cmd.set_bridge(self._gateway_bridge)
+                    except Exception as e:
+                        logger.warning(f"[RNS] Could not register bridge: {e}")
+
                 GLib.idle_add(self._gateway_start_complete, success)
             except ImportError as e:
                 logger.debug(f"[RNS] Gateway start failed - missing module: {e}")


### PR DESCRIPTION
- Add set_bridge() function to commands/gateway.py
- GTK panel now registers its bridge instance after starting
- Allows messaging panel to use the running gateway bridge