### PR TITLE
fix: Gateway status shows 'via rnsd' instead of false 'disconnected'

### DIFF
--- a/src/gateway/bridge_cli.py
+++ b/src/gateway/bridge_cli.py
@@ -82,7 +82,12 @@ def print_status(status: dict):
     """Print bridge status."""
     running = status.get('running', False)
     mesh = "connected" if status.get('meshtastic_connected') else "disconnected"
-    rns = "connected" if status.get('rns_connected') else "disconnected"
+    if status.get('rns_connected'):
+        rns = "connected"
+    elif status.get('rns_via_rnsd'):
+        rns = "via rnsd (transport handled by rnsd)"
+    else:
+        rns = "disconnected"
 
     print(f"\n{'='*50}")
     print(f"Gateway Status: {'RUNNING' if running else 'STOPPED'}")
@@ -99,7 +104,8 @@ def print_status(status: dict):
     if node_stats:
         print(f"Nodes tracked: {node_stats.get('total', 0)}")
 
-    print(f"{'='*50}\n")
+    print(f"{'='*50}")
+    print("Press Ctrl+C to stop and return to menu\n")
 
 
 def on_message(msg):
@@ -162,6 +168,18 @@ def main():
         bridge_started = True
         print("Gateway started successfully!")
         print("Press Ctrl+C to stop\n")
+
+        # Wait for connections before showing initial status
+        print("Waiting for connections...", end="", flush=True)
+        for _ in range(10):
+            if not running:
+                break
+            status = bridge.get_status()
+            if status.get('meshtastic_connected') and status.get('rns_connected'):
+                break
+            time.sleep(1)
+            print(".", end="", flush=True)
+        print()
 
         # Print initial status
         print_status(bridge.get_status())

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -97,6 +97,7 @@ class RNSMeshtasticBridge:
         self._running = False
         self._connected_mesh = False
         self._connected_rns = False
+        self._rns_via_rnsd = False  # True when rnsd handles RNS (bridge defers)
         self._rns_init_failed_permanently = False  # True if RNS can't be initialized from this thread
 
         # Reconnection strategies (exponential backoff with jitter)
@@ -289,6 +290,7 @@ class RNSMeshtasticBridge:
             'enabled': self.config.enabled,
             'meshtastic_connected': self._connected_mesh,
             'rns_connected': self._connected_rns,
+            'rns_via_rnsd': self._rns_via_rnsd,
             'uptime_seconds': uptime,
             'statistics': self.stats.copy(),
             'node_stats': self.node_tracker.get_stats(),
@@ -756,10 +758,11 @@ class RNSMeshtasticBridge:
                 # rnsd is running - DON'T try to initialize RNS (it would conflict)
                 # MeshForge gateway bridge cannot coexist with rnsd
                 # Use rnsd + NomadNet for RNS-based communications instead
-                logger.info(f"rnsd detected (PID: {rns_pids[0]}), skipping gateway RNS initialization")
-                logger.info("Gateway bridge RNS features disabled - use NomadNet for RNS messaging")
+                logger.info(f"rnsd detected (PID: {rns_pids[0]}), deferring RNS to rnsd")
+                logger.info("Bridge RNS features deferred - rnsd handles transport")
                 self._reticulum = None
                 self._connected_rns = False
+                self._rns_via_rnsd = True
                 self._rns_init_failed_permanently = True  # Don't retry
                 return  # Skip all RNS/LXMF operations - rnsd handles them
             else:


### PR DESCRIPTION
Three fixes to gateway bridge status display:

1. RNS status now shows "via rnsd (transport handled by rnsd)" when rnsd is running and the bridge defers to it, instead of misleading "disconnected". Added _rns_via_rnsd flag to bridge state.

2. Initial status waits up to 10s for connections before printing, so the first status block shows actual connection state instead of "disconnected" due to threads not having connected yet.

3. "Press Ctrl+C to stop and return to menu" shown after every status block so users always see how to exit.

https://claude.ai/code/session_011Y6b2TS9tEHTWGNHSw9LNL