### PR TITLE
security: Fix critical input validation and subprocess safety issues

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -167,6 +167,10 @@ class RNSMeshtasticBridge:
             except Exception as e:
                 logger.warning(f"Failed to initialize persistent queue: {e}")
 
+        # Pre-compile routing rule regexes to avoid re-compilation per message
+        # and catch invalid patterns at startup rather than at runtime
+        self._compiled_rules = self._compile_routing_rules()
+
         # Routing classifier with confidence scoring
         self._classifier = None
         self._last_classification: Optional[ClassificationResult] = None
@@ -1149,8 +1153,39 @@ class RNSMeshtasticBridge:
 
         return False
 
+    def _compile_routing_rules(self) -> dict:
+        """Pre-compile regex patterns from routing rules at init time.
+
+        Returns a dict mapping rule name to compiled filter patterns.
+        Invalid patterns are logged and skipped — the rule will never match.
+        """
+        compiled = {}
+        for rule in self.config.routing_rules:
+            filters = {}
+            for field in ('source_filter', 'dest_filter', 'message_filter'):
+                pattern = getattr(rule, field, '')
+                if pattern:
+                    try:
+                        filters[field] = re.compile(pattern)
+                    except re.error as e:
+                        logger.warning(
+                            f"Invalid regex in rule '{rule.name}' "
+                            f"field '{field}': {e} — rule will be skipped"
+                        )
+                        filters[field] = None  # Mark as broken
+            compiled[rule.name] = filters
+        return compiled
+
+    # Maximum input length for regex matching to bound execution time
+    _REGEX_INPUT_LIMIT = 512
+
     def _should_bridge_legacy(self, msg: BridgedMessage) -> bool:
         """Legacy routing logic (fallback when classifier unavailable)."""
+        # Re-compile if routing rules changed since last compile
+        current_names = {r.name for r in self.config.routing_rules}
+        if current_names != set(self._compiled_rules.keys()):
+            self._compiled_rules = self._compile_routing_rules()
+
         for rule in self.config.routing_rules:
             if not rule.enabled:
                 continue
@@ -1161,27 +1196,38 @@ class RNSMeshtasticBridge:
             if msg.source_network == "rns" and rule.direction == "mesh_to_rns":
                 continue
 
-            # Apply regex filters
-            try:
-                # Source filter
-                if rule.source_filter:
-                    if not msg.source_id or not re.search(rule.source_filter, msg.source_id):
-                        continue
+            # Get pre-compiled filters for this rule
+            filters = self._compiled_rules.get(rule.name, {})
 
-                # Destination filter
-                if rule.dest_filter:
-                    dest = msg.destination_id or ""
-                    if not re.search(rule.dest_filter, dest):
-                        continue
-
-                # Message content filter
-                if rule.message_filter:
-                    if not msg.content or not re.search(rule.message_filter, msg.content):
-                        continue
-
-            except re.error as e:
-                logger.warning(f"Invalid regex in rule '{rule.name}': {e}")
+            # Skip rule entirely if any of its patterns failed to compile
+            if any(v is None for v in filters.values()):
                 continue
+
+            # Apply pre-compiled regex filters with bounded input
+            # Source filter
+            if rule.source_filter:
+                compiled = filters.get('source_filter')
+                if not compiled or not msg.source_id:
+                    continue
+                if not compiled.search(msg.source_id[:self._REGEX_INPUT_LIMIT]):
+                    continue
+
+            # Destination filter
+            if rule.dest_filter:
+                compiled = filters.get('dest_filter')
+                if not compiled:
+                    continue
+                dest = (msg.destination_id or "")[:self._REGEX_INPUT_LIMIT]
+                if not compiled.search(dest):
+                    continue
+
+            # Message content filter
+            if rule.message_filter:
+                compiled = filters.get('message_filter')
+                if not compiled or not msg.content:
+                    continue
+                if not compiled.search(msg.content[:self._REGEX_INPUT_LIMIT]):
+                    continue
 
             # All filters passed - this rule matches
             return True

--- a/src/launcher_tui/backend.py
+++ b/src/launcher_tui/backend.py
@@ -74,7 +74,9 @@ class DialogBackend:
             # Run with stderr redirected to file to capture selection
             # whiptail/dialog opens /dev/tty directly for ncurses display
             with open(tmp_path, 'w') as stderr_file:
-                result = subprocess.run(cmd_parts, stderr=stderr_file)  # Interactive
+                # Interactive: user controls timing, but timeout prevents orphaned
+                # processes if terminal disconnects or dialog crashes
+                result = subprocess.run(cmd_parts, stderr=stderr_file, timeout=3600)
 
             # Read the captured selection
             with open(tmp_path, 'r') as f:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -11,6 +11,7 @@ Falls back to basic terminal menu if neither available.
 """
 
 import os
+import re
 import sys
 import shutil
 import subprocess
@@ -119,6 +120,30 @@ class MeshForgeLauncher(
         if self._meshtastic_path is None:
             self._meshtastic_path = shutil.which('meshtastic') or 'meshtastic'
         return self._meshtastic_path
+
+    @staticmethod
+    def _validate_hostname(host: str) -> bool:
+        """Validate hostname or IP address for use in network commands.
+
+        Prevents flag injection (args starting with '-') and restricts
+        to safe characters. Used before passing user input to ping,
+        DNS lookup, or other network tools.
+        """
+        if not host or len(host) > 253:
+            return False
+        if host.startswith('-'):
+            return False
+        # Allow hostnames, IPv4, IPv6 — alphanumeric, dots, hyphens, colons
+        return bool(re.match(r'^[a-zA-Z0-9.\-:]+$', host))
+
+    @staticmethod
+    def _validate_port(port_str: str) -> bool:
+        """Validate a network port number string."""
+        try:
+            port = int(port_str)
+            return 1 <= port <= 65535
+        except (ValueError, TypeError):
+            return False
 
     def _setup_status_bar(self) -> None:
         """Initialize and attach the status bar to the dialog backend."""
@@ -1671,6 +1696,10 @@ class MeshForgeLauncher(
         if not host:
             return
 
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
         self.dialog.infobox("Pinging", f"Pinging {host}...")
 
         try:
@@ -1744,6 +1773,10 @@ class MeshForgeLauncher(
         )
 
         if not host:
+            return
+
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname.")
             return
 
         try:
@@ -2561,6 +2594,10 @@ WantedBy=multi-user.target
         )
 
         if host:
+            if not self._validate_hostname(host):
+                self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+                return
+
             port = self.dialog.inputbox(
                 "HamClock API Port",
                 "Enter API port (default 8082):",
@@ -2568,6 +2605,10 @@ WantedBy=multi-user.target
             )
 
             if port:
+                if not self._validate_port(port):
+                    self.dialog.msgbox("Error", "Invalid port number (1-65535).")
+                    return
+
                 try:
                     import urllib.request
                     url = f"http://{host}:{port}/get_de.txt"

--- a/src/launcher_tui/service_discovery_mixin.py
+++ b/src/launcher_tui/service_discovery_mixin.py
@@ -8,6 +8,7 @@ Provides unified discovery of all mesh network services:
 - USB devices (serial ports)
 """
 
+import re
 import socket
 import subprocess
 from typing import Dict, List, Optional, Tuple
@@ -153,6 +154,11 @@ class ServiceDiscoveryMixin:
         )
 
         if not network:
+            return
+
+        # Validate network range — allow CIDR (192.168.1.0/24) or plain IP
+        if not re.match(r'^[0-9./]+$', network) or len(network) > 18:
+            self.dialog.msgbox("Error", "Invalid network range.")
             return
 
         self.dialog.infobox("Scanning", f"Scanning {network} for Meshtastic devices...\nThis may take a minute...")

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -437,6 +437,10 @@ class SystemToolsMixin:
         if not host:
             return
 
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
         subprocess.run(['clear'], check=False, timeout=5)
         print(f"=== DNS Lookup: {host} ===\n")
 
@@ -479,6 +483,10 @@ class SystemToolsMixin:
         if not host:
             return
 
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
         subprocess.run(['clear'], check=False, timeout=5)
         print(f"=== Traceroute to {host} ===\n")
         print("(Ctrl+C to stop)\n")
@@ -507,6 +515,10 @@ class SystemToolsMixin:
         )
 
         if not host:
+            return
+
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
             return
 
         count = self.dialog.inputbox(


### PR DESCRIPTION
C1: Add timeout=3600 safety net to interactive whiptail/dialog subprocess
    in backend.py to prevent orphaned processes on terminal disconnect.

C2: Add _validate_hostname() and _validate_port() to validate all user
    input before passing to ping, DNS lookup, traceroute, nmap, and
    HamClock API commands. Prevents flag injection (args starting with
    '-') and restricts to safe characters. Applied across main.py,
    system_tools_mixin.py, and service_discovery_mixin.py.

C3: Pre-compile routing rule regexes at bridge init time in rns_bridge.py.
    Invalid patterns are caught and logged at startup instead of failing
    silently per-message. Match inputs are truncated to 512 chars to
    bound regex execution time and mitigate ReDoS risk. Compiled rules
    auto-refresh when routing rules change.

All 2,614 tests pass with 0 failures.

https://claude.ai/code/session_013bEh9ss4AnH7Ldik9oGYGu