### PR TITLE
feat: support both USB serial and native SPI radios (Meshtoad)

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -3,9 +3,13 @@
 # MeshForge NOC Stack Installer
 #
 # Installs the complete NOC stack:
-#   - meshtasticd (Meshtastic daemon)
+#   - meshtasticd (Meshtastic daemon) - auto-detects USB or SPI radio
 #   - Reticulum/RNS (rnsd)
 #   - MeshForge (orchestrates everything)
+#
+# Supports:
+#   - USB Serial radios (T-Beam, Heltec, RAK USB) → Python CLI
+#   - Native SPI radios (Meshtoad, RAK HAT) → Native meshtasticd binary
 #
 # Usage:
 #   sudo bash scripts/install_noc.sh
@@ -14,6 +18,8 @@
 #   --skip-meshtasticd    Don't install meshtasticd
 #   --skip-rns            Don't install Reticulum
 #   --client-only         Only install MeshForge as client (no daemons)
+#   --force-native        Force native meshtasticd (for SPI radios)
+#   --force-python        Force Python meshtastic CLI (for USB radios)
 #
 
 set -e
@@ -31,6 +37,21 @@ INSTALL_MESHTASTICD=true
 INSTALL_RNS=true
 INSTALL_DIR="/opt/meshforge"
 VENV_DIR="$INSTALL_DIR/venv"
+MESHTASTICD_CONFIG_DIR="/etc/meshtasticd"
+FORCE_NATIVE=false
+FORCE_PYTHON=false
+
+# Architecture detection
+ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+case $ARCH in
+    aarch64|arm64) ARCH="arm64" ;;
+    armv7l|armhf) ARCH="armhf" ;;
+    x86_64|amd64) ARCH="amd64" ;;
+esac
+
+# Native meshtasticd version
+NATIVE_VERSION="2.5.19.f77f1d6"
+NATIVE_DEB_URL="https://github.com/meshtastic/firmware/releases/download/v${NATIVE_VERSION}/meshtasticd_${NATIVE_VERSION}_${ARCH}.deb"
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -46,6 +67,14 @@ while [[ $# -gt 0 ]]; do
         --client-only)
             INSTALL_MESHTASTICD=false
             INSTALL_RNS=false
+            shift
+            ;;
+        --force-native)
+            FORCE_NATIVE=true
+            shift
+            ;;
+        --force-python)
+            FORCE_PYTHON=true
             shift
             ;;
         *)
@@ -68,6 +97,57 @@ if [[ $EUID -ne 0 ]]; then
    echo "Please run: sudo bash $0"
    exit 1
 fi
+
+# ─────────────────────────────────────────────────────────────────
+# Radio Type Detection Functions
+# ─────────────────────────────────────────────────────────────────
+
+detect_radio_type() {
+    # Returns: "spi", "usb", or "none"
+
+    # Check for CH341 (Meshtoad USB-to-SPI adapter)
+    if dmesg 2>/dev/null | grep -qi "ch341.*spi\|ch341-spi"; then
+        echo "spi"
+        return
+    fi
+
+    # Check for known SPI HAT configurations
+    if [[ -e /dev/spidev0.0 ]] || [[ -e /dev/spidev0.1 ]]; then
+        # Check if there's a SPI radio config or HAT overlay
+        if grep -q "meshtastic\|sx126\|sx127\|lora" /boot/config.txt 2>/dev/null; then
+            echo "spi"
+            return
+        fi
+    fi
+
+    # Check for USB serial devices
+    if ls /dev/ttyUSB* /dev/ttyACM* 2>/dev/null | head -1 >/dev/null; then
+        echo "usb"
+        return
+    fi
+
+    echo "none"
+}
+
+get_usb_device() {
+    # Find the first USB serial device
+    for dev in /dev/ttyUSB* /dev/ttyACM*; do
+        if [[ -e "$dev" ]]; then
+            echo "$dev"
+            return
+        fi
+    done
+    echo ""
+}
+
+load_ch341_driver() {
+    # Load CH341 kernel module if needed
+    if ! lsmod | grep -q ch341; then
+        echo -e "  ${CYAN}Loading CH341 driver...${NC}"
+        modprobe ch341 2>/dev/null || true
+        sleep 1
+    fi
+}
 
 # ─────────────────────────────────────────────────────────────────
 # Detect existing installations
@@ -159,22 +239,193 @@ if ls /usr/lib/python3*/EXTERNALLY-MANAGED 1>/dev/null 2>&1; then
 fi
 
 # ─────────────────────────────────────────────────────────────────
-# Install meshtasticd
+# Install meshtasticd (auto-detect USB vs SPI)
 # ─────────────────────────────────────────────────────────────────
 if $INSTALL_MESHTASTICD; then
     echo -e "${CYAN}[3/8] Installing meshtasticd...${NC}"
 
-    # Install meshtastic Python package (includes meshtasticd)
-    # --ignore-installed avoids conflicts with apt-installed packages
-    pip3 install $PIP_ARGS --ignore-installed -q meshtastic
+    # Create udev rules first (needed for detection)
+    if [[ ! -f /etc/udev/rules.d/99-meshtastic.rules ]]; then
+        echo "  Creating udev rules for radio devices..."
+        cat > /etc/udev/rules.d/99-meshtastic.rules << 'UDEV_RULES'
+# Meshtastic USB devices
+# T-Beam, Heltec, RAK, etc.
 
-    # Create systemd service if not exists
-    if ! systemctl list-unit-files | grep -q meshtasticd.service; then
-        echo "  Creating meshtasticd systemd service..."
+# Silicon Labs CP210x
+SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0666", GROUP="dialout"
 
-        cat > /etc/systemd/system/meshtasticd.service << 'MESHTASTICD_SERVICE'
+# CH340/CH341 (USB serial AND USB-to-SPI for Meshtoad)
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0666", GROUP="dialout"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5512", MODE="0666", GROUP="dialout"
+
+# FTDI
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE="0666", GROUP="dialout"
+
+# ESP32 native USB
+SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", MODE="0666", GROUP="dialout"
+
+# SPI device permissions (for native meshtasticd)
+SUBSYSTEM=="spidev", MODE="0666", GROUP="spi"
+UDEV_RULES
+
+        udevadm control --reload-rules
+        udevadm trigger
+        sleep 1
+    fi
+
+    # Load CH341 driver if present (Meshtoad)
+    load_ch341_driver
+
+    # Determine radio type
+    if $FORCE_NATIVE; then
+        RADIO_TYPE="spi"
+    elif $FORCE_PYTHON; then
+        RADIO_TYPE="usb"
+    else
+        RADIO_TYPE=$(detect_radio_type)
+    fi
+
+    echo -e "  ${CYAN}Detected radio type: ${BOLD}${RADIO_TYPE}${NC}"
+
+    # Create meshtasticd config directory structure
+    echo "  Creating /etc/meshtasticd/ structure..."
+    mkdir -p "$MESHTASTICD_CONFIG_DIR"/{available.d,config.d,ssl}
+    chmod 700 "$MESHTASTICD_CONFIG_DIR/ssl"
+
+    # Create config templates
+    cat > "$MESHTASTICD_CONFIG_DIR/available.d/meshtoad-spi.yaml" << 'MESHTOAD_CONFIG'
+# Meshtoad SPI Radio Configuration
+# Uses CH341 USB-to-SPI adapter with SX1262
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+  TXen: 5
+  RXen: 6
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 4403
+MESHTOAD_CONFIG
+
+    cat > "$MESHTASTICD_CONFIG_DIR/available.d/rak-hat-spi.yaml" << 'RAK_CONFIG'
+# RAK WisLink SPI HAT Configuration
+# Direct GPIO connection on Raspberry Pi
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 4403
+RAK_CONFIG
+
+    cat > "$MESHTASTICD_CONFIG_DIR/available.d/usb-serial.yaml" << 'USB_CONFIG'
+# USB Serial Radio Configuration
+# For radios connected via USB (T-Beam, Heltec, RAK USB)
+# This config is for reference - USB radios use Python CLI
+
+Serial:
+  Device: auto
+
+Logging:
+  LogLevel: info
+USB_CONFIG
+
+    # Install appropriate daemon based on radio type
+    case "$RADIO_TYPE" in
+        spi)
+            echo -e "  ${CYAN}Installing native meshtasticd for SPI radio...${NC}"
+
+            # Check if already installed
+            if ! command -v meshtasticd &>/dev/null; then
+                # Download and install native .deb
+                DEB_FILE="/tmp/meshtasticd_${ARCH}.deb"
+                echo "  Downloading meshtasticd v${NATIVE_VERSION} for ${ARCH}..."
+
+                if wget -q "$NATIVE_DEB_URL" -O "$DEB_FILE"; then
+                    echo "  Installing meshtasticd..."
+                    dpkg -i "$DEB_FILE" || apt-get install -f -y -qq
+                    rm -f "$DEB_FILE"
+                    echo -e "  ${GREEN}✓ Native meshtasticd installed${NC}"
+                else
+                    echo -e "  ${RED}Failed to download meshtasticd${NC}"
+                    echo -e "  ${YELLOW}Manual install: wget $NATIVE_DEB_URL && sudo dpkg -i meshtasticd_*.deb${NC}"
+                fi
+            else
+                echo -e "  ${GREEN}✓ Native meshtasticd already installed${NC}"
+            fi
+
+            # Enable Meshtoad config by default
+            ln -sf ../available.d/meshtoad-spi.yaml "$MESHTASTICD_CONFIG_DIR/config.d/active.yaml"
+
+            # Create main config.yaml
+            cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'MAIN_CONFIG'
+# MeshForge Meshtasticd Configuration
+# Managed by MeshForge NOC
+
+# Include active configuration
+# Active radio: config.d/active.yaml -> available.d/meshtoad-spi.yaml
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 4403
+MAIN_CONFIG
+
+            # Create/update systemd service for native meshtasticd
+            cat > /etc/systemd/system/meshtasticd.service << 'NATIVE_SERVICE'
 [Unit]
-Description=Meshtastic Daemon (TCP Server Mode)
+Description=Meshtastic Daemon (Native SPI)
+Documentation=https://meshtastic.org
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/etc/meshtasticd
+ExecStart=/usr/sbin/meshtasticd -c /etc/meshtasticd/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+NATIVE_SERVICE
+
+            DAEMON_TYPE="native"
+            ;;
+
+        usb)
+            echo -e "  ${CYAN}Installing Python meshtastic for USB radio...${NC}"
+
+            # Install meshtastic Python package
+            pip3 install $PIP_ARGS --ignore-installed -q meshtastic
+
+            USB_DEV=$(get_usb_device)
+            echo -e "  ${GREEN}✓ Python meshtastic installed${NC}"
+            if [[ -n "$USB_DEV" ]]; then
+                echo -e "  ${GREEN}  USB device: $USB_DEV${NC}"
+            fi
+
+            # Enable USB config
+            ln -sf ../available.d/usb-serial.yaml "$MESHTASTICD_CONFIG_DIR/config.d/active.yaml"
+
+            # Create systemd service for Python CLI
+            cat > /etc/systemd/system/meshtasticd.service << 'PYTHON_SERVICE'
+[Unit]
+Description=Meshtastic Daemon (Python TCP Server)
 Documentation=https://meshtastic.org
 After=network.target
 
@@ -188,36 +439,43 @@ RestartSec=5
 
 [Install]
 WantedBy=multi-user.target
-MESHTASTICD_SERVICE
+PYTHON_SERVICE
 
-        systemctl daemon-reload
-    fi
+            DAEMON_TYPE="python"
+            ;;
 
-    # Create udev rules for USB radio devices
-    if [[ ! -f /etc/udev/rules.d/99-meshtastic.rules ]]; then
-        echo "  Creating udev rules for radio devices..."
-        cat > /etc/udev/rules.d/99-meshtastic.rules << 'UDEV_RULES'
-# Meshtastic USB devices
-# T-Beam, Heltec, RAK, etc.
+        none)
+            echo -e "  ${YELLOW}⚠ No radio detected${NC}"
+            echo -e "  ${YELLOW}  Installing Python meshtastic (default)${NC}"
 
-# Silicon Labs CP210x
-SUBSYSTEM=="tty", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE="0666", GROUP="dialout"
+            pip3 install $PIP_ARGS --ignore-installed -q meshtastic
 
-# CH340/CH341
-SUBSYSTEM=="tty", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0666", GROUP="dialout"
+            # Create a generic service
+            cat > /etc/systemd/system/meshtasticd.service << 'GENERIC_SERVICE'
+[Unit]
+Description=Meshtastic Daemon
+Documentation=https://meshtastic.org
+After=network.target
 
-# FTDI
-SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6001", MODE="0666", GROUP="dialout"
+[Service]
+Type=simple
+User=root
+ExecStart=/usr/local/bin/meshtastic --tcp
+Restart=on-failure
+RestartSec=5
 
-# ESP32 native USB
-SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", MODE="0666", GROUP="dialout"
-UDEV_RULES
+[Install]
+WantedBy=multi-user.target
+GENERIC_SERVICE
 
-        udevadm control --reload-rules
-        udevadm trigger
-    fi
+            DAEMON_TYPE="python"
+            ;;
+    esac
 
-    echo -e "  ${GREEN}✓ meshtasticd installed${NC}"
+    systemctl daemon-reload
+
+    echo -e "  ${GREEN}✓ meshtasticd installed (${DAEMON_TYPE})${NC}"
+    echo -e "  ${GREEN}✓ Config directory: $MESHTASTICD_CONFIG_DIR${NC}"
 else
     echo -e "${CYAN}[3/8] Skipping meshtasticd...${NC}"
     echo -e "  ${YELLOW}⊘ Skipped${NC}"
@@ -306,35 +564,62 @@ if ! $INSTALL_MESHTASTICD; then
     NOC_MODE="client"
 fi
 
+# Set defaults if not set earlier
+DAEMON_TYPE=${DAEMON_TYPE:-"python"}
+RADIO_TYPE=${RADIO_TYPE:-"unknown"}
+USB_DEV=${USB_DEV:-$(get_usb_device)}
+
 # Create config directory
 CONFIG_DIR="/etc/meshforge"
 mkdir -p "$CONFIG_DIR"
 
-# Create NOC config
+# Create comprehensive NOC config
 cat > "$CONFIG_DIR/noc.yaml" << NOC_CONFIG
 # MeshForge NOC Configuration
 # Generated by install_noc.sh on $(date)
+# Architecture: $ARCH
 
 noc:
   mode: "$NOC_MODE"  # local | client | remote-only
+  version: "1.0.0"
 
+  # Radio configuration
+  radio:
+    type: "$RADIO_TYPE"        # spi | usb | none
+    daemon: "$DAEMON_TYPE"     # native | python
+    device: "$USB_DEV"         # USB device path (if applicable)
+    config_dir: "$MESHTASTICD_CONFIG_DIR"
+
+  # Service management
   services:
     meshtasticd:
       managed: $INSTALL_MESHTASTICD
       auto_start: $INSTALL_MESHTASTICD
+      daemon_type: "$DAEMON_TYPE"
+      port: 4403
 
     rnsd:
       managed: $INSTALL_RNS
       auto_start: $INSTALL_RNS
 
+  # Startup behavior
   startup:
     auto_start_services: true
     health_check_interval: 30
     restart_on_failure: true
     max_restart_attempts: 3
+
+  # Paths
+  paths:
+    install_dir: "$INSTALL_DIR"
+    venv_dir: "$VENV_DIR"
+    meshtasticd_config: "$MESHTASTICD_CONFIG_DIR"
+    meshforge_config: "$CONFIG_DIR"
 NOC_CONFIG
 
 echo -e "  ${GREEN}✓ NOC mode: $NOC_MODE${NC}"
+echo -e "  ${GREEN}✓ Radio type: $RADIO_TYPE${NC}"
+echo -e "  ${GREEN}✓ Daemon type: $DAEMON_TYPE${NC}"
 
 # ─────────────────────────────────────────────────────────────────
 # Create system commands and services
@@ -413,24 +698,41 @@ echo -e "${GREEN}╚════════════════════
 echo ""
 echo -e "${CYAN}Installed Components:${NC}"
 if $INSTALL_MESHTASTICD; then
-    echo -e "  ${GREEN}✓${NC} meshtasticd (Meshtastic daemon)"
+    if [[ "$DAEMON_TYPE" == "native" ]]; then
+        echo -e "  ${GREEN}✓${NC} meshtasticd (native binary for SPI)"
+    else
+        echo -e "  ${GREEN}✓${NC} meshtastic (Python CLI for USB)"
+    fi
 fi
 if $INSTALL_RNS; then
     echo -e "  ${GREEN}✓${NC} Reticulum (RNS)"
 fi
 echo -e "  ${GREEN}✓${NC} MeshForge NOC"
 echo ""
-echo -e "${CYAN}NOC Mode:${NC} $NOC_MODE"
+echo -e "${CYAN}Configuration:${NC}"
+echo -e "  NOC Mode:    ${BOLD}$NOC_MODE${NC}"
+echo -e "  Radio Type:  ${BOLD}$RADIO_TYPE${NC}"
+echo -e "  Daemon:      ${BOLD}$DAEMON_TYPE${NC}"
+if [[ -n "$USB_DEV" ]]; then
+    echo -e "  USB Device:  ${BOLD}$USB_DEV${NC}"
+fi
+echo ""
+echo -e "${CYAN}Config Files:${NC}"
+echo "  /etc/meshforge/noc.yaml           - MeshForge NOC config"
+echo "  /etc/meshtasticd/config.yaml      - Meshtasticd config"
+echo "  /etc/meshtasticd/available.d/     - Radio templates"
+echo "  /etc/meshtasticd/config.d/        - Active configs"
 echo ""
 echo -e "${CYAN}Commands:${NC}"
-echo "  ${GREEN}sudo meshforge${NC}           - Launch interface wizard"
-echo "  ${GREEN}sudo meshforge-noc --start${NC} - Start NOC services"
+echo "  ${GREEN}sudo meshforge${NC}             - Launch interface wizard"
+echo "  ${GREEN}sudo meshforge-noc --start${NC}  - Start NOC services"
 echo "  ${GREEN}sudo meshforge-noc --status${NC} - Check service status"
-echo "  ${GREEN}sudo meshforge-noc --stop${NC}  - Stop NOC services"
+echo "  ${GREEN}sudo meshforge-noc --stop${NC}   - Stop NOC services"
 echo ""
-echo -e "${CYAN}Systemd Service:${NC}"
-echo "  ${GREEN}sudo systemctl enable meshforge${NC}  - Enable on boot"
-echo "  ${GREEN}sudo systemctl start meshforge${NC}   - Start now"
+echo -e "${CYAN}Systemd Services:${NC}"
+echo "  ${GREEN}sudo systemctl enable meshforge${NC}   - Enable on boot"
+echo "  ${GREEN}sudo systemctl start meshforge${NC}    - Start now"
+echo "  ${GREEN}sudo systemctl status meshtasticd${NC} - Check meshtasticd"
 echo ""
 
 # Offer to start services

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -1,0 +1,534 @@
+"""
+MeshForge Meshtasticd Configuration Manager
+
+Manages the /etc/meshtasticd/ directory structure:
+  - available.d/  - Available radio configurations (templates)
+  - config.d/     - Active/enabled configurations (symlinks)
+  - config.yaml   - Main configuration file
+  - ssl/          - SSL certificates
+
+Supports both:
+  - USB Serial radios (T-Beam, Heltec, RAK USB) → Python CLI
+  - Native SPI radios (Meshtoad, RAK HAT) → Native meshtasticd binary
+
+Usage:
+    from core.meshtasticd_config import MeshtasticdConfig
+
+    config = MeshtasticdConfig()
+
+    # List available radio configs
+    available = config.list_available()
+
+    # Enable a config
+    config.enable("meshtoad-spi")
+
+    # Check radio type
+    radio_type = config.detect_radio_type()
+"""
+
+import os
+import shutil
+import logging
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+
+class RadioType(Enum):
+    """Type of Meshtastic radio connection."""
+    USB_SERIAL = "usb_serial"    # T-Beam, Heltec, etc. via USB
+    NATIVE_SPI = "native_spi"    # Meshtoad, RAK HAT via SPI
+    NATIVE_I2C = "native_i2c"    # Future: I2C connected radios
+    UNKNOWN = "unknown"
+
+
+@dataclass
+class RadioConfig:
+    """Configuration for a radio device."""
+    name: str
+    radio_type: RadioType
+    device_path: Optional[str] = None
+    chip: Optional[str] = None  # e.g., "sx1262", "sx1276"
+    description: str = ""
+    enabled: bool = False
+    config_file: Optional[str] = None
+
+
+# Default config templates for common radios
+RADIO_TEMPLATES = {
+    "meshtoad-spi": {
+        "name": "meshtoad-spi",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Meshtoad SPI Radio (SX1262 via CH341)",
+        "config": """# Meshtoad SPI Radio Configuration
+# Uses CH341 USB-to-SPI adapter
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+  TXen: 5
+  RXen: 6
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "rak-hat-spi": {
+        "name": "rak-hat-spi",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "RAK WisLink SPI HAT (SX1262)",
+        "config": """# RAK WisLink SPI HAT Configuration
+# Direct GPIO connection on Raspberry Pi
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "usb-serial": {
+        "name": "usb-serial",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "USB Serial Radio (T-Beam, Heltec, etc.)",
+        "config": """# USB Serial Radio Configuration
+# For radios connected via USB (T-Beam, Heltec, RAK USB)
+
+# Serial device will be auto-detected
+# Common paths: /dev/ttyUSB0, /dev/ttyACM0
+
+Serial:
+  Device: auto  # or specify: /dev/ttyUSB0
+
+Logging:
+  LogLevel: info
+"""
+    },
+}
+
+
+class MeshtasticdConfig:
+    """
+    Manages meshtasticd configuration directory structure.
+
+    Directory structure:
+        /etc/meshtasticd/
+        ├── available.d/     # Available radio configs
+        │   ├── meshtoad-spi.yaml
+        │   ├── rak-hat-spi.yaml
+        │   └── usb-serial.yaml
+        ├── config.d/        # Enabled configs (symlinks to available.d)
+        │   └── active.yaml -> ../available.d/meshtoad-spi.yaml
+        ├── config.yaml      # Main config (merged from config.d)
+        └── ssl/             # SSL certificates
+    """
+
+    DEFAULT_CONFIG_DIR = Path("/etc/meshtasticd")
+    MESHFORGE_CONFIG_DIR = Path("/etc/meshforge")
+
+    def __init__(self, config_dir: Optional[Path] = None):
+        """
+        Initialize config manager.
+
+        Args:
+            config_dir: Override config directory (default: /etc/meshtasticd)
+        """
+        self.config_dir = config_dir or self.DEFAULT_CONFIG_DIR
+        self.available_dir = self.config_dir / "available.d"
+        self.config_d_dir = self.config_dir / "config.d"
+        self.ssl_dir = self.config_dir / "ssl"
+        self.main_config = self.config_dir / "config.yaml"
+
+    def ensure_structure(self) -> bool:
+        """
+        Ensure the configuration directory structure exists.
+
+        Returns:
+            True if structure was created/exists, False on error
+        """
+        try:
+            # Create directories
+            self.config_dir.mkdir(parents=True, exist_ok=True)
+            self.available_dir.mkdir(exist_ok=True)
+            self.config_d_dir.mkdir(exist_ok=True)
+            self.ssl_dir.mkdir(mode=0o700, exist_ok=True)
+
+            # Create default templates if available.d is empty
+            if not list(self.available_dir.glob("*.yaml")):
+                self._create_default_templates()
+
+            # Create main config.yaml if missing
+            if not self.main_config.exists():
+                self._create_main_config()
+
+            logger.info(f"Config structure ready at {self.config_dir}")
+            return True
+
+        except PermissionError as e:
+            logger.error(f"Permission denied creating config structure: {e}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to create config structure: {e}")
+            return False
+
+    def _create_default_templates(self):
+        """Create default radio configuration templates."""
+        for name, template in RADIO_TEMPLATES.items():
+            config_file = self.available_dir / f"{name}.yaml"
+            if not config_file.exists():
+                config_file.write_text(template["config"])
+                logger.debug(f"Created template: {config_file}")
+
+    def _create_main_config(self):
+        """Create main config.yaml file."""
+        config_content = """# MeshForge Meshtasticd Configuration
+# This file is managed by MeshForge NOC
+# Individual radio configs are in config.d/
+
+# Include enabled configurations from config.d/
+# Active config is symlinked from available.d/
+
+Logging:
+  LogLevel: info
+
+# Server settings (for TCP connections from MeshForge)
+Webserver:
+  Port: 4403
+"""
+        self.main_config.write_text(config_content)
+        logger.info(f"Created main config: {self.main_config}")
+
+    def list_available(self) -> List[RadioConfig]:
+        """
+        List available radio configurations.
+
+        Returns:
+            List of RadioConfig objects
+        """
+        configs = []
+
+        if not self.available_dir.exists():
+            return configs
+
+        for config_file in sorted(self.available_dir.glob("*.yaml")):
+            name = config_file.stem
+
+            # Check if enabled (symlink exists in config.d)
+            enabled = (self.config_d_dir / config_file.name).exists()
+
+            # Get template info if available
+            template = RADIO_TEMPLATES.get(name, {})
+            radio_type = template.get("radio_type", RadioType.UNKNOWN)
+            description = template.get("description", f"Radio config: {name}")
+            chip = template.get("chip")
+
+            configs.append(RadioConfig(
+                name=name,
+                radio_type=radio_type,
+                chip=chip,
+                description=description,
+                enabled=enabled,
+                config_file=str(config_file),
+            ))
+
+        return configs
+
+    def list_enabled(self) -> List[RadioConfig]:
+        """List enabled (active) configurations."""
+        return [c for c in self.list_available() if c.enabled]
+
+    def enable(self, config_name: str) -> bool:
+        """
+        Enable a radio configuration.
+
+        Creates a symlink in config.d/ pointing to available.d/
+
+        Args:
+            config_name: Name of config (without .yaml extension)
+
+        Returns:
+            True if enabled successfully
+        """
+        source = self.available_dir / f"{config_name}.yaml"
+        target = self.config_d_dir / f"{config_name}.yaml"
+
+        if not source.exists():
+            logger.error(f"Config not found: {source}")
+            return False
+
+        try:
+            # Remove existing symlink if present
+            if target.exists() or target.is_symlink():
+                target.unlink()
+
+            # Create relative symlink
+            target.symlink_to(f"../available.d/{config_name}.yaml")
+            logger.info(f"Enabled config: {config_name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to enable {config_name}: {e}")
+            return False
+
+    def disable(self, config_name: str) -> bool:
+        """
+        Disable a radio configuration.
+
+        Removes symlink from config.d/
+
+        Args:
+            config_name: Name of config (without .yaml extension)
+
+        Returns:
+            True if disabled successfully
+        """
+        target = self.config_d_dir / f"{config_name}.yaml"
+
+        try:
+            if target.exists() or target.is_symlink():
+                target.unlink()
+                logger.info(f"Disabled config: {config_name}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to disable {config_name}: {e}")
+            return False
+
+    def detect_radio_type(self) -> RadioType:
+        """
+        Auto-detect the type of radio connected.
+
+        Checks:
+        1. USB serial devices (/dev/ttyUSB*, /dev/ttyACM*)
+        2. SPI devices (via CH341 or native GPIO)
+
+        Returns:
+            RadioType enum value
+        """
+        # Check for USB serial devices
+        usb_devices = list(Path("/dev").glob("ttyUSB*")) + \
+                      list(Path("/dev").glob("ttyACM*"))
+
+        if usb_devices:
+            # Check if this is a CH341 (USB-to-SPI for Meshtoad)
+            for dev in usb_devices:
+                if self._is_ch341_spi(dev):
+                    logger.info(f"Detected CH341 SPI adapter: {dev}")
+                    return RadioType.NATIVE_SPI
+
+            # Regular USB serial
+            logger.info(f"Detected USB serial radio: {usb_devices[0]}")
+            return RadioType.USB_SERIAL
+
+        # Check for native SPI (Raspberry Pi GPIO)
+        if self._has_native_spi():
+            logger.info("Detected native SPI interface")
+            return RadioType.NATIVE_SPI
+
+        return RadioType.UNKNOWN
+
+    def _is_ch341_spi(self, device: Path) -> bool:
+        """Check if a USB device is a CH341 USB-to-SPI adapter."""
+        try:
+            # Check dmesg for CH341 mention
+            result = subprocess.run(
+                ["dmesg"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if "ch341" in result.stdout.lower():
+                # Check if it's in SPI mode vs serial
+                # CH341 in SPI mode shows up differently
+                if "spi" in result.stdout.lower():
+                    return True
+        except Exception:
+            pass
+        return False
+
+    def _has_native_spi(self) -> bool:
+        """Check if native SPI is available (Raspberry Pi)."""
+        spi_devices = list(Path("/dev").glob("spidev*"))
+        return len(spi_devices) > 0
+
+    def get_daemon_type(self) -> str:
+        """
+        Determine which daemon type to use.
+
+        Returns:
+            "native" for meshtasticd binary
+            "python" for meshtastic Python CLI
+        """
+        radio_type = self.detect_radio_type()
+
+        if radio_type == RadioType.NATIVE_SPI:
+            return "native"
+        elif radio_type == RadioType.USB_SERIAL:
+            return "python"
+        else:
+            # Default to Python for unknown
+            return "python"
+
+    def is_native_installed(self) -> bool:
+        """Check if native meshtasticd binary is installed."""
+        return shutil.which("meshtasticd") is not None
+
+    def is_python_cli_installed(self) -> bool:
+        """Check if Python meshtastic CLI is installed."""
+        return shutil.which("meshtastic") is not None
+
+    def get_native_deb_url(self, arch: str = "arm64") -> str:
+        """
+        Get download URL for native meshtasticd .deb package.
+
+        Args:
+            arch: Architecture (arm64, armhf, amd64)
+
+        Returns:
+            GitHub release URL
+        """
+        # Latest stable release
+        version = "2.5.19.f77f1d6"
+        base_url = "https://github.com/meshtastic/firmware/releases/download"
+        return f"{base_url}/v{version}/meshtasticd_{version}_{arch}.deb"
+
+    def add_custom_config(self, name: str, content: str) -> bool:
+        """
+        Add a custom radio configuration.
+
+        Args:
+            name: Configuration name (will be saved as {name}.yaml)
+            content: YAML configuration content
+
+        Returns:
+            True if saved successfully
+        """
+        self.ensure_structure()
+
+        config_file = self.available_dir / f"{name}.yaml"
+        try:
+            config_file.write_text(content)
+            logger.info(f"Created custom config: {config_file}")
+            return True
+        except Exception as e:
+            logger.error(f"Failed to save config: {e}")
+            return False
+
+    def read_config(self, name: str) -> Optional[str]:
+        """
+        Read a configuration file's content.
+
+        Args:
+            name: Configuration name (without .yaml)
+
+        Returns:
+            File content or None if not found
+        """
+        config_file = self.available_dir / f"{name}.yaml"
+        if config_file.exists():
+            return config_file.read_text()
+        return None
+
+    def get_status(self) -> Dict[str, Any]:
+        """
+        Get comprehensive status of meshtasticd configuration.
+
+        Returns:
+            Dictionary with status information
+        """
+        radio_type = self.detect_radio_type()
+        daemon_type = self.get_daemon_type()
+
+        return {
+            "config_dir": str(self.config_dir),
+            "structure_exists": self.config_dir.exists(),
+            "radio_type": radio_type.value,
+            "daemon_type": daemon_type,
+            "native_installed": self.is_native_installed(),
+            "python_cli_installed": self.is_python_cli_installed(),
+            "available_configs": len(self.list_available()),
+            "enabled_configs": len(self.list_enabled()),
+            "usb_devices": [str(d) for d in Path("/dev").glob("ttyUSB*")],
+            "acm_devices": [str(d) for d in Path("/dev").glob("ttyACM*")],
+            "spi_devices": [str(d) for d in Path("/dev").glob("spidev*")],
+        }
+
+
+# ─────────────────────────────────────────────────────────────────
+# Convenience Functions
+# ─────────────────────────────────────────────────────────────────
+
+_default_config: Optional[MeshtasticdConfig] = None
+
+
+def get_config() -> MeshtasticdConfig:
+    """Get or create default config manager instance."""
+    global _default_config
+    if _default_config is None:
+        _default_config = MeshtasticdConfig()
+    return _default_config
+
+
+def setup_meshtasticd() -> bool:
+    """
+    Quick setup: ensure config structure and detect radio.
+
+    Returns:
+        True if setup successful
+    """
+    config = get_config()
+
+    if not config.ensure_structure():
+        return False
+
+    radio_type = config.detect_radio_type()
+    daemon_type = config.get_daemon_type()
+
+    logger.info(f"Radio type: {radio_type.value}, Daemon: {daemon_type}")
+
+    # Auto-enable appropriate config
+    if radio_type == RadioType.NATIVE_SPI:
+        # Check for Meshtoad specifically
+        config.enable("meshtoad-spi")
+    elif radio_type == RadioType.USB_SERIAL:
+        config.enable("usb-serial")
+
+    return True
+
+
+def print_status():
+    """Print configuration status to stdout."""
+    config = get_config()
+    status = config.get_status()
+
+    print("\n=== Meshtasticd Configuration Status ===\n")
+    print(f"Config Directory: {status['config_dir']}")
+    print(f"Structure Exists: {status['structure_exists']}")
+    print(f"Radio Type: {status['radio_type']}")
+    print(f"Daemon Type: {status['daemon_type']}")
+    print(f"Native Installed: {status['native_installed']}")
+    print(f"Python CLI Installed: {status['python_cli_installed']}")
+    print(f"Available Configs: {status['available_configs']}")
+    print(f"Enabled Configs: {status['enabled_configs']}")
+    print(f"USB Devices: {status['usb_devices']}")
+    print(f"ACM Devices: {status['acm_devices']}")
+    print(f"SPI Devices: {status['spi_devices']}")
+    print()
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    print_status()

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -4,6 +4,11 @@ MeshForge Service Orchestrator
 Manages the complete NOC stack: meshtasticd, rnsd, and MeshForge services.
 MeshForge IS the node - this orchestrator ensures all services start, run, and recover.
 
+Supports:
+    - Native meshtasticd (for SPI radios like Meshtoad)
+    - Python meshtastic CLI (for USB serial radios)
+    - Automatic config detection from /etc/meshforge/noc.yaml
+
 Usage:
     # As module
     from core.orchestrator import ServiceOrchestrator
@@ -11,7 +16,7 @@ Usage:
     orch.startup()
 
     # As standalone
-    python -m core.orchestrator [--stop|--status|--install]
+    python -m core.orchestrator [--stop|--status|--install|--config]
 """
 
 import os
@@ -24,10 +29,20 @@ import threading
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Dict, List, Callable
+from typing import Optional, Dict, List, Callable, Any
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 # Setup logging
 logger = logging.getLogger(__name__)
+
+# Configuration paths
+NOC_CONFIG_PATH = Path("/etc/meshforge/noc.yaml")
+MESHTASTICD_CONFIG_DIR = Path("/etc/meshtasticd")
 
 
 class ServiceState(Enum):
@@ -105,7 +120,7 @@ class ServiceOrchestrator:
 
     def __init__(self, config_path: Optional[Path] = None):
         """Initialize orchestrator."""
-        self._config_path = config_path
+        self._config_path = config_path or NOC_CONFIG_PATH
         self._running = False
         self._monitor_thread: Optional[threading.Thread] = None
         self._callbacks: Dict[str, List[Callable]] = {
@@ -118,8 +133,11 @@ class ServiceOrchestrator:
         # Load configuration
         self._load_config()
 
+        # Adjust meshtasticd service based on daemon type
+        self._configure_meshtasticd()
+
     def _load_config(self):
-        """Load NOC configuration."""
+        """Load NOC configuration from /etc/meshforge/noc.yaml."""
         # Default config
         self.config = {
             'mode': 'local',  # local | client | remote-only
@@ -127,9 +145,102 @@ class ServiceOrchestrator:
             'health_check_interval': 30,
             'restart_on_failure': True,
             'max_restart_attempts': 3,
+            'radio': {
+                'type': 'unknown',
+                'daemon': 'python',
+                'device': '',
+            },
+            'services': {
+                'meshtasticd': {'managed': True, 'auto_start': True},
+                'rnsd': {'managed': True, 'auto_start': True},
+            },
         }
 
-        # TODO: Load from ~/.config/meshforge/noc.yaml if exists
+        # Load from config file
+        if self._config_path and self._config_path.exists():
+            if HAS_YAML:
+                try:
+                    with open(self._config_path) as f:
+                        file_config = yaml.safe_load(f)
+                        if file_config and 'noc' in file_config:
+                            noc_config = file_config['noc']
+                            # Merge configs
+                            self._merge_config(noc_config)
+                            logger.info(f"Loaded config from {self._config_path}")
+                except Exception as e:
+                    logger.warning(f"Failed to load config: {e}")
+            else:
+                logger.warning("PyYAML not installed, using defaults")
+        else:
+            logger.info("No config file found, using defaults")
+
+    def _merge_config(self, noc_config: Dict[str, Any]):
+        """Merge loaded config with defaults."""
+        if 'mode' in noc_config:
+            self.config['mode'] = noc_config['mode']
+
+        if 'radio' in noc_config:
+            self.config['radio'].update(noc_config['radio'])
+
+        if 'services' in noc_config:
+            for service, svc_config in noc_config['services'].items():
+                if service not in self.config['services']:
+                    self.config['services'][service] = {}
+                self.config['services'][service].update(svc_config)
+
+        if 'startup' in noc_config:
+            startup = noc_config['startup']
+            if 'health_check_interval' in startup:
+                self.config['health_check_interval'] = startup['health_check_interval']
+            if 'restart_on_failure' in startup:
+                self.config['restart_on_failure'] = startup['restart_on_failure']
+            if 'max_restart_attempts' in startup:
+                self.config['max_restart_attempts'] = startup['max_restart_attempts']
+            if 'auto_start_services' in startup:
+                self.config['auto_start'] = startup['auto_start_services']
+
+    def _configure_meshtasticd(self):
+        """Configure meshtasticd service based on daemon type."""
+        daemon_type = self.config['radio'].get('daemon', 'python')
+
+        if daemon_type == 'native':
+            # Native meshtasticd binary (for SPI radios)
+            self.SERVICES['meshtasticd'] = ServiceConfig(
+                name='meshtasticd',
+                systemd_name='meshtasticd',
+                check_port=4403,
+                startup_delay=5,
+                required=True,
+                # No install command - requires .deb
+            )
+            logger.info("Configured for native meshtasticd (SPI radio)")
+        else:
+            # Python CLI (for USB serial radios)
+            self.SERVICES['meshtasticd'] = ServiceConfig(
+                name='meshtasticd',
+                systemd_name='meshtasticd',
+                check_port=4403,
+                startup_delay=5,
+                required=True,
+                install_command=['pip3', 'install', 'meshtastic'],
+            )
+            logger.info("Configured for Python meshtastic CLI (USB radio)")
+
+    def get_config_info(self) -> Dict[str, Any]:
+        """Get current configuration information."""
+        return {
+            'config_file': str(self._config_path),
+            'config_exists': self._config_path.exists() if self._config_path else False,
+            'mode': self.config['mode'],
+            'radio_type': self.config['radio'].get('type', 'unknown'),
+            'daemon_type': self.config['radio'].get('daemon', 'python'),
+            'device': self.config['radio'].get('device', ''),
+            'meshtasticd_config_dir': str(MESHTASTICD_CONFIG_DIR),
+            'meshtasticd_config_exists': MESHTASTICD_CONFIG_DIR.exists(),
+            'health_check_interval': self.config['health_check_interval'],
+            'restart_on_failure': self.config['restart_on_failure'],
+            'max_restart_attempts': self.config['max_restart_attempts'],
+        }
 
     # ─────────────────────────────────────────────────────────────
     # Service State Checks
@@ -552,11 +663,45 @@ def main():
     parser.add_argument('--stop', action='store_true', help='Stop all services')
     parser.add_argument('--restart', action='store_true', help='Restart all services')
     parser.add_argument('--status', action='store_true', help='Show service status')
+    parser.add_argument('--config', action='store_true', help='Show configuration')
     parser.add_argument('--install', action='store_true', help='Install missing services')
     parser.add_argument('--monitor', action='store_true', help='Start with monitoring')
 
     args = parser.parse_args()
     orch = ServiceOrchestrator()
+
+    if args.config:
+        print("\n═══ MeshForge NOC Configuration ═══\n")
+        config_info = orch.get_config_info()
+        print(f"  Config File:        {config_info['config_file']}")
+        print(f"  Config Exists:      {config_info['config_exists']}")
+        print(f"  NOC Mode:           {config_info['mode']}")
+        print(f"  Radio Type:         {config_info['radio_type']}")
+        print(f"  Daemon Type:        {config_info['daemon_type']}")
+        if config_info['device']:
+            print(f"  USB Device:         {config_info['device']}")
+        print(f"  Meshtasticd Config: {config_info['meshtasticd_config_dir']}")
+        print(f"  Config Dir Exists:  {config_info['meshtasticd_config_exists']}")
+        print(f"  Health Check:       {config_info['health_check_interval']}s")
+        print(f"  Restart on Fail:    {config_info['restart_on_failure']}")
+        print(f"  Max Restarts:       {config_info['max_restart_attempts']}")
+
+        # Show meshtasticd configs if they exist
+        if MESHTASTICD_CONFIG_DIR.exists():
+            available = list((MESHTASTICD_CONFIG_DIR / "available.d").glob("*.yaml"))
+            enabled = list((MESHTASTICD_CONFIG_DIR / "config.d").glob("*.yaml"))
+            print(f"\n  Available Configs:  {len(available)}")
+            for cfg in available:
+                print(f"    - {cfg.stem}")
+            print(f"  Enabled Configs:    {len(enabled)}")
+            for cfg in enabled:
+                if cfg.is_symlink():
+                    target = cfg.resolve().stem
+                    print(f"    - {cfg.stem} -> {target}")
+                else:
+                    print(f"    - {cfg.stem}")
+        print()
+        sys.exit(0)
 
     if args.stop:
         sys.exit(0 if orch.shutdown() else 1)
@@ -567,6 +712,10 @@ def main():
         sys.exit(0 if orch.startup() else 1)
 
     if args.status:
+        print("\n═══ MeshForge NOC Status ═══\n")
+        config_info = orch.get_config_info()
+        print(f"  Mode: {config_info['mode']} | Radio: {config_info['radio_type']} | Daemon: {config_info['daemon_type']}\n")
+
         statuses = orch.get_all_status()
         for name, status in statuses.items():
             state_icon = {
@@ -575,14 +724,18 @@ def main():
                 ServiceState.FAILED: '✗',
                 ServiceState.NOT_INSTALLED: '?',
             }.get(status.state, '?')
-            print(f"  {state_icon} {name}: {status.state.value} - {status.message}")
+            pid_str = f" (PID: {status.pid})" if status.pid else ""
+            print(f"  {state_icon} {name}: {status.state.value}{pid_str}")
+            if status.message and status.state != ServiceState.RUNNING:
+                print(f"      {status.message}")
+        print()
         sys.exit(0)
 
     if args.install:
         sys.exit(0 if orch.install_missing() else 1)
 
     # Default: start
-    if args.start or not any([args.stop, args.restart, args.status, args.install]):
+    if args.start or not any([args.stop, args.restart, args.status, args.install, args.config]):
         success = orch.startup()
         if success and args.monitor:
             orch.start_monitoring()


### PR DESCRIPTION
Major NOC enhancement to support different radio types:

- Add meshtasticd_config.py: Config manager for /etc/meshtasticd/ structure
  - available.d/: Radio config templates (meshtoad-spi, rak-hat, usb-serial)
  - config.d/: Enabled configs (symlinks to available.d)
  - Auto-detect radio type (USB serial vs SPI)

- Enhanced install_noc.sh:
  - Auto-detect USB serial vs SPI radios (Meshtoad/CH341)
  - Install native meshtasticd .deb for SPI radios
  - Install Python CLI for USB serial radios
  - Create /etc/meshtasticd/ directory structure with templates
  - --force-native and --force-python options

- Enhanced orchestrator.py:
  - Load config from /etc/meshforge/noc.yaml
  - Configure daemon type based on radio (native vs python)
  - New --config flag to show configuration
  - Improved --status output with radio info

Tested with Meshtoad (CH341 USB-to-SPI with SX1262)