### PR TITLE
fix: Add periodic gateway status refresh to prevent stale UI

### DIFF
--- a/src/gtk_ui/panels/rns.py
+++ b/src/gtk_ui/panels/rns.py
@@ -131,9 +131,10 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
         self._schedule_timer(5000, self._check_service_status_periodic)
 
     def _check_service_status_periodic(self):
-        """Lightweight periodic check of rnsd service status.
+        """Lightweight periodic check of rnsd service and gateway status.
 
         Only updates UI if status changed to avoid unnecessary redraws.
+        Also updates gateway connection status to prevent "false lights".
         """
         def do_check():
             try:
@@ -142,6 +143,10 @@ class RNSPanel(ComponentsMixin, ConfigMixin, GatewayMixin,
                 if is_running != self._last_rnsd_running:
                     self._last_rnsd_running = is_running
                     GLib.idle_add(self._update_service_status_only, is_running)
+
+                # Also update gateway status to keep connection indicators in sync
+                # This prevents "false lights" where UI shows stale connection state
+                GLib.idle_add(self._update_gateway_status)
             except Exception:
                 pass
 

--- a/src/gtk_ui/panels/rns_mixins/components.py
+++ b/src/gtk_ui/panels/rns_mixins/components.py
@@ -309,6 +309,11 @@ class ComponentsMixin:
 
         self._component_status = component_status
         self.main_window.set_status_message("RNS status updated")
+
+        # Also update gateway status to ensure connection indicators are current
+        if hasattr(self, '_update_gateway_status'):
+            self._update_gateway_status()
+
         return False
 
     def _install_component(self, component):


### PR DESCRIPTION
The gateway connection indicators (Meshtastic: Connected, RNS: Connected) were only updated on gateway start/stop, causing "false lights" where UI showed stale state.

Changes:
- _check_service_status_periodic() now also calls _update_gateway_status() every 5 seconds to keep connection indicators current
- _update_ui() (in components mixin) calls _update_gateway_status() on initial panel load to ensure correct state on first display

This prevents UI from showing "Unknown" or stale connection status when the gateway is actually connected and working.