### PR TITLE
feat: Add NomadNet service detection, fix RNS interface validator

### DIFF
--- a/src/utils/ports.py
+++ b/src/utils/ports.py
@@ -80,4 +80,5 @@ SERVICE_PORTS = {
     'hamclock': HAMCLOCK_PORT,
     'mqtt': MQTT_PORT,
     'openwebrx': OPENWEBRX_PORT,
+    'nomadnet': None,  # NomadNet uses RNS shared instance, no dedicated port
 }

--- a/src/utils/rns_config.py
+++ b/src/utils/rns_config.py
@@ -101,7 +101,8 @@ def validate_interface_section(section: str) -> Tuple[bool, List[str]]:
         valid_types = [
             'AutoInterface', 'TCPServerInterface', 'TCPClientInterface',
             'UDPInterface', 'RNodeInterface', 'SerialInterface',
-            'KISSInterface', 'AX25KISSInterface', 'I2PInterface'
+            'KISSInterface', 'AX25KISSInterface', 'I2PInterface',
+            'Meshtastic_Interface', 'PipeInterface'
         ]
         if iface_type not in valid_types:
             errors.append(f"Unknown interface type: {iface_type}")

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -110,6 +110,13 @@ KNOWN_SERVICES = {
         'description': 'MQTT broker',
         'fix_hint': 'Start with: sudo systemctl start mosquitto',
     },
+    'nomadnet': {
+        'port': None,  # NomadNet uses RNS shared instance, no dedicated port
+        'systemd_name': 'nomadnet',
+        'is_systemd': False,  # NomadNet is a user-space app, NOT a systemd service
+        'description': 'NomadNet mesh messaging client',
+        'fix_hint': 'Start with: nomadnetwork (run as user, not root)',
+    },
 }
 
 

--- a/tests/test_rns_config.py
+++ b/tests/test_rns_config.py
@@ -83,6 +83,43 @@ class TestRNSConfigValidation:
         is_valid, errors = validate_interface_section(section)
         assert not is_valid, "Interface without type should fail"
 
+    def test_meshtastic_interface_valid(self):
+        """Test Meshtastic_Interface type is recognized as valid."""
+        from src.utils.rns_config import validate_interface_section
+
+        section = """
+[[Meshtastic Bridge]]
+  type = Meshtastic_Interface
+  interface_enabled = True
+"""
+        is_valid, errors = validate_interface_section(section)
+        assert is_valid, f"Meshtastic_Interface should be valid: {errors}"
+
+    def test_pipe_interface_valid(self):
+        """Test PipeInterface type is recognized as valid."""
+        from src.utils.rns_config import validate_interface_section
+
+        section = """
+[[Pipe Link]]
+  type = PipeInterface
+  interface_enabled = True
+"""
+        is_valid, errors = validate_interface_section(section)
+        assert is_valid, f"PipeInterface should be valid: {errors}"
+
+    def test_unknown_interface_type_rejected(self):
+        """Test that unknown interface types are rejected."""
+        from src.utils.rns_config import validate_interface_section
+
+        section = """
+[[Bad Interface]]
+  type = FakeInterface
+  interface_enabled = True
+"""
+        is_valid, errors = validate_interface_section(section)
+        assert not is_valid, "Unknown interface type should be rejected"
+        assert any("Unknown interface type" in e for e in errors)
+
 
 class TestRNSConfigBackup:
     """Test config backup functionality"""

--- a/tests/test_service_check.py
+++ b/tests/test_service_check.py
@@ -226,3 +226,20 @@ class TestKnownServices:
         # rnsd uses UDP shared instance port (37428)
         assert config['port'] == 37428
         assert config['port_type'] == 'udp'
+
+    def test_nomadnet_config(self):
+        """Test NomadNet configuration in KNOWN_SERVICES."""
+        assert 'nomadnet' in KNOWN_SERVICES
+        config = KNOWN_SERVICES['nomadnet']
+        # NomadNet uses RNS shared instance, no dedicated port
+        assert config['port'] is None
+        assert config['is_systemd'] is False
+        assert 'nomadnetwork' in config['fix_hint']
+        assert config['description'] == 'NomadNet mesh messaging client'
+
+    def test_all_known_services_have_required_fields(self):
+        """Test that all services have required configuration fields."""
+        required_fields = {'port', 'systemd_name', 'is_systemd', 'description', 'fix_hint'}
+        for name, config in KNOWN_SERVICES.items():
+            for field in required_fields:
+                assert field in config, f"Service '{name}' missing required field '{field}'"


### PR DESCRIPTION
- Add NomadNet to KNOWN_SERVICES in service_check.py (user-space daemon, no dedicated port, uses RNS shared instance)
- Add NomadNet to SERVICE_PORTS in ports.py
- Add Meshtastic_Interface and PipeInterface to rns_config.py validator (was present in commands/rns.py but missing from utils/rns_config.py)
- Add tests for NomadNet service config, interface type validation, and required fields coverage for all known services

https://claude.ai/code/session_01JpQjMHgKGj1bdD7X7kZiAZ