### PR TITLE
fix: Remove invalid -s flag from rnstatus command

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -807,7 +807,7 @@ class MeshForgeLauncher(
             if choice == "status":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== RNS Status ===\n")
-                self._run_rns_tool(['rnstatus', '-s'], 'rnstatus')
+                self._run_rns_tool(['rnstatus'], 'rnstatus')
                 input("\nPress Enter to continue...")
             elif choice == "paths":
                 subprocess.run(['clear'], check=False, timeout=5)


### PR DESCRIPTION
The -s flag is --sort (requires a field argument) in current RNS versions, not a summary flag. Using it without an argument causes rnstatus to fail with "error: argument -s/--sort: expected one argument". Plain rnstatus with no flags shows the basic interface status display.

https://claude.ai/code/session_011LHiACuRHEcYqpXSayKTYw