### PR TITLE
fix: Handle RNS reinitialise as OSError in pre-init

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -806,6 +806,12 @@ class RNSMeshtasticBridge:
             if hasattr(e, 'errno') and e.errno == 98:
                 logger.warning(f"RNS port conflict during pre-init: {e}")
                 # Will be retried in _connect_rns() background thread
+            elif "reinitialise" in str(e).lower() or "already running" in str(e).lower():
+                # RNS raises OSError for reinitialise - node_tracker already
+                # initialized the singleton, so RNS transport is available
+                self._rns_pre_initialized = True
+                logger.info("RNS already initialized (node tracker), "
+                           "bridge will use existing instance")
             else:
                 logger.warning(f"RNS pre-init failed: {e}")
         except Exception as e:


### PR DESCRIPTION
RNS raises OSError (not Exception) for "reinitialise Reticulum" when the singleton already exists (initialized by node_tracker). The except OSError handler only checked for errno 98, missing this case and logging it as a generic failure instead of recognizing that RNS is already available.

Add reinitialise/already-running check to the OSError handler so the bridge correctly sets _rns_pre_initialized=True and proceeds to LXMF setup using the existing RNS instance.

https://claude.ai/code/session_011LHiACuRHEcYqpXSayKTYw