### PR TITLE
fix: Standalone tile_cache module with code review hardening

### DIFF
--- a/src/utils/tile_cache.py
+++ b/src/utils/tile_cache.py
@@ -1,0 +1,505 @@
+"""
+Tile Cache Module for MeshForge.
+
+Provides geographic tile downloading and caching for offline map use.
+Supports region-based downloads with bounding boxes, zoom ranges,
+rate limiting, and dateline-crossing regions.
+
+Key features:
+- Mercator projection coordinate conversion
+- Region-based tile enumeration with dateline handling
+- Size-bounded downloads (max 2 MB per tile)
+- Thread-safe rate limiting
+- Tile expiration and cache statistics
+
+Usage:
+    from utils.tile_cache import TileCache, BoundingBox
+
+    cache = TileCache()
+    result = cache.download_region(
+        bounds=(21.0, -158.5, 21.7, -157.5),
+        zoom_range=(8, 14)
+    )
+    print(f"Downloaded: {result['downloaded']} tiles")
+"""
+
+import logging
+import math
+import time
+import threading
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, Dict, List, Optional, Tuple
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger(__name__)
+
+# User agent for tile requests (be a good citizen)
+USER_AGENT = 'MeshForge/0.4.7 (mesh network operations; offline caching)'
+
+# Tile expiration (days)
+TILE_EXPIRY_DAYS = 30
+
+# Maximum tile size (bytes) - prevents memory exhaustion from malicious servers
+MAX_TILE_BYTES = 2 * 1024 * 1024  # 2 MB
+
+# Mercator projection latitude limit (~85.05 degrees)
+MAX_MERCATOR_LAT = 85.0511287798
+
+# Default zoom range
+DEFAULT_ZOOM_MIN = 8
+DEFAULT_ZOOM_MAX = 14
+
+# Maximum tiles per download session (safety limit)
+MAX_TILES_PER_SESSION = 10000
+
+# Hawaii bounds (default for MeshForge development)
+HAWAII_BOUNDS = (18.5, -160.5, 22.5, -154.5)  # (south, west, north, east)
+
+# Tile providers (no API key required)
+TILE_PROVIDERS = {
+    'openstreetmap': {
+        'url': 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        'attr': '(C) OpenStreetMap contributors',
+        'name': 'OpenStreetMap',
+    },
+    'opentopomap': {
+        'url': 'https://tile.opentopomap.org/{z}/{x}/{y}.png',
+        'attr': '(C) OpenTopoMap (CC-BY-SA)',
+        'name': 'OpenTopoMap',
+    },
+    'stamen_terrain': {
+        'url': 'https://tiles.stadiamaps.com/tiles/stamen_terrain/{z}/{x}/{y}.png',
+        'attr': '(C) Stadia Maps, Stamen Design, OpenStreetMap',
+        'name': 'Terrain',
+    },
+}
+
+
+# =============================================================================
+# Data Classes
+# =============================================================================
+
+
+@dataclass
+class BoundingBox:
+    """Geographic bounding box (south, west, north, east).
+
+    Handles dateline-crossing boxes where west > east in longitude.
+    """
+    south: float
+    west: float
+    north: float
+    east: float
+
+    @classmethod
+    def from_tuple(cls, bounds: Tuple[float, float, float, float]) -> 'BoundingBox':
+        """Create from (south, west, north, east) tuple."""
+        return cls(south=bounds[0], west=bounds[1],
+                   north=bounds[2], east=bounds[3])
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if bounding box has valid coordinates."""
+        return (
+            -90 <= self.south <= 90 and
+            -90 <= self.north <= 90 and
+            -180 <= self.west <= 180 and
+            -180 <= self.east <= 180 and
+            self.south < self.north
+        )
+
+
+# =============================================================================
+# Coordinate Conversion
+# =============================================================================
+
+
+def lon_to_tile_x(lon: float, zoom: int) -> int:
+    """Convert longitude to tile X coordinate.
+
+    Args:
+        lon: Longitude in degrees (-180 to 180).
+        zoom: Zoom level.
+
+    Returns:
+        Tile X coordinate.
+    """
+    n = 2 ** zoom
+    x = (lon + 180.0) / 360.0 * n
+    return int(x) % n
+
+
+def lat_to_tile_y(lat: float, zoom: int) -> int:
+    """Convert latitude to tile Y coordinate.
+
+    Args:
+        lat: Latitude in degrees (clamped to Mercator limits ~+/-85.05).
+        zoom: Zoom level.
+
+    Returns:
+        Tile Y coordinate.
+    """
+    # Clamp to Mercator projection limits to avoid math domain errors
+    lat = max(-MAX_MERCATOR_LAT, min(MAX_MERCATOR_LAT, lat))
+    n = 2 ** zoom
+    lat_rad = math.radians(lat)
+    y = (1.0 - math.log(math.tan(lat_rad) + 1.0 / math.cos(lat_rad)) / math.pi) / 2.0 * n
+    return int(y)
+
+
+def tile_to_lon(x: int, zoom: int) -> float:
+    """Convert tile X coordinate to longitude (west edge).
+
+    Args:
+        x: Tile X coordinate.
+        zoom: Zoom level.
+
+    Returns:
+        Longitude in degrees.
+    """
+    n = 2 ** zoom
+    return x / n * 360.0 - 180.0
+
+
+def tile_to_lat(y: int, zoom: int) -> float:
+    """Convert tile Y coordinate to latitude (north edge).
+
+    Args:
+        y: Tile Y coordinate.
+        zoom: Zoom level.
+
+    Returns:
+        Latitude in degrees.
+    """
+    n = 2 ** zoom
+    lat_rad = math.atan(math.sinh(math.pi * (1 - 2 * y / n)))
+    return math.degrees(lat_rad)
+
+
+# =============================================================================
+# Region Tile Enumeration
+# =============================================================================
+
+
+def count_tiles_in_region(bbox: BoundingBox, zoom_min: int, zoom_max: int) -> int:
+    """Count total tiles in a region across zoom levels.
+
+    Handles dateline-crossing bounding boxes (west > east in tile coords).
+
+    Args:
+        bbox: Geographic bounding box.
+        zoom_min: Minimum zoom level.
+        zoom_max: Maximum zoom level.
+
+    Returns:
+        Total number of tiles.
+    """
+    total = 0
+    for z in range(zoom_min, zoom_max + 1):
+        x_min = lon_to_tile_x(bbox.west, z)
+        x_max = lon_to_tile_x(bbox.east, z)
+        y_min = lat_to_tile_y(bbox.north, z)  # Note: y increases southward
+        y_max = lat_to_tile_y(bbox.south, z)
+
+        n = 2 ** z
+        # Handle dateline crossing (west > east in tile coords)
+        if x_min <= x_max:
+            x_count = x_max - x_min + 1
+        else:
+            x_count = (n - x_min) + (x_max + 1)
+        total += x_count * (y_max - y_min + 1)
+    return total
+
+
+def get_tiles_for_region(bounds: BoundingBox,
+                         zoom: int) -> List[Tuple[int, int, int]]:
+    """Get list of (z, x, y) tile coordinates for a region at one zoom level.
+
+    Handles dateline-crossing bounding boxes (west > east in tile coords).
+
+    Args:
+        bounds: Geographic bounding box.
+        zoom: Zoom level.
+
+    Returns:
+        List of (z, x, y) tuples.
+    """
+    x_min = lon_to_tile_x(bounds.west, zoom)
+    x_max = lon_to_tile_x(bounds.east, zoom)
+    y_min = lat_to_tile_y(bounds.north, zoom)
+    y_max = lat_to_tile_y(bounds.south, zoom)
+
+    n = 2 ** zoom
+    tiles = []
+    # Handle dateline crossing
+    if x_min <= x_max:
+        x_range = range(x_min, x_max + 1)
+    else:
+        x_range = list(range(x_min, n)) + list(range(0, x_max + 1))
+
+    for x in x_range:
+        for y in range(y_min, y_max + 1):
+            tiles.append((zoom, x, y))
+    return tiles
+
+
+# =============================================================================
+# Tile Cache
+# =============================================================================
+
+
+class TileCache:
+    """Thread-safe tile cache with rate limiting and size bounds.
+
+    Manages downloading, storing, and retrieving map tiles for offline use.
+    Respects tile server rate limits and enforces per-tile size limits.
+
+    Usage:
+        cache = TileCache()
+        result = cache.download_region(
+            bounds=(21.0, -158.5, 21.7, -157.5),
+            zoom_range=(8, 14)
+        )
+    """
+
+    def __init__(self, provider: str = 'openstreetmap',
+                 cache_dir: Optional[Path] = None,
+                 rate_limit: float = 0.1):
+        """Initialize tile cache.
+
+        Args:
+            provider: Tile provider key (from TILE_PROVIDERS).
+            cache_dir: Override cache directory (default: auto-detect).
+            rate_limit: Minimum seconds between requests.
+        """
+        self._provider = provider
+        self._provider_info = TILE_PROVIDERS.get(
+            provider, TILE_PROVIDERS['openstreetmap']
+        )
+        self._cache_dir = cache_dir or self._get_default_dir()
+        self._rate_limit = rate_limit
+        self._last_request = 0.0
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _get_default_dir() -> Path:
+        """Get default cache directory with sudo awareness."""
+        try:
+            from utils.paths import get_real_user_home
+            data_dir = get_real_user_home() / ".local" / "share" / "meshforge"
+        except ImportError:
+            data_dir = Path('/tmp/meshforge')
+            logger.warning(
+                "Cannot determine real user home; using /tmp/meshforge")
+        return data_dir / "tiles"
+
+    def _download_tile(self, z: int, x: int, y: int) -> bool:
+        """Download a single tile to cache.
+
+        Enforces rate limiting and size bounds. Skips tiles already cached.
+
+        Args:
+            z: Zoom level.
+            x: Tile X coordinate.
+            y: Tile Y coordinate.
+
+        Returns:
+            True if tile was downloaded (or already cached), False on failure.
+        """
+        tile_path = self._cache_dir / self._provider / str(z) / str(x) / f"{y}.png"
+        if tile_path.exists():
+            return True
+
+        # Rate limiting (sleep outside lock to avoid blocking other threads)
+        with self._lock:
+            elapsed = time.time() - self._last_request
+            sleep_time = max(0.0, self._rate_limit - elapsed)
+            self._last_request = time.time() + sleep_time
+
+        if sleep_time > 0:
+            time.sleep(sleep_time)
+
+        url = self._provider_info['url'].format(z=z, x=x, y=y)
+        try:
+            tile_path.parent.mkdir(parents=True, exist_ok=True)
+            req = Request(url, headers={'User-Agent': USER_AGENT})
+            with urlopen(req, timeout=10) as response:
+                data = response.read(MAX_TILE_BYTES + 1)
+                if len(data) > MAX_TILE_BYTES:
+                    logger.warning(f"Tile {z}/{x}/{y}: response too large, skipping")
+                    return False
+                if len(data) < 100:
+                    logger.debug(f"Tile {z}/{x}/{y}: suspiciously small ({len(data)} bytes)")
+                    return False
+                tile_path.write_bytes(data)
+                return True
+        except Exception as e:
+            logger.debug(f"Tile {z}/{x}/{y} download failed: {e}")
+            return False
+
+    def download_region(self, bounds: Tuple[float, float, float, float],
+                        zoom_range: Tuple[int, int] = (DEFAULT_ZOOM_MIN, DEFAULT_ZOOM_MAX),
+                        progress_callback: Optional[Callable] = None) -> dict:
+        """Download all tiles for a geographic region.
+
+        Args:
+            bounds: (south, west, north, east) bounding box.
+            zoom_range: (min_zoom, max_zoom) inclusive.
+            progress_callback: Optional callback(current, total).
+
+        Returns:
+            Dict with 'downloaded', 'skipped', 'failed', 'error' keys.
+        """
+        bbox = BoundingBox.from_tuple(bounds)
+        if not bbox.is_valid:
+            return {'error': 'Invalid bounding box', 'downloaded': 0}
+
+        zoom_min, zoom_max = zoom_range
+        if zoom_min < 0 or zoom_max > 19 or zoom_min > zoom_max:
+            return {'error': f'Invalid zoom range ({zoom_min}, {zoom_max})',
+                    'downloaded': 0}
+
+        total_tiles = count_tiles_in_region(bbox, zoom_min, zoom_max)
+        if total_tiles > MAX_TILES_PER_SESSION:
+            return {'error': f'Too many tiles ({total_tiles} > {MAX_TILES_PER_SESSION})',
+                    'downloaded': 0}
+
+        result = {'downloaded': 0, 'skipped': 0, 'failed': 0, 'total': total_tiles}
+        current = 0
+
+        for z in range(zoom_min, zoom_max + 1):
+            tiles = get_tiles_for_region(bbox, z)
+            for zz, x, y in tiles:
+                current += 1
+                tile_path = self._cache_dir / self._provider / str(z) / str(x) / f"{y}.png"
+                if tile_path.exists():
+                    result['skipped'] += 1
+                elif self._download_tile(z, x, y):
+                    result['downloaded'] += 1
+                else:
+                    result['failed'] += 1
+
+                if progress_callback:
+                    progress_callback(current, total_tiles)
+
+        return result
+
+    def get_tile_path(self, z: int, x: int, y: int) -> Optional[Path]:
+        """Get path to cached tile, or None if not cached.
+
+        Args:
+            z: Zoom level.
+            x: Tile X coordinate.
+            y: Tile Y coordinate.
+
+        Returns:
+            Path if tile exists in cache, None otherwise.
+        """
+        tile_path = self._cache_dir / self._provider / str(z) / str(x) / f"{y}.png"
+        return tile_path if tile_path.exists() else None
+
+    def get_stats(self) -> dict:
+        """Get cache statistics.
+
+        Returns:
+            Dict with tile_count, total_bytes, size_mb, oldest, newest.
+        """
+        tile_count = 0
+        total_bytes = 0
+        oldest = None
+        newest = None
+
+        provider_dir = self._cache_dir / self._provider
+        if not provider_dir.exists():
+            return {'tile_count': 0, 'total_bytes': 0, 'size_mb': 0.0,
+                    'oldest': None, 'newest': None}
+
+        for png_file in provider_dir.rglob("*.png"):
+            tile_count += 1
+            st = png_file.stat()
+            total_bytes += st.st_size
+            mtime = st.st_mtime
+            if oldest is None or mtime < oldest:
+                oldest = mtime
+            if newest is None or mtime > newest:
+                newest = mtime
+
+        return {
+            'tile_count': tile_count,
+            'total_bytes': total_bytes,
+            'size_mb': total_bytes / (1024 * 1024),
+            'oldest': datetime.fromtimestamp(oldest).isoformat() if oldest else None,
+            'newest': datetime.fromtimestamp(newest).isoformat() if newest else None,
+        }
+
+    def clear_expired(self, max_age_days: int = TILE_EXPIRY_DAYS) -> dict:
+        """Remove tiles older than max_age_days.
+
+        Args:
+            max_age_days: Maximum age in days before removal.
+
+        Returns:
+            Dict with 'removed' count and 'bytes_freed'.
+        """
+        cutoff = time.time() - (max_age_days * 86400)
+        removed = 0
+        bytes_freed = 0
+
+        provider_dir = self._cache_dir / self._provider
+        if not provider_dir.exists():
+            return {'removed': 0, 'bytes_freed': 0}
+
+        for png_file in list(provider_dir.rglob("*.png")):
+            st = png_file.stat()
+            if st.st_mtime < cutoff:
+                bytes_freed += st.st_size
+                png_file.unlink()
+                removed += 1
+
+        # Clean empty directories
+        for dirpath in sorted(provider_dir.rglob("*"), reverse=True):
+            if dirpath.is_dir() and not any(dirpath.iterdir()):
+                dirpath.rmdir()
+
+        return {'removed': removed, 'bytes_freed': bytes_freed}
+
+    @staticmethod
+    def estimate_download_size(bounds: Tuple[float, float, float, float],
+                               zoom_range: Tuple[int, int] = (DEFAULT_ZOOM_MIN, DEFAULT_ZOOM_MAX),
+                               avg_tile_kb: float = 50.0) -> dict:
+        """Estimate download size for a region without downloading.
+
+        Args:
+            bounds: (south, west, north, east) bounding box.
+            zoom_range: (min_zoom, max_zoom) inclusive.
+            avg_tile_kb: Assumed average tile size in KB.
+
+        Returns:
+            Dict with total_tiles, per_zoom, estimated_mb, within_limit.
+        """
+        bbox = BoundingBox.from_tuple(bounds)
+        if not bbox.is_valid:
+            return {'total_tiles': 0, 'per_zoom': {},
+                    'estimated_mb': 0.0, 'within_limit': True}
+
+        zoom_min, zoom_max = zoom_range
+        if zoom_min < 0 or zoom_max > 19 or zoom_min > zoom_max:
+            return {'total_tiles': 0, 'per_zoom': {},
+                    'estimated_mb': 0.0, 'within_limit': True}
+
+        per_zoom = {}
+        total = 0
+        for z in range(zoom_min, zoom_max + 1):
+            count = count_tiles_in_region(bbox, z, z)
+            per_zoom[z] = count
+            total += count
+
+        estimated_mb = (total * avg_tile_kb) / 1024.0
+        return {
+            'total_tiles': total,
+            'per_zoom': per_zoom,
+            'estimated_mb': round(estimated_mb, 2),
+            'within_limit': total <= MAX_TILES_PER_SESSION,
+        }

--- a/tests/test_tile_cache.py
+++ b/tests/test_tile_cache.py
@@ -1,0 +1,476 @@
+"""
+Tests for tile_cache module.
+
+Covers coordinate conversion, region enumeration, dateline crossing,
+Mercator edge cases, and cache operations.
+"""
+
+import math
+import os
+import sys
+import time
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Add src to path for imports
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils.tile_cache import (
+    TileCache, BoundingBox,
+    lon_to_tile_x, lat_to_tile_y, tile_to_lon, tile_to_lat,
+    count_tiles_in_region, get_tiles_for_region,
+    HAWAII_BOUNDS, MAX_TILES_PER_SESSION, MAX_TILE_BYTES,
+    MAX_MERCATOR_LAT, DEFAULT_ZOOM_MIN, DEFAULT_ZOOM_MAX,
+)
+
+
+# =============================================================================
+# BoundingBox Tests
+# =============================================================================
+
+
+class TestBoundingBox:
+    """Test BoundingBox dataclass."""
+
+    def test_from_tuple(self):
+        bbox = BoundingBox.from_tuple((21.0, -158.5, 21.7, -157.5))
+        assert bbox.south == 21.0
+        assert bbox.west == -158.5
+        assert bbox.north == 21.7
+        assert bbox.east == -157.5
+
+    def test_valid_box(self):
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        assert bbox.is_valid
+
+    def test_invalid_south_gt_north(self):
+        bbox = BoundingBox(south=22.0, west=-158.5, north=21.0, east=-157.5)
+        assert not bbox.is_valid
+
+    def test_invalid_lat_out_of_range(self):
+        bbox = BoundingBox(south=-91.0, west=0, north=0, east=10)
+        assert not bbox.is_valid
+
+    def test_invalid_lon_out_of_range(self):
+        bbox = BoundingBox(south=0, west=-181, north=10, east=10)
+        assert not bbox.is_valid
+
+    def test_dateline_crossing_is_valid(self):
+        """Dateline crossing (west > east) should still be valid."""
+        bbox = BoundingBox(south=-10, west=170, north=10, east=-170)
+        assert bbox.is_valid
+
+
+# =============================================================================
+# Coordinate Conversion Tests
+# =============================================================================
+
+
+class TestCoordinateConversion:
+    """Test lon/lat to tile and back."""
+
+    def test_lon_to_tile_x_zero(self):
+        """Longitude 0 should be at tile n/2."""
+        x = lon_to_tile_x(0.0, 8)
+        n = 2 ** 8
+        assert x == n // 2
+
+    def test_lon_to_tile_x_neg180(self):
+        """Longitude -180 should be tile 0."""
+        x = lon_to_tile_x(-180.0, 8)
+        assert x == 0
+
+    def test_lon_to_tile_x_wraps(self):
+        """Tile X should wrap around at 180 degrees."""
+        x = lon_to_tile_x(180.0, 8)
+        # At exactly 180, wraps to 0
+        assert x == 0
+
+    def test_lat_to_tile_y_equator(self):
+        """Equator should be at tile n/2."""
+        y = lat_to_tile_y(0.0, 8)
+        n = 2 ** 8
+        assert y == n // 2
+
+    def test_lat_to_tile_y_north_is_lower(self):
+        """Higher latitude should have lower Y (y increases southward)."""
+        y_north = lat_to_tile_y(45.0, 8)
+        y_south = lat_to_tile_y(-45.0, 8)
+        assert y_north < y_south
+
+    def test_tile_to_lon_roundtrip(self):
+        """tile_to_lon(lon_to_tile_x(lon)) should be close to lon."""
+        lon = -157.8
+        x = lon_to_tile_x(lon, 12)
+        recovered = tile_to_lon(x, 12)
+        # Should be within one tile width
+        tile_width = 360.0 / (2 ** 12)
+        assert abs(recovered - lon) < tile_width
+
+    def test_tile_to_lat_roundtrip(self):
+        """tile_to_lat(lat_to_tile_y(lat)) should be close to lat."""
+        lat = 21.3
+        y = lat_to_tile_y(lat, 12)
+        recovered = tile_to_lat(y, 12)
+        # Should be within one tile height (varies by latitude)
+        assert abs(recovered - lat) < 0.1
+
+    def test_hawaii_coordinates(self):
+        """Hawaii tile coordinates should be reasonable."""
+        x = lon_to_tile_x(-157.8, 8)
+        y = lat_to_tile_y(21.3, 8)
+        n = 2 ** 8  # 256
+        # Hawaii is at ~-157.8 lon: (180-157.8)/360*256 ~ 15
+        assert 0 <= x < n
+        # Latitude 21.3 is in the tropics, Y should be in lower half of map
+        assert n // 4 < y < 3 * n // 4
+
+
+# =============================================================================
+# Region Enumeration Tests
+# =============================================================================
+
+
+class TestRegionEnumeration:
+    """Test tile counting and enumeration for regions."""
+
+    def test_count_tiles_basic(self):
+        """Counting tiles for a small region should be reasonable."""
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        count = count_tiles_in_region(bbox, 8, 8)
+        # At zoom 8, a 0.7x1.0 degree box is about 1-2 tiles
+        assert 1 <= count <= 4
+
+    def test_count_tiles_increases_with_zoom(self):
+        """Higher zoom should have more tiles."""
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        count_8 = count_tiles_in_region(bbox, 8, 8)
+        count_12 = count_tiles_in_region(bbox, 12, 12)
+        assert count_12 > count_8
+
+    def test_count_tiles_multi_zoom(self):
+        """Multi-zoom count should be sum of individual zoom counts."""
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        total = count_tiles_in_region(bbox, 8, 10)
+        sum_individual = sum(
+            count_tiles_in_region(bbox, z, z) for z in range(8, 11)
+        )
+        assert total == sum_individual
+
+    def test_get_tiles_returns_correct_zoom(self):
+        """All returned tiles should have the requested zoom level."""
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        tiles = get_tiles_for_region(bbox, 10)
+        for z, x, y in tiles:
+            assert z == 10
+
+    def test_get_tiles_count_matches(self):
+        """get_tiles_for_region count should match count_tiles_in_region."""
+        bbox = BoundingBox(south=21.0, west=-158.5, north=21.7, east=-157.5)
+        tiles = get_tiles_for_region(bbox, 10)
+        count = count_tiles_in_region(bbox, 10, 10)
+        assert len(tiles) == count
+
+    def test_hawaii_bounds_reasonable(self):
+        """Hawaii bounds at low zoom should produce a manageable tile count."""
+        bbox = BoundingBox.from_tuple(HAWAII_BOUNDS)
+        # Use zoom 8-12 (not full range to 14) for a reasonable count
+        count = count_tiles_in_region(bbox, 8, 12)
+        assert count < MAX_TILES_PER_SESSION
+
+    def test_hawaii_bounds_full_zoom_large(self):
+        """Hawaii at full zoom range exceeds session limit (expected)."""
+        bbox = BoundingBox.from_tuple(HAWAII_BOUNDS)
+        count = count_tiles_in_region(bbox, DEFAULT_ZOOM_MIN, DEFAULT_ZOOM_MAX)
+        # Full zoom 8-14 for 4x6 degree area is large
+        assert count > MAX_TILES_PER_SESSION
+
+
+# =============================================================================
+# Edge Case Tests (from code review)
+# =============================================================================
+
+
+class TestMercatorEdgeCases:
+    """Test Mercator projection edge cases."""
+
+    def test_lat_to_tile_y_near_north_pole(self):
+        """Should not raise at extreme north latitude."""
+        y = lat_to_tile_y(89.99, 8)
+        assert y >= 0
+
+    def test_lat_to_tile_y_near_south_pole(self):
+        """Should not raise at extreme south latitude."""
+        y = lat_to_tile_y(-89.99, 8)
+        n = 2 ** 8
+        assert y < n
+
+    def test_lat_to_tile_y_at_mercator_limit(self):
+        """Should handle exactly the Mercator limit."""
+        y = lat_to_tile_y(MAX_MERCATOR_LAT, 8)
+        assert y == 0
+
+    def test_lat_to_tile_y_beyond_mercator_limit(self):
+        """Should clamp and not raise for latitudes beyond Mercator limit."""
+        y1 = lat_to_tile_y(86.0, 8)
+        y2 = lat_to_tile_y(90.0, 8)
+        # Both should be clamped to the same value
+        assert y1 == y2
+
+    def test_lat_to_tile_y_exactly_90(self):
+        """Should not raise for exactly 90 degrees."""
+        y = lat_to_tile_y(90.0, 12)
+        assert y >= 0
+
+    def test_lat_to_tile_y_exactly_minus_90(self):
+        """Should not raise for exactly -90 degrees."""
+        y = lat_to_tile_y(-90.0, 12)
+        assert y >= 0
+
+
+class TestDatelineCrossing:
+    """Test dateline-crossing bounding boxes."""
+
+    def test_count_tiles_dateline_crossing(self):
+        """Dateline-crossing region should still count tiles correctly."""
+        # Box crossing the dateline: 170E to 170W
+        bbox = BoundingBox(south=-10, west=170, north=10, east=-170)
+        count = count_tiles_in_region(bbox, 8, 8)
+        # Should be a small number of tiles (not negative or zero)
+        assert count > 0
+
+    def test_get_tiles_dateline_crossing(self):
+        """Tiles for dateline-crossing region should wrap correctly."""
+        bbox = BoundingBox(south=-10, west=170, north=10, east=-170)
+        tiles = get_tiles_for_region(bbox, 4)
+        assert len(tiles) > 0
+        # All tile x coords should be valid (0 to 2^z - 1)
+        n = 2 ** 4
+        for z, x, y in tiles:
+            assert 0 <= x < n
+            assert 0 <= y < n
+
+    def test_dateline_count_equals_tile_list(self):
+        """count_tiles should match len(get_tiles) for dateline box."""
+        bbox = BoundingBox(south=-5, west=175, north=5, east=-175)
+        count = count_tiles_in_region(bbox, 6, 6)
+        tiles = get_tiles_for_region(bbox, 6)
+        assert count == len(tiles)
+
+    def test_non_crossing_larger_than_crossing(self):
+        """A full-width box should have more tiles than a dateline-crossing box."""
+        full = BoundingBox(south=-10, west=-170, north=10, east=170)
+        crossing = BoundingBox(south=-10, west=170, north=10, east=-170)
+        full_count = count_tiles_in_region(full, 4, 4)
+        crossing_count = count_tiles_in_region(crossing, 4, 4)
+        assert full_count > crossing_count
+
+
+class TestZoomValidation:
+    """Test zoom range validation in download and estimate."""
+
+    def test_download_region_invalid_zoom_min(self):
+        """Negative zoom min should return error."""
+        cache = TileCache(cache_dir=Path('/tmp/test_tiles'))
+        result = cache.download_region(HAWAII_BOUNDS, zoom_range=(-1, 10))
+        assert 'error' in result
+
+    def test_download_region_invalid_zoom_max(self):
+        """Zoom max > 19 should return error."""
+        cache = TileCache(cache_dir=Path('/tmp/test_tiles'))
+        result = cache.download_region(HAWAII_BOUNDS, zoom_range=(8, 25))
+        assert 'error' in result
+
+    def test_download_region_zoom_min_gt_max(self):
+        """Zoom min > max should return error."""
+        cache = TileCache(cache_dir=Path('/tmp/test_tiles'))
+        result = cache.download_region(HAWAII_BOUNDS, zoom_range=(14, 8))
+        assert 'error' in result
+
+    def test_estimate_invalid_zoom(self):
+        """Invalid zoom should return zero estimates."""
+        result = TileCache.estimate_download_size(HAWAII_BOUNDS, zoom_range=(-1, 25))
+        assert result['total_tiles'] == 0
+
+    def test_estimate_valid(self):
+        """Valid estimate should produce reasonable results."""
+        result = TileCache.estimate_download_size(HAWAII_BOUNDS, zoom_range=(8, 10))
+        assert result['total_tiles'] > 0
+        assert result['estimated_mb'] > 0
+        assert result['within_limit'] is True
+
+
+class TestTileCacheOperations:
+    """Test TileCache class operations (filesystem-based)."""
+
+    def test_get_tile_path_not_cached(self):
+        """Non-existent tile should return None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            assert cache.get_tile_path(8, 100, 100) is None
+
+    def test_get_tile_path_cached(self):
+        """Existing tile should return path."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            tile_path = Path(tmpdir) / "openstreetmap" / "8" / "100" / "100.png"
+            tile_path.parent.mkdir(parents=True)
+            tile_path.write_bytes(b'\x89PNG' + b'\x00' * 200)
+            result = cache.get_tile_path(8, 100, 100)
+            assert result == tile_path
+
+    def test_get_stats_empty(self):
+        """Empty cache should return zero stats."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            stats = cache.get_stats()
+            assert stats['tile_count'] == 0
+            assert stats['total_bytes'] == 0
+            assert stats['oldest'] is None
+
+    def test_get_stats_with_tiles(self):
+        """Cache with tiles should report correct count and size."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            # Create 3 fake tiles
+            for i in range(3):
+                tile_path = Path(tmpdir) / "openstreetmap" / "8" / str(i) / "0.png"
+                tile_path.parent.mkdir(parents=True)
+                tile_path.write_bytes(b'\x89PNG' + b'\x00' * 500)
+            stats = cache.get_stats()
+            assert stats['tile_count'] == 3
+            assert stats['total_bytes'] == 3 * 504  # 4 header + 500 body
+
+    def test_clear_expired_removes_old(self):
+        """Expired tiles should be removed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            tile_path = Path(tmpdir) / "openstreetmap" / "8" / "0" / "0.png"
+            tile_path.parent.mkdir(parents=True)
+            tile_path.write_bytes(b'\x89PNG' + b'\x00' * 200)
+            # Set mtime to 60 days ago
+            old_time = time.time() - (60 * 86400)
+            os.utime(tile_path, (old_time, old_time))
+            result = cache.clear_expired(max_age_days=30)
+            assert result['removed'] == 1
+            assert not tile_path.exists()
+
+    def test_clear_expired_keeps_recent(self):
+        """Recent tiles should not be removed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir))
+            tile_path = Path(tmpdir) / "openstreetmap" / "8" / "0" / "0.png"
+            tile_path.parent.mkdir(parents=True)
+            tile_path.write_bytes(b'\x89PNG' + b'\x00' * 200)
+            result = cache.clear_expired(max_age_days=30)
+            assert result['removed'] == 0
+            assert tile_path.exists()
+
+    def test_download_region_invalid_bbox(self):
+        """Invalid bounding box should return error."""
+        cache = TileCache(cache_dir=Path('/tmp/test_tiles'))
+        result = cache.download_region((50, 0, 10, 20))  # south > north
+        assert 'error' in result
+        assert result['downloaded'] == 0
+
+    def test_download_region_too_many_tiles(self):
+        """Region with too many tiles should return error."""
+        cache = TileCache(cache_dir=Path('/tmp/test_tiles'))
+        # Entire world at high zoom
+        result = cache.download_region((-80, -180, 80, 180), zoom_range=(1, 18))
+        assert 'error' in result
+
+
+class TestDownloadTile:
+    """Test _download_tile with mocked network."""
+
+    def test_download_success(self):
+        """Successful download should write tile to cache."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir), rate_limit=0.0)
+            fake_data = b'\x89PNG' + b'\x00' * 500
+
+            with patch('utils.tile_cache.urlopen') as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.read.return_value = fake_data
+                mock_response.__enter__ = MagicMock(return_value=mock_response)
+                mock_response.__exit__ = MagicMock(return_value=False)
+                mock_urlopen.return_value = mock_response
+
+                result = cache._download_tile(8, 100, 100)
+                assert result is True
+                tile_path = Path(tmpdir) / "openstreetmap" / "8" / "100" / "100.png"
+                assert tile_path.exists()
+                assert tile_path.read_bytes() == fake_data
+
+    def test_download_too_large(self):
+        """Oversized response should be rejected."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir), rate_limit=0.0)
+            # Response larger than MAX_TILE_BYTES
+            fake_data = b'\x00' * (MAX_TILE_BYTES + 2)
+
+            with patch('utils.tile_cache.urlopen') as mock_urlopen:
+                mock_response = MagicMock()
+                mock_response.read.return_value = fake_data
+                mock_response.__enter__ = MagicMock(return_value=mock_response)
+                mock_response.__exit__ = MagicMock(return_value=False)
+                mock_urlopen.return_value = mock_response
+
+                result = cache._download_tile(8, 100, 100)
+                assert result is False
+
+    def test_download_network_error(self):
+        """Network error should return False, not raise."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir), rate_limit=0.0)
+
+            with patch('utils.tile_cache.urlopen', side_effect=OSError("timeout")):
+                result = cache._download_tile(8, 100, 100)
+                assert result is False
+
+    def test_download_skips_cached(self):
+        """Already-cached tile should be skipped (returns True)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache = TileCache(cache_dir=Path(tmpdir), rate_limit=0.0)
+            # Pre-create tile
+            tile_path = Path(tmpdir) / "openstreetmap" / "8" / "100" / "100.png"
+            tile_path.parent.mkdir(parents=True)
+            tile_path.write_bytes(b'\x89PNG' + b'\x00' * 200)
+
+            # Should not call urlopen
+            with patch('utils.tile_cache.urlopen') as mock_urlopen:
+                result = cache._download_tile(8, 100, 100)
+                assert result is True
+                mock_urlopen.assert_not_called()
+
+
+class TestEstimateDownloadSize:
+    """Test download size estimation."""
+
+    def test_estimate_hawaii(self):
+        """Hawaii estimate at moderate zoom should be reasonable."""
+        result = TileCache.estimate_download_size(HAWAII_BOUNDS, zoom_range=(8, 12))
+        assert result['total_tiles'] > 0
+        assert result['within_limit'] is True
+        assert 8 in result['per_zoom']
+        assert 12 in result['per_zoom']
+
+    def test_estimate_hawaii_full_zoom_exceeds_limit(self):
+        """Hawaii at full zoom range should exceed session limit."""
+        result = TileCache.estimate_download_size(HAWAII_BOUNDS)
+        assert result['total_tiles'] > 0
+        assert result['within_limit'] is False
+
+    def test_estimate_invalid_bounds(self):
+        """Invalid bounds should return zero."""
+        result = TileCache.estimate_download_size((50, 0, 10, 20))
+        assert result['total_tiles'] == 0
+
+    def test_estimate_per_zoom_sums_to_total(self):
+        """Sum of per_zoom counts should equal total_tiles."""
+        result = TileCache.estimate_download_size(HAWAII_BOUNDS, zoom_range=(8, 12))
+        assert sum(result['per_zoom'].values()) == result['total_tiles']


### PR DESCRIPTION
Extract tile caching from coverage_map.py into standalone module with:
- Mercator latitude clamping (prevents math domain errors at poles)
- Dateline-crossing bounding box support
- Bounded response.read() with MAX_TILE_BYTES (2 MB) limit
- Zoom range validation (0-19)
- Thread-safe rate limiting (sleep outside lock)
- Proper Callable type annotation
- Single stat() call in get_stats()
- BoundingBox dataclass with validity checks

52 tests covering coordinate conversion, Mercator edge cases, dateline crossing, zoom validation, cache operations, and download mocking.