### PR TITLE
fix: Improve SPI HAT detection and add menu back options

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -104,6 +104,7 @@ fi
 
 detect_radio_type() {
     # Returns: "spi", "usb", or "none"
+    # Priority: SPI HAT > USB Serial > None
 
     # Check for CH341 (Meshtoad USB-to-SPI adapter)
     if dmesg 2>/dev/null | grep -qi "ch341.*spi\|ch341-spi"; then
@@ -111,18 +112,41 @@ detect_radio_type() {
         return
     fi
 
-    # Check for known SPI HAT configurations
+    # Check for SPI devices (Raspberry Pi HATs)
     if [[ -e /dev/spidev0.0 ]] || [[ -e /dev/spidev0.1 ]]; then
-        # Check if there's a SPI radio config or HAT overlay
-        if grep -q "meshtastic\|sx126\|sx127\|lora" /boot/config.txt 2>/dev/null; then
-            echo "spi"
-            return
+        # SPI device exists - check for Raspberry Pi
+        if [[ -f /proc/device-tree/model ]]; then
+            if grep -qi "raspberry" /proc/device-tree/model 2>/dev/null; then
+                # On Raspberry Pi with SPI enabled = likely HAT
+                # Check boot config for SPI enabled
+                for cfg in /boot/config.txt /boot/firmware/config.txt; do
+                    if [[ -f "$cfg" ]]; then
+                        # SPI enabled = HAT is likely present
+                        if grep -q "dtparam=spi=on" "$cfg" 2>/dev/null || \
+                           grep -q "^spi=on" "$cfg" 2>/dev/null; then
+                            echo "spi"
+                            return
+                        fi
+                        # Check for specific LoRa overlays
+                        if grep -qi "meshtastic\|sx126\|sx127\|lora\|waveshare" "$cfg" 2>/dev/null; then
+                            echo "spi"
+                            return
+                        fi
+                    fi
+                done
+            fi
         fi
     fi
 
     # Check for USB serial devices
     if ls /dev/ttyUSB* /dev/ttyACM* 2>/dev/null | head -1 >/dev/null; then
         echo "usb"
+        return
+    fi
+
+    # If SPI exists but we couldn't confirm HAT, still prefer SPI
+    if [[ -e /dev/spidev0.0 ]] || [[ -e /dev/spidev0.1 ]]; then
+        echo "spi"
         return
     fi
 
@@ -518,6 +542,32 @@ WantedBy=multi-user.target
 SPI_NEEDS_NATIVE
                     DAEMON_TYPE="spi-pending"
                     RADIO_TYPE="spi"  # Mark as SPI mode needing native daemon
+
+                    # Still create config.yaml for when native daemon is installed
+                    cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'SPI_CONFIG'
+### MeshForge NOC - Meshtasticd Configuration (SPI HAT)
+### Device configs are loaded from /etc/meshtasticd/config.d/
+### Native meshtasticd required - install from meshtastic.org
+---
+Lora:
+  Module: sx1262
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 9443
+  RootPath: /usr/share/meshtasticd/web
+
+General:
+  MaxNodes: 400
+  MaxMessageQueue: 100
+  ConfigDirectory: /etc/meshtasticd/config.d/
+  AvailableDirectory: /etc/meshtasticd/available.d/
+SPI_CONFIG
+
+                    # Enable SPI HAT config (Waveshare default - common HAT)
+                    cp "$MESHTASTICD_CONFIG_DIR/available.d/waveshare-spi.yaml" "$MESHTASTICD_CONFIG_DIR/config.d/" 2>/dev/null || true
                 fi
             fi
 

--- a/src/config/radio.py
+++ b/src/config/radio.py
@@ -21,7 +21,7 @@ def ask_yes_no_cancel(prompt: str, default: bool = False) -> bool | None:
         True for yes, False for no, None for cancel
     """
     default_str = "y" if default else "n"
-    hint = f"[y/n/c] ({default_str})" if default else "[y/n/c] (n)"
+    hint = f"[y/n/m] ({default_str})" if default else "[y/n/m] (n)"
 
     while True:
         response = Prompt.ask(
@@ -34,10 +34,10 @@ def ask_yes_no_cancel(prompt: str, default: bool = False) -> bool | None:
             return True
         elif response in ('n', 'no', ''):
             return False
-        elif response in ('c', 'cancel', 'q', 'quit', 'back'):
+        elif response in ('c', 'cancel', 'q', 'quit', 'back', 'm', 'menu', 'b'):
             return None
         else:
-            console.print("[yellow]Enter y (yes), n (no), or c (cancel)[/yellow]")
+            console.print("[yellow]Enter y/n/m (yes, no, or m for menu)[/yellow]")
 
 
 class RadioConfigurator:
@@ -113,17 +113,27 @@ class RadioConfigurator:
             return {'channel_slot': 20 if preset_name == 'LongFast' else 0, 'slot_info': 'Default (cancelled)'}
 
         if use_custom:
-            slot = IntPrompt.ask(
-                "Enter channel slot number",
-                default=20,
-                show_default=True
+            # Get slot with back/cancel option
+            slot_input = Prompt.ask(
+                "Enter channel slot number (or 'm' for menu)",
+                default="20"
             )
 
-            # Validate slot
-            if 0 <= slot < max_slots:
-                console.print(f"[green]Channel slot set to: {slot}[/green]")
-            else:
-                console.print(f"[yellow]Invalid slot. Using default: 20[/yellow]")
+            # Check for back/cancel
+            if slot_input.lower().strip() in ('m', 'menu', 'b', 'back', 'c', 'cancel'):
+                console.print("[yellow]Cancelled - using default slot[/yellow]")
+                return {'channel_slot': 20 if preset_name == 'LongFast' else 0, 'slot_info': 'Default (cancelled)'}
+
+            try:
+                slot = int(slot_input)
+                # Validate slot
+                if 0 <= slot < max_slots:
+                    console.print(f"[green]Channel slot set to: {slot}[/green]")
+                else:
+                    console.print(f"[yellow]Invalid slot. Using default: 20[/yellow]")
+                    slot = 20
+            except ValueError:
+                console.print(f"[yellow]Invalid input. Using default: 20[/yellow]")
                 slot = 20
         else:
             # Use recommended slot
@@ -154,22 +164,29 @@ class RadioConfigurator:
         console.print("  27 dBm: High power (500mW)")
         console.print("  30 dBm: Maximum (1W, MeshToad/high-power modules)")
 
-        tx_power = IntPrompt.ask(
-            "\nEnter TX power in dBm",
-            default=20,
-            show_default=True
+        tx_input = Prompt.ask(
+            "\nEnter TX power in dBm (or 'm' for menu)",
+            default="20"
         )
 
-        # Validate
-        if tx_power < 0:
-            tx_power = 0
-        elif tx_power > 30:
-            console.print("[yellow]Warning: 30 dBm is maximum for most modules[/yellow]")
-            tx_power = 30
+        # Check for back/cancel
+        if tx_input.lower().strip() in ('m', 'menu', 'b', 'back', 'c', 'cancel'):
+            console.print("[yellow]Using default: 20 dBm[/yellow]")
+            return 20
 
-        console.print(f"[green]TX power set to: {tx_power} dBm[/green]")
-
-        return tx_power
+        try:
+            tx_power = int(tx_input)
+            # Validate
+            if tx_power < 0:
+                tx_power = 0
+            elif tx_power > 30:
+                console.print("[yellow]Warning: 30 dBm is maximum for most modules[/yellow]")
+                tx_power = 30
+            console.print(f"[green]TX power set to: {tx_power} dBm[/green]")
+            return tx_power
+        except ValueError:
+            console.print("[yellow]Invalid input. Using default: 20 dBm[/yellow]")
+            return 20
 
     def configure_hop_limit(self):
         """Configure hop limit"""
@@ -183,22 +200,29 @@ class RadioConfigurator:
         console.print("  4-7: Larger networks")
         console.print("  1-2: Small, local networks")
 
-        hop_limit = IntPrompt.ask(
-            "\nEnter hop limit",
-            default=3,
-            show_default=True
+        hop_input = Prompt.ask(
+            "\nEnter hop limit (or 'm' for menu)",
+            default="3"
         )
 
-        # Validate
-        if hop_limit < 0:
-            hop_limit = 0
-        elif hop_limit > 7:
-            console.print("[yellow]Warning: Values above 7 can cause network congestion[/yellow]")
-            hop_limit = 7
+        # Check for back/cancel
+        if hop_input.lower().strip() in ('m', 'menu', 'b', 'back', 'c', 'cancel'):
+            console.print("[yellow]Using default: 3 hops[/yellow]")
+            return 3
 
-        console.print(f"[green]Hop limit set to: {hop_limit}[/green]")
-
-        return hop_limit
+        try:
+            hop_limit = int(hop_input)
+            # Validate
+            if hop_limit < 0:
+                hop_limit = 0
+            elif hop_limit > 7:
+                console.print("[yellow]Warning: Values above 7 can cause network congestion[/yellow]")
+                hop_limit = 7
+            console.print(f"[green]Hop limit set to: {hop_limit}[/green]")
+            return hop_limit
+        except ValueError:
+            console.print("[yellow]Invalid input. Using default: 3 hops[/yellow]")
+            return 3
 
     def configure_gps_position(self):
         """Configure GPS position manually or via GPS module"""

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -41,14 +41,27 @@ class StatusDashboard:
         if COMMANDS_AVAILABLE:
             try:
                 result = service.check_status('meshtasticd')
+                status_data = result.data
+
+                # Check for misconfiguration (SPI HAT with USB placeholder)
+                message = status_data.get('message', '')
+                if 'WRONG CONFIG' in message:
+                    return {
+                        'status': 'misconfigured',
+                        'running': False,
+                        'color': 'red',
+                        'message': 'SPI HAT needs native daemon'
+                    }
+
                 return {
-                    'status': result.data.get('status', 'unknown'),
-                    'running': result.data.get('running', False),
-                    'color': 'green' if result.data.get('running') else 'red'
+                    'status': status_data.get('status', 'unknown'),
+                    'running': status_data.get('running', False),
+                    'color': 'green' if status_data.get('running') else 'red',
+                    'message': message
                 }
             except Exception as e:
                 logger.error(f"Failed to get service status: {e}")
-                return {'status': 'unknown', 'running': False, 'color': 'yellow'}
+                return {'status': 'unknown', 'running': False, 'color': 'yellow', 'message': str(e)}
         else:
             # Fallback to direct subprocess call
             import subprocess
@@ -58,14 +71,43 @@ class StatusDashboard:
                     capture_output=True, text=True, timeout=5
                 )
                 status = result.stdout.strip()
+
+                # Check SubState to detect placeholder services
+                if status == 'active':
+                    state_result = subprocess.run(
+                        ['systemctl', 'show', 'meshtasticd', '--property=SubState'],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    sub_state = state_result.stdout.strip().split('=')[-1] if '=' in state_result.stdout else ''
+
+                    # Exited = placeholder service
+                    if sub_state == 'exited':
+                        # Check for SPI HAT mismatch
+                        spi_exists = list(Path('/dev').glob('spidev*'))
+                        usb_exists = list(Path('/dev').glob('ttyUSB*')) + list(Path('/dev').glob('ttyACM*'))
+                        if spi_exists and not usb_exists:
+                            return {
+                                'status': 'misconfigured',
+                                'running': False,
+                                'color': 'red',
+                                'message': 'SPI HAT needs native daemon'
+                            }
+                        return {
+                            'status': 'placeholder',
+                            'running': False,
+                            'color': 'yellow',
+                            'message': 'USB mode (no daemon)'
+                        }
+
                 return {
                     'status': status,
                     'running': status == 'active',
-                    'color': 'green' if status == 'active' else 'red'
+                    'color': 'green' if status == 'active' else 'red',
+                    'message': ''
                 }
             except Exception as e:
                 logger.error(f"Failed to get service status: {e}")
-                return {'status': 'unknown', 'running': False, 'color': 'yellow'}
+                return {'status': 'unknown', 'running': False, 'color': 'yellow', 'message': str(e)}
 
     def get_installed_version(self):
         """Get installed meshtasticd version or connection mode."""
@@ -95,8 +137,14 @@ class StatusDashboard:
                     pass
                 return 'Native'
 
-        # No native daemon - check for USB devices (direct connection mode)
+        # No native daemon - check what hardware exists
+        spi_devices = list(Path('/dev').glob('spidev*'))
         usb_devices = list(Path('/dev').glob('ttyUSB*')) + list(Path('/dev').glob('ttyACM*'))
+
+        if spi_devices and not usb_devices:
+            # SPI HAT but no native daemon - this is a problem
+            return 'SPI (needs daemon)'
+
         if usb_devices:
             return f'USB ({usb_devices[0].name})'
 
@@ -163,15 +211,35 @@ class StatusDashboard:
         console.clear()
 
         # Service Status Table
-        service = self.get_service_status()
+        svc = self.get_service_status()
         status_table = Table(title=f"{em.get('📡')} Meshtasticd Service", box=ROUNDED, show_header=False)
         status_table.add_column("Property", style="cyan")
         status_table.add_column("Value", style="green")
 
-        status_icon = em.get('🟢') if service['running'] else em.get('🔴')
-        status_str = "RUNNING" if service['running'] else "STOPPED"
+        # Status with color based on state
+        if svc['status'] == 'misconfigured':
+            status_icon = em.get('🔴')
+            status_str = "[red]MISCONFIGURED[/red]"
+            status_style = "red"
+        elif svc['running']:
+            status_icon = em.get('🟢')
+            status_str = "[green]RUNNING[/green]"
+            status_style = "green"
+        elif svc['status'] == 'placeholder':
+            status_icon = em.get('🟡')
+            status_str = "[yellow]USB MODE[/yellow]"
+            status_style = "yellow"
+        else:
+            status_icon = em.get('🔴')
+            status_str = "[red]STOPPED[/red]"
+            status_style = "red"
+
         status_table.add_row(f"{status_icon} Status", status_str)
         status_table.add_row(f"{em.get('📦')} Version", self.get_installed_version())
+
+        # Show message if there's a problem
+        if svc.get('message') and 'needs' in svc.get('message', '').lower():
+            status_table.add_row(f"{em.get('⚠️')} Issue", f"[red]{svc['message']}[/red]")
 
         console.print(status_table)
         console.print()
@@ -194,16 +262,28 @@ class StatusDashboard:
 
     def get_quick_status_line(self):
         """Get a single line status for menu display"""
-        service = self.get_service_status()
+        svc = self.get_service_status()
         info = self.get_system_info()
 
-        status_icon = em.get('🟢') if service['running'] else em.get('🔴')
+        # Status indicator with appropriate icon
+        if svc['status'] == 'misconfigured':
+            status_icon = em.get('🔴')
+            status_text = "[red]MISCONFIG[/red]"
+        elif svc['running']:
+            status_icon = em.get('🟢')
+            status_text = "[green]Running[/green]"
+        elif svc['status'] == 'placeholder':
+            status_icon = em.get('🟡')
+            status_text = "[yellow]USB[/yellow]"
+        else:
+            status_icon = em.get('🔴')
+            status_text = "[red]Stopped[/red]"
+
         version = self.get_installed_version()
 
-        return Text(
-            f"{status_icon} Service | {em.get('📦')} {version} | {em.get('🌡️')} {info['cpu_temp']} | "
-            f"{em.get('💾')} {info['memory']} | {em.get('💿')} {info['disk']}",
-            style="dim"
+        return Text.from_markup(
+            f"{status_icon} {status_text} | {em.get('📦')} {version} | {em.get('🌡️')} {info['cpu_temp']} | "
+            f"{em.get('💾')} {info['memory']} | {em.get('💿')} {info['disk']}"
         )
 
     def interactive_dashboard(self):

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1145,7 +1145,11 @@ class MeshForgeLauncher(
             service_content = ""
 
         is_placeholder = "No Daemon Needed" in service_content or "USB radios work directly" in service_content
-        is_native = "meshtasticd" in service_content and "/usr/bin/meshtasticd" in service_content
+        is_spi_pending = "Native daemon required for SPI" in service_content
+        is_native = ("meshtasticd" in service_content and
+                     ("/usr/bin/meshtasticd" in service_content or
+                      "/usr/local/bin/meshtasticd" in service_content or
+                      "ExecStart=" in service_content and "meshtasticd -c" in service_content))
 
         # Build status report
         lines = ["Hardware & Service Check\n" + "=" * 40]
@@ -1156,6 +1160,8 @@ class MeshForgeLauncher(
         lines.append(f"\nService Configuration:")
         if is_placeholder:
             lines.append("  Type: USB Placeholder (no daemon)")
+        elif is_spi_pending:
+            lines.append("  Type: SPI pending (native daemon required)")
         elif is_native:
             lines.append("  Type: Native meshtasticd daemon")
         else:
@@ -1196,15 +1202,30 @@ class MeshForgeLauncher(
                 # Not installed - try to install
                 self.dialog.infobox("Installing", "Adding Meshtastic repository...")
 
+                # Detect OS for correct repo
+                os_repo = "Raspbian_12"  # Default for Pi
+                if Path('/etc/os-release').exists():
+                    with open('/etc/os-release') as f:
+                        for line in f:
+                            if line.startswith('ID='):
+                                os_id = line.strip().split('=')[1].strip('"')
+                                if os_id == 'debian':
+                                    os_repo = "Debian_12"
+                                elif os_id == 'ubuntu':
+                                    os_repo = "xUbuntu_24.04"
+
+                repo_url = f"https://download.opensuse.org/repositories/network:/Meshtastic:/beta/{os_repo}/"
+
                 # Add repo
-                subprocess.run([
-                    'bash', '-c',
-                    'echo "deb http://download.opensuse.org/repositories/home:/meshtastic/Raspbian_12/ /" | sudo tee /etc/apt/sources.list.d/meshtastic.list'
-                ], timeout=30, check=False)
+                subprocess.run(
+                    ['tee', '/etc/apt/sources.list.d/meshtastic.list'],
+                    input=f"deb {repo_url} /\n",
+                    text=True, timeout=30, check=False
+                )
 
                 subprocess.run([
                     'bash', '-c',
-                    'curl -fsSL https://download.opensuse.org/repositories/home:meshtastic/Raspbian_12/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/meshtastic.gpg > /dev/null'
+                    f'curl -fsSL {repo_url}Release.key | gpg --dearmor > /etc/apt/trusted.gpg.d/meshtastic.gpg'
                 ], timeout=30, check=False)
 
                 self.dialog.infobox("Installing", "Updating package list...")
@@ -1217,8 +1238,70 @@ class MeshForgeLauncher(
                     self.dialog.msgbox("Error", f"Failed to install meshtasticd:\n{result.stderr[:500]}")
                     return
 
+            # Find actual meshtasticd binary path
+            result = subprocess.run(['which', 'meshtasticd'], capture_output=True, text=True, timeout=5)
+            meshtasticd_bin = result.stdout.strip() if result.returncode == 0 else '/usr/bin/meshtasticd'
+
+            # Create config directory structure
+            config_dir = Path('/etc/meshtasticd')
+            config_dir.mkdir(parents=True, exist_ok=True)
+            (config_dir / 'available.d').mkdir(exist_ok=True)
+            (config_dir / 'config.d').mkdir(exist_ok=True)
+            (config_dir / 'ssl').mkdir(mode=0o700, exist_ok=True)
+
+            # Create config.yaml if missing
+            config_yaml = config_dir / 'config.yaml'
+            if not config_yaml.exists():
+                config_yaml.write_text("""### MeshForge NOC - Meshtasticd Configuration
+### Device configs are loaded from /etc/meshtasticd/config.d/
+---
+Lora:
+  Module: sx1262
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 9443
+  RootPath: /usr/share/meshtasticd/web
+
+General:
+  MaxNodes: 400
+  MaxMessageQueue: 100
+  ConfigDirectory: /etc/meshtasticd/config.d/
+  AvailableDirectory: /etc/meshtasticd/available.d/
+""")
+                self.dialog.infobox("Installing", "Created /etc/meshtasticd/config.yaml")
+
+            # Create Waveshare SPI HAT config template
+            waveshare_config = config_dir / 'available.d' / 'waveshare-spi.yaml'
+            if not waveshare_config.exists():
+                waveshare_config.write_text("""# Waveshare SX1262 LoRa HAT Configuration
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  # Uncomment for Raspberry Pi 5:
+  # gpiochip: 4
+
+Logging:
+  LogLevel: info
+
+Webserver:
+  Port: 9443
+""")
+
+            # Remove wrong USB config if present
+            usb_config = config_dir / 'config.d' / 'usb-serial.yaml'
+            if usb_config.exists():
+                usb_config.unlink()
+                self.dialog.infobox("Installing", "Removed incorrect USB config")
+
             # Create service file
-            service_content = """[Unit]
+            service_content = f"""[Unit]
 Description=Meshtastic Daemon (Native SPI)
 Documentation=https://meshtastic.org
 After=network.target
@@ -1227,7 +1310,7 @@ After=network.target
 Type=simple
 User=root
 WorkingDirectory=/etc/meshtasticd
-ExecStart=/usr/bin/meshtasticd -c /etc/meshtasticd/config.yaml
+ExecStart={meshtasticd_bin} -c /etc/meshtasticd/config.yaml
 Restart=on-failure
 RestartSec=5
 
@@ -1245,6 +1328,7 @@ WantedBy=multi-user.target
                 "Success",
                 "Native meshtasticd installed and started!\n\n"
                 "Service configured for SPI HAT.\n"
+                "Config: /etc/meshtasticd/config.yaml\n\n"
                 "Check status: sudo systemctl status meshtasticd"
             )
 


### PR DESCRIPTION
- Add 'm' as back/menu option in all prompts (radio.py)
- Improve SPI HAT detection in install_noc.sh (check boot config)
- Always create config.yaml for SPI systems even if native daemon not available
- Fix service detection to show MISCONFIGURED state for SPI HAT with USB placeholder
- Update dashboard to show proper status for SPI HAT misconfigurations
- Native meshtasticd install now uses correct OpenSUSE Build Service URL
- Remove wrong USB config when fixing SPI HAT misconfiguration