### PR TITLE
feat: Add missing RNS/Reticulum tools to TUI menu

### DIFF
--- a/.claude/research/rns_complete.md
+++ b/.claude/research/rns_complete.md
@@ -290,31 +290,39 @@ RNS -> Queue -> Translate -> Meshtastic API -> Mesh
 
 ```python
 # STATUS
-get_status()           # RNS daemon status
-get_nodes()            # Discovered nodes
-get_interfaces()       # Active interfaces
+get_status()                 # ✅ RNS daemon status
+list_known_destinations()    # ✅ Discovered nodes (path_table + known_destinations)
+list_interfaces()            # ✅ Configured interfaces
+discover_nodes()             # ✅ Active announce-based discovery
 
-# MESSAGES
-send_message()         # Send LXMF message
-get_messages()         # Get inbox/outbox
-mark_read()            # Mark as read
+# MESSAGES (LXMF - Phase 2)
+send_message()         # ❌ Pending - LXMF send
+get_messages()         # ❌ Pending - LXMF inbox/outbox
+mark_read()            # ❌ Pending - LXMF read status
 
 # CONFIG
-read_config()          # Read ~/.reticulum/config
-write_config()         # Write config (with backup)
-add_interface()        # Add new interface
-remove_interface()     # Remove interface
-validate_config()      # Validate syntax
+read_config()          # ✅ Read ~/.reticulum/config
+write_config()         # ✅ Write config (with backup)
+create_default_config() # ✅ Create default config
+get_backups()          # ✅ List config backups
+restore_backup()       # ✅ Restore from backup
+add_interface()        # ✅ Add new interface
+remove_interface()     # ✅ Remove interface
+enable_interface()     # ✅ Enable interface
+disable_interface()    # ✅ Disable interface
+validate_config()      # ✅ Validate syntax
+get_interface_templates() # ✅ Pre-built templates
+apply_template()       # ✅ Apply interface template
 
 # SERVICE
-start_rnsd()           # Start daemon
-stop_rnsd()            # Stop daemon
-restart_rnsd()         # Restart daemon
+start_rnsd()           # ✅ Start daemon
+stop_rnsd()            # ✅ Stop daemon
+restart_rnsd()         # ✅ Restart daemon
 
 # DIAGNOSTICS
-test_path()            # Test path to node
-check_connectivity()   # Test network
-get_path_info()        # Path metrics
+test_path()            # ✅ Test path to node
+check_connectivity()   # ✅ Full network test
+get_path_info()        # ✅ Path metrics (hops, next_hop, interface)
 ```
 
 ---
@@ -347,10 +355,10 @@ get_path_info()        # Path metrics
 ## 8. Implementation Priority
 
 **Phase 1 - Config Management**:
-- [ ] Read/write ~/.reticulum/config
-- [ ] Interface CRUD operations
-- [ ] Config validation
-- [ ] Backup/restore
+- [x] Read/write ~/.reticulum/config
+- [x] Interface CRUD operations
+- [x] Config validation
+- [x] Backup/restore
 
 **Phase 2 - Messaging**:
 - [ ] LXMF send/receive via commands layer
@@ -358,7 +366,7 @@ get_path_info()        # Path metrics
 - [ ] Delivery confirmation
 
 **Phase 3 - Reliability Testing**:
-- [ ] Path testing
+- [x] Path testing (test_path, get_path_info, rnprobe integration)
 - [ ] Latency measurements
 - [ ] Link quality tracking
 

--- a/.claude/tasks/roadmap.md
+++ b/.claude/tasks/roadmap.md
@@ -79,7 +79,13 @@
 
 ### Reticulum/RNS (In Progress)
 - [x] Basic panel structure
-- [x] Interface management
+- [x] Interface management (CRUD, templates, enable/disable)
+- [x] Config management (read/write/validate/backup/restore)
+- [x] Service control (start/stop/restart rnsd)
+- [x] Path testing & diagnostics (rnprobe, get_path_info, check_connectivity)
+- [x] Node discovery (list_known_destinations, discover_nodes)
+- [x] Identity management (rnid integration in TUI)
+- [x] RNS tool availability checks in TUI diagnostics
 - [ ] LXMF messaging UI
 - [ ] Store-and-forward queue
 - [ ] Gateway configuration wizard

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -829,6 +829,99 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
         return CommandResult.fail(f"Path test failed: {e}")
 
 
+def get_path_info(destination_hash: str) -> CommandResult:
+    """
+    Get detailed path information for an RNS destination.
+
+    Queries the running RNS instance for path metrics including
+    hop count, next hop, and interface used.
+
+    Args:
+        destination_hash: Hex string of destination hash (32 hex chars)
+
+    Returns:
+        CommandResult with path details (hops, next_hop, interface, etc.)
+    """
+    if not re.match(r'^[0-9a-fA-F]{32}$', destination_hash):
+        return CommandResult.fail(
+            "Invalid hash format",
+            error="Hash must be 32 hex characters"
+        )
+
+    try:
+        import RNS
+
+        dest_bytes = bytes.fromhex(destination_hash)
+        has_path = RNS.Transport.has_path(dest_bytes)
+
+        if not has_path:
+            return CommandResult.fail(
+                "No path known",
+                data={
+                    'destination': destination_hash,
+                    'has_path': False,
+                    'note': 'Use rnprobe or test_path() to discover paths'
+                }
+            )
+
+        info = {
+            'destination': destination_hash,
+            'has_path': True,
+            'hops': None,
+            'next_hop': None,
+            'expires': None,
+            'interface': None,
+        }
+
+        # Query path table for detailed info
+        if hasattr(RNS.Transport, 'path_table') and RNS.Transport.path_table:
+            path_entry = RNS.Transport.path_table.get(dest_bytes)
+            if path_entry and isinstance(path_entry, (list, tuple)):
+                # Path table entry format: (timestamp, next_hop, interface, hops, expires, ...)
+                # Format may vary by RNS version
+                if len(path_entry) > 0:
+                    info['timestamp'] = path_entry[0] if isinstance(path_entry[0], (int, float)) else None
+                if len(path_entry) > 1:
+                    next_hop = path_entry[1]
+                    if isinstance(next_hop, bytes):
+                        info['next_hop'] = next_hop.hex()
+                if len(path_entry) > 2:
+                    iface = path_entry[2]
+                    if hasattr(iface, 'name'):
+                        info['interface'] = iface.name
+                    elif isinstance(iface, str):
+                        info['interface'] = iface
+                if len(path_entry) > 3:
+                    if isinstance(path_entry[3], int):
+                        info['hops'] = path_entry[3]
+                if len(path_entry) > 4:
+                    if isinstance(path_entry[4], (int, float)):
+                        info['expires'] = path_entry[4]
+
+        # Check if identity is known
+        if hasattr(RNS.Identity, 'recall') and callable(RNS.Identity.recall):
+            try:
+                identity = RNS.Identity.recall(dest_bytes)
+                info['identity_known'] = identity is not None
+            except Exception:
+                info['identity_known'] = False
+
+        return CommandResult.ok(
+            f"Path info for {destination_hash[:8]}...",
+            data=info
+        )
+
+    except ImportError:
+        return CommandResult.not_available(
+            "RNS not installed",
+            fix_hint="pip install rns"
+        )
+    except (SystemExit, KeyboardInterrupt, GeneratorExit):
+        raise
+    except BaseException as e:
+        return CommandResult.fail(f"Path info failed: {e}")
+
+
 # ============================================================================
 # INTERFACE TEMPLATES
 # ============================================================================

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -832,6 +832,10 @@ class MeshForgeLauncher(
             choices = [
                 ("status", "RNS Status (rnstatus)"),
                 ("paths", "RNS Path Table (rnpath)"),
+                ("probe", "Probe Destination (rnprobe)"),
+                ("identity", "Identity Info (rnid)"),
+                ("nodes", "Known Destinations"),
+                ("diag", "RNS Diagnostics"),
                 ("bridge", "Gateway Bridge (start/stop)"),
                 ("config", "View Reticulum Config"),
                 ("edit", "Edit Reticulum Config"),
@@ -858,6 +862,14 @@ class MeshForgeLauncher(
                 print("=== RNS Path Table ===\n")
                 self._run_rns_tool(['rnpath', '-t'], 'rnpath')
                 input("\nPress Enter to continue...")
+            elif choice == "probe":
+                self._rns_probe_destination()
+            elif choice == "identity":
+                self._rns_identity_info()
+            elif choice == "nodes":
+                self._rns_known_destinations()
+            elif choice == "diag":
+                self._rns_diagnostics()
             elif choice == "bridge":
                 self._run_bridge()
             elif choice == "config":
@@ -866,6 +878,221 @@ class MeshForgeLauncher(
                 self._edit_rns_config()
             elif choice == "check":
                 self._check_rns_setup()
+
+    def _rns_probe_destination(self):
+        """Probe an RNS destination to test reachability."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Probe RNS Destination ===\n")
+        print("Probe tests reachability of a destination on the RNS network.")
+        print("Enter the full destination hash (32 hex chars), or a partial hash.\n")
+
+        dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+        if not dest_hash or dest_hash.lower() == 'q':
+            return
+
+        # Validate hex format to prevent flag injection
+        if not re.match(r'^[0-9a-fA-F]+$', dest_hash):
+            print("Error: Hash must contain only hex characters (0-9, a-f).")
+            input("\nPress Enter to continue...")
+            return
+
+        print(f"\nProbing {dest_hash}...\n")
+        self._run_rns_tool(['rnprobe', dest_hash], 'rnprobe')
+        input("\nPress Enter to continue...")
+
+    def _rns_identity_info(self):
+        """Show RNS identity information."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== RNS Identity Info ===\n")
+
+        while True:
+            choices = [
+                ("show", "Show local identity"),
+                ("path", "Show identity file paths"),
+                ("recall", "Recall identity by hash"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "RNS Identity",
+                "Identity management:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "show":
+                subprocess.run(['clear'], check=False, timeout=5)
+                print("=== Local RNS Identity ===\n")
+                # rnid with no args shows the local identity
+                self._run_rns_tool(['rnid'], 'rnid')
+
+                # Also show MeshForge gateway identity path
+                try:
+                    from commands.rns import get_identity_path
+                    gw_id = get_identity_path()
+                    print(f"\nMeshForge gateway identity: {gw_id}")
+                    if gw_id.exists():
+                        print("  Status: exists")
+                    else:
+                        print("  Status: not created (starts on first bridge run)")
+                except ImportError:
+                    pass
+                input("\nPress Enter to continue...")
+
+            elif choice == "path":
+                subprocess.run(['clear'], check=False, timeout=5)
+                print("=== RNS Identity Paths ===\n")
+                config_dir = ReticulumPaths.get_config_dir()
+                identity_path = config_dir / 'identity'
+                print(f"RNS config dir:    {config_dir}")
+                print(f"RNS identity file: {identity_path}")
+                if identity_path.exists():
+                    stat = identity_path.stat()
+                    print(f"  Size: {stat.st_size} bytes")
+                    from datetime import datetime
+                    mtime = datetime.fromtimestamp(stat.st_mtime)
+                    print(f"  Modified: {mtime.strftime('%Y-%m-%d %H:%M:%S')}")
+                else:
+                    print("  Not found (created on first rnsd start)")
+
+                # Show gateway identity
+                try:
+                    from commands.rns import get_identity_path
+                    gw_id = get_identity_path()
+                    print(f"\nMeshForge gateway:  {gw_id}")
+                    if gw_id.exists():
+                        stat = gw_id.stat()
+                        print(f"  Size: {stat.st_size} bytes")
+                    else:
+                        print("  Not created yet")
+                except ImportError:
+                    pass
+                input("\nPress Enter to continue...")
+
+            elif choice == "recall":
+                subprocess.run(['clear'], check=False, timeout=5)
+                print("=== Recall RNS Identity ===\n")
+                print("Look up a known identity by its destination hash.\n")
+                dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+                if dest_hash and dest_hash.lower() != 'q':
+                    # Validate hex format to prevent flag injection
+                    if not re.match(r'^[0-9a-fA-F]+$', dest_hash):
+                        print("Error: Hash must contain only hex characters (0-9, a-f).")
+                    else:
+                        self._run_rns_tool(['rnid', '--recall', dest_hash], 'rnid')
+                input("\nPress Enter to continue...")
+
+    def _rns_known_destinations(self):
+        """Show known RNS destinations from the running rnsd instance."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Known RNS Destinations ===\n")
+
+        try:
+            from commands.rns import list_known_destinations
+            result = list_known_destinations()
+
+            if result.success:
+                nodes = result.data.get('nodes', [])
+                count = result.data.get('count', 0)
+
+                if count == 0:
+                    print("No known destinations yet.")
+                    print("\nNodes appear when they announce or when you request paths.")
+                    print("Make sure rnsd is running: sudo systemctl start rnsd")
+                else:
+                    print(f"Found {count} destination(s):\n")
+                    print(f"{'Hash':>10}  {'Hops':>5}  {'Source':<20}  {'Name'}")
+                    print("-" * 60)
+                    for node in nodes:
+                        short = node.get('short_hash', '?')
+                        hops = node.get('hops', -1)
+                        hops_str = str(hops) if hops >= 0 else '?'
+                        source = node.get('source', 'unknown')
+                        name = node.get('name', '')
+                        print(f"{short:>10}  {hops_str:>5}  {source:<20}  {name}")
+            else:
+                print(f"Error: {result.message}")
+                fix_hint = (result.data or {}).get('fix_hint', '')
+                if fix_hint:
+                    print(f"Fix: {fix_hint}")
+        except ImportError:
+            # Fallback: use rnstatus which also shows some destination info
+            print("Commands module not available, falling back to rnstatus...\n")
+            self._run_rns_tool(['rnstatus', '-a'], 'rnstatus')
+
+        input("\nPress Enter to continue...")
+
+    def _rns_diagnostics(self):
+        """Run comprehensive RNS diagnostics."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== RNS Diagnostics ===\n")
+
+        try:
+            from commands.rns import check_connectivity, get_status
+        except ImportError:
+            print("RNS commands module not available.")
+            print("Run from MeshForge root: sudo python3 src/launcher_tui/main.py")
+            input("\nPress Enter to continue...")
+            return
+
+        # 1. Service status
+        print("[1/4] Checking rnsd service...")
+        status = get_status()
+        status_data = status.data or {}
+        running = status_data.get('rnsd_running', False)
+        print(f"  rnsd: {'RUNNING' if running else 'NOT RUNNING'}")
+        if status_data.get('rnsd_pid'):
+            print(f"  PID: {status_data['rnsd_pid']}")
+        if status_data.get('service_state'):
+            print(f"  State: {status_data['service_state']}")
+
+        # 2. Config check
+        print("\n[2/4] Checking configuration...")
+        config_exists = status_data.get('config_exists', False)
+        print(f"  Config: {'found' if config_exists else 'MISSING'}")
+        if config_exists:
+            iface_count = status_data.get('interface_count', 0)
+            print(f"  Interfaces: {iface_count}")
+
+        # 3. Identity check
+        print("\n[3/4] Checking identity...")
+        identity_exists = status_data.get('identity_exists', False)
+        print(f"  Gateway identity: {'found' if identity_exists else 'not created'}")
+        config_dir = ReticulumPaths.get_config_dir()
+        rns_identity = config_dir / 'identity'
+        print(f"  RNS identity: {'found' if rns_identity.exists() else 'not created'}")
+
+        # 4. Full connectivity check
+        print("\n[4/4] Running connectivity check...")
+        conn = check_connectivity()
+        conn_data = conn.data or {}
+        print(f"  RNS importable: {'yes' if conn_data.get('can_import_rns') else 'NO'}")
+        if conn_data.get('rns_version'):
+            print(f"  RNS version: {conn_data['rns_version']}")
+        print(f"  Config valid: {'yes' if conn_data.get('config_valid') else 'NO'}")
+        print(f"  Interfaces enabled: {conn_data.get('interfaces_enabled', 0)}")
+
+        # Summary
+        issues = conn_data.get('issues', [])
+        if issues:
+            print(f"\n--- Issues Found ({len(issues)}) ---")
+            for issue in issues:
+                print(f"  ! {issue}")
+        else:
+            print("\n--- All checks passed ---")
+
+        # RNS tool availability
+        print("\n--- RNS Tool Availability ---")
+        for tool in ['rnsd', 'rnstatus', 'rnpath', 'rnprobe', 'rnid', 'rncp', 'rnx']:
+            path = shutil.which(tool)
+            if path:
+                print(f"  {tool}: {path}")
+            else:
+                print(f"  {tool}: not found")
+
+        input("\nPress Enter to continue...")
 
     def _view_rns_config(self):
         """View current Reticulum config."""


### PR DESCRIPTION
The RNS menu was missing several standard Reticulum utilities and diagnostic tools. This adds:

TUI Menu (launcher_tui/main.py):
- rnprobe: Probe destination hash to test reachability
- rnid: Identity management (show local, paths, recall by hash)
- Known Destinations: Query rnsd for discovered nodes via path_table
- RNS Diagnostics: 4-step check (service, config, identity, connectivity) with RNS tool availability scan (rnsd/rnstatus/rnpath/rnprobe/rnid/rncp/rnx)

Commands layer (commands/rns.py):
- get_path_info(): Query detailed path metrics (hops, next_hop, interface) for a destination hash from the RNS transport path table

Security:
- Hex-only input validation on all user-supplied destination hashes to prevent flag injection into subprocess calls
- Null guards on CommandResult.data access in diagnostics
- Fixed fix_hint access pattern (data dict, not top-level attribute)

Also updates research doc checklists and roadmap to reflect actual implementation status of RNS tools.

https://claude.ai/code/session_011AcXn5ooSr5jBWrhdquYcH