### PR TITLE
docs: Fix ralph-wiggum-healthcheck and update stale file size data

### DIFF
--- a/.claude/TODO_PRIORITIES.md
+++ b/.claude/TODO_PRIORITIES.md
@@ -1,6 +1,6 @@
 # MeshForge Development Priorities
 
-> **Last Updated:** 2026-01-12
+> **Last Updated:** 2026-01-15
 > **Maintainer:** WH6GXZ / Dude AI
 
 ---
@@ -17,10 +17,11 @@
 
 ### Code Quality
 - [x] **Consolidate `get_real_user_home()`** - Reviewed: try/except fallback pattern is intentional for robustness when utils.paths unavailable
-- [ ] **Split large files** (>1500 lines):
-  - `rns.py` (2953 lines) → Extract config editor, MeshChat to separate modules
-  - `main_web.py` (2911 lines) → Flask blueprints
-  - `tools.py` (2695 lines) → Split into rf_tools.py, network_diag.py
+- [x] **Split large files** (>1500 lines) - PARTIAL:
+  - [x] `rns.py` (673 lines now) - Successfully refactored
+  - [x] `main_web.py` (1314 lines now) - Successfully refactored
+  - [ ] `launcher_tui/main.py` (2822 lines) - Extract menu handlers
+  - [ ] `hamclock.py` (2625 lines) - Extract API client
 
 ### Testing
 - [x] **Install pytest** - Available in environment
@@ -133,11 +134,13 @@
 
 | File | Lines | Action |
 |------|-------|--------|
-| rns.py | 2953 | Split: config_editor.py, meshchat_panel.py |
-| main_web.py | 2911 | Split: Flask blueprints |
-| tools.py | 2695 | Split: rf_tools.py, network_diag.py |
-| hamclock.py | ~2400 | Monitor - approaching split threshold |
-| radio_config.py | 1839 | Consider splitting |
+| launcher_tui/main.py | 2822 | Split: extract menu handlers |
+| hamclock.py | 2625 | Split: extract API client |
+| mesh_tools.py | 1953 | Monitor |
+| tools.py | 1842 | Monitor |
+| tui/app.py | 1734 | Consider extracting panes |
+
+*Note: rns.py (673) and main_web.py (1314) successfully refactored.*
 
 ---
 

--- a/.claude/commands/ralph-wiggum-healthcheck.md
+++ b/.claude/commands/ralph-wiggum-healthcheck.md
@@ -49,10 +49,8 @@ cd src && python3 -c "
 from utils.auto_review import ReviewOrchestrator
 r = ReviewOrchestrator()
 report = r.run_full_review()
-print(f'Security: {report.security_issues}')
-print(f'Redundancy: {report.redundancy_issues}')
-print(f'Performance: {report.performance_issues}')
-print(f'Reliability: {report.reliability_issues}')
+for cat, result in report.agent_results.items():
+    print(f'{cat.value.title()}: {result.total_issues}')
 print(f'Total: {report.total_issues}')
 "
 ```
@@ -69,12 +67,17 @@ python3 -m pytest tests/ -v --tb=no -q 2>&1 | tail -20
 - Map information dependencies
 
 ### 7. File Size Audit
-Flag files over 1,500 lines:
-| File | Threshold | Action |
-|------|-----------|--------|
-| rns.py | 2900+ | Split: config_editor, meshchat_panel |
-| main_web.py | 2900+ | Flask blueprints |
-| tools.py | 2600+ | rf_tools, network_diag |
+Flag files over 1,500 lines (run: `find src -name "*.py" -exec wc -l {} \; | sort -rn | head -10`):
+
+| File | Lines | Status |
+|------|-------|--------|
+| launcher_tui/main.py | 2800+ | Consider splitting |
+| gtk_ui/panels/hamclock.py | 2600+ | Extract API client |
+| gtk_ui/panels/mesh_tools.py | 1900+ | Monitor |
+| gtk_ui/panels/tools.py | 1800+ | Monitor |
+| tui/app.py | 1700+ | Extract panes |
+
+*Note: rns.py, main_web.py have been successfully refactored.*
 
 ---
 

--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -232,21 +232,22 @@ from utils.service_check import check_service, check_port, ServiceState
 ### Symptom
 Files exceed the 1,500 line guideline from CLAUDE.md, making them difficult to navigate, test, and maintain.
 
-### Current Status (2026-01-10)
+### Current Status (2026-01-15)
 
 **Python files over 1,500 lines:**
 
 | File | Lines | Priority | Suggested Split |
 |------|-------|----------|-----------------|
-| `src/main_web.py` | 3,524 | HIGH | Flask blueprints |
-| `src/gtk_ui/panels/rns.py` | 3,162 | HIGH | Extract config editor |
-| `src/gtk_ui/panels/tools.py` | 2,869 | MEDIUM | Split by tool category |
-| `src/gtk_ui/panels/radio_config.py` | 2,496 | MEDIUM | Extract channel config |
-| `src/gtk_ui/panels/mesh_tools.py` | 1,921 | LOW | Extract RF calculations |
-| `src/gtk_ui/panels/hamclock.py` | 1,894 | LOW | Extract API client |
-| `src/core/diagnostics/engine.py` | 1,685 | LOW | Extract rules |
-| `src/tui/app.py` | 1,650 | LOW | Extract panes to modules |
-| `src/gtk_ui/panels/ham_tools.py` | 1,611 | LOW | Extract tool groups |
+| `src/launcher_tui/main.py` | 2,822 | HIGH | Extract menu handlers |
+| `src/gtk_ui/panels/hamclock.py` | 2,625 | HIGH | Extract API client |
+| `src/gtk_ui/panels/mesh_tools.py` | 1,953 | MEDIUM | Extract RF calculations |
+| `src/gtk_ui/panels/tools.py` | 1,842 | MEDIUM | Split by tool category |
+| `src/tui/app.py` | 1,734 | LOW | Extract panes to modules |
+| `src/core/diagnostics/engine.py` | 1,677 | LOW | Extract rules |
+| `src/gtk_ui/panels/ham_tools.py` | 1,657 | LOW | Extract tool groups |
+| `src/gtk_ui/app.py` | 1,532 | LOW | Monitor |
+
+*Note: rns.py (673), main_web.py (1,314) successfully refactored.*
 
 **Markdown files over 1,000 lines:**
 
@@ -855,4 +856,4 @@ def __init__(self, main_window):
 
 ---
 
-*Last updated: 2026-01-14 - Added startup performance / lazy loading fix*
+*Last updated: 2026-01-15 - Updated file size audit with current line counts*


### PR DESCRIPTION
- Fix broken auto-review code example in healthcheck (report.security_issues doesn't exist, changed to iterate report.agent_results)
- Update file size audit tables across 3 docs to reflect current reality:
  - rns.py refactored from 3162 to 673 lines
  - main_web.py refactored from 3524 to 1314 lines
  - tools.py reduced from 2869 to 1842 lines
- Add new large files to monitor: launcher_tui/main.py (2822), hamclock.py (2625)
- Update TODO_PRIORITIES to mark file split as partial success
- Sync dates across documentation files