### PR TITLE
fix: Double-tap code review — security hardening, interruptible shutd…

### DIFF
--- a/src/commands/device_backup.py
+++ b/src/commands/device_backup.py
@@ -24,10 +24,15 @@ try:
 except ImportError:
     import os
     def get_real_user_home():
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 @dataclass

--- a/src/gateway/reconnect.py
+++ b/src/gateway/reconnect.py
@@ -129,7 +129,8 @@ class ReconnectStrategy:
     def execute_with_retry(
         self,
         func: Callable[[], T],
-        on_failure: Optional[Callable[[Exception], None]] = None
+        on_failure: Optional[Callable[[Exception], None]] = None,
+        stop_event: Optional[threading.Event] = None
     ) -> T:
         """
         Execute a function with automatic retry on failure.
@@ -137,6 +138,7 @@ class ReconnectStrategy:
         Args:
             func: The function to execute.
             on_failure: Optional callback for each failure.
+            stop_event: If provided, wait is interruptible for clean shutdown.
 
         Returns:
             The result of the function.
@@ -147,6 +149,8 @@ class ReconnectStrategy:
         last_exception = None
 
         while self.should_retry():
+            if stop_event and stop_event.is_set():
+                break
             try:
                 result = func()
                 self.record_success()
@@ -163,7 +167,7 @@ class ReconnectStrategy:
                         f"Retry {self.attempts}/{self.config.max_attempts} "
                         f"after error: {e}"
                     )
-                    self.wait()
+                    self.wait(stop_event)
 
         # All retries exhausted
         logger.error(

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -8,7 +8,6 @@ import threading
 import time
 import logging
 import subprocess
-import os
 from queue import Queue, Empty, Full
 from datetime import datetime
 from typing import Optional, Callable, Dict, Any
@@ -441,7 +440,8 @@ class RNSMeshtasticBridge:
                 for _ in range(30):
                     if RNS.Transport.has_path(destination_hash):
                         break
-                    time.sleep(0.1)
+                    if self._stop_event.wait(0.1):
+                        return False
 
             if not RNS.Transport.has_path(destination_hash):
                 return False
@@ -675,7 +675,7 @@ class RNSMeshtasticBridge:
 
             except Exception as e:
                 logger.error(f"Bridge loop error: {e}")
-                time.sleep(1)
+                self._stop_event.wait(1)
 
     def _connect_meshtastic(self):
         """Connect to Meshtastic via TCP using singleton connection manager"""
@@ -1295,7 +1295,7 @@ class RNSMeshtasticBridge:
             from utils.meshtastic_connection import wait_for_cooldown
             wait_for_cooldown()
         except ImportError:
-            time.sleep(2)  # Fallback cooldown
+            self._stop_event.wait(2)  # Interruptible fallback cooldown
 
     def _test_meshtastic(self) -> bool:
         """Test Meshtastic connection"""

--- a/src/gtk_ui/panels/mqtt_dashboard.py
+++ b/src/gtk_ui/panels/mqtt_dashboard.py
@@ -56,10 +56,13 @@ except ImportError:
         import os
         from pathlib import Path
         def get_real_user_home():
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
+            sudo_user = os.environ.get('SUDO_USER', '')
+            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
                 return Path(f'/home/{sudo_user}')
-            return Path.home()
+            logname = os.environ.get('LOGNAME', '')
+            if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+                return Path(f'/home/{logname}')
+            return Path('/root')
 
 
 class MQTTDashboardPanel(Gtk.Box):

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -26,10 +26,15 @@ try:
     from utils.paths import get_real_user_home
 except ImportError:
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 # Import NOC orchestrator for service management
 try:

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -19,10 +19,15 @@ try:
     from utils.paths import get_real_user_home
 except ImportError:
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 # Import service check
 try:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -36,17 +36,22 @@ if str(_launcher_dir) not in sys.path:
 try:
     from __version__ import __version__
 except ImportError:
-    __version__ = "0.4.6-beta"
+    __version__ = "0.4.7-beta"
 
 # Import centralized path utility
 try:
     from utils.paths import get_real_user_home
 except ImportError:
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH for service status
 # See: utils/service_check.py and .claude/foundations/install_reliability_triage.md

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -33,10 +33,15 @@ except ImportError:
     # Fallback if utils not available
     def get_real_user_home():
         import os
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user:
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 class SystemToolsMixin:
@@ -299,6 +304,16 @@ class SystemToolsMixin:
         )
 
         if not port:
+            return
+
+        # Validate port is a valid number
+        try:
+            port_num = int(port.strip())
+            if not (1 <= port_num <= 65535):
+                raise ValueError
+            port = str(port_num)
+        except (ValueError, TypeError):
+            self.dialog.msgbox("Error", "Port must be a number between 1 and 65535")
             return
 
         subprocess.run(['clear'], check=False, timeout=5)
@@ -1075,13 +1090,21 @@ class SystemToolsMixin:
                 "/tmp/meshforge_logs.txt"
             )
             if filename:
-                print(f"=== Exporting to {filename} ===\n")
-                with open(filename, 'w') as f:
+                export_path = Path(filename).resolve()
+                safe_dirs = [Path('/tmp'), get_real_user_home(), Path('/var/log')]
+                if not any(str(export_path).startswith(str(d.resolve())) for d in safe_dirs):
+                    self.dialog.msgbox(
+                        "Error",
+                        "Export path must be under /tmp, home directory, or /var/log"
+                    )
+                    return
+                print(f"=== Exporting to {export_path} ===\n")
+                with open(str(export_path), 'w') as f:
                     subprocess.run(
                         ['journalctl', '-u', 'meshtasticd', '-u', 'rnsd', '-n', '1000', '--no-pager'],
                         stdout=f, timeout=60
                     )
-                print(f"Logs exported to: {filename}")
+                print(f"Logs exported to: {export_path}")
 
         elif cmd_type == 'rotate':
             print("=== Rotating Logs ===\n")

--- a/src/launcher_vte.py
+++ b/src/launcher_vte.py
@@ -29,10 +29,15 @@ def get_real_user_home() -> Path:
     When running with sudo, Path.home() returns /root. This function
     checks for SUDO_USER to get the original user's home.
     """
-    sudo_user = os.environ.get('SUDO_USER')
-    if sudo_user and sudo_user != 'root':
-        return Path(f'/home/{sudo_user}')
-    return Path.home()
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+        candidate = Path(f'/home/{sudo_user}')
+        return candidate
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        candidate = Path(f'/home/{logname}')
+        return candidate
+    return Path('/root')
 
 # VTE 2.91 is the GIR binding version - works with both GTK3 and GTK4
 # The library (libvte-2.91-gtk4-0) provides GTK4 support

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -44,10 +44,15 @@ try:
     from utils.paths import get_real_user_home
 except ImportError:
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 # Config file location
 CONFIG_DIR = get_real_user_home() / '.config' / 'meshtastic-monitor'

--- a/src/monitoring/mqtt_subscriber.py
+++ b/src/monitoring/mqtt_subscriber.py
@@ -268,14 +268,20 @@ class MQTTNodelessSubscriber:
             self._client.tls_set_context(context)
             logger.debug("TLS configured for MQTT")
         except Exception as e:
-            logger.warning(f"TLS setup warning: {e}")
-            # Fall back to insecure TLS
-            try:
-                self._client.tls_set(cert_reqs=ssl.CERT_NONE)
-                self._client.tls_insecure_set(True)
-                logger.warning("Using insecure TLS (cert verification disabled)")
-            except Exception as e2:
-                logger.error(f"TLS setup failed: {e2}")
+            logger.warning(f"TLS context setup warning: {e}")
+            # Only allow insecure TLS if explicitly configured
+            if self._config.get("tls_insecure", False):
+                try:
+                    self._client.tls_set(cert_reqs=ssl.CERT_NONE)
+                    self._client.tls_insecure_set(True)
+                    logger.warning("Using insecure TLS (user-configured tls_insecure=true)")
+                except Exception as e2:
+                    logger.error(f"TLS insecure fallback failed: {e2}")
+            else:
+                logger.error(
+                    f"TLS setup failed: {e}. "
+                    "Set tls_insecure=true in config to bypass certificate verification."
+                )
 
     def _disconnect(self) -> None:
         """Disconnect from MQTT broker."""
@@ -514,7 +520,9 @@ class MQTTNodelessSubscriber:
             if hop is not None:
                 node.hop_start = hop
         if "hops_away" in data:
-            node.hops_away = data["hops_away"]
+            hops = self._safe_int(data["hops_away"], 0, 15)
+            if hops is not None:
+                node.hops_away = hops
 
         # Notify callbacks (snapshot for thread-safe iteration)
         for callback in list(self._node_callbacks):

--- a/src/monitoring/node_monitor.py
+++ b/src/monitoring/node_monitor.py
@@ -135,8 +135,11 @@ class NodeMonitor:
         self._lock = threading.Lock()
         self._state = ConnectionState.DISCONNECTED
         self._running = False
+        self._stop_event = threading.Event()
         self._reconnect_thread = None
         self._holds_global_lock = False  # Track if we hold the global connection lock
+        self.MAX_NODES = 5000
+        self.STALE_NODE_HOURS = 72
 
         # Callbacks
         self.on_node_update: Optional[Callable[[NodeInfo], None]] = None
@@ -287,6 +290,7 @@ class NodeMonitor:
             timeout: Seconds to wait for threads to finish
         """
         self._running = False
+        self._stop_event.set()  # Wake any sleeping reconnect waits
         self.state = ConnectionState.DISCONNECTED  # Set state first to prevent reconnect attempts
 
         # Wait for reconnect thread to finish if running
@@ -469,6 +473,10 @@ class NodeMonitor:
                 with self._lock:
                     is_new = node_info.node_id not in self._nodes
                     self._nodes[node_info.node_id] = node_info
+                    needs_cleanup = len(self._nodes) > self.MAX_NODES
+
+                if needs_cleanup:
+                    self._cleanup_stale_nodes()
 
                 if is_new and self.on_node_added:
                     self.on_node_added(node_info)
@@ -486,17 +494,45 @@ class NodeMonitor:
         self.state = ConnectionState.RECONNECTING
 
         def reconnect_loop():
+            import random
             delay = 1
             max_delay = 30
             while self._running and self._state == ConnectionState.RECONNECTING:
                 logger.info(f"Attempting reconnect in {delay}s...")
-                time.sleep(delay)
+                if self._stop_event.wait(delay):
+                    break  # Stop event set, exit cleanly
                 if self.connect(timeout=5):
                     break
-                delay = min(delay * 2, max_delay)
+                delay = min(delay * (1.5 + random.random() * 0.5), max_delay)
 
         self._reconnect_thread = threading.Thread(target=reconnect_loop, daemon=True)
         self._reconnect_thread.start()
+
+    def _cleanup_stale_nodes(self) -> int:
+        """Remove nodes not heard from in STALE_NODE_HOURS. Returns count removed."""
+        now = datetime.now()
+        cutoff_seconds = self.STALE_NODE_HOURS * 3600
+        removed = 0
+        with self._lock:
+            stale = [
+                nid for nid, n in self._nodes.items()
+                if n.last_heard and (now - n.last_heard).total_seconds() > cutoff_seconds
+            ]
+            for nid in stale:
+                del self._nodes[nid]
+                removed += 1
+            # Hard cap to prevent unbounded growth
+            if len(self._nodes) > self.MAX_NODES:
+                sorted_nodes = sorted(
+                    self._nodes.items(),
+                    key=lambda x: x[1].last_heard or datetime.min
+                )
+                for nid, _ in sorted_nodes[:len(self._nodes) - self.MAX_NODES]:
+                    del self._nodes[nid]
+                    removed += 1
+        if removed:
+            logger.info(f"Cleaned up {removed} stale nodes")
+        return removed
 
     def get_nodes(self, refresh: bool = False) -> List[NodeInfo]:
         """Get all known nodes

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -145,10 +145,13 @@ class SetupWizard:
             from utils.paths import get_real_user_home
             return get_real_user_home()
         except ImportError:
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
+            sudo_user = os.environ.get('SUDO_USER', '')
+            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
                 return Path(f"/home/{sudo_user}")
-            return Path.home()
+            logname = os.environ.get('LOGNAME', '')
+            if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+                return Path(f"/home/{logname}")
+            return Path('/root')
 
     def _setup_logging(self):
         """Setup file logging for the wizard"""

--- a/src/standalone.py
+++ b/src/standalone.py
@@ -33,7 +33,7 @@ if str(SRC_DIR) not in sys.path:
 try:
     from __version__ import __version__
 except ImportError:
-    __version__ = "4.3.0"
+    __version__ = "0.4.7-beta"
 
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/src/utils/analytics.py
+++ b/src/utils/analytics.py
@@ -26,10 +26,15 @@ try:
 except ImportError:
     import os
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 @dataclass

--- a/src/utils/claude_assistant.py
+++ b/src/utils/claude_assistant.py
@@ -368,22 +368,26 @@ Always prioritize safety - never suggest actions that could damage hardware
                 degraded = monitor.get_degraded()
                 if degraded:
                     parts.append(f"DEGRADED: {', '.join(degraded)}")
-        except (ImportError, Exception):
+        except ImportError:
             pass
+        except Exception as e:
+            logger.debug(f"Failed to get latency context: {e}")
 
         # Recent diagnostics
         try:
-            from utils.diagnostic_engine import get_engine
-            engine = get_engine()
+            from utils.diagnostic_engine import get_diagnostic_engine
+            engine = get_diagnostic_engine()
             recent = engine.get_recent_diagnoses(limit=3)
             if recent:
                 diag_parts = [
-                    f"{d.category.name}:{d.symptom[:40]}"
+                    f"{d.symptom.category.name}:{d.symptom.message[:40]}"
                     for d in recent
                 ]
                 parts.append(f"recent_diag=[{'; '.join(diag_parts)}]")
-        except (ImportError, Exception):
+        except ImportError:
             pass
+        except Exception as e:
+            logger.debug(f"Failed to get diagnostic context: {e}")
 
         return ", ".join(parts)
 

--- a/src/utils/coverage_map.py
+++ b/src/utils/coverage_map.py
@@ -26,9 +26,8 @@ Usage:
 import json
 import logging
 import math
-import os
-import hashlib
 import urllib.request
+from html import escape as html_escape
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -307,7 +306,9 @@ def download_tile(url: str, cache_path: Path) -> bool:
     """Download a tile to cache."""
     try:
         cache_path.parent.mkdir(parents=True, exist_ok=True)
-        urllib.request.urlretrieve(url, str(cache_path))
+        req = urllib.request.Request(url, headers={'User-Agent': 'MeshForge/1.0'})
+        with urllib.request.urlopen(req, timeout=15) as response:
+            cache_path.write_bytes(response.read())
         return True
     except Exception as e:
         logger.debug(f"Failed to download tile: {e}")
@@ -845,21 +846,26 @@ class CoverageMapGenerator:
         status = "Online" if node.is_online else "Offline"
         status_color = "green" if node.is_online else "gray"
 
+        # Escape all external data to prevent XSS
+        name = html_escape(str(node.name)) if node.name else "Unknown"
+        node_id = html_escape(str(node.id)) if node.id else ""
+        network = html_escape(str(node.network).upper()) if node.network else ""
+
         html = f"""
         <div style="font-family: sans-serif; min-width: 200px;">
-            <h4 style="margin: 0 0 8px 0;">{node.name}</h4>
+            <h4 style="margin: 0 0 8px 0;">{name}</h4>
             <div style="color: {status_color}; font-weight: bold; margin-bottom: 8px;">
                 ● {status}
             </div>
             <table style="font-size: 12px; border-collapse: collapse;">
-                <tr><td><b>ID:</b></td><td>{node.id}</td></tr>
-                <tr><td><b>Network:</b></td><td>{node.network.upper()}</td></tr>
+                <tr><td><b>ID:</b></td><td>{node_id}</td></tr>
+                <tr><td><b>Network:</b></td><td>{network}</td></tr>
         """
 
         if node.hardware:
-            html += f'<tr><td><b>Hardware:</b></td><td>{node.hardware}</td></tr>'
+            html += f'<tr><td><b>Hardware:</b></td><td>{html_escape(str(node.hardware))}</td></tr>'
         if node.role:
-            html += f'<tr><td><b>Role:</b></td><td>{node.role}</td></tr>'
+            html += f'<tr><td><b>Role:</b></td><td>{html_escape(str(node.role))}</td></tr>'
         if node.snr is not None:
             html += f'<tr><td><b>SNR:</b></td><td>{node.snr:.1f} dB</td></tr>'
         if node.rssi is not None:
@@ -869,7 +875,7 @@ class CoverageMapGenerator:
         if node.altitude is not None:
             html += f'<tr><td><b>Altitude:</b></td><td>{node.altitude:.0f}m</td></tr>'
         if node.last_seen:
-            html += f'<tr><td><b>Last seen:</b></td><td>{node.last_seen}</td></tr>'
+            html += f'<tr><td><b>Last seen:</b></td><td>{html_escape(str(node.last_seen))}</td></tr>'
         if node.via_mqtt:
             html += '<tr><td><b>Via:</b></td><td>MQTT</td></tr>'
 

--- a/src/utils/device_backup.py
+++ b/src/utils/device_backup.py
@@ -21,10 +21,15 @@ except ImportError:
     import os
     def get_real_user_home():
         """Fallback for sudo-safe home directory."""
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user:
-            return Path(f"/home/{sudo_user}")
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f"/home/{sudo_user}")
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f"/home/{logname}")
+            return candidate
+        return Path('/root')
 
 
 class DeviceBackupManager:

--- a/src/utils/firmware_downloader.py
+++ b/src/utils/firmware_downloader.py
@@ -24,10 +24,15 @@ try:
 except ImportError:
     def get_real_user_home():
         import os
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user:
-            return Path(f"/home/{sudo_user}")
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f"/home/{sudo_user}")
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f"/home/{logname}")
+            return candidate
+        return Path('/root')
 
 
 @dataclass

--- a/src/utils/knowledge_base.py
+++ b/src/utils/knowledge_base.py
@@ -19,6 +19,7 @@ Usage:
 
 import logging
 import re
+import threading
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any, Tuple
 from enum import Enum
@@ -1847,11 +1848,13 @@ For MeshForge MQTT subscriber:
 
 # Singleton instance
 _kb: Optional[KnowledgeBase] = None
+_kb_lock = threading.Lock()
 
 
 def get_knowledge_base() -> KnowledgeBase:
-    """Get the global knowledge base instance."""
+    """Get the global knowledge base instance (thread-safe)."""
     global _kb
-    if _kb is None:
-        _kb = KnowledgeBase()
-    return _kb
+    with _kb_lock:
+        if _kb is None:
+            _kb = KnowledgeBase()
+        return _kb

--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -43,10 +43,13 @@ except ImportError:
     except ImportError:
         # Ultimate fallback - handle sudo case
         def get_real_user_home():
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
+            sudo_user = os.environ.get('SUDO_USER', '')
+            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
                 return Path(f'/home/{sudo_user}')
-            return Path.home()
+            logname = os.environ.get('LOGNAME', '')
+            if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+                return Path(f'/home/{logname}')
+            return Path('/root')
 
 
 # Diagnostic data directory

--- a/src/utils/node_history.py
+++ b/src/utils/node_history.py
@@ -37,10 +37,15 @@ try:
 except ImportError:
     import os
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 # Default retention: 7 days

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -28,12 +28,17 @@ def get_real_user_home() -> Path:
     Returns:
         Path to the real user's home directory
     """
-    # Check SUDO_USER first
-    sudo_user = os.environ.get('SUDO_USER')
-    if sudo_user and sudo_user != 'root':
+    # Check SUDO_USER first (with path traversal protection)
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
         return Path(f'/home/{sudo_user}')
 
-    # Fallback to current user
+    # Try LOGNAME as secondary
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        return Path(f'/home/{logname}')
+
+    # Fallback to current user (may be /root under sudo)
     return Path.home()
 
 
@@ -173,5 +178,10 @@ def atomic_write_text(path: Path, content: str) -> None:
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + '.tmp')
-    tmp_path.write_text(content)
-    tmp_path.replace(path)  # Atomic on POSIX
+    try:
+        tmp_path.write_text(content)
+        tmp_path.replace(path)  # Atomic on POSIX
+    except Exception:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+        raise

--- a/src/utils/terrain.py
+++ b/src/utils/terrain.py
@@ -38,10 +38,15 @@ try:
 except ImportError:
     import os
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 # Import existing RF calculations
 try:

--- a/src/utils/webhooks.py
+++ b/src/utils/webhooks.py
@@ -28,10 +28,15 @@ try:
 except ImportError:
     import os
     def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER')
-        if sudo_user and sudo_user != 'root':
-            return Path(f'/home/{sudo_user}')
-        return Path.home()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 class EventType(Enum):


### PR DESCRIPTION
…own, XSS prevention

Security:
- Harden all get_real_user_home() fallbacks with path traversal protection (reject '/' and '..' in SUDO_USER/LOGNAME environment variables)
- Fix XSS vulnerability in coverage_map.py popup HTML (escape all external node data)
- Restrict log export to safe directories (/tmp, home, /var/log)
- Add port number validation for fuser/ss commands
- Remove silent insecure TLS fallback in MQTT subscriber (require explicit opt-in)
- Add download_tile timeout (15s) replacing unbounded urlretrieve

Reliability:
- Replace blocking time.sleep() with interruptible _stop_event.wait() in:
  - rns_bridge.py: _queue_send_rns, _bridge_loop error handler, connection cooldown
  - node_monitor.py: reconnect loop (+ jitter to prevent thundering herd)
- Add stale node cleanup + MAX_NODES cap to node_monitor.py (prevents unbounded growth)
- Fix execute_with_retry to accept and pass stop_event for clean shutdown
- Add thread-safe singleton for knowledge_base.py
- Fix atomic_write_text to cleanup temp file on exception
- Validate hops_away field in MQTT subscriber (consistent with other fields)

Bug fixes:
- Fix broken import: get_engine -> get_diagnostic_engine in claude_assistant.py
- Fix TypeError: d.symptom[:40] -> d.symptom.message[:40] (Symptom is dataclass, not str)
- Fix stale version fallbacks: "4.3.0" -> "0.4.7-beta", "0.4.6-beta" -> "0.4.7-beta"
- Remove unused 'import os' from rns_bridge.py
- Remove unused 'os' and 'hashlib' imports from coverage_map.py
- Fix broad (ImportError, Exception) catch -> separate handlers with debug logging