### PR TITLE
fix: Improve TUI navigation and fix rnsd service detection

### DIFF
--- a/src/tui/app.py
+++ b/src/tui/app.py
@@ -261,23 +261,33 @@ class MeshtasticdTUI(App):
 [bold]Navigation[/bold]
   [green]d[/green]  Dashboard    [green]s[/green]  Service     [green]c[/green]  Config
   [green]h[/green]  Hardware     [green]m[/green]  CLI         [green]t[/green]  Tools
-  [green]Tab[/green]  Next tab   [green]Shift+Tab[/green]  Previous tab
+  [green]Tab[/green]  Next widget   [green]Shift+Tab[/green]  Previous widget
 
 [bold]Actions[/bold]
   [green]r[/green]  Refresh current view
   [green]T[/green]  Toggle dark/light theme
   [green]?[/green]  Show this help
 
-[bold]Exit[/bold]
-  [green]q[/green]  or  [green]Escape[/green]  Quit application
+[bold]Exit / Back[/bold]
+  [green]q[/green]  Quit application
+  [green]Escape[/green]  Go back / Cancel / Quit
+
+[bold]In Text Inputs[/bold]
+  [green]Tab[/green]  Move to next field
+  [green]Escape[/green]  Cancel editing
 
 [bold]In Lists[/bold]
   [green]↑/↓[/green]  Navigate items
   [green]Enter[/green]  Select/Preview
+  [green]Escape[/green]  Unfocus list
+
+[bold]In External Editor (nano)[/bold]
+  [green]Ctrl+O[/green]  Save file
+  [green]Ctrl+X[/green]  Exit editor (returns to TUI)
 
 Press any key to close this help.
 """
-        self.notify(help_text, title="Help", timeout=15)
+        self.notify(help_text, title="Help", timeout=20)
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """Global button handler"""

--- a/src/tui/panes/config.py
+++ b/src/tui/panes/config.py
@@ -164,6 +164,70 @@ class ConfigPane(Container):
             active_status.update("[red]N/A[/red]")
             active_detail.update("Directory missing")
 
+    def _check_config_status_sync(self):
+        """Synchronous version of config status check for use after editor closes"""
+        # Check main config.yaml
+        main_status = self.query_one("#cfg-main-status", Static)
+        main_detail = self.query_one("#cfg-main-detail", Static)
+        main_config = self.CONFIG_BASE / "config.yaml"
+
+        if main_config.exists():
+            try:
+                content = main_config.read_text()
+                missing = []
+                found = []
+                for section in self.REQUIRED_SECTIONS:
+                    if section + ':' in content:
+                        found.append(section)
+                    else:
+                        missing.append(section)
+
+                if missing:
+                    main_status.update(f"[yellow]Incomplete[/yellow]")
+                    main_detail.update(f"Missing: {', '.join(missing)}")
+                else:
+                    main_status.update("[green]Valid[/green]")
+                    main_detail.update(f"Found: {', '.join(found)}")
+            except Exception as e:
+                main_status.update("[red]Error[/red]")
+                main_detail.update(str(e)[:30])
+        else:
+            main_status.update("[red]Missing[/red]")
+            main_detail.update("Create or copy from template")
+
+        # Check hardware config (active in config.d)
+        hw_status = self.query_one("#cfg-hw-status", Static)
+        hw_detail = self.query_one("#cfg-hw-detail", Static)
+
+        if self.CONFIG_D.exists():
+            lora_configs = list(self.CONFIG_D.glob("lora-*.yaml"))
+            if lora_configs:
+                hw_status.update("[green]Configured[/green]")
+                hw_detail.update(lora_configs[0].name)
+            else:
+                hw_status.update("[yellow]No LoRa[/yellow]")
+                hw_detail.update("Activate a lora-*.yaml")
+        else:
+            hw_status.update("[red]Missing[/red]")
+            hw_detail.update("config.d/ not found")
+
+        # Count active configs
+        active_status = self.query_one("#cfg-active-count", Static)
+        active_detail = self.query_one("#cfg-active-detail", Static)
+
+        if self.CONFIG_D.exists():
+            active_files = list(self.CONFIG_D.glob("*.yaml"))
+            count = len(active_files)
+            if count > 0:
+                active_status.update(f"[green]{count} files[/green]")
+                active_detail.update("Ready")
+            else:
+                active_status.update("[yellow]0 files[/yellow]")
+                active_detail.update("No configs active")
+        else:
+            active_status.update("[red]N/A[/red]")
+            active_detail.update("Directory missing")
+
     async def refresh_lists(self):
         """Refresh config lists"""
         available_list = self.query_one("#available-list", ListView)
@@ -255,10 +319,12 @@ class ConfigPane(Container):
             await self._deactivate_selected()
 
         elif button_id == "cfg-edit":
-            self._edit_selected()
+            self._edit_selected()  # Sync - suspends app for nano
+            await self.refresh_lists()  # Refresh after editor closes
 
         elif button_id == "cfg-main":
-            self._edit_main_config()
+            self._edit_main_config()  # Sync - suspends app for nano
+            await self._check_config_status()  # Refresh after editor closes
 
         elif button_id == "cfg-apply":
             await self._apply_and_restart()
@@ -420,9 +486,8 @@ class ConfigPane(Container):
                     preview.write(f"[red]Error: {e}[/red]")
                 break
 
-    @work
-    async def _edit_selected(self):
-        """Edit selected config in nano"""
+    def _edit_selected(self):
+        """Edit selected config in nano - properly suspends TUI"""
         preview = self.query_one("#cfg-preview", Log)
         available_list = self.query_one("#available-list", ListView)
         active_list = self.query_one("#active-list", ListView)
@@ -450,25 +515,28 @@ class ConfigPane(Container):
 
         if config_path:
             preview.write(f"[yellow]Opening {config_path.name} in nano...[/yellow]")
-            preview.write("[dim]Press Ctrl+O to save, Ctrl+X to exit[/dim]")
-            subprocess.run(['nano', str(config_path)], timeout=300)
-            preview.write("[green]Editor closed[/green]")
-            await self.refresh_lists()
+            preview.write("[dim]Press Ctrl+O to save, Ctrl+X to exit nano[/dim]")
+            # Suspend app to properly release terminal for external editor
+            with self.app.suspend():
+                subprocess.run(['nano', str(config_path)], timeout=300)
+            preview.write("[green]Editor closed - returned to TUI[/green]")
+            # Note: refresh_lists() is called by the button handler after this returns
         else:
             preview.write("[yellow]Select a config first[/yellow]")
 
-    @work
-    async def _edit_main_config(self):
-        """Edit main config.yaml"""
+    def _edit_main_config(self):
+        """Edit main config.yaml - properly suspends TUI"""
         preview = self.query_one("#cfg-preview", Log)
         main_config = self.CONFIG_BASE / "config.yaml"
 
         if main_config.exists():
             preview.write(f"[yellow]Opening {main_config} in nano...[/yellow]")
-            preview.write("[dim]Press Ctrl+O to save, Ctrl+X to exit[/dim]")
-            subprocess.run(['nano', str(main_config)], timeout=300)
-            preview.write("[green]Editor closed[/green]")
-            await self._check_config_status()
+            preview.write("[dim]Press Ctrl+O to save, Ctrl+X to exit nano[/dim]")
+            # Suspend app to properly release terminal for external editor
+            with self.app.suspend():
+                subprocess.run(['nano', str(main_config)], timeout=300)
+            preview.write("[green]Editor closed - returned to TUI[/green]")
+            # Note: _check_config_status() is called by the button handler after this returns
         else:
             preview.write(f"[red]Main config not found: {main_config}[/red]")
             preview.write("[yellow]Creating template config.yaml...[/yellow]")
@@ -494,8 +562,11 @@ General:
                 self.CONFIG_BASE.mkdir(parents=True, exist_ok=True)
                 main_config.write_text(template)
                 preview.write(f"[green]Created template: {main_config}[/green]")
-                subprocess.run(['nano', str(main_config)], timeout=300)
-                await self._check_config_status()
+                # Suspend app to properly release terminal for external editor
+                with self.app.suspend():
+                    subprocess.run(['nano', str(main_config)], timeout=300)
+                preview.write("[green]Editor closed - returned to TUI[/green]")
+                # Note: _check_config_status() is called by the button handler after this returns
             except Exception as e:
                 preview.write(f"[red]Error creating config: {e}[/red]")
 

--- a/src/tui/panes/hardware.py
+++ b/src/tui/panes/hardware.py
@@ -231,7 +231,8 @@ class HardwarePane(Container):
             await self._enable_uart()
 
         elif button_id == "hw-edit-boot":
-            await self._edit_boot_config()
+            self._edit_boot_config()  # Sync - suspends app for nano
+            self.refresh_status()  # Refresh after editor closes
 
         elif button_id == "hw-reboot":
             await self._prompt_reboot()
@@ -385,22 +386,23 @@ class HardwarePane(Container):
 
         self.refresh_status()
 
-    @work
-    async def _edit_boot_config(self):
-        """Edit boot config in nano"""
+    def _edit_boot_config(self):
+        """Edit boot config in nano - properly suspends TUI"""
         log = self.query_one("#hw-log", Log)
 
         boot_config = self.BOOT_CONFIG if self.BOOT_CONFIG.exists() else self.BOOT_CONFIG_ALT
 
         if boot_config.exists():
             log.write(f"[yellow]Opening {boot_config} in nano...[/yellow]")
-            log.write("Press Ctrl+O to save, Ctrl+X to exit")
+            log.write("[dim]Press Ctrl+O to save, Ctrl+X to exit nano[/dim]")
 
-            import subprocess
-            subprocess.run(['nano', str(boot_config)], timeout=300)
+            # Suspend app to properly release terminal for external editor
+            with self.app.suspend():
+                import subprocess
+                subprocess.run(['nano', str(boot_config)], timeout=300)
 
-            log.write("[green]Editor closed[/green]")
-            self.refresh_status()
+            log.write("[green]Editor closed - returned to TUI[/green]")
+            # Note: refresh_status() is called by the button handler after this returns
         else:
             log.write("[red]Boot config not found[/red]")
 

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -92,9 +92,9 @@ KNOWN_SERVICES = {
         'port': RNS_SHARED_INSTANCE_PORT,
         'port_type': 'udp',
         'systemd_name': 'rnsd',
-        'is_systemd': True,  # Trust systemctl only
+        'is_systemd': False,  # rnsd is a user-space daemon, NOT a systemd service
         'description': 'Reticulum Network Stack daemon',
-        'fix_hint': 'Start with: sudo systemctl start rnsd',
+        'fix_hint': 'Start with: rnsd (run as user, not root)',
     },
     'hamclock': {
         'port': HAMCLOCK_PORT,

--- a/tests/test_service_check.py
+++ b/tests/test_service_check.py
@@ -117,44 +117,50 @@ class TestCheckService:
     """Tests for check_service function."""
 
     def test_meshtasticd_available(self):
-        """Test detection of available meshtasticd."""
-        with patch('src.utils.service_check.check_port') as mock_port:
-            with patch('src.utils.service_check.check_meshtasticd_responsive') as mock_responsive:
-                mock_port.return_value = True
-                mock_responsive.return_value = (True, "Responsive")
+        """Test detection of available meshtasticd (Issue #17: systemctl only)."""
+        with patch('subprocess.run') as mock_run:
+            # systemctl is-active meshtasticd returns "active"
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout='active\n'
+            )
 
-                status = check_service('meshtasticd')
+            status = check_service('meshtasticd')
 
-                assert status.available is True
-                assert status.state == ServiceState.AVAILABLE
-                assert status.port == 4403
-                mock_port.assert_called_once_with(4403, 'localhost')
+            assert status.available is True
+            assert status.state == ServiceState.AVAILABLE
+            assert status.port == 4403
+            assert status.detection_method == "systemctl"
 
     def test_hamclock_not_running(self):
-        """Test detection of stopped hamclock."""
-        with patch('src.utils.service_check.check_port') as mock_port:
-            with patch('src.utils.service_check.check_systemd_service') as mock_systemd:
-                mock_port.return_value = False
-                mock_systemd.return_value = (False, True)  # not running, but enabled
+        """Test detection of stopped hamclock (Issue #17: systemctl only)."""
+        with patch('subprocess.run') as mock_run:
+            # systemctl is-active hamclock returns "inactive"
+            mock_run.return_value = MagicMock(
+                returncode=3,
+                stdout='inactive\n'
+            )
 
-                status = check_service('hamclock')
+            status = check_service('hamclock')
 
-                assert status.available is False
-                assert status.state == ServiceState.NOT_RUNNING
-                assert 'not running' in status.message.lower()
-                assert 'systemctl start' in status.fix_hint.lower()
+            assert status.available is False
+            assert status.state == ServiceState.NOT_RUNNING
+            assert 'not running' in status.message.lower()
+            assert status.detection_method == "systemctl"
 
     def test_unknown_service(self):
-        """Test handling of unknown service."""
-        with patch('src.utils.service_check.check_port') as mock_port:
-            with patch('src.utils.service_check.check_systemd_service') as mock_systemd:
-                mock_port.return_value = False
-                mock_systemd.return_value = (False, False)
+        """Test handling of unknown service (defaults to systemd check)."""
+        with patch('subprocess.run') as mock_run:
+            # Unknown service treated as systemd service by default
+            mock_run.return_value = MagicMock(
+                returncode=3,
+                stdout='inactive\n'
+            )
 
-                status = check_service('unknown_service', port=9999)
+            status = check_service('unknown_service', port=9999)
 
-                assert status.available is False
-                assert status.port == 9999
+            assert status.available is False
+            assert status.port == 9999
 
     def test_service_status_bool(self):
         """Test ServiceStatus boolean conversion."""

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -186,37 +186,43 @@ class TestRnsdStatusAcrossUIs:
 class TestMeshtasticdStatusConsistency:
     """Verify meshtasticd status is consistent across UIs."""
 
-    @patch('src.utils.service_check.check_port')
-    @patch('src.utils.service_check.check_process_running')
-    @patch('src.utils.service_check.check_systemd_service')
-    @patch('src.utils.service_check.check_meshtasticd_responsive')
-    def test_meshtasticd_running_consistent(self, mock_responsive, mock_systemd, mock_proc, mock_port):
-        """When meshtasticd is running, all UIs should report it as running."""
-        mock_port.return_value = True  # TCP port 4403 open
-        mock_proc.return_value = True
-        mock_systemd.return_value = (True, True)
-        mock_responsive.return_value = (True, "Responsive")
+    @patch('subprocess.run')
+    def test_meshtasticd_running_consistent(self, mock_run):
+        """When meshtasticd is running, all UIs should report it as running.
+
+        Issue #17: meshtasticd is a systemd service, so we trust systemctl only.
+        """
+        # systemctl is-active meshtasticd returns "active"
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout='active\n'
+        )
 
         from src.utils.service_check import check_service
 
         result = check_service('meshtasticd')
         assert result.available is True, \
-            "meshtasticd should be reported as available when TCP port is open"
+            "meshtasticd should be reported as available when systemctl says active"
+        assert result.detection_method == "systemctl", \
+            "meshtasticd status should be via systemctl"
 
-    @patch('src.utils.service_check.check_port')
-    @patch('src.utils.service_check.check_process_running')
-    @patch('src.utils.service_check.check_systemd_service')
-    def test_meshtasticd_stopped_consistent(self, mock_systemd, mock_proc, mock_port):
-        """When meshtasticd is stopped, all UIs should report it as stopped."""
-        mock_port.return_value = False  # TCP port closed
-        mock_proc.return_value = False
-        mock_systemd.return_value = (False, False)
+    @patch('subprocess.run')
+    def test_meshtasticd_stopped_consistent(self, mock_run):
+        """When meshtasticd is stopped, all UIs should report it as stopped.
+
+        Issue #17: meshtasticd is a systemd service, so we trust systemctl only.
+        """
+        # systemctl is-active meshtasticd returns "inactive"
+        mock_run.return_value = MagicMock(
+            returncode=3,
+            stdout='inactive\n'
+        )
 
         from src.utils.service_check import check_service
 
         result = check_service('meshtasticd')
         assert result.available is False, \
-            "meshtasticd should be reported as unavailable when stopped"
+            "meshtasticd should be reported as unavailable when systemctl says inactive"
 
 
 class TestNoOrphanedImplementations:


### PR DESCRIPTION
TUI Navigation Improvements:
- Fix nano editor calls in config.py and hardware.py to use Textual's app.suspend() properly - user no longer needs Ctrl+C to return from external editor
- Expand help text (?) to show escape/back keys for all contexts: Input widgets, ListView, external editor (nano)
- Add sync helper _check_config_status_sync() for post-edit refresh

Service Detection Fix (Issue #17 follow-up):
- Fix rnsd detection: rnsd is NOT a systemd service, it's a user-space daemon. Changed is_systemd=False so it uses UDP port check (37428) and process detection instead of systemctl
- Update fix_hint to show "rnsd" command instead of systemctl

Test Updates:
- Update test_service_check.py tests to use subprocess.run mock instead of removed check_meshtasticd_responsive function
- Update test_status_consistency.py meshtasticd tests for Issue #17 systemctl-only architecture

This resolves:
- User having to Ctrl+C out of nano editor in TUI
- rnsd showing "not running" immediately after starting