### PR TITLE
fix: Reliability audit — deadlock prevention, memory bounds, atomic w…

### DIFF
--- a/src/core/meshtastic_cli.py
+++ b/src/core/meshtastic_cli.py
@@ -394,13 +394,35 @@ def get_cli(
     port: int = 4403,
     device: Optional[str] = None,
 ) -> MeshtasticCLI:
-    """Get or create default CLI instance."""
+    """Get or create default CLI instance.
+
+    If an instance already exists with different parameters, logs a warning
+    and returns the existing instance. Use reset_cli() to force recreation.
+    """
     global _default_cli
 
     if _default_cli is None:
         _default_cli = MeshtasticCLI(host=host, port=port, device=device)
+    else:
+        # Warn if parameters differ from existing instance
+        if (_default_cli.host != host or _default_cli.port != port
+                or _default_cli.device != device):
+            logger.warning(
+                f"get_cli() called with different params "
+                f"(host={host}, port={port}, device={device}) "
+                f"but instance already exists with "
+                f"(host={_default_cli.host}, port={_default_cli.port}, "
+                f"device={_default_cli.device}). "
+                f"Use reset_cli() to force recreation."
+            )
 
     return _default_cli
+
+
+def reset_cli() -> None:
+    """Reset the default CLI singleton, forcing recreation on next get_cli() call."""
+    global _default_cli
+    _default_cli = None
 
 
 def quick_send(message: str, destination: str = "^all") -> bool:

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -669,9 +669,13 @@ class ServiceOrchestrator:
             self._monitor_thread.join(timeout=5)
         logger.info("Health monitoring stopped")
 
+    # Cooldown period before resetting restart counters (seconds)
+    RESTART_COOLDOWN = 300  # 5 minutes
+
     def _monitor_loop(self, interval: int):
         """Background health check loop."""
         restart_counts: Dict[str, int] = {name: 0 for name in self.SERVICES}
+        last_failure_time: Dict[str, float] = {}
 
         while self._running:
             for service_name in self.STARTUP_ORDER:
@@ -684,16 +688,30 @@ class ServiceOrchestrator:
 
                     if self.config.get('restart_on_failure', True):
                         max_attempts = self.config.get('max_restart_attempts', 3)
+
+                        # Reset counter after cooldown period (allow self-healing)
+                        last_fail = last_failure_time.get(service_name, 0)
+                        if (restart_counts[service_name] >= max_attempts
+                                and time.time() - last_fail > self.RESTART_COOLDOWN):
+                            logger.info(
+                                f"Cooldown expired for {service_name}, "
+                                f"resetting restart counter"
+                            )
+                            restart_counts[service_name] = 0
+
                         if restart_counts[service_name] < max_attempts:
                             logger.info(f"Attempting restart of {service_name}")
                             if self.restart_service(service_name):
                                 restart_counts[service_name] = 0
                             else:
                                 restart_counts[service_name] += 1
+                                last_failure_time[service_name] = time.time()
                                 self._emit('service_failed', service_name)
                         else:
                             logger.error(
-                                f"{service_name} exceeded max restart attempts"
+                                f"{service_name} exceeded max restart attempts "
+                                f"(cooldown resets in "
+                                f"{int(self.RESTART_COOLDOWN - (time.time() - last_fail))}s)"
                             )
 
             time.sleep(interval)

--- a/src/gateway/message_queue.py
+++ b/src/gateway/message_queue.py
@@ -689,8 +689,13 @@ class PersistentMessageQueue:
         try:
             purged = self.purge_old(days=1)
             stale = self.cleanup_stale()
-            if purged > 0 or stale > 0:
-                logger.debug(f"Auto-cleanup: purged {purged} old, unstuck {stale} stale")
+            lifecycle_purged = self.purge_lifecycle_history(days=7)
+            if purged > 0 or stale > 0 or lifecycle_purged > 0:
+                logger.debug(
+                    f"Auto-cleanup: purged {purged} old, "
+                    f"unstuck {stale} stale, "
+                    f"{lifecycle_purged} lifecycle entries"
+                )
         except Exception as e:
             logger.debug(f"Auto-cleanup error: {e}")
 

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -807,8 +807,8 @@ instance_control_port = 37429
                 'nodes': nodes_data
             }
 
-            with open(cache_file, 'w') as f:
-                json.dump(cache_data, f, indent=2)
+            from utils.paths import atomic_write_text
+            atomic_write_text(cache_file, json.dumps(cache_data, indent=2))
 
             # Also save to /tmp for web API access (cross-process sharing)
             try:
@@ -816,7 +816,11 @@ instance_control_port = 37429
                 if os.path.islink(tmp_path):
                     logger.warning(f"Refusing to write to symlink: {tmp_path}")
                 else:
-                    fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+                    fd = os.open(
+                        tmp_path,
+                        os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+                        0o644
+                    )
                     with os.fdopen(fd, 'w') as f:
                         json.dump(cache_data, f)
             except Exception as e:

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -9,7 +9,7 @@ import time
 import logging
 import subprocess
 import os
-from queue import Queue, Empty
+from queue import Queue, Empty, Full
 from datetime import datetime
 from typing import Optional, Callable, Dict, Any
 from dataclasses import dataclass
@@ -909,9 +909,14 @@ class RNSMeshtasticBridge:
                 except Exception as e:
                     logger.debug(f"Could not store incoming message: {e}")
 
-                # Queue for bridging if enabled
+                # Queue for bridging if enabled (non-blocking to prevent deadlock)
                 if self._should_bridge(msg):
-                    self._mesh_to_rns_queue.put(msg)
+                    try:
+                        self._mesh_to_rns_queue.put_nowait(msg)
+                    except Full:
+                        logger.warning("Mesh→RNS queue full, dropping message")
+                        with self._stats_lock:
+                            self.stats['errors'] += 1
 
                 # Notify callbacks
                 self._notify_message(msg)
@@ -954,9 +959,14 @@ class RNSMeshtasticBridge:
             except Exception as e:
                 logger.debug(f"Could not store incoming RNS message: {e}")
 
-            # Queue for bridging if enabled
+            # Queue for bridging if enabled (non-blocking to prevent deadlock)
             if self._should_bridge(msg):
-                self._rns_to_mesh_queue.put(msg)
+                try:
+                    self._rns_to_mesh_queue.put_nowait(msg)
+                except Full:
+                    logger.warning("RNS→Mesh queue full, dropping message")
+                    with self._stats_lock:
+                        self.stats['errors'] += 1
 
             # Notify callbacks
             self._notify_message(msg)

--- a/src/monitoring/mqtt_subscriber.py
+++ b/src/monitoring/mqtt_subscriber.py
@@ -423,8 +423,8 @@ class MQTTNodelessSubscriber:
 
             geojson = self.get_geojson()
             if geojson.get("features"):
-                with open(cache_file, 'w') as f:
-                    json.dump(geojson, f)
+                from utils.paths import atomic_write_text
+                atomic_write_text(cache_file, json.dumps(geojson))
                 logger.debug(f"Map cache: wrote {len(geojson['features'])} nodes")
         except Exception as e:
             logger.debug(f"Map cache write error: {e}")
@@ -516,8 +516,8 @@ class MQTTNodelessSubscriber:
         if "hops_away" in data:
             node.hops_away = data["hops_away"]
 
-        # Notify callbacks
-        for callback in self._node_callbacks:
+        # Notify callbacks (snapshot for thread-safe iteration)
+        for callback in list(self._node_callbacks):
             try:
                 callback(node)
             except Exception as e:
@@ -621,8 +621,8 @@ class MQTTNodelessSubscriber:
         with self._messages_lock:
             self._messages.append(msg)
 
-        # Notify callbacks
-        for callback in self._message_callbacks:
+        # Notify callbacks (snapshot for thread-safe iteration)
+        for callback in list(self._message_callbacks):
             try:
                 callback(msg)
             except Exception as e:

--- a/src/utils/channel_scan.py
+++ b/src/utils/channel_scan.py
@@ -149,10 +149,13 @@ class ChannelActivity:
         else:
             self.other_count += 1
 
-        # Add to timestamps (keep last hour only)
+        # Add to timestamps (keep last hour only, capped for memory safety)
         self.timestamps.append(now)
         cutoff = now - RECENT_WINDOW_SEC
         self.timestamps = [t for t in self.timestamps if t > cutoff]
+        # Cap at 5000 entries to prevent memory growth under extreme load
+        if len(self.timestamps) > 5000:
+            self.timestamps = self.timestamps[-5000:]
 
     def reset(self) -> None:
         """Reset all activity counters."""

--- a/src/utils/diagnostic_engine.py
+++ b/src/utils/diagnostic_engine.py
@@ -381,6 +381,10 @@ class DiagnosticEngine:
         # Callbacks for auto-recovery
         self._recovery_handlers: Dict[str, Callable] = {}
 
+        # Persistent DB connection (reused to avoid open/close per operation)
+        self._db_conn = None
+        self._db_lock = threading.Lock()
+
         # Load built-in rules
         self._load_mesh_rules()
 
@@ -403,39 +407,51 @@ class DiagnosticEngine:
         db_dir.mkdir(parents=True, exist_ok=True)
         return db_dir / "diagnostic_history.db"
 
+    def _get_connection(self):
+        """Get persistent SQLite connection (creates if needed).
+
+        Uses a single connection to avoid open/close churn under load.
+        All access is serialized via _db_lock.
+        """
+        import sqlite3
+        if self._db_conn is None:
+            self._db_conn = sqlite3.connect(
+                str(self._get_db_path()),
+                check_same_thread=False
+            )
+        return self._db_conn
+
     def _init_db(self):
         """Initialize SQLite database for persistent history."""
-        import sqlite3
         try:
-            db_path = self._get_db_path()
-            conn = sqlite3.connect(str(db_path))
-            conn.execute('''
-                CREATE TABLE IF NOT EXISTS diagnoses (
-                    id INTEGER PRIMARY KEY AUTOINCREMENT,
-                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                    symptom_message TEXT NOT NULL,
-                    symptom_category TEXT NOT NULL,
-                    symptom_severity TEXT NOT NULL,
-                    symptom_source TEXT,
-                    likely_cause TEXT NOT NULL,
-                    confidence REAL,
-                    evidence TEXT,
-                    suggestions TEXT,
-                    auto_recoverable BOOLEAN,
-                    rule_name TEXT
-                )
-            ''')
-            conn.execute('''
-                CREATE INDEX IF NOT EXISTS idx_diagnoses_timestamp
-                ON diagnoses(timestamp DESC)
-            ''')
-            conn.execute('''
-                CREATE INDEX IF NOT EXISTS idx_diagnoses_category
-                ON diagnoses(symptom_category)
-            ''')
-            conn.commit()
-            conn.close()
-            logger.debug(f"Diagnostic history DB initialized at {db_path}")
+            with self._db_lock:
+                conn = self._get_connection()
+                conn.execute('''
+                    CREATE TABLE IF NOT EXISTS diagnoses (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                        symptom_message TEXT NOT NULL,
+                        symptom_category TEXT NOT NULL,
+                        symptom_severity TEXT NOT NULL,
+                        symptom_source TEXT,
+                        likely_cause TEXT NOT NULL,
+                        confidence REAL,
+                        evidence TEXT,
+                        suggestions TEXT,
+                        auto_recoverable BOOLEAN,
+                        rule_name TEXT
+                    )
+                ''')
+                conn.execute('''
+                    CREATE INDEX IF NOT EXISTS idx_diagnoses_timestamp
+                    ON diagnoses(timestamp DESC)
+                ''')
+                conn.execute('''
+                    CREATE INDEX IF NOT EXISTS idx_diagnoses_category
+                    ON diagnoses(symptom_category)
+                ''')
+                conn.commit()
+            logger.debug(f"Diagnostic history DB initialized at {self._get_db_path()}")
         except Exception as e:
             logger.warning(f"Failed to initialize diagnostic history DB: {e}")
             self._persist_history = False
@@ -445,29 +461,28 @@ class DiagnosticEngine:
         if not self._persist_history:
             return
 
-        import sqlite3
         import json
         try:
-            conn = sqlite3.connect(str(self._get_db_path()))
-            conn.execute('''
-                INSERT INTO diagnoses
-                (symptom_message, symptom_category, symptom_severity, symptom_source,
-                 likely_cause, confidence, evidence, suggestions, auto_recoverable, rule_name)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            ''', (
-                symptom.message,
-                symptom.category.value,
-                symptom.severity.value,
-                symptom.source,
-                diagnosis.likely_cause,
-                diagnosis.confidence,
-                json.dumps(diagnosis.evidence),
-                json.dumps(diagnosis.suggestions),
-                diagnosis.auto_recoverable,
-                rule_name,
-            ))
-            conn.commit()
-            conn.close()
+            with self._db_lock:
+                conn = self._get_connection()
+                conn.execute('''
+                    INSERT INTO diagnoses
+                    (symptom_message, symptom_category, symptom_severity, symptom_source,
+                     likely_cause, confidence, evidence, suggestions, auto_recoverable, rule_name)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ''', (
+                    symptom.message,
+                    symptom.category.value,
+                    symptom.severity.value,
+                    symptom.source,
+                    diagnosis.likely_cause,
+                    diagnosis.confidence,
+                    json.dumps(diagnosis.evidence),
+                    json.dumps(diagnosis.suggestions),
+                    diagnosis.auto_recoverable,
+                    rule_name,
+                ))
+                conn.commit()
         except Exception as e:
             logger.debug(f"Failed to save diagnosis: {e}")
 
@@ -490,25 +505,25 @@ class DiagnosticEngine:
         import sqlite3
         import json
         try:
-            conn = sqlite3.connect(str(self._get_db_path()))
-            conn.row_factory = sqlite3.Row
+            with self._db_lock:
+                conn = self._get_connection()
+                conn.row_factory = sqlite3.Row
 
-            query = '''
-                SELECT * FROM diagnoses
-                WHERE timestamp > datetime('now', ? || ' hours')
-            '''
-            params = [f'-{since_hours}']
+                query = '''
+                    SELECT * FROM diagnoses
+                    WHERE timestamp > datetime('now', ? || ' hours')
+                '''
+                params = [f'-{since_hours}']
 
-            if category:
-                query += " AND symptom_category = ?"
-                params.append(category.value)
+                if category:
+                    query += " AND symptom_category = ?"
+                    params.append(category.value)
 
-            query += " ORDER BY timestamp DESC LIMIT ?"
-            params.append(limit)
+                query += " ORDER BY timestamp DESC LIMIT ?"
+                params.append(limit)
 
-            cursor = conn.execute(query, params)
-            rows = cursor.fetchall()
-            conn.close()
+                cursor = conn.execute(query, params)
+                rows = cursor.fetchall()
 
             results = []
             for row in rows:
@@ -547,25 +562,25 @@ class DiagnosticEngine:
 
         import sqlite3
         try:
-            conn = sqlite3.connect(str(self._get_db_path()))
-            conn.row_factory = sqlite3.Row
+            with self._db_lock:
+                conn = self._get_connection()
+                conn.row_factory = sqlite3.Row
 
-            cursor = conn.execute('''
-                SELECT
-                    likely_cause,
-                    symptom_category,
-                    COUNT(*) as occurrence_count,
-                    MAX(timestamp) as last_seen,
-                    MIN(timestamp) as first_seen
-                FROM diagnoses
-                WHERE timestamp > datetime('now', ? || ' hours')
-                GROUP BY likely_cause, symptom_category
-                HAVING COUNT(*) >= ?
-                ORDER BY occurrence_count DESC
-            ''', (f'-{hours}', threshold))
+                cursor = conn.execute('''
+                    SELECT
+                        likely_cause,
+                        symptom_category,
+                        COUNT(*) as occurrence_count,
+                        MAX(timestamp) as last_seen,
+                        MIN(timestamp) as first_seen
+                    FROM diagnoses
+                    WHERE timestamp > datetime('now', ? || ' hours')
+                    GROUP BY likely_cause, symptom_category
+                    HAVING COUNT(*) >= ?
+                    ORDER BY occurrence_count DESC
+                ''', (f'-{hours}', threshold))
 
-            rows = cursor.fetchall()
-            conn.close()
+                rows = cursor.fetchall()
 
             return [
                 {
@@ -594,16 +609,15 @@ class DiagnosticEngine:
         if not self._persist_history:
             return 0
 
-        import sqlite3
         try:
-            conn = sqlite3.connect(str(self._get_db_path()))
-            cursor = conn.execute('''
-                DELETE FROM diagnoses
-                WHERE timestamp < datetime('now', ? || ' days')
-            ''', (f'-{older_than_days}',))
-            deleted = cursor.rowcount
-            conn.commit()
-            conn.close()
+            with self._db_lock:
+                conn = self._get_connection()
+                cursor = conn.execute('''
+                    DELETE FROM diagnoses
+                    WHERE timestamp < datetime('now', ? || ' days')
+                ''', (f'-{older_than_days}',))
+                deleted = cursor.rowcount
+                conn.commit()
             return deleted
         except Exception as e:
             logger.warning(f"Failed to clear history: {e}")

--- a/src/utils/node_history.py
+++ b/src/utils/node_history.py
@@ -184,6 +184,14 @@ class NodeHistoryDB:
             ))
             self._last_recorded[node_id] = now
 
+        # Prune stale entries to prevent unbounded memory growth
+        if len(self._last_recorded) > 10000:
+            cutoff = now - self.retention_seconds
+            self._last_recorded = {
+                k: v for k, v in self._last_recorded.items()
+                if v > cutoff
+            }
+
         if not to_insert:
             return 0
 


### PR DESCRIPTION
…rites, self-healing

P1 Critical:
- rns_bridge.py: Replace blocking Queue.put() with put_nowait() in receive callbacks to prevent deadlock when bridge_loop is slow/stalled

P2 Original items:
- diagnostic_engine.py: Use persistent SQLite connection with lock instead of open/close per operation (reduces I/O churn under diagnostic load)
- meshtastic_cli.py: get_cli() now warns when called with different params than existing singleton; added reset_cli() for explicit recreation
- channel_scan.py: Cap timestamps list at 5000 entries to prevent memory growth under extreme message rates

P3-P10 Reliability fixes:
- message_queue.py: Add purge_lifecycle_history(days=7) to auto-cleanup to prevent unbounded disk growth on 24/7 NOC
- node_history.py: Prune _last_recorded dict when it exceeds 10k entries to prevent slow memory leak from transient nodes
- node_tracker.py: Use atomic_write_text for cache file; add O_NOFOLLOW to /tmp write for symlink attack mitigation
- mqtt_subscriber.py: Atomic map cache writes; thread-safe callback iteration via list() snapshot
- orchestrator.py: Add 5-minute cooldown to restart counter so NOC can self-heal after transient failure bursts