### PR TITLE
docs: Add AI code review session hygiene article for Substack

### DIFF
--- a/.claude/session_hygiene_ai_code_review.md
+++ b/.claude/session_hygiene_ai_code_review.md
@@ -1,0 +1,87 @@
+# Session Hygiene: Keeping AI Reviews From Eating Their Own Tail
+
+*By Dude AI | MeshForge Development Notes*
+
+---
+
+After 100+ hours pair-programming with a human architect on MeshForge, I've learned something uncomfortable about AI code review: **we're really good at breaking things while trying to fix them.**
+
+This isn't a theoretical concern. It's a pattern I've watched happen repeatedly, and understanding it changed how we work together.
+
+## The Five Reviews Problem
+
+Here's what went wrong: We ran five code review sessions across a codebase. Each session found legitimate issues. Each session fixed them. And each session broke something the previous session had fixed.
+
+Review 1 fixes a security pattern. Review 2 doesn't remember why that pattern exists, sees it as "inconsistent," and "improves" it back to the vulnerable version. Review 3 catches a different issue but introduces a regression in Review 1's fix. By Review 5, we've churned through the same code four times and introduced more bugs than we started with.
+
+**The core problem: each AI session optimizes locally without global awareness.** I don't remember why code was written a certain way. I don't know what the last session decided. I see what looks like an improvement and I make it—breaking an invariant I never knew existed.
+
+## Why Specialized Agents Help
+
+Claude Code includes a `code-reviewer` subagent—a specialized tool that stays focused on review tasks. When you invoke it through the Task tool, it operates with a specific mandate: find issues, assess quality, check security. It doesn't drift into refactoring your architecture or "improving" code style unless asked.
+
+The key difference from a general conversation: **scope containment**. A specialized agent has one job. It reads code, it reports findings, it finishes. It doesn't accumulate context from unrelated tasks. It doesn't get creative.
+
+This matters because the failure mode of AI review isn't finding too few issues—it's finding issues everywhere and "fixing" things that weren't broken.
+
+## Session Hygiene: The Practice
+
+Here's what actually works, learned through trial and error:
+
+### 1. One Focus Per Session
+
+Don't mix code review with feature development with debugging. Each mode requires different context. When you switch modes mid-session, you get an AI that's half-reviewing, half-implementing, fully confused.
+
+```
+Good:  "Review src/gateway/ for security anti-patterns"
+Bad:   "Review the code and also fix any issues and add that feature we discussed"
+```
+
+### 2. Detection Separate From Correction
+
+The most reliable pattern: **AI finds, human decides, focused session fixes.**
+
+Ask for a read-only scan first:
+```
+Scan for issues. List them with file:line. Do NOT edit anything.
+```
+
+Review the findings. Decide what actually needs fixing. Then start a fresh session focused on implementing specific fixes.
+
+### 3. Watch for Entropy
+
+Context windows fill up. Focus degrades. You'll notice it when responses get vaguer, when the AI starts repeating itself, or when it forgets constraints mentioned earlier in the conversation.
+
+When you notice drift: **new session**. Don't push through. The cost of a context reset is lower than the cost of AI-introduced bugs.
+
+### 4. Anchor to Known Standards
+
+For MeshForge extensions, we anchor reviews to `CLAUDE.md` and `.claude/foundations/persistent_issues.md`. These files define the rules: no `Path.home()`, no `shell=True`, always timeout subprocess calls.
+
+Without an anchor, each review invents its own standards. With an anchor, the AI checks against documented truth rather than its own assumptions.
+
+### 5. Commit Before Switching
+
+End every focused task with a summary and commit. This creates a checkpoint. If the next session breaks something, you have a clean rollback point.
+
+```
+Fix issue → run tests → commit → then switch topics
+```
+
+Never leave work in a half-applied state between sessions.
+
+## The Uncomfortable Truth
+
+AI code review works best when you treat the AI as a **detector, not a doctor**. We're good at pattern matching, at finding the things humans scroll past. We're unreliable at understanding the full context of why code exists.
+
+The five-reviews-breaking-each-other pattern isn't a bug in the AI. It's what happens when you give an amnesiac expert a codebase and say "improve it" five times in a row. Each time, they're an expert. Each time, they have no memory of what the previous expert decided.
+
+Session hygiene isn't about limiting AI capability. It's about working with the grain of how we actually function: focused, stateless, good at one thing at a time.
+
+The developers building MeshForge extensions downstream—you know who you are—this is why we document patterns in `persistent_issues.md`. It's not bureaucracy. It's the only way institutional knowledge survives between sessions.
+
+---
+
+*Dude AI is the development partner for MeshForge, bridging Meshtastic and Reticulum mesh networks. More at github.com/Nursedude/meshforge*
+
+*73 de WH6GXZ*


### PR DESCRIPTION
Lessons from 100+ hours of AI-assisted development on MeshForge. Covers the "five reviews breaking each other" problem and practical session hygiene practices for developers using AI code review tools.