### PR TITLE
docs: add gateway template and update priorities for MOC2

### DIFF
--- a/.claude/TODO_PRIORITIES.md
+++ b/.claude/TODO_PRIORITIES.md
@@ -1,6 +1,6 @@
 # MeshForge Development Priorities
 
-> **Last Updated:** 2026-01-17
+> **Last Updated:** 2026-01-20
 > **Maintainer:** WH6GXZ / Dude AI
 
 ---
@@ -36,6 +36,25 @@
 - [x] **Gateway setup wizard** - Guided configuration for new users (2026-01-12)
 - [x] **Bridge status monitoring** - Real-time health checks (API endpoints)
 - [x] `rns_bridge.py:624` - Implement regex matching for filters (2026-01-11)
+- [x] **Gateway config template** - gateway-hawaiinet.yaml (2026-01-20)
+
+### Rich CLI Enhancements (MOC2 Testing)
+- [ ] **RNS/RNSD tools menu** - Mirror GTK panel functionality:
+  - [ ] rnsd service status/control
+  - [ ] Config file editor
+  - [ ] Interface list
+  - [ ] Announce management
+  - [ ] NomadNet launcher
+- [ ] **Device config wizard** - Complete setup flow:
+  - [ ] Long name (40 char)
+  - [ ] Short name (4 char)
+  - [ ] Region selection
+  - [ ] Frequency slot
+  - [ ] Modem preset (Short Turbo, etc.)
+  - [ ] TX power
+  - [ ] Position (lat/lon)
+  - [ ] MQTT policy
+- [ ] **Gateway config menu** - For RNS bridge setup
 
 ### Code Quality
 - [x] **Consolidate `get_real_user_home()`** - Reviewed: try/except fallback pattern is intentional for robustness when utils.paths unavailable
@@ -152,6 +171,15 @@
 - [x] **Link budget history/trends** (2026-01-17)
 - [x] **REST API documentation** (2026-01-17)
 - [x] **Webhook support** (2026-01-17)
+- [x] **MOC2 Health Check Fixes** (2026-01-20):
+  - [x] Fixed Table import in radio.py
+  - [x] Fixed meshtasticd.service (was using `meshtastic --tcp` client instead of daemon)
+  - [x] Added post-reboot guidance ("type meshforge to continue")
+  - [x] Added MeshAdv-Pi-Hat to template menu
+  - [x] Added post-config guidance (browser/CLI next steps)
+  - [x] Improved hardware-to-template mapping
+  - [x] Improved auto-review index_no_check pattern (19→0 false positives)
+  - [x] Created gateway-hawaiinet.yaml template
 
 ---
 

--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1086,7 +1086,7 @@ if current_time - last_check >= 30:
 
 ---
 
-*Last updated: 2026-01-18 - Added Issues #17-19 (Connection Contention, Auto-Reconnect, path_table Discovery)*
+*Last updated: 2026-01-20 - Added Issues #17-21*
 
 ---
 
@@ -1236,5 +1236,51 @@ def _on_message(self, event):
 - Don't add more detection fallback methods - simplify instead
 - Test with actual hardware in various states (running, stopped, misconfigured)
 - UI should always distinguish "service state" from "detection capability"
+
+---
+
+## Issue #21: Meshtastic CLI Preset Settings Not Reliably Applied
+
+### Symptom (Discovered MOC2 2026-01-20)
+- User sets modem preset via CLI: `meshtastic --host localhost --set lora.modem_preset SHORT_TURBO`
+- CLI reports success
+- Browser UI at localhost:9443 shows LONG_FAST (not SHORT_TURBO)
+- Other settings (region, owner) apply correctly
+
+### Root Cause
+**Upstream meshtastic CLI issue** - The Python meshtastic CLI doesn't always apply preset changes correctly. This is NOT a MeshForge bug.
+
+### Impact
+- Users think they're on one preset but actually on another
+- Network performance expectations don't match reality
+- Slot coordination fails if nodes on different presets
+
+### Workaround
+**Always verify in browser** - The Web UI at port 9443 is the source of truth:
+1. Apply settings via CLI
+2. Verify in browser: `http://localhost:9443`
+3. If mismatch, use browser to set correct value
+
+### MeshForge Recommendation
+Add verification step after CLI config:
+
+```python
+# In device config wizard
+def apply_preset(preset_name):
+    result = run_meshtastic_cli(['--set', 'lora.modem_preset', preset_name])
+    if result.success:
+        console.print(f"[yellow]Verify preset in browser: http://localhost:9443[/yellow]")
+        console.print("[dim]Note: CLI preset changes may not always apply correctly[/dim]")
+```
+
+### Files to Update
+- `src/config/radio.py` - Add verification warning
+- `src/main.py` - Add verification step in config wizard
+- Documentation - Note the CLI limitation
+
+### Prevention
+- Always recommend browser verification after CLI changes
+- Consider implementing direct meshtasticd API calls instead of CLI
+- Track upstream meshtastic-python issue
 
 ---

--- a/templates/available.d/gateway-hawaiinet.yaml
+++ b/templates/available.d/gateway-hawaiinet.yaml
@@ -1,0 +1,102 @@
+# MeshForge Gateway Configuration - HawaiiNet RNS Bridge
+# Meshtastic: Short Turbo, Slot 8 → MeshForge Gateway → RNS HawaiiNet
+#
+# Use Case: Bridging local Meshtastic mesh to HawaiiNet RNS network
+# Created: 2026-01-20
+# Author: WH6GXZ / Dude AI
+#
+# This template configures meshtasticd for gateway bridge operation
+# with Short Turbo preset on frequency slot 8.
+
+# === LoRa Configuration ===
+Lora:
+  # SX1262 module (MeshAdv-Pi-Hat or similar)
+  Module: sx1262
+
+  # GPIO Configuration (MeshAdv-Pi-Hat pinout)
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  TXen: 13
+  RXen: 12
+  DIO3_TCXO_VOLTAGE: true
+
+# === Radio Settings ===
+# Short Turbo preset for high-throughput gateway operations
+# Good balance of speed and range for gateway use
+Radio:
+  # Region: US (902-928 MHz ISM band)
+  Region: US
+
+  # Frequency Slot 8 - dedicated gateway channel
+  # Avoids default slot 0 used by most nodes
+  FrequencySlot: 8
+
+  # Short Turbo Modem Preset
+  # - Bandwidth: 250 kHz
+  # - Spreading Factor: 11
+  # - Coding Rate: 4/5
+  # - ~6.8 kbps effective data rate
+  ModemPreset: SHORT_TURBO
+
+  # Hop Limit - gateway typically uses 3
+  HopLimit: 3
+
+  # TX Power - adjust based on your setup
+  # MeshAdv-Pi-Hat: 30 dBm max (1W)
+  TxPower: 30
+
+# === Device Identity ===
+Device:
+  # Long name (up to 40 characters)
+  LongName: "wh6gxz-ecom"
+
+  # Short name (4 characters for mesh display)
+  ShortName: "ecom"
+
+  # Role: Router for gateway operations
+  Role: ROUTER
+
+# === Position (Big Island, Hawaii) ===
+Position:
+  Latitude: 19.435175
+  Longitude: -155.213842
+  Altitude: 0
+  PositionBroadcastSecs: 900  # 15 minutes
+
+# === MQTT Configuration ===
+# Disable MQTT since we're bridging to RNS instead
+MQTT:
+  Enabled: false
+  IgnoreMQTT: true
+
+# === Webserver ===
+Webserver:
+  Port: 9443
+  RootPath: /usr/share/meshtasticd/web
+
+# === Logging ===
+Logging:
+  LogLevel: info
+
+# === General ===
+General:
+  MaxNodes: 200
+
+# === MeshForge Gateway Notes ===
+#
+# After applying this config:
+# 1. Restart meshtasticd: sudo systemctl restart meshtasticd
+# 2. Verify via browser: http://localhost:9443
+# 3. Configure RNS bridge in MeshForge:
+#    - meshforge → Gateway Configuration
+#    - Set RNS interface to HawaiiNet
+#    - Enable bidirectional bridge
+#
+# RNS Config (~/.reticulum/config):
+#   [[HawaiiNet]]
+#     type = TCPClientInterface
+#     enabled = yes
+#     target_host = hawaiinet.example.com
+#     target_port = 4242


### PR DESCRIPTION
New files:
- templates/available.d/gateway-hawaiinet.yaml Short Turbo preset, Slot 8 → MeshForge Gateway → RNS HawaiiNet

Updated TODO_PRIORITIES.md:
- Added Rich CLI enhancements (RNS/RNSD tools, device config wizard)
- Added MOC2 health check fixes to completed list
- Updated date to 2026-01-20

Updated persistent_issues.md:
- Added Issue #21: Meshtastic CLI preset not reliably applied (upstream bug - settings via CLI may not apply, browser is source of truth)