### PR TITLE
refactor: Implement Issue #17 service detection redesign (P1-P3)

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -42,6 +42,14 @@ logger = logging.getLogger(__name__)
 # Import centralized path utility
 from utils.paths import get_real_user_home
 
+# Import event bus for RX message notifications (Issue #17 Phase 3)
+try:
+    from utils.event_bus import emit_message
+    HAS_EVENT_BUS = True
+except ImportError:
+    HAS_EVENT_BUS = False
+    emit_message = None
+
 
 @dataclass
 class BridgedMessage:
@@ -1109,13 +1117,38 @@ class RNSMeshtasticBridge:
             return False
 
     def _notify_message(self, msg: BridgedMessage):
-        """Notify message callbacks (thread-safe snapshot)"""
+        """Notify message callbacks and emit to event bus (thread-safe snapshot).
+
+        Issue #17 Phase 3: Emit messages to event bus so UI panels can subscribe
+        and display RX messages without being directly coupled to the bridge.
+        """
         callbacks = list(self._message_callbacks)  # Snapshot to avoid race condition
         for callback in callbacks:
             try:
                 callback(msg)
             except Exception as e:
                 logger.error(f"Message callback error: {e}")
+
+        # Emit to event bus for UI panels (Issue #17 Phase 3)
+        if HAS_EVENT_BUS and emit_message:
+            try:
+                emit_message(
+                    direction='rx',
+                    content=msg.content,
+                    node_id=msg.source_id or "",
+                    node_name="",  # Could be enhanced with node lookup
+                    channel=msg.metadata.get('channel', 0) if msg.metadata else 0,
+                    network=msg.source_network,
+                    raw_data={
+                        'destination_id': msg.destination_id,
+                        'is_broadcast': msg.is_broadcast,
+                        'title': msg.title,
+                        'timestamp': msg.timestamp.isoformat() if msg.timestamp else None,
+                        'metadata': msg.metadata
+                    }
+                )
+            except Exception as e:
+                logger.debug(f"Event bus emit failed: {e}")
 
     def _notify_status(self, status: str):
         """Notify status callbacks (thread-safe snapshot)"""

--- a/src/gtk_ui/panels/messaging.py
+++ b/src/gtk_ui/panels/messaging.py
@@ -3,6 +3,8 @@ MeshForge Native Messaging Panel - GTK4 Interface
 
 Send and receive messages across Meshtastic and RNS networks.
 Integrates with commands/messaging.py for SQLite storage.
+
+Issue #17 Phase 3: Subscribes to event bus for real-time RX message display.
 """
 
 import gi
@@ -10,7 +12,19 @@ gi.require_version('Gtk', '4.0')
 gi.require_version('Adw', '1')
 from gi.repository import Gtk, Adw, GLib
 import threading
+import logging
 from datetime import datetime
+
+# Import event bus for real-time message updates (Issue #17 Phase 3)
+try:
+    from utils.event_bus import event_bus, MessageEvent
+    HAS_EVENT_BUS = True
+except ImportError:
+    HAS_EVENT_BUS = False
+    event_bus = None
+    MessageEvent = None
+
+logger = logging.getLogger(__name__)
 
 
 class MessagingPanel(Gtk.Box):
@@ -28,6 +42,13 @@ class MessagingPanel(Gtk.Box):
         self._build_ui()
         GLib.idle_add(self._load_messages)
         GLib.idle_add(self._load_stats)
+
+        # Subscribe to event bus for real-time RX messages (Issue #17 Phase 3)
+        self._event_handler = None
+        if HAS_EVENT_BUS and event_bus:
+            self._event_handler = self._on_message_event
+            event_bus.subscribe('message', self._event_handler)
+            logger.debug("MessagingPanel subscribed to message events")
 
     def _build_ui(self):
         """Build the messaging panel UI"""
@@ -501,7 +522,54 @@ class MessagingPanel(Gtk.Box):
         thread = threading.Thread(target=clear, daemon=True)
         thread.start()
 
+    def _on_message_event(self, event: 'MessageEvent'):
+        """Handle incoming message from event bus (Issue #17 Phase 3).
+
+        This is called from a background thread, so use GLib.idle_add for UI updates.
+        """
+        if event.direction != 'rx':
+            return  # Only handle RX messages
+
+        # Update UI on main thread
+        def update_ui():
+            # Add the message to the display
+            self._append_message(event)
+            # Update stats
+            self._load_stats()
+            # Update conversations
+            self._load_conversations()
+            return False
+
+        GLib.idle_add(update_ui)
+
+    def _append_message(self, event: 'MessageEvent'):
+        """Append a single message to the display (called on main thread)."""
+        buffer = self.msg_text.get_buffer()
+
+        # Format the message
+        timestamp = event.timestamp.strftime("%Y-%m-%d %H:%M") if event.timestamp else "now"
+        from_id = event.node_name or event.node_id or "unknown"
+        network = event.network or "mesh"
+        content = event.content
+
+        # Build the message line
+        direction = f"← {from_id}"
+        new_line = f"[{timestamp}] [{network}] {direction}\n  {content}\n\n"
+
+        # Append to end
+        end_iter = buffer.get_end_iter()
+        buffer.insert(end_iter, new_line)
+
+        # Scroll to show new message
+        self.msg_text.scroll_to_iter(buffer.get_end_iter(), 0, False, 0, 0)
+
+        # Visual feedback
+        if hasattr(self.main_window, 'set_status_message'):
+            self.main_window.set_status_message(f"New message from {from_id}")
+
     def cleanup(self):
         """Clean up panel resources."""
-        # No timers or persistent resources to clean up
-        pass
+        # Unsubscribe from event bus (Issue #17 Phase 3)
+        if HAS_EVENT_BUS and event_bus and self._event_handler:
+            event_bus.unsubscribe('message', self._event_handler)
+            logger.debug("MessagingPanel unsubscribed from message events")

--- a/src/gtk_ui/panels/rns_mixins/rnode.py
+++ b/src/gtk_ui/panels/rns_mixins/rnode.py
@@ -43,11 +43,13 @@ except ImportError:
 
 # Import service check for meshtasticd
 try:
-    from utils.service_check import check_port
+    from utils.service_check import check_service, check_port, ServiceState
     HAS_SERVICE_CHECK = True
 except ImportError:
     HAS_SERVICE_CHECK = False
+    check_service = None
     check_port = None
+    ServiceState = None
 
 
 class RNodeMixin:
@@ -801,7 +803,12 @@ class RNodeMixin:
             self.preset_description.set_label(desc)
 
     def _on_detect_meshtastic(self, button):
-        """Detect Meshtastic LoRa settings from connected device"""
+        """Detect Meshtastic LoRa settings from connected device.
+
+        PHASE 2 (Issue #17): Clearly separates service status from preset detection.
+        - Service status: from check_service() (systemctl-only)
+        - Preset detection: from meshtastic CLI (optional, not required)
+        """
         if not HAS_LORA_PRESETS:
             self._set_rnode_status("Preset module not available")
             return
@@ -816,100 +823,72 @@ class RNodeMixin:
         self._log_detection(f"Time: {datetime.datetime.now().strftime('%H:%M:%S')}")
 
         def do_detect():
-            import subprocess
-
-            # Step 1: Check if meshtasticd service is running (most reliable method)
+            # =================================================================
+            # STEP 1: Service Status (via check_service - systemctl only)
+            # =================================================================
             service_running = False
-            service_status = "unknown"
-            service_uptime = ""
+            service_msg = "unknown"
 
-            try:
-                result = subprocess.run(
-                    ['systemctl', 'is-active', 'meshtasticd'],
-                    capture_output=True, text=True, timeout=5
-                )
-                if result.stdout.strip() == 'active':
-                    service_running = True
-                    service_status = "active"
+            self._log_detection("\n--- SERVICE STATUS ---")
 
-                    # Get uptime info
-                    try:
-                        status_result = subprocess.run(
-                            ['systemctl', 'show', 'meshtasticd', '--property=ActiveEnterTimestamp'],
-                            capture_output=True, text=True, timeout=5
-                        )
-                        if status_result.returncode == 0:
-                            timestamp = status_result.stdout.strip().split('=')[1] if '=' in status_result.stdout else ''
-                            if timestamp:
-                                service_uptime = f" (since {timestamp[:19]})"
-                    except Exception:
-                        pass
+            if HAS_SERVICE_CHECK and check_service:
+                status = check_service('meshtasticd')
+                service_running = status.available
+                service_msg = status.message
 
-                    self._log_detection(f"✓ meshtasticd service: RUNNING{service_uptime}")
+                if status.available:
+                    self._log_detection(f"✓ Service: {status.message}")
+                    self._log_detection(f"  Method: {status.detection_method}")
+                elif status.state == ServiceState.DEGRADED:
+                    self._log_detection(f"⚠️ Service: {status.message}")
+                    self._log_detection(f"  {status.fix_hint}")
                 else:
-                    service_status = result.stdout.strip() or "inactive"
-                    self._log_detection(f"✗ meshtasticd service: {service_status}")
-            except subprocess.TimeoutExpired:
-                self._log_detection("⚠️ meshtasticd service: check timed out")
-            except FileNotFoundError:
-                self._log_detection("⚠️ systemctl not found (non-systemd system?)")
-            except Exception as e:
-                self._log_detection(f"⚠️ Error checking service: {e}")
+                    self._log_detection(f"✗ Service: {status.message}")
+                    if status.fix_hint:
+                        self._log_detection(f"  {status.fix_hint}")
+            else:
+                self._log_detection("⚠️ service_check module not available")
 
-            # Step 2: Check TCP port 4403 (API port)
-            port_open = False
-            try:
-                import socket
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.settimeout(2)
-                result = sock.connect_ex(('localhost', 4403))
-                port_open = (result == 0)
-                sock.close()
+            # =================================================================
+            # STEP 2: Preset Detection (via meshtastic CLI - OPTIONAL)
+            # This is SEPARATE from service status!
+            # =================================================================
+            self._log_detection("\n--- PRESET DETECTION ---")
 
-                if port_open:
-                    self._log_detection("✓ API port 4403: open (TCP)")
-                else:
-                    self._log_detection("✗ API port 4403: closed")
-            except Exception as e:
-                self._log_detection(f"⚠️ Port check error: {e}")
+            # Use verbose mode to get detailed logging
+            settings = detect_meshtastic_settings(verbose=True)
 
-            # Step 3: If service is running, try to detect preset settings
+            # Log all attempts
+            attempts = settings.get('attempts_log', []) if settings else []
+            for attempt in attempts:
+                self._log_detection(attempt)
+
+            preset_detected = settings and settings.get('preset')
+
+            # =================================================================
+            # STEP 3: Update UI with BOTH statuses clearly shown
+            # =================================================================
             if service_running:
-                GLib.idle_add(self.detected_settings_label.set_label, "✓ Service running - detecting preset...")
-                GLib.idle_add(self._set_rnode_status, "Service OK - detecting preset...")
-
-                self._log_detection("\n--- Preset Detection ---")
-
-                # Use verbose mode to get detailed logging
-                settings = detect_meshtastic_settings(verbose=True)
-
-                # Log all attempts
-                attempts = settings.get('attempts_log', []) if settings else []
-                for attempt in attempts:
-                    self._log_detection(attempt)
-
-                if settings and settings.get('preset'):
-                    # Update UI with detected settings
+                if preset_detected:
+                    # Service OK + Preset detected = Full success
                     preset = settings.get('preset', 'Unknown')
                     region = settings.get('region', 'US')
-                    bw = settings.get('bandwidth', 0) / 1000  # Hz to kHz
+                    bw = settings.get('bandwidth', 0) / 1000
                     sf = settings.get('spreading_factor', 0)
                     cr = settings.get('coding_rate', 0)
                     method = settings.get('detection_method', 'unknown')
 
-                    # Short summary in label
-                    info = f"✓ {preset} ({region}) via {method}"
+                    # Summary label shows BOTH statuses
+                    info = f"Service: ✓ Running | Preset: ✓ {preset}"
                     GLib.idle_add(self.detected_settings_label.set_label, info)
 
-                    # Detailed info in log
+                    # Detailed log
                     self._log_detection(f"\n✓ SUCCESS: Detected {preset}")
                     self._log_detection(f"  Region: {region}")
-                    self._log_detection(f"  Bandwidth: {bw:.0f} kHz")
-                    self._log_detection(f"  Spreading Factor: {sf}")
-                    self._log_detection(f"  Coding Rate: 4/{cr}")
+                    self._log_detection(f"  BW: {bw:.0f} kHz, SF: {sf}, CR: 4/{cr}")
                     self._log_detection(f"  Method: {method}")
 
-                    # Select the detected preset in dropdown
+                    # Select preset in dropdown
                     preset_names = list(MESHTASTIC_PRESETS.keys())
                     try:
                         idx = preset_names.index(preset)
@@ -917,40 +896,34 @@ class RNodeMixin:
                     except ValueError:
                         pass
 
-                    GLib.idle_add(self._set_rnode_status, f"Detected: {preset} via {method}")
+                    GLib.idle_add(self._set_rnode_status, f"Service OK, preset: {preset}")
                 else:
-                    # Service running but preset auto-detect failed - this is OK!
-                    GLib.idle_add(self.detected_settings_label.set_label, "✓ Service OK - select preset manually")
+                    # Service OK but preset not detected - this is FINE!
+                    # UI clearly shows service is working
+                    info = "Service: ✓ Running | Preset: Select manually"
+                    GLib.idle_add(self.detected_settings_label.set_label, info)
 
-                    self._log_detection("\n⚠️ Preset auto-detection unavailable")
-                    self._log_detection("This is normal if meshtastic CLI is not installed.")
+                    self._log_detection("\n✓ SERVICE IS RUNNING")
+                    self._log_detection("Preset auto-detection unavailable (CLI issue)")
                     self._log_detection("")
-                    self._log_detection("✓ meshtasticd IS RUNNING - your node is working!")
-                    self._log_detection("")
-                    self._log_detection("To use this panel:")
-                    self._log_detection("  1. Select your preset from the dropdown above")
-                    self._log_detection("  2. Click 'Apply Preset' to configure RNode")
-                    self._log_detection("")
-                    self._log_detection("Common presets: LONG_FAST, MEDIUM_FAST, SHORT_FAST")
+                    self._log_detection("This is normal - your node IS working!")
+                    self._log_detection("Select preset manually from dropdown above.")
 
-                    GLib.idle_add(self._set_rnode_status, "Service OK - select preset from dropdown")
+                    GLib.idle_add(self._set_rnode_status, "Service OK - select preset manually")
             else:
-                # Service NOT running - this is the real problem
-                GLib.idle_add(self.detected_settings_label.set_label, "✗ Service not running")
+                # Service NOT running
+                info = "Service: ✗ Not running | Preset: N/A"
+                GLib.idle_add(self.detected_settings_label.set_label, info)
 
-                self._log_detection("\n✗ MESHTASTICD NOT RUNNING")
+                self._log_detection("\n✗ SERVICE NOT RUNNING")
                 self._log_detection("")
-                self._log_detection("To start the service:")
+                self._log_detection("Start the service:")
                 self._log_detection("  sudo systemctl start meshtasticd")
                 self._log_detection("")
-                self._log_detection("To enable on boot:")
-                self._log_detection("  sudo systemctl enable meshtasticd")
-                self._log_detection("")
-                self._log_detection("Check configuration:")
-                self._log_detection("  sudo systemctl status meshtasticd")
-                self._log_detection("  journalctl -u meshtasticd -f")
+                self._log_detection("Check status:")
+                self._log_detection("  systemctl status meshtasticd")
 
-                GLib.idle_add(self._set_rnode_status, "Service not running - start with systemctl")
+                GLib.idle_add(self._set_rnode_status, "Service not running")
 
             GLib.idle_add(button.set_sensitive, True)
 
@@ -1034,7 +1007,11 @@ class RNodeMixin:
     # =========================================================================
 
     def _check_radio_services(self):
-        """Check status of meshtasticd and rnsd services"""
+        """Check status of meshtasticd and rnsd services.
+
+        SIMPLIFIED (Issue #17): Uses systemctl-only detection via check_service().
+        No more conflicting port/process/systemctl methods.
+        """
         def do_check():
             import datetime
 
@@ -1042,97 +1019,59 @@ class RNodeMixin:
             self._log_detection("--- Service Status Check ---", clear=True)
             self._log_detection(f"Time: {datetime.datetime.now().strftime('%H:%M:%S')}")
 
-            # Check meshtasticd - use responsive check if available
+            # ===================================================================
+            # Check meshtasticd via check_service() - systemctl only
+            # ===================================================================
             meshtasticd_status = "stopped"
-            meshtasticd_msg = "not running"
             meshtasticd_css = "warning"
 
-            try:
-                from utils.service_check import check_meshtasticd_responsive, check_port
-                port_open = check_port(4403)
-
-                if port_open:
-                    # Port is open, verify responsiveness
-                    is_responsive, verify_msg = check_meshtasticd_responsive(timeout=5.0)
-                    if is_responsive:
-                        meshtasticd_status = "running"
-                        meshtasticd_msg = verify_msg
-                        meshtasticd_css = "success"
-                        self._log_detection(f"✓ meshtasticd: {verify_msg}")
-                    else:
-                        # Port open but not responding!
-                        meshtasticd_status = "unresponsive"
-                        meshtasticd_msg = verify_msg
-                        meshtasticd_css = "error"
-                        self._log_detection(f"⚠️ meshtasticd: {verify_msg}")
-                        self._log_detection("   Restart suggested: sudo systemctl restart meshtasticd")
+            if HAS_SERVICE_CHECK and check_service:
+                status = check_service('meshtasticd')
+                if status.available:
+                    meshtasticd_status = "running"
+                    meshtasticd_css = "success"
+                    self._log_detection(f"✓ meshtasticd: {status.message}")
+                    self._log_detection(f"  (via {status.detection_method})")
+                elif status.state == ServiceState.DEGRADED:
+                    meshtasticd_status = "failed"
+                    meshtasticd_css = "error"
+                    self._log_detection(f"⚠️ meshtasticd: {status.message}")
+                    self._log_detection(f"  {status.fix_hint}")
+                elif status.state == ServiceState.NOT_INSTALLED:
+                    meshtasticd_status = "not installed"
+                    meshtasticd_css = "warning"
+                    self._log_detection(f"✗ meshtasticd: {status.message}")
                 else:
-                    self._log_detection("✗ meshtasticd: not running (port 4403 closed)")
-
-            except ImportError:
-                # Fallback: basic port check only
-                import socket
-                sock = None
-                try:
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                    sock.settimeout(1)
-                    result = sock.connect_ex(('localhost', 4403))
-                    if result == 0:
-                        meshtasticd_status = "running"
-                        meshtasticd_msg = "port open (unverified)"
-                        meshtasticd_css = "success"
-                        self._log_detection("✓ meshtasticd: running (TCP :4403)")
-                    else:
-                        self._log_detection("✗ meshtasticd: not running (port 4403 closed)")
-                except (socket.error, OSError):
-                    self._log_detection("✗ meshtasticd: not running (connection failed)")
-                finally:
-                    if sock:
-                        try:
-                            sock.close()
-                        except Exception:
-                            pass
-
-            # Check rnsd (use UDP port check first, then systemctl)
-            rnsd_running = False
-            rnsd_method = "unknown"
-
-            # Method 1: UDP port 37428 check
-            try:
-                import socket
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                sock.settimeout(1)
-                try:
-                    sock.bind(('127.0.0.1', 37428))
-                    sock.close()
-                    # Port NOT in use
-                except OSError as e:
-                    sock.close()
-                    if e.errno in (98, 48, 10048):  # EADDRINUSE
-                        rnsd_running = True
-                        rnsd_method = "UDP port"
-            except Exception:
-                pass
-
-            # Method 2: systemctl fallback
-            if not rnsd_running:
-                try:
-                    import subprocess
-                    result = subprocess.run(
-                        ['systemctl', 'is-active', 'rnsd'],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    if result.returncode == 0:
-                        rnsd_running = True
-                        rnsd_method = "systemctl"
-                except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-                    pass
-
-            # Log rnsd results
-            if rnsd_running:
-                self._log_detection(f"✓ rnsd: running ({rnsd_method})")
+                    self._log_detection(f"✗ meshtasticd: {status.message}")
+                    if status.fix_hint:
+                        self._log_detection(f"  {status.fix_hint}")
             else:
-                self._log_detection("✗ rnsd: not running")
+                # Fallback if service_check not available
+                self._log_detection("⚠️ service_check module not available")
+
+            # ===================================================================
+            # Check rnsd via check_service() - systemctl only
+            # ===================================================================
+            rnsd_status = "stopped"
+            rnsd_css = "warning"
+
+            if HAS_SERVICE_CHECK and check_service:
+                status = check_service('rnsd')
+                if status.available:
+                    rnsd_status = "running"
+                    rnsd_css = "success"
+                    self._log_detection(f"✓ rnsd: {status.message}")
+                    self._log_detection(f"  (via {status.detection_method})")
+                elif status.state == ServiceState.NOT_INSTALLED:
+                    rnsd_status = "not installed"
+                    rnsd_css = "warning"
+                    self._log_detection(f"✗ rnsd: {status.message}")
+                else:
+                    self._log_detection(f"✗ rnsd: {status.message}")
+                    if status.fix_hint:
+                        self._log_detection(f"  {status.fix_hint}")
+            else:
+                self._log_detection("⚠️ Cannot check rnsd (service_check not available)")
 
             self._log_detection("\nClick 'Detect' to scan for hardware devices.")
             self._log_detection("Click 'Detect Meshtastic' to read radio settings.")
@@ -1142,35 +1081,18 @@ class RNodeMixin:
                 self.meshtasticd_status.set_label,
                 f"● meshtasticd: {meshtasticd_status}"
             )
-            GLib.idle_add(
-                self.meshtasticd_status.remove_css_class, "error"
-            )
-            GLib.idle_add(
-                self.meshtasticd_status.remove_css_class, "success"
-            )
-            GLib.idle_add(
-                self.meshtasticd_status.remove_css_class, "warning"
-            )
-            GLib.idle_add(
-                self.meshtasticd_status.add_css_class, meshtasticd_css
-            )
+            # Clear old CSS classes
+            for css in ["error", "success", "warning"]:
+                GLib.idle_add(self.meshtasticd_status.remove_css_class, css)
+            GLib.idle_add(self.meshtasticd_status.add_css_class, meshtasticd_css)
 
-            if rnsd_running:
-                GLib.idle_add(
-                    self.rnsd_status.set_label,
-                    "● rnsd: running"
-                )
-                GLib.idle_add(
-                    self.rnsd_status.add_css_class, "success"
-                )
-            else:
-                GLib.idle_add(
-                    self.rnsd_status.set_label,
-                    "● rnsd: stopped"
-                )
-                GLib.idle_add(
-                    self.rnsd_status.add_css_class, "warning"
-                )
+            GLib.idle_add(
+                self.rnsd_status.set_label,
+                f"● rnsd: {rnsd_status}"
+            )
+            for css in ["error", "success", "warning"]:
+                GLib.idle_add(self.rnsd_status.remove_css_class, css)
+            GLib.idle_add(self.rnsd_status.add_css_class, rnsd_css)
 
         threading.Thread(target=do_check, daemon=True).start()
 

--- a/src/utils/event_bus.py
+++ b/src/utils/event_bus.py
@@ -1,0 +1,305 @@
+"""
+MeshForge Event Bus
+
+Simple pub/sub event system for decoupled component communication.
+Primary use case: Gateway RX messages → UI panel updates.
+
+Issue #17 Phase 3: Instead of RX messages only appearing in logs,
+this event bus allows UI panels to subscribe and display them.
+
+Usage:
+    from utils.event_bus import event_bus, MessageEvent
+
+    # In gateway (publisher):
+    event_bus.emit('message', MessageEvent(
+        direction='rx',
+        content='Hello from mesh',
+        node_id='!abc123',
+        channel=0
+    ))
+
+    # In UI panel (subscriber):
+    def _on_message(event):
+        GLib.idle_add(self._add_to_message_list, event)
+
+    event_bus.subscribe('message', _on_message)
+
+    # Cleanup on panel destroy:
+    event_bus.unsubscribe('message', _on_message)
+"""
+
+import logging
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class MessageDirection(Enum):
+    """Direction of a mesh message."""
+    TX = "tx"  # Transmitted (outgoing)
+    RX = "rx"  # Received (incoming)
+
+
+@dataclass
+class MessageEvent:
+    """Event representing a mesh network message."""
+    direction: str  # 'tx' or 'rx'
+    content: str
+    timestamp: datetime = field(default_factory=datetime.now)
+    node_id: str = ""  # Node ID (e.g., '!abc123')
+    node_name: str = ""  # Human-readable node name if available
+    channel: int = 0  # Channel number
+    network: str = ""  # 'meshtastic', 'rns', or 'bridge'
+    raw_data: Optional[Dict] = None  # Original packet data if available
+
+    def __str__(self):
+        direction = "←" if self.direction == "rx" else "→"
+        source = self.node_name or self.node_id or "unknown"
+        time_str = self.timestamp.strftime("%H:%M:%S")
+        return f"[{time_str}] {direction} {source}: {self.content[:50]}"
+
+
+@dataclass
+class ServiceEvent:
+    """Event representing a service status change."""
+    service_name: str
+    available: bool
+    message: str
+    timestamp: datetime = field(default_factory=datetime.now)
+
+
+@dataclass
+class NodeEvent:
+    """Event representing a node update (new node, position change, etc.)."""
+    event_type: str  # 'discovered', 'updated', 'lost'
+    node_id: str
+    node_name: str = ""
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    timestamp: datetime = field(default_factory=datetime.now)
+    raw_data: Optional[Dict] = None
+
+
+class EventBus:
+    """
+    Thread-safe event bus for pub/sub messaging.
+
+    Subscribers are called in a separate thread to avoid blocking the publisher.
+    For GTK UI updates, subscribers should use GLib.idle_add().
+    """
+
+    def __init__(self):
+        self._subscribers: Dict[str, List[Callable]] = {}
+        self._lock = threading.RLock()
+        self._worker_thread: Optional[threading.Thread] = None
+        self._event_queue: List[tuple] = []
+        self._queue_lock = threading.Lock()
+        self._running = False
+
+    def subscribe(self, event_type: str, callback: Callable) -> None:
+        """
+        Subscribe to an event type.
+
+        Args:
+            event_type: Type of event (e.g., 'message', 'service', 'node')
+            callback: Function to call when event is emitted
+        """
+        with self._lock:
+            if event_type not in self._subscribers:
+                self._subscribers[event_type] = []
+            if callback not in self._subscribers[event_type]:
+                self._subscribers[event_type].append(callback)
+                logger.debug(f"Subscribed to '{event_type}': {callback.__name__}")
+
+    def unsubscribe(self, event_type: str, callback: Callable) -> None:
+        """
+        Unsubscribe from an event type.
+
+        Args:
+            event_type: Type of event
+            callback: The callback function to remove
+        """
+        with self._lock:
+            if event_type in self._subscribers:
+                try:
+                    self._subscribers[event_type].remove(callback)
+                    logger.debug(f"Unsubscribed from '{event_type}': {callback.__name__}")
+                except ValueError:
+                    pass  # Callback wasn't subscribed
+
+    def emit(self, event_type: str, event: Any) -> None:
+        """
+        Emit an event to all subscribers.
+
+        Subscribers are called in their own threads to avoid blocking.
+
+        Args:
+            event_type: Type of event
+            event: The event data (MessageEvent, ServiceEvent, etc.)
+        """
+        with self._lock:
+            subscribers = self._subscribers.get(event_type, []).copy()
+
+        if not subscribers:
+            logger.debug(f"Event '{event_type}' emitted with no subscribers")
+            return
+
+        logger.debug(f"Emitting '{event_type}' to {len(subscribers)} subscribers")
+
+        # Call each subscriber in a separate thread
+        for callback in subscribers:
+            try:
+                # Use daemon thread so it doesn't block app shutdown
+                thread = threading.Thread(
+                    target=self._safe_call,
+                    args=(callback, event),
+                    daemon=True
+                )
+                thread.start()
+            except Exception as e:
+                logger.error(f"Error starting callback thread: {e}")
+
+    def emit_sync(self, event_type: str, event: Any) -> None:
+        """
+        Emit an event synchronously (for testing or simple cases).
+
+        Args:
+            event_type: Type of event
+            event: The event data
+        """
+        with self._lock:
+            subscribers = self._subscribers.get(event_type, []).copy()
+
+        for callback in subscribers:
+            self._safe_call(callback, event)
+
+    def _safe_call(self, callback: Callable, event: Any) -> None:
+        """Call a callback with exception handling."""
+        try:
+            callback(event)
+        except Exception as e:
+            logger.error(f"Error in event callback {callback.__name__}: {e}")
+
+    def clear_subscribers(self, event_type: Optional[str] = None) -> None:
+        """
+        Clear all subscribers for an event type, or all subscribers.
+
+        Args:
+            event_type: If specified, only clear this type. Otherwise clear all.
+        """
+        with self._lock:
+            if event_type:
+                self._subscribers[event_type] = []
+            else:
+                self._subscribers.clear()
+
+    def get_subscriber_count(self, event_type: str) -> int:
+        """Get the number of subscribers for an event type."""
+        with self._lock:
+            return len(self._subscribers.get(event_type, []))
+
+
+# Global singleton instance
+event_bus = EventBus()
+
+
+# =============================================================================
+# Convenience functions for common event types
+# =============================================================================
+
+def emit_message(
+    direction: str,
+    content: str,
+    node_id: str = "",
+    node_name: str = "",
+    channel: int = 0,
+    network: str = "",
+    raw_data: Optional[Dict] = None
+) -> None:
+    """
+    Emit a message event.
+
+    Args:
+        direction: 'tx' or 'rx'
+        content: Message content
+        node_id: Node ID
+        node_name: Human-readable node name
+        channel: Channel number
+        network: Network source ('meshtastic', 'rns', 'bridge')
+        raw_data: Optional raw packet data
+    """
+    event = MessageEvent(
+        direction=direction,
+        content=content,
+        node_id=node_id,
+        node_name=node_name,
+        channel=channel,
+        network=network,
+        raw_data=raw_data
+    )
+    event_bus.emit('message', event)
+
+
+def emit_service_status(service_name: str, available: bool, message: str) -> None:
+    """
+    Emit a service status event.
+
+    Args:
+        service_name: Name of the service
+        available: Whether the service is available
+        message: Status message
+    """
+    event = ServiceEvent(
+        service_name=service_name,
+        available=available,
+        message=message
+    )
+    event_bus.emit('service', event)
+
+
+def emit_node_update(
+    event_type: str,
+    node_id: str,
+    node_name: str = "",
+    latitude: Optional[float] = None,
+    longitude: Optional[float] = None,
+    raw_data: Optional[Dict] = None
+) -> None:
+    """
+    Emit a node update event.
+
+    Args:
+        event_type: 'discovered', 'updated', or 'lost'
+        node_id: Node ID
+        node_name: Human-readable name
+        latitude: GPS latitude
+        longitude: GPS longitude
+        raw_data: Optional raw node data
+    """
+    event = NodeEvent(
+        event_type=event_type,
+        node_id=node_id,
+        node_name=node_name,
+        latitude=latitude,
+        longitude=longitude,
+        raw_data=raw_data
+    )
+    event_bus.emit('node', event)
+
+
+# Export public API
+__all__ = [
+    'event_bus',
+    'EventBus',
+    'MessageEvent',
+    'MessageDirection',
+    'ServiceEvent',
+    'NodeEvent',
+    'emit_message',
+    'emit_service_status',
+    'emit_node_update',
+]

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -4,17 +4,20 @@ Service Availability Utilities for MeshForge
 Provides standardized service checking before connecting to external services.
 Use these instead of assuming services are running.
 
+ARCHITECTURE (Issue #17 redesign):
+    - For systemd services: Trust systemctl ONLY (single source of truth)
+    - Port/process checks kept for utilities but NOT used in check_service()
+    - "Unknown" state is better than wrong state from conflicting methods
+
 Usage:
     from utils.service_check import check_port, check_service, ServiceStatus
     from utils.ports import MESHTASTICD_PORT
 
-    # Quick port check
+    # Quick port check (utility function)
     if check_port(MESHTASTICD_PORT):
         connect_to_meshtasticd()
-    else:
-        show_error(f"meshtasticd not running on port {MESHTASTICD_PORT}")
 
-    # Full service check with actionable feedback
+    # Full service check - trusts systemctl for systemd services
     status = check_service('meshtasticd')
     if not status.available:
         show_error(status.message)
@@ -24,7 +27,7 @@ Usage:
 import socket
 import subprocess
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional, Tuple
 from enum import Enum
 
@@ -37,11 +40,10 @@ __all__ = [
     # Main entry points
     'check_service',        # Primary status checker (SINGLE SOURCE OF TRUTH)
     'require_service',      # Check with exception on failure
-    'check_port',           # TCP port check
-    'check_udp_port',       # UDP port check
-    'check_process_running', # Process check via pgrep
+    'check_port',           # TCP port check (utility)
+    'check_udp_port',       # UDP port check (utility)
+    'check_process_running', # Process check via pgrep (utility)
     'check_systemd_service', # Systemd status check
-    'check_meshtasticd_responsive',  # Meshtasticd-specific verification
     # Data classes
     'ServiceStatus',        # Return type from check_service
     'ServiceState',         # Status enum (AVAILABLE, DEGRADED, etc.)
@@ -53,11 +55,10 @@ __all__ = [
 class ServiceState(Enum):
     """Service availability states."""
     AVAILABLE = "available"
-    DEGRADED = "degraded"       # Port open but not responsive
-    PORT_CLOSED = "port_closed"
+    DEGRADED = "degraded"       # Running but with issues
     NOT_RUNNING = "not_running"
     NOT_INSTALLED = "not_installed"
-    UNKNOWN = "unknown"
+    UNKNOWN = "unknown"         # Cannot determine state
 
 
 @dataclass
@@ -69,6 +70,8 @@ class ServiceStatus:
     message: str
     fix_hint: str = ""
     port: Optional[int] = None
+    # Additional context (Phase 2: separate service state from detection)
+    detection_method: str = ""  # How was this determined
 
     def __bool__(self) -> bool:
         return self.available
@@ -76,90 +79,45 @@ class ServiceStatus:
 
 # Known services and their configurations
 # Port numbers imported from utils.ports for centralization
+# NOTE: is_systemd=True means we ONLY trust systemctl for status
 KNOWN_SERVICES = {
     'meshtasticd': {
         'port': MESHTASTICD_PORT,
         'systemd_name': 'meshtasticd',
+        'is_systemd': True,  # Trust systemctl only
         'description': 'Meshtastic daemon',
         'fix_hint': 'Start with: sudo systemctl start meshtasticd',
-        'verify_func': 'check_meshtasticd_responsive',  # Extra verification
     },
     'rnsd': {
-        'port': RNS_SHARED_INSTANCE_PORT,  # UDP 37428 - shared instance port
-        'port_type': 'udp',  # rnsd uses UDP, not TCP
+        'port': RNS_SHARED_INSTANCE_PORT,
+        'port_type': 'udp',
         'systemd_name': 'rnsd',
+        'is_systemd': True,  # Trust systemctl only
         'description': 'Reticulum Network Stack daemon',
-        'fix_hint': 'Start with: rnsd or sudo systemctl start rnsd',
+        'fix_hint': 'Start with: sudo systemctl start rnsd',
     },
     'hamclock': {
         'port': HAMCLOCK_PORT,
         'systemd_name': 'hamclock',
+        'is_systemd': True,
         'description': 'HamClock space weather display',
         'fix_hint': 'Start with: sudo systemctl start hamclock',
     },
     'mosquitto': {
         'port': MQTT_PORT,
         'systemd_name': 'mosquitto',
+        'is_systemd': True,
         'description': 'MQTT broker',
         'fix_hint': 'Start with: sudo systemctl start mosquitto',
     },
 }
 
 
-def check_meshtasticd_responsive(timeout: float = 5.0) -> tuple:
-    """
-    Verify meshtasticd is actually responsive, not just that port is open.
-
-    Sometimes meshtasticd hangs with port open but not responding.
-
-    Args:
-        timeout: How long to wait for response
-
-    Returns:
-        Tuple of (is_responsive: bool, message: str)
-    """
-    import subprocess
-
-    # First check if port is even open
-    if not check_port(MESHTASTICD_PORT, timeout=2.0):
-        return False, "Port 4403 not open"
-
-    # Try a quick meshtastic CLI command to verify responsiveness
-    try:
-        result = subprocess.run(
-            ['meshtastic', '--host', 'localhost', '--info'],
-            capture_output=True,
-            text=True,
-            timeout=timeout
-        )
-
-        if result.returncode == 0:
-            # Check for actual device info in output
-            if 'Owner:' in result.stdout or 'Nodes' in result.stdout:
-                return True, "Responsive (device info received)"
-            elif 'Connected to' in result.stdout:
-                return True, "Responsive (connected)"
-            else:
-                return True, "Responsive"
-
-        # Non-zero return but process completed
-        stderr = result.stderr.lower()
-        if 'timed out' in stderr or 'timeout' in stderr:
-            return False, "Port open but not responding (try: sudo systemctl restart meshtasticd)"
-        elif 'connection refused' in stderr:
-            return False, "Connection refused"
-        elif 'error' in stderr:
-            return False, f"Error: {result.stderr[:100]}"
-        else:
-            return False, "Command failed"
-
-    except subprocess.TimeoutExpired:
-        return False, "Port open but unresponsive (hung?) - try: sudo systemctl restart meshtasticd"
-    except FileNotFoundError:
-        # meshtastic CLI not installed, fall back to port check only
-        return True, "Port open (CLI not available for verification)"
-    except Exception as e:
-        return False, f"Check failed: {e}"
+# =============================================================================
+# UTILITY FUNCTIONS
+# These are kept for direct use but NOT used by check_service() for systemd
+# services (Issue #17: avoid conflicting detection methods)
+# =============================================================================
 
 
 def check_port(port: int, host: str = 'localhost', timeout: float = 2.0) -> bool:
@@ -327,10 +285,10 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
     """
     Check if a service is available and provide actionable feedback.
 
-    Uses multiple detection methods for reliability:
-    1. Port check (TCP or UDP based on service config)
-    2. Process check (pgrep)
-    3. Systemd status
+    SIMPLIFIED ARCHITECTURE (Issue #17):
+        - For systemd services: ONLY trust systemctl (single source of truth)
+        - No conflicting fallback methods (port check, pgrep)
+        - "Unknown" is better than wrong state
 
     Args:
         name: Service name (e.g., 'meshtasticd', 'hamclock', 'rnsd')
@@ -343,123 +301,159 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
     API Contract:
         - ALWAYS returns a ServiceStatus (never None)
         - ServiceStatus.available: bool indicating if service is ready
-        - ServiceStatus.state: ServiceState enum (AVAILABLE, UNAVAILABLE, DEGRADED, UNKNOWN)
-        - ServiceStatus.fix_hint: Actionable command to fix the issue
+        - ServiceStatus.state: ServiceState enum (AVAILABLE, NOT_RUNNING, etc.)
+        - ServiceStatus.detection_method: How status was determined
         - Known services: meshtasticd, rnsd, hamclock, mosquitto
-        - Tests: tests/test_service_check.py::TestCheckService
     """
-    # Get known service config
     config = KNOWN_SERVICES.get(name, {})
     check_port_num = port or config.get('port')
-    port_type = config.get('port_type', 'tcp')  # Default to TCP
     systemd_name = config.get('systemd_name', name)
     description = config.get('description', name)
     fix_hint = config.get('fix_hint', f'Start {name} service')
-    verify_func_name = config.get('verify_func')
+    is_systemd = config.get('is_systemd', True)  # Default to systemd
 
-    # Check port if applicable (TCP or UDP)
-    port_is_open = False
+    # =========================================================================
+    # SYSTEMD SERVICES: Trust systemctl ONLY
+    # =========================================================================
+    if is_systemd:
+        try:
+            # Single source of truth: systemctl is-active
+            result = subprocess.run(
+                ['systemctl', 'is-active', systemd_name],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            is_active = result.returncode == 0
+            status_text = result.stdout.strip()  # "active", "inactive", "failed"
+
+            if is_active:
+                return ServiceStatus(
+                    name=name,
+                    available=True,
+                    state=ServiceState.AVAILABLE,
+                    message=f"{description} is running",
+                    port=check_port_num,
+                    detection_method="systemctl"
+                )
+
+            # Not active - check if it exists
+            if status_text == "inactive":
+                # Service exists but not running
+                return ServiceStatus(
+                    name=name,
+                    available=False,
+                    state=ServiceState.NOT_RUNNING,
+                    message=f"{description} is not running",
+                    fix_hint=fix_hint,
+                    port=check_port_num,
+                    detection_method="systemctl"
+                )
+
+            if status_text == "failed":
+                return ServiceStatus(
+                    name=name,
+                    available=False,
+                    state=ServiceState.DEGRADED,
+                    message=f"{description} has failed",
+                    fix_hint=f"Check logs: journalctl -u {systemd_name}",
+                    port=check_port_num,
+                    detection_method="systemctl"
+                )
+
+            # Check if service unit exists
+            check_result = subprocess.run(
+                ['systemctl', 'list-unit-files', f'{systemd_name}.service'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if systemd_name not in check_result.stdout:
+                return ServiceStatus(
+                    name=name,
+                    available=False,
+                    state=ServiceState.NOT_INSTALLED,
+                    message=f"{description} is not installed",
+                    fix_hint=f"Install {name} first",
+                    port=check_port_num,
+                    detection_method="systemctl"
+                )
+
+            # Generic not running
+            return ServiceStatus(
+                name=name,
+                available=False,
+                state=ServiceState.NOT_RUNNING,
+                message=f"{description} is not running",
+                fix_hint=fix_hint,
+                port=check_port_num,
+                detection_method="systemctl"
+            )
+
+        except FileNotFoundError:
+            # systemctl not available (non-systemd system)
+            logger.warning(f"systemctl not found - cannot check {name}")
+            return ServiceStatus(
+                name=name,
+                available=False,
+                state=ServiceState.UNKNOWN,
+                message=f"{description}: cannot determine status (no systemctl)",
+                fix_hint="Check manually or use port check",
+                port=check_port_num,
+                detection_method="none"
+            )
+        except subprocess.TimeoutExpired:
+            return ServiceStatus(
+                name=name,
+                available=False,
+                state=ServiceState.UNKNOWN,
+                message=f"{description}: status check timed out",
+                fix_hint="System may be overloaded",
+                port=check_port_num,
+                detection_method="systemctl-timeout"
+            )
+        except Exception as e:
+            logger.error(f"Service check failed for {name}: {e}")
+            return ServiceStatus(
+                name=name,
+                available=False,
+                state=ServiceState.UNKNOWN,
+                message=f"{description}: check failed ({e})",
+                port=check_port_num,
+                detection_method="error"
+            )
+
+    # =========================================================================
+    # NON-SYSTEMD SERVICES: Fall back to port/process check
+    # =========================================================================
+    port_type = config.get('port_type', 'tcp')
+
     if check_port_num:
         if port_type == 'udp':
-            port_is_open = check_udp_port(check_port_num, host)
+            port_open = check_udp_port(check_port_num, host)
         else:
-            port_is_open = check_port(check_port_num, host)
+            port_open = check_port(check_port_num, host)
 
-        if port_is_open:
-            # For services with verification function, verify actual responsiveness
-            if verify_func_name and verify_func_name == 'check_meshtasticd_responsive':
-                is_responsive, verify_msg = check_meshtasticd_responsive()
-                if is_responsive:
-                    return ServiceStatus(
-                        name=name,
-                        available=True,
-                        state=ServiceState.AVAILABLE,
-                        message=f"{description}: {verify_msg}",
-                        port=check_port_num
-                    )
-                else:
-                    # Port open but service not responding properly
-                    return ServiceStatus(
-                        name=name,
-                        available=False,
-                        state=ServiceState.DEGRADED,
-                        message=f"{description}: {verify_msg}",
-                        fix_hint="Try: sudo systemctl restart meshtasticd",
-                        port=check_port_num
-                    )
-
-            # Standard port check without verification
-            proto = 'UDP' if port_type == 'udp' else 'TCP'
+        if port_open:
             return ServiceStatus(
                 name=name,
                 available=True,
                 state=ServiceState.AVAILABLE,
-                message=f"{description} is running ({proto} {check_port_num})",
-                port=check_port_num
+                message=f"{description} is running (port {check_port_num})",
+                port=check_port_num,
+                detection_method="port"
             )
 
-    # Check if process is running (catches non-systemd starts)
+    # Try process check as fallback
     if check_process_running(systemd_name):
-        # Process is running - if we have a port and it's not open,
-        # it might be starting up or using a different port
-        if check_port_num and not port_is_open:
-            # Service running but port not responding - might be starting
-            return ServiceStatus(
-                name=name,
-                available=True,  # Mark as available since process IS running
-                state=ServiceState.AVAILABLE,
-                message=f"{description} is running (process detected)",
-                port=check_port_num
-            )
         return ServiceStatus(
             name=name,
             available=True,
             state=ServiceState.AVAILABLE,
-            message=f"{description} is running (process detected)"
+            message=f"{description} is running (process detected)",
+            port=check_port_num,
+            detection_method="process"
         )
-
-    # Check systemd service
-    is_running, is_enabled = check_systemd_service(systemd_name)
-
-    if is_running:
-        # Systemd says running but port not open and process not found
-        # Trust systemd in this case
-        return ServiceStatus(
-            name=name,
-            available=True,
-            state=ServiceState.AVAILABLE,
-            message=f"{description} is running (systemd)"
-        )
-
-    if is_enabled:
-        return ServiceStatus(
-            name=name,
-            available=False,
-            state=ServiceState.NOT_RUNNING,
-            message=f"{description} is enabled but not running",
-            fix_hint=fix_hint,
-            port=check_port_num
-        )
-
-    # Check if service exists at all
-    try:
-        result = subprocess.run(
-            ['systemctl', 'status', systemd_name],
-            capture_output=True,
-            text=True,
-            timeout=5
-        )
-        if 'could not be found' in result.stderr.lower():
-            return ServiceStatus(
-                name=name,
-                available=False,
-                state=ServiceState.NOT_INSTALLED,
-                message=f"{description} is not installed (no systemd service)",
-                fix_hint=f"Install {name} first or start manually",
-                port=check_port_num
-            )
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        pass
 
     return ServiceStatus(
         name=name,
@@ -467,7 +461,8 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
         state=ServiceState.NOT_RUNNING,
         message=f"{description} is not running",
         fix_hint=fix_hint,
-        port=check_port_num
+        port=check_port_num,
+        detection_method="port+process"
     )
 
 


### PR DESCRIPTION
Phase 1: Simplified service_check.py to use systemctl-only for systemd
- Removed conflicting port/process/systemctl detection methods
- Single source of truth: systemctl is-active for known services
- Added detection_method field to ServiceStatus for transparency
- ServiceState now has UNKNOWN instead of conflicting states

Phase 2: Separated service status from CLI detection in UI
- rnode.py _check_radio_services() now uses check_service()
- _on_detect_meshtastic() shows BOTH service status AND preset detection
- UI shows "Service: Running | Preset: Select manually" when CLI unavailable
- Clear messages: service running != preset detection working

Phase 3: Created event bus for RX message display
- New src/utils/event_bus.py - thread-safe pub/sub system
- MessageEvent dataclass for message data
- rns_bridge.py emits 'message' events for all RX messages
- messaging.py panel subscribes and shows real-time updates
- Proper cleanup on panel destruction

This addresses the persistent issues with:
- RNS panel showing wrong status lights
- Meshtastic detection showing "FAILED" when service is running
- RX messages only in logs, not displayed in UI