### PR TITLE
fix: Pipe status overview through less so output doesn't disappear

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1330,15 +1330,41 @@ class MeshForgeLauncher(
         """Run meshforge-status (terminal-native one-shot status)."""
         subprocess.run(['clear'], check=False, timeout=5)
         try:
-            subprocess.run([sys.executable, str(self.src_dir / 'cli' / 'status.py')], timeout=30)
+            # Capture output and pipe through less so user can scroll
+            result = subprocess.run(
+                [sys.executable, str(self.src_dir / 'cli' / 'status.py')],
+                capture_output=True, text=True, timeout=30
+            )
+            output = result.stdout or ""
+            if result.stderr:
+                output += result.stderr
+
+            if output.strip():
+                # Use less with -R for ANSI colors, -X to not clear on exit
+                proc = subprocess.Popen(
+                    ['less', '-R', '-X'],
+                    stdin=subprocess.PIPE
+                )
+                try:
+                    proc.communicate(input=output.encode(), timeout=300)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                except KeyboardInterrupt:
+                    proc.kill()
+            else:
+                print("No status output available.")
+                try:
+                    input("\nPress Enter to continue...")
+                except KeyboardInterrupt:
+                    print()
         except subprocess.TimeoutExpired:
             print("\n\nStatus check timed out (30s).")
+            try:
+                input("\nPress Enter to return to menu...")
+            except KeyboardInterrupt:
+                print()
         except KeyboardInterrupt:
             print("\n\nAborted.")
-        try:
-            input("\nPress Enter to return to menu...")
-        except KeyboardInterrupt:
-            print()
 
     def _run_terminal_network(self):
         """Show network diagnostics directly in terminal."""


### PR DESCRIPTION
Status output was printing then getting overwritten by whiptail menu redraw before the user could read it. Now captures status.py output and pipes through 'less -R -X' (ANSI colors preserved, screen not cleared on exit) so the user can scroll through all info and quit with q when done.

https://claude.ai/code/session_011Y6b2TS9tEHTWGNHSw9LNL