### PR TITLE
fix: Fix interface type validation regex matching 'type' as substring

### DIFF
--- a/rns_config_utils.py
+++ b/rns_config_utils.py
@@ -182,13 +182,16 @@ def validate_interface_section(section: str) -> Tuple[bool, List[str]]:
         return False, errors
 
     # Extract type and validate
-    type_match = re.search(r'type\s*=\s*(\w+)', section, re.IGNORECASE)
+    # Use line-anchored regex to only match 'type' as a standalone key,
+    # not as a suffix of other keys (e.g., 'connection_type = tcp').
+    type_match = re.search(r'^\s*(?!#)type\s*=\s*(\w+)', section, re.MULTILINE | re.IGNORECASE)
     if type_match:
         iface_type = type_match.group(1)
         valid_types = [
             'AutoInterface', 'TCPServerInterface', 'TCPClientInterface',
-            'UDPInterface', 'RNodeInterface', 'SerialInterface',
-            'KISSInterface', 'AX25KISSInterface', 'I2PInterface'
+            'BackboneInterface', 'UDPInterface', 'RNodeInterface',
+            'SerialInterface', 'KISSInterface', 'AX25KISSInterface',
+            'I2PInterface', 'Meshtastic_Interface', 'PipeInterface'
         ]
         if iface_type not in valid_types:
             errors.append(f"Unknown interface type: {iface_type}")

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -198,6 +198,9 @@ def validate_config(content: str) -> Tuple[bool, List[str]]:
                 errors.append(f"Line {line_num}: Malformed section header: {stripped}")
 
     # Check for valid interface types
+    # Use line-anchored regex to only match 'type' as a standalone key,
+    # not as a suffix of other keys (e.g., 'connection_type = tcp').
+    # Skip comment lines starting with '#'.
     valid_types = [
         'AutoInterface', 'TCPServerInterface', 'TCPClientInterface',
         'BackboneInterface', 'SerialInterface', 'RNodeInterface',
@@ -205,7 +208,7 @@ def validate_config(content: str) -> Tuple[bool, List[str]]:
         'Meshtastic_Interface', 'UDPInterface', 'PipeInterface'
     ]
 
-    for match in re.finditer(r'type\s*=\s*(\w+)', content):
+    for match in re.finditer(r'^\s*(?!#)type\s*=\s*(\w+)', content, re.MULTILINE):
         iface_type = match.group(1)
         if iface_type not in valid_types:
             errors.append(f"Unknown interface type: {iface_type}")

--- a/src/utils/rns_config.py
+++ b/src/utils/rns_config.py
@@ -95,7 +95,9 @@ def validate_interface_section(section: str) -> Tuple[bool, List[str]]:
         errors.append("Interface section missing required 'type' field")
 
     # Extract type and validate it's a known type
-    type_match = re.search(r'type\s*=\s*(\w+)', section, re.IGNORECASE)
+    # Use line-anchored regex to only match 'type' as a standalone key,
+    # not as a suffix of other keys (e.g., 'connection_type = tcp').
+    type_match = re.search(r'^\s*(?!#)type\s*=\s*(\w+)', section, re.MULTILINE | re.IGNORECASE)
     if type_match:
         iface_type = type_match.group(1)
         valid_types = [


### PR DESCRIPTION
The validate_config regex r'type\s*=\s*(\w+)' matched 'type' as a substring of other config keys (e.g., 'connection_type = tcp' would falsely capture 'tcp' as an unknown interface type). Also matched commented-out lines.

Fix: Use line-anchored regex r'^\s*(?!#)type\s*=\s*(\w+)' with re.MULTILINE to only match 'type' at the start of non-comment lines.

Also update rns_config_utils.py valid_types list to include BackboneInterface, Meshtastic_Interface, and PipeInterface.

https://claude.ai/code/session_01T7mZQ87zqyikcC5cBqqE83