### PR TITLE
fix: Handle RNS 'Address already in use' error with actionable diagno…

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -772,8 +772,25 @@ class RNSMeshtasticBridge:
                     self._reticulum = RNS.Reticulum(configdir=config_dir)
                 except OSError as e:
                     if hasattr(e, 'errno') and e.errno == 98:
-                        logger.warning("RNS port conflict - will use shared transport if available")
+                        # Port conflict - re-check for RNS processes
+                        # (rnsd may have started between our initial check and bind)
+                        from utils.gateway_diagnostic import handle_address_in_use_error
+                        diag = handle_address_in_use_error(e, logger)
+
                         self._reticulum = None
+                        self._connected_rns = False
+
+                        if diag['rns_pids']:
+                            # rnsd started after our initial check - defer to it
+                            logger.info(f"rnsd now detected (PID: {diag['rns_pids'][0]}), deferring to rnsd")
+                            self._rns_via_rnsd = True
+                            self._rns_init_failed_permanently = True
+                        else:
+                            # Stale socket or unknown process - transient, will retry
+                            logger.warning("RNS port in use by unknown process (stale socket?)")
+                            logger.info("Will retry after backoff - port may become available")
+                            # Don't set _rns_init_failed_permanently - allow retry
+                        return
                     else:
                         raise
                 except Exception as e:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -807,18 +807,12 @@ class MeshForgeLauncher(
             if choice == "status":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== RNS Status ===\n")
-                result = subprocess.run(['rnstatus', '-s'], timeout=15)
-                if result.returncode != 0:
-                    print("\nrnstatus not found or rnsd not running.")
-                    print("Install: pip3 install rns")
-                    print("Start:   sudo systemctl start rnsd")
+                self._run_rns_tool(['rnstatus', '-s'], 'rnstatus')
                 input("\nPress Enter to continue...")
             elif choice == "paths":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== RNS Path Table ===\n")
-                result = subprocess.run(['rnpath', '-t'], timeout=15)
-                if result.returncode != 0:
-                    print("\nrnpath not available. Is RNS installed?")
+                self._run_rns_tool(['rnpath', '-t'], 'rnpath')
                 input("\nPress Enter to continue...")
             elif choice == "bridge":
                 self._run_bridge()
@@ -920,6 +914,62 @@ class MeshForgeLauncher(
             return
 
         subprocess.run([editor, config_path], timeout=None)  # Interactive editor
+
+    def _run_rns_tool(self, cmd: list, tool_name: str):
+        """Run an RNS CLI tool with address-in-use error detection.
+
+        Captures stderr to detect specific error patterns and provides
+        actionable diagnostics instead of generic error messages.
+
+        Args:
+            cmd: Command and arguments to run
+            tool_name: Display name for error messages (e.g., "rnpath")
+        """
+        try:
+            result = subprocess.run(
+                cmd, stderr=subprocess.PIPE, text=True, timeout=15
+            )
+            if result.returncode != 0:
+                stderr = result.stderr or ""
+                if "address already in use" in stderr.lower():
+                    print(f"\nError: RNS port conflict (Address already in use)")
+                    print("Another process is bound to the RNS AutoInterface port.\n")
+                    self._diagnose_rns_port_conflict()
+                else:
+                    print(f"\n{tool_name} failed. Possible causes:")
+                    print("  - rnsd not running: sudo systemctl start rnsd")
+                    print("  - RNS not installed: pip3 install rns")
+                    if stderr.strip():
+                        # Show last 3 lines of stderr for context
+                        err_lines = stderr.strip().split('\n')[-3:]
+                        print(f"\nDetails:")
+                        for line in err_lines:
+                            print(f"  {line}")
+        except FileNotFoundError:
+            print(f"\n{tool_name} not found. Is RNS installed?")
+            print("Install: pip3 install rns")
+        except subprocess.TimeoutExpired:
+            print(f"\n{tool_name} timed out. RNS may be unresponsive.")
+            print("Try restarting rnsd: sudo systemctl restart rnsd")
+
+    def _diagnose_rns_port_conflict(self):
+        """Print diagnostic info for RNS Address-in-use port conflicts."""
+        try:
+            rnsd_check = subprocess.run(
+                ['pgrep', '-f', 'rnsd'],
+                capture_output=True, text=True, timeout=5
+            )
+            if rnsd_check.returncode == 0:
+                pid = rnsd_check.stdout.strip().split('\n')[0]
+                print(f"rnsd is running (PID: {pid}) but may need a restart:")
+                print("  sudo systemctl restart rnsd")
+            else:
+                print("No rnsd found. A stale process may be holding the port.")
+                print("  Find it:    sudo lsof -i UDP:29716")
+                print("  Kill stale: pkill -f rnsd")
+                print("  Or wait ~30s for the socket to timeout")
+        except Exception:
+            print("  Try: sudo systemctl restart rnsd")
 
     # =========================================================================
     # AREDN Menu


### PR DESCRIPTION
…stics

TUI: Replace generic "Is RNS installed?" message with specific error detection. Captures stderr from rnpath/rnstatus to identify port conflicts, checks if rnsd is running, and suggests concrete fixes (restart rnsd, find stale processes, etc.).

Bridge: Fix _connect_rns() errno 98 handler that set _reticulum=None but fell through to identity/LXMF setup. Now properly returns after diagnosing the conflict: defers to rnsd if detected, or allows retry with backoff for stale sockets.

https://claude.ai/code/session_011LHiACuRHEcYqpXSayKTYw