### PR TITLE
docs: Add session summary for messaging debug session (2026-01-15)

### DIFF
--- a/.claude/foundations/session_2026-01-15_messaging_debug.md
+++ b/.claude/foundations/session_2026-01-15_messaging_debug.md
@@ -1,0 +1,76 @@
+# Session Summary: Messaging Debug Session (2026-01-15)
+
+## Session Outcome: INCOMPLETE - Needs Fresh Approach
+
+This session attempted to fix TX/RX messaging between MeshForge GTK and meshtasticd but ended in a "whack-a-mole" debugging loop. **Do not continue from this session's approach.**
+
+## What Was Attempted
+
+### The Core Problem
+- meshtasticd only allows ONE TCP client connection at a time
+- MeshForge needs persistent connection for RX (pub/sub callbacks)
+- TX via interface was unreliable
+- TX via CLI kicks out the persistent connection, breaking RX
+
+### Approaches Tried (All Had Issues)
+1. **Interface sendText** - Said "completed" but messages didn't reach devices
+2. **CLI fallback** - TX worked but broke RX connection
+3. **Auto-reconnect after CLI** - Unreliable, pub/sub didn't restore properly
+4. **wantAck=False** - Helped with blocking but TX still inconsistent
+5. **Health check before TX** - Added complexity without solving root cause
+
+### What Actually Worked (Briefly)
+- Scroll position fix (save/restore vadjustment) - KEEP THIS
+- Using `^all` for broadcast destination
+- `wantAck=False` to prevent blocking
+
+### What's Broken
+- TX/RX reliability is inconsistent
+- RNS panel shows conflicting on/off states
+- "Failed to bridge Mesh→RNS" warnings appear when user doesn't have RNS running
+- Interface sendText doesn't reliably transmit
+
+## Known Good State
+- **main branch** is stable - user confirmed production network with 300+ nodes works fine
+- The issue is specific to this branch's messaging implementation
+
+## Recommendations for Next Session
+
+### 1. Start Fresh - Don't Continue This Approach
+The debugging became circular. Each fix broke something else.
+
+### 2. Investigate Root Cause First
+Before writing code, understand WHY interface sendText doesn't work:
+- Is meshtasticd receiving the command?
+- Is the radio transmitting?
+- Compare exact API calls between working CLI and failing interface
+
+### 3. Consider Alternative Architectures
+- **Serial connection** instead of TCP (bypasses meshtasticd entirely)
+- **Single shared interface** for both TX and RX without reconnection
+- **Queue-based approach** - queue TX, send in batches, maintain connection
+
+### 4. Fix RNS Panel State
+The RNS panel shows inconsistent on/off states. This is a separate issue from messaging but confuses users.
+
+### 5. Suppress "Failed to bridge Mesh→RNS" When RNS Not Configured
+These warnings appear constantly when user isn't running RNS. Should only warn once or not at all.
+
+## Files Modified This Session
+- `src/gateway/rns_bridge.py` - Multiple TX/RX changes (mostly problematic)
+- `src/gtk_ui/panels/messaging.py` - Scroll fix (KEEP), auto-refresh changes
+- `src/utils/meshtastic_connection.py` - Persistent connection support
+
+## Test Environment
+- Raspberry Pi 5
+- Two Meshtastic nodes on same Pi
+- Channel 3 for MeshForge testing
+- Other network nodes don't have channel 3 access
+
+## Branch State
+- Branch: `claude/review-meshforge-status-9IZ4J`
+- All changes committed and pushed
+- **Consider reverting to a known-good commit before next attempt**
+
+## Key Lesson
+When fixes start breaking other things, STOP and reassess the architecture. Don't keep patching - the approach itself may be flawed.


### PR DESCRIPTION
Documents the debugging session that became circular. Provides recommendations for next session to start fresh rather than continue the flawed approach.