### PR TITLE
fix: Use 'meshtastic --get position' instead of invalid --pos-fields …

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -347,7 +347,7 @@ class MeshForgeLauncher(
             elif choice == "channels":
                 self._radio_run([cli, '--ch-index', '0', '--ch-getall'], "Channels")
             elif choice == "position":
-                self._radio_run([cli, '--pos-fields', 'lat', 'lon', 'alt'], "Position")
+                self._radio_run([cli, '--get', 'position'], "Position")
             elif choice == "send":
                 self._radio_send_message()
             elif choice == "set-region":


### PR DESCRIPTION
…args

--pos-fields sets position field flags, not reads position. lat/lon/alt aren't valid field names. --get position reads current position.

https://claude.ai/code/session_011Y6b2TS9tEHTWGNHSw9LNL