### PR TITLE
fix(security): Address MF001 Path.home() violations and timeout enfor…

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -1724,7 +1724,12 @@ class MeshtasticdTUI(App):
                 from utils.paths import get_real_user_home
                 settings_dir = get_real_user_home() / ".config" / "meshforge"
             except ImportError:
-                settings_dir = Path.home() / ".config" / "meshforge"
+                import os
+                sudo_user = os.environ.get('SUDO_USER')
+                if sudo_user:
+                    settings_dir = Path(f"/home/{sudo_user}") / ".config" / "meshforge"
+                else:
+                    settings_dir = Path.home() / ".config" / "meshforge"
 
             settings_file = settings_dir / "settings.json"
             if settings_file.exists():
@@ -1745,7 +1750,12 @@ class MeshtasticdTUI(App):
                 from utils.paths import get_real_user_home
                 settings_dir = get_real_user_home() / ".config" / "meshforge"
             except ImportError:
-                settings_dir = Path.home() / ".config" / "meshforge"
+                import os
+                sudo_user = os.environ.get('SUDO_USER')
+                if sudo_user:
+                    settings_dir = Path(f"/home/{sudo_user}") / ".config" / "meshforge"
+                else:
+                    settings_dir = Path.home() / ".config" / "meshforge"
 
             settings_dir.mkdir(parents=True, exist_ok=True)
             settings_file = settings_dir / "settings.json"

--- a/src/utils/device_backup.py
+++ b/src/utils/device_backup.py
@@ -18,7 +18,12 @@ logger = logging.getLogger(__name__)
 try:
     from utils.paths import get_real_user_home
 except ImportError:
+    import os
     def get_real_user_home():
+        """Fallback for sudo-safe home directory."""
+        sudo_user = os.environ.get('SUDO_USER')
+        if sudo_user:
+            return Path(f"/home/{sudo_user}")
         return Path.home()
 
 

--- a/src/utils/esptool_wrapper.py
+++ b/src/utils/esptool_wrapper.py
@@ -322,12 +322,18 @@ class EsptoolWrapper:
 
             try:
                 while True:
+                    # Check for timeout
+                    elapsed = time.time() - start_time
+                    if elapsed > self.FLASH_TIMEOUT:
+                        process.terminate()
+                        raise subprocess.TimeoutExpired(cmd, self.FLASH_TIMEOUT)
+
                     if self._abort_flag.is_set():
                         process.terminate()
                         return FlashResult(
                             success=False,
                             message="Flash aborted by user",
-                            duration_seconds=time.time() - start_time
+                            duration_seconds=elapsed
                         )
 
                     line = process.stdout.readline()


### PR DESCRIPTION
…cement

Fixes 3 critical issues found in domain continuity review:

1. device_backup.py: Fallback now uses SUDO_USER for sudo-safe paths
2. tui/app.py: Theme persistence fallback now handles sudo correctly
3. esptool_wrapper.py: Flash loop now enforces FLASH_TIMEOUT (300s)

All fixes align with MeshForge security patterns in:
- .claude/rules/security.md (MF001)
- .claude/foundations/persistent_issues.md (Issue #1)