### PR TITLE
fix: Complete reliability sweep — interruptible shutdown, auto-cleanu…

### DIFF
--- a/src/gateway/bridge_health.py
+++ b/src/gateway/bridge_health.py
@@ -370,6 +370,22 @@ class DeliveryTracker:
             "timed_out": 0,
         }
 
+    def _force_timeout_oldest(self) -> None:
+        """Force-timeout the oldest pending record to make room.
+
+        Called under _lock when _pending exceeds MAX_HISTORY.
+        Prevents unbounded memory growth if check_timeouts() is delayed.
+        """
+        if not self._pending:
+            return
+        oldest_id = min(self._pending, key=lambda k: self._pending[k].sent_at)
+        record = self._pending.pop(oldest_id)
+        record.status = "failed"
+        record.confirmed_at = time.time()
+        record.failure_reason = "evicted_overflow"
+        self._history.append(record)
+        self._stats["timed_out"] += 1
+
     def track_message(self, msg_id: str, destination_hash: bytes,
                       content_preview: str = "") -> None:
         """Register a new LXMF message for delivery tracking.
@@ -386,6 +402,9 @@ class DeliveryTracker:
             sent_at=time.time(),
         )
         with self._lock:
+            # Prevent unbounded growth if check_timeouts() is delayed
+            if len(self._pending) >= self.MAX_HISTORY:
+                self._force_timeout_oldest()
             self._pending[msg_id] = record
             self._stats["total_sent"] += 1
             logger.debug(f"Tracking delivery: {msg_id} -> {record.destination_hash[:8]}...")

--- a/src/gateway/reconnect.py
+++ b/src/gateway/reconnect.py
@@ -6,6 +6,7 @@ for both Meshtastic and RNS connections.
 """
 
 import random
+import threading
 import time
 import logging
 from dataclasses import dataclass, field
@@ -82,16 +83,23 @@ class ReconnectStrategy:
 
         return max(0.0, base_delay + jitter)
 
-    def wait(self) -> float:
+    def wait(self, stop_event: Optional[threading.Event] = None) -> float:
         """
-        Wait for the current backoff delay.
+        Wait for the current backoff delay, interruptible via stop_event.
+
+        Args:
+            stop_event: If provided, wait is interrupted when event is set,
+                        allowing fast shutdown instead of sleeping up to max_delay.
 
         Returns:
-            The actual delay slept.
+            The actual delay slept (may be shorter if interrupted).
         """
         delay = self.get_delay()
         logger.debug(f"Reconnect backoff: waiting {delay:.2f}s (attempt {self.attempts})")
-        time.sleep(delay)
+        if stop_event:
+            stop_event.wait(delay)  # Returns immediately if event is set
+        else:
+            time.sleep(delay)
         return delay
 
     def record_failure(self) -> None:

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -103,6 +103,7 @@ class RNSMeshtasticBridge:
         # Reconnection strategies (exponential backoff with jitter)
         self._mesh_reconnect = ReconnectStrategy.for_meshtastic()
         self._rns_reconnect = ReconnectStrategy.for_rns()
+        self._stop_event = threading.Event()
 
         # Health monitoring
         self.health = BridgeHealthMonitor()
@@ -257,6 +258,7 @@ class RNSMeshtasticBridge:
 
         logger.info("Stopping bridge...")
         self._running = False
+        self._stop_event.set()  # Wake any sleeping reconnect waits
 
         # Stop persistent queue processing
         if self._persistent_queue:
@@ -333,11 +335,12 @@ class RNSMeshtasticBridge:
                 # Direct message
                 if not RNS.Transport.has_path(destination_hash):
                     RNS.Transport.request_path(destination_hash)
-                    # Wait briefly for path
+                    # Wait briefly for path (interruptible on shutdown)
                     for _ in range(50):
                         if RNS.Transport.has_path(destination_hash):
                             break
-                        time.sleep(0.1)
+                        if self._stop_event.wait(0.1):
+                            break
 
                 if not RNS.Transport.has_path(destination_hash):
                     logger.warning("No path to destination")
@@ -558,7 +561,7 @@ class RNSMeshtasticBridge:
                     if not self._mesh_reconnect.should_retry():
                         logger.warning("Meshtastic reconnection: max attempts reached, resetting")
                         self._mesh_reconnect.reset()
-                        time.sleep(self._mesh_reconnect.config.max_delay)
+                        self._stop_event.wait(self._mesh_reconnect.config.max_delay)
                         continue
 
                     logger.info(f"Attempting Meshtastic connection "
@@ -572,13 +575,13 @@ class RNSMeshtasticBridge:
                         logger.info("Meshtastic connection established")
                     else:
                         self._mesh_reconnect.record_failure()
-                        self._mesh_reconnect.wait()
+                        self._mesh_reconnect.wait(self._stop_event)
                         continue
 
                 if self._connected_mesh:
                     self._poll_meshtastic()
 
-                time.sleep(1)
+                self._stop_event.wait(1)
 
             except (BrokenPipeError, ConnectionResetError, OSError) as e:
                 category = self.health.record_error("meshtastic", e)
@@ -586,14 +589,14 @@ class RNSMeshtasticBridge:
                 self._handle_connection_lost()
                 self.health.record_connection_event("meshtastic", "disconnected", str(e))
                 self._mesh_reconnect.record_failure()
-                self._mesh_reconnect.wait()
+                self._mesh_reconnect.wait(self._stop_event)
             except Exception as e:
                 category = self.health.record_error("meshtastic", e)
                 logger.error(f"Meshtastic loop error ({category}): {e}")
                 self._connected_mesh = False
                 self.health.record_connection_event("meshtastic", "error", str(e))
                 self._mesh_reconnect.record_failure()
-                self._mesh_reconnect.wait()
+                self._mesh_reconnect.wait(self._stop_event)
 
     def _rns_loop(self):
         """Main loop for RNS connection with auto-reconnect.
@@ -605,14 +608,14 @@ class RNSMeshtasticBridge:
             try:
                 # Don't retry if RNS init failed permanently (e.g., signal handler issue)
                 if self._rns_init_failed_permanently:
-                    time.sleep(30)
+                    self._stop_event.wait(30)
                     continue
 
                 if not self._connected_rns:
                     if not self._rns_reconnect.should_retry():
                         logger.warning("RNS reconnection: max attempts reached, resetting")
                         self._rns_reconnect.reset()
-                        time.sleep(self._rns_reconnect.config.max_delay)
+                        self._stop_event.wait(self._rns_reconnect.config.max_delay)
                         continue
 
                     logger.info(f"Attempting RNS connection "
@@ -626,12 +629,12 @@ class RNSMeshtasticBridge:
                         logger.info("RNS connection established")
                     else:
                         self._rns_reconnect.record_failure()
-                        self._rns_reconnect.wait()
+                        self._rns_reconnect.wait(self._stop_event)
                         continue
 
                 if self._connected_rns:
                     # RNS handles its own event loop
-                    time.sleep(1)
+                    self._stop_event.wait(1)
 
             except Exception as e:
                 category = self.health.record_error("rns", e)
@@ -644,7 +647,7 @@ class RNSMeshtasticBridge:
                     self._rns_init_failed_permanently = True
                 else:
                     self._rns_reconnect.record_failure()
-                    self._rns_reconnect.wait()
+                    self._rns_reconnect.wait(self._stop_event)
 
     def _bridge_loop(self):
         """Main loop for message bridging"""

--- a/src/utils/analytics.py
+++ b/src/utils/analytics.py
@@ -12,6 +12,7 @@ import json
 import logging
 import sqlite3
 import threading
+import time
 from dataclasses import dataclass, asdict
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -78,6 +79,7 @@ class AnalyticsStore:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         self.db_path = db_path
         self._lock = threading.Lock()
+        self._last_cleanup = 0.0  # epoch time of last auto-cleanup
         self._init_db()
 
     def _init_db(self):
@@ -153,8 +155,23 @@ class AnalyticsStore:
             finally:
                 conn.close()
 
+    # Auto-cleanup interval: once per hour
+    AUTO_CLEANUP_INTERVAL = 3600
+
+    def _maybe_cleanup(self):
+        """Periodically clean up old analytics data to prevent unbounded disk growth."""
+        now = time.time()
+        if now - self._last_cleanup < self.AUTO_CLEANUP_INTERVAL:
+            return
+        self._last_cleanup = now
+        try:
+            self.cleanup_old_data(days=30)
+        except Exception as e:
+            logger.debug(f"Analytics auto-cleanup error: {e}")
+
     def record_link_budget(self, sample: LinkBudgetSample):
         """Record a link budget measurement."""
+        self._maybe_cleanup()
         with self._lock:
             conn = sqlite3.connect(self.db_path)
             try:
@@ -175,6 +192,7 @@ class AnalyticsStore:
 
     def record_network_health(self, metrics: NetworkHealthMetrics):
         """Record network health snapshot."""
+        self._maybe_cleanup()
         with self._lock:
             conn = sqlite3.connect(self.db_path)
             try:
@@ -195,6 +213,7 @@ class AnalyticsStore:
 
     def record_coverage(self, stats: CoverageStats):
         """Record coverage snapshot."""
+        self._maybe_cleanup()
         with self._lock:
             conn = sqlite3.connect(self.db_path)
             try:

--- a/src/utils/logging_structured.py
+++ b/src/utils/logging_structured.py
@@ -97,7 +97,8 @@ def setup_structured_logging(
             if sudo_user and sudo_user != 'root':
                 log_dir = Path(f'/home/{sudo_user}/.config/meshforge/logs')
             else:
-                log_dir = Path.home() / ".config" / "meshforge" / "logs"
+                # Avoid Path.home() which returns /root under sudo (MF001)
+                log_dir = Path('/tmp/meshforge/logs')
 
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "meshforge_structured.jsonl"

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -390,7 +390,8 @@ class MapDataCollector:
             if sudo_user and sudo_user != 'root':
                 cache_path = Path(f'/home/{sudo_user}/.config/meshforge/node_cache.json')
             else:
-                cache_path = Path.home() / ".config" / "meshforge" / "node_cache.json"
+                # Avoid Path.home() which returns /root under sudo (MF001)
+                cache_path = Path('/tmp/meshforge/node_cache.json')
 
         if cache_path.exists():
             try:

--- a/src/utils/node_inventory.py
+++ b/src/utils/node_inventory.py
@@ -145,7 +145,8 @@ class NodeInventory:
             if sudo_user and sudo_user != 'root':
                 config_dir = Path(f'/home/{sudo_user}/.config/meshforge')
             else:
-                config_dir = Path.home() / ".config" / "meshforge"
+                # Avoid Path.home() which returns /root under sudo (MF001)
+                config_dir = Path('/tmp/meshforge')
         return config_dir / "node_inventory.json"
 
     def _load(self) -> None:


### PR DESCRIPTION
…p, bounded dicts, MF001

P2: Interruptible shutdown (reconnect.py, rns_bridge.py)
- ReconnectStrategy.wait() now accepts optional stop_event for immediate wake on shutdown instead of sleeping up to 60s
- All bridge loop sleeps use _stop_event.wait() instead of time.sleep()
- Path-wait loop in send_to_rns checks _stop_event for fast abort
- Bridge.stop() sets _stop_event to unblock all waiting threads

P4: Analytics auto-cleanup (analytics.py)
- Add _maybe_cleanup() called hourly from record_* methods
- Purges data older than 30 days to prevent unbounded disk growth

P8: Delivery tracker overflow protection (bridge_health.py)
- Add _force_timeout_oldest() to evict oldest pending record when _pending reaches MAX_HISTORY, preventing unbounded memory if check_timeouts() is delayed

P11: Path.home() elimination (MF001) in fallback paths
- map_data_service.py, node_inventory.py, logging_structured.py
- Replace Path.home() with /tmp/meshforge/ in edge-case fallback where get_real_user_home() import fails AND no SUDO_USER is set

P14: Path-wait loop respects shutdown (rns_bridge.py)
- send_to_rns path discovery loop now breaks on _stop_event, preventing 5s shutdown delay