### PR TITLE
fix: remove invalid load_cache() call in mesh_tools_sensors

### DIFF
--- a/src/gtk_ui/panels/mesh_tools_sensors.py
+++ b/src/gtk_ui/panels/mesh_tools_sensors.py
@@ -217,7 +217,7 @@ class SensorsTabMixin:
                     try:
                         from gateway.node_tracker import UnifiedNodeTracker
                         tracker = UnifiedNodeTracker()
-                        tracker.load_cache()  # Load cached nodes
+                        # Cache is auto-loaded in __init__
                     except ImportError:
                         logger.warning("UnifiedNodeTracker not available")
                         tracker = None


### PR DESCRIPTION
UnifiedNodeTracker.__init__ already loads the cache automatically. The external call was using the wrong method name (load_cache vs _load_cache) and was unnecessary regardless.