### PR TITLE
fix: Use client-only RNS config to prevent "Address already in use" e…

### DIFF
--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -1030,6 +1030,36 @@ def apply_template(template_name: str, interface_name: str, overrides: Dict[str,
 
 
 # ============================================================================
+# RNS CLIENT INITIALIZATION
+# ============================================================================
+
+def _init_rns_client():
+    """Initialize RNS as a client connecting to the running rnsd instance.
+
+    Creates a client-only config with no interfaces to avoid
+    "Address already in use" errors when rnsd already owns the ports.
+    See: .claude/foundations/persistent_issues.md Issue #12
+    """
+    import RNS
+    import tempfile
+
+    client_config_dir = Path(tempfile.gettempdir()) / "meshforge_rns_client"
+    client_config_dir.mkdir(exist_ok=True)
+    client_config_file = client_config_dir / "config"
+
+    client_config_file.write_text(
+        "# MeshForge RNS Client Config (auto-generated)\n"
+        "# Connects to existing rnsd without creating interfaces\n\n"
+        "[reticulum]\n"
+        "share_instance = Yes\n"
+        "shared_instance_port = 37428\n"
+        "instance_control_port = 37429\n"
+    )
+
+    return RNS.Reticulum(configdir=str(client_config_dir))
+
+
+# ============================================================================
 # RNS NODE DISCOVERY
 # ============================================================================
 
@@ -1074,9 +1104,8 @@ def list_known_destinations() -> CommandResult:
     try:
         import RNS
 
-        # Try to connect to the running rnsd instance
-        # This will use the shared instance if one is running
-        reticulum = RNS.Reticulum()
+        # Connect as client to avoid "Address already in use" when rnsd owns ports
+        reticulum = _init_rns_client()
 
         nodes = []
 
@@ -1184,8 +1213,8 @@ def discover_nodes(timeout: int = 30) -> CommandResult:
         import RNS
         import time
 
-        # Connect to rnsd
-        reticulum = RNS.Reticulum()
+        # Connect as client to avoid "Address already in use" when rnsd owns ports
+        reticulum = _init_rns_client()
 
         initial_count = 0
         if hasattr(RNS.Identity, 'known_destinations'):

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1118,10 +1118,14 @@ class MeshForgeLauncher(
                 print(f"Try: sudo cat {config_path}")
         else:
             print(f"No Reticulum config found at: {config_path}")
-            print(f"\nRNS config resolution (checked in order):")
+            user_home = get_real_user_home()
+            print(f"\nMeshForge checks (in order):")
             print(f"  1. /etc/reticulum/config")
-            print(f"  2. {get_real_user_home()}/.config/reticulum/config")
-            print(f"  3. {get_real_user_home()}/.reticulum/config")
+            print(f"  2. {user_home}/.config/reticulum/config")
+            print(f"  3. {user_home}/.reticulum/config")
+            if str(user_home) != str(Path.home()):
+                print(f"\nNote: rnsd (running as root) uses: {Path.home()}/.reticulum/config")
+                print(f"  For shared use, place config in /etc/reticulum/config")
             print(f"\nTo create: use 'Edit Reticulum Config' to deploy template")
             print(f"Template:  templates/reticulum.conf")
 

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -441,7 +441,11 @@ class SetupWizard:
         if (rns_status and rns_status.state == WizardServiceState.RUNNING and
             nomad_status and nomad_status.state == WizardServiceState.RUNNING):
             # Both running - check if nomadnet is configured to use shared instance
-            config_path = self._get_real_home() / ".reticulum" / "config"
+            try:
+                from utils.paths import ReticulumPaths
+                config_path = ReticulumPaths.get_config_file()
+            except ImportError:
+                config_path = self._get_real_home() / ".reticulum" / "config"
             if config_path.exists():
                 try:
                     config_text = config_path.read_text()


### PR DESCRIPTION
…rrors

Three fixes for RNS config location issues when running under sudo:

1. commands/rns.py: RNS.Reticulum() was called without configdir, causing it to read /root/.reticulum/config and try to bind ports already owned by rnsd. Now uses a client-only temp config with share_instance=Yes and no interfaces (same pattern as gateway/node_tracker.py).

2. setup_wizard.py: Hardcoded ~/.reticulum/config path skipped /etc/reticulum and ~/.config/reticulum locations. Now uses ReticulumPaths.get_config_file() which checks all three locations in correct order.

3. launcher_tui/main.py: Diagnostic messages now clarify that rnsd (running as root) uses /root/.reticulum/config while MeshForge resolves to the real user's home, and suggests /etc/reticulum/config for shared use.

Fixes Issue #12 (persistent_issues.md): RNS "Address Already in Use"

https://claude.ai/code/session_016AoPDpQER1A2anRqiByZpM