### PR TITLE
fix: ReticulumPaths uses get_real_user_home(), not Path.home()

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -57,10 +57,11 @@ except ImportError:
         def get_config_dir(cls) -> Path:
             if Path('/etc/reticulum/config').is_file():
                 return Path('/etc/reticulum')
-            xdg = Path.home() / '.config' / 'reticulum'
+            home = get_real_user_home()
+            xdg = home / '.config' / 'reticulum'
             if (xdg / 'config').is_file():
                 return xdg
-            return Path.home() / '.reticulum'
+            return home / '.reticulum'
 
         @classmethod
         def get_config_file(cls) -> Path:

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -87,13 +87,10 @@ class MeshtasticPaths:
 class ReticulumPaths:
     """Paths related to Reticulum/RNS configuration.
 
-    IMPORTANT: Unlike MeshForge paths, RNS paths use the EFFECTIVE user's
-    home (Path.home()), NOT get_real_user_home(). This is because RNS itself
-    uses os.path.expanduser("~") to find its config. When rnsd runs as root
-    (via systemd), the config is in /root/.reticulum/. When MeshForge runs
-    with sudo, the effective user is root, so RNS tools also look in /root/.
+    Uses get_real_user_home() so that .reticulum resolves to the real
+    user's home (e.g. /home/user/.reticulum) even when running under sudo.
 
-    RNS config resolution order (mirrors RNS.Reticulum.__init__):
+    Resolution order (mirrors RNS.Reticulum.__init__):
       1. /etc/reticulum/config (system-wide)
       2. ~/.config/reticulum/config (XDG-style)
       3. ~/.reticulum/config (traditional fallback)
@@ -101,7 +98,7 @@ class ReticulumPaths:
 
     @classmethod
     def get_config_dir(cls) -> Path:
-        """Get Reticulum config directory using RNS's own resolution logic.
+        """Get Reticulum config directory.
 
         Checks locations in the same order as RNS.Reticulum.__init__:
           1. /etc/reticulum/ (system-wide)
@@ -113,7 +110,7 @@ class ReticulumPaths:
             return Path('/etc/reticulum')
 
         # XDG-style user config
-        user_home = Path.home()
+        user_home = get_real_user_home()
         xdg_dir = user_home / '.config' / 'reticulum'
         if xdg_dir.is_dir() and (xdg_dir / 'config').is_file():
             return xdg_dir

--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -695,13 +695,10 @@ def get_config_dir(app_name: str = 'meshforge') -> Path:
 
 
 def get_rns_config_dir() -> Path:
-    """Get Reticulum configuration directory using RNS's own resolution.
+    """Get Reticulum configuration directory.
 
-    RNS checks: /etc/reticulum/ -> ~/.config/reticulum/ -> ~/.reticulum/
-    On Windows: %APPDATA%/Reticulum
-
-    NOTE: RNS uses the effective user's home (os.path.expanduser("~")),
-    NOT get_real_user_home(). This is intentional - see ReticulumPaths.
+    Delegates to ReticulumPaths which uses get_real_user_home()
+    so .reticulum resolves to /home/user/.reticulum under sudo.
 
     Returns:
         Path to RNS config directory

--- a/tests/test_rns_config.py
+++ b/tests/test_rns_config.py
@@ -119,11 +119,8 @@ class TestRNSConfigBackup:
 class TestRNSConfigPath:
     """Test config path handling for root/user scenarios.
 
-    RNS config paths use the EFFECTIVE user's home (Path.home()), not
-    get_real_user_home(). This is correct because RNS itself uses
-    os.path.expanduser("~") and rnsd runs as root. When MeshForge
-    runs with sudo, the effective user is root, so RNS config is
-    at /root/.reticulum/ - matching what rnsd uses.
+    RNS config lives in the real user's home (~/.reticulum), not /root.
+    Uses get_real_user_home() so it resolves correctly under sudo.
     """
 
     def test_get_config_path_as_user(self):
@@ -135,17 +132,15 @@ class TestRNSConfigPath:
             assert '.reticulum' in str(path)
 
     def test_get_config_path_as_sudo(self):
-        """Test config path uses effective user home (root) under sudo.
-
-        RNS config intentionally resolves to /root/.reticulum/ when
-        running as root, because rnsd uses the same path. This ensures
-        MeshForge TUI sees the same config that rnsd is using.
-        """
+        """Test config path resolves to real user's home under sudo"""
         from src.utils.rns_config import get_rns_config_path
 
-        # Under sudo, effective user is root, so RNS config is in /root/
-        path = get_rns_config_path()
-        assert '.reticulum' in str(path)
+        with patch.dict(os.environ, {'SUDO_USER': 'testuser'}):
+            with patch('os.geteuid', return_value=0):
+                path = get_rns_config_path()
+                assert '.reticulum' in str(path)
+                # Should be in real user's home, not root
+                assert str(path) != '/root/.reticulum/config'
         # Path uses RNS's resolution logic, which depends on effective user
 
 


### PR DESCRIPTION
.reticulum lives in /home/user/.reticulum, not /root/.reticulum. Previous commit wrongly used Path.home() which returns /root under sudo, violating the MF001 security rule. Reverted to get_real_user_home() which correctly resolves to the real user's home directory.

https://claude.ai/code/session_011LHiACuRHEcYqpXSayKTYw