### PR TITLE
fix: Use pipx instead of pip for NomadNet/RNS install (PEP 668)

### DIFF
--- a/src/commands/gateway.py
+++ b/src/commands/gateway.py
@@ -579,7 +579,7 @@ def check_prerequisites() -> CommandResult:
         import RNS
         checks['rns_package'] = True
     except ImportError:
-        issues.append("RNS package not installed (pip install rns)")
+        issues.append("RNS package not installed (pipx install rns)")
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -649,7 +649,7 @@ def start_rnsd() -> CommandResult:
     except FileNotFoundError:
         return CommandResult.not_available(
             "rnsd not installed",
-            fix_hint="Install with: pip install rns"
+            fix_hint="Install with: pipx install rns"
         )
     except Exception as e:
         return CommandResult.fail(f"Start failed: {e}")
@@ -841,7 +841,7 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
     except ImportError:
         return CommandResult.not_available(
             "RNS not installed",
-            fix_hint="pip install rns"
+            fix_hint="pipx install rns"
         )
     except Exception as e:
         # Catch pyo3 PanicException and other RNS errors
@@ -933,7 +933,7 @@ def get_path_info(destination_hash: str) -> CommandResult:
     except ImportError:
         return CommandResult.not_available(
             "RNS not installed",
-            fix_hint="pip install rns"
+            fix_hint="pipx install rns"
         )
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
@@ -1204,7 +1204,7 @@ def list_known_destinations() -> CommandResult:
     except ImportError:
         return CommandResult.not_available(
             "RNS not installed",
-            fix_hint="pip install rns"
+            fix_hint="pipx install rns"
         )
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
@@ -1308,7 +1308,7 @@ def discover_nodes(timeout: int = 30) -> CommandResult:
     except ImportError:
         return CommandResult.not_available(
             "RNS not installed",
-            fix_hint="pip install rns"
+            fix_hint="pipx install rns"
         )
     except Exception as e:
         return CommandResult.fail(f"Discovery failed: {e}")

--- a/src/core/diagnostics/engine.py
+++ b/src/core/diagnostics/engine.py
@@ -669,7 +669,7 @@ class DiagnosticEngine:
                 category=CheckCategory.RNS,
                 status=CheckStatus.FAIL,
                 message="Not installed",
-                fix_hint="pip3 install rns",
+                fix_hint="pipx install rns",
                 duration_ms=(time.time() - start) * 1000
             )
 

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -115,7 +115,7 @@ class ServiceOrchestrator:
             # rnstatus -s fails on fresh installs before interfaces are configured.
             startup_delay=3,
             required=True,
-            install_command=['pip3', 'install', 'rns'],
+            install_command=['pipx', 'install', 'rns'],
             dependencies=['meshtasticd'],  # Start after meshtasticd
         ),
         'mosquitto': ServiceConfig(
@@ -624,7 +624,7 @@ class ServiceOrchestrator:
         """Get actionable install command for a missing service."""
         hints = {
             'meshtasticd': 'sudo apt install meshtasticd (add repo first: see meshforge docs)',
-            'rnsd': 'pip3 install rns && sudo systemctl enable rnsd',
+            'rnsd': 'pipx install rns && sudo systemctl enable rnsd',
             'mosquitto': 'sudo apt install mosquitto',
         }
         return hints.get(service_name, f'Install {service_name}')

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -512,7 +512,7 @@ instance_control_port = 37429
 
         except ImportError:
             logger.info("RNS module not installed. To enable RNS node discovery:")
-            logger.info("  1. Install RNS: pip install rns")
+            logger.info("  1. Install RNS: pipx install rns")
             logger.info("  2. Start rnsd: sudo systemctl start rnsd")
             logger.info("  3. Restart MeshForge")
         except Exception as e:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1370,7 +1370,7 @@ class MeshForgeLauncher(
                 self.dialog.msgbox(
                     "No Config",
                     "No Reticulum config found and template missing.\n\n"
-                    "Install RNS first: pip3 install rns\n"
+                    "Install RNS first: pipx install rns\n"
                     "Then run rnsd once to generate default config."
                 )
                 return
@@ -1607,7 +1607,7 @@ class MeshForgeLauncher(
                     print(result.stdout, end='')
                 print(f"\n{tool_name} failed. Possible causes:")
                 print("  - rnsd not running: sudo systemctl start rnsd")
-                print("  - RNS not installed: pip3 install rns")
+                print("  - RNS not installed: pipx install rns")
                 if result.stderr and result.stderr.strip():
                     # Show last 3 lines of stderr for context
                     err_lines = result.stderr.strip().split('\n')[-3:]
@@ -1616,7 +1616,7 @@ class MeshForgeLauncher(
                         print(f"  {line}")
         except FileNotFoundError:
             print(f"\n{tool_name} not found. Is RNS installed?")
-            print("Install: pip3 install rns")
+            print("Install: pipx install rns")
         except subprocess.TimeoutExpired:
             print(f"\n{tool_name} timed out. RNS may be unresponsive.")
             print("Try restarting rnsd: sudo systemctl restart rnsd")

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -12,7 +12,7 @@ mode to serve pages and propagate LXMF messages.
 Config directory resolution (mirrors NomadNet upstream):
   /etc/nomadnetwork  ->  ~/.config/nomadnetwork  ->  ~/.nomadnetwork
 
-Requires:  pip install nomadnet   (pulls in rns + lxmf automatically)
+Requires:  pipx install nomadnet   (pulls in rns + lxmf automatically)
 """
 
 import os
@@ -114,7 +114,7 @@ class NomadNetClientMixin:
         # Installation
         nn_path = shutil.which('nomadnet')
         if not nn_path:
-            # Check user local bin (pip install --user)
+            # Check user local bin (pipx / pip install --user)
             user_home = get_real_user_home()
             candidate = user_home / '.local' / 'bin' / 'nomadnet'
             if candidate.exists():
@@ -135,7 +135,7 @@ class NomadNetClientMixin:
                 pass
         else:
             print("  NOT INSTALLED")
-            print("  Install:   pip install nomadnet")
+            print("  Install:   pipx install nomadnet")
             print("             (installs rns + lxmf automatically)")
 
         # Process
@@ -456,7 +456,7 @@ class NomadNetClientMixin:
     # ------------------------------------------------------------------
 
     def _install_nomadnet(self):
-        """Install NomadNet via pip."""
+        """Install NomadNet via pipx (isolated environment)."""
         if self._is_nomadnet_installed():
             self.dialog.msgbox("Already Installed", "NomadNet is already installed.")
             return
@@ -465,7 +465,7 @@ class NomadNetClientMixin:
             "Install NomadNet",
             "Install NomadNet RNS client?\n\n"
             "This will run:\n"
-            "  pip install nomadnet\n\n"
+            "  pipx install nomadnet\n\n"
             "NomadNet pulls in RNS and LXMF automatically.\n\n"
             "It provides:\n"
             "  - Text UI with micron page browser\n"
@@ -479,11 +479,38 @@ class NomadNetClientMixin:
 
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== Installing NomadNet ===\n")
-        print("Running: pip install nomadnet\n")
 
         try:
+            # Ensure pipx is available
+            if not shutil.which('pipx'):
+                print("Installing pipx...\n")
+                result = subprocess.run(
+                    ['apt-get', 'install', '-y', 'pipx'],
+                    timeout=60
+                )
+                if result.returncode != 0:
+                    print("\nFailed to install pipx.")
+                    print("Try manually: sudo apt install pipx")
+                    input("\nPress Enter to continue...")
+                    return
+
+            # Ensure pipx bin dir is in PATH for this session
+            print("Ensuring pipx paths...\n")
+            subprocess.run(['pipx', 'ensurepath'], timeout=15)
+
+            # Add common pipx bin dirs to current process PATH
+            for bindir in [
+                get_real_user_home() / '.local' / 'bin',
+                Path('/root/.local/bin'),
+                Path('/usr/local/bin'),
+            ]:
+                if bindir.is_dir() and str(bindir) not in os.environ.get('PATH', ''):
+                    os.environ['PATH'] = f"{bindir}:{os.environ.get('PATH', '')}"
+
+            # Install nomadnet via pipx (live output)
+            print("\nInstalling NomadNet via pipx...\n")
             result = subprocess.run(
-                ['pip', 'install', 'nomadnet'],
+                ['pipx', 'install', 'nomadnet'],
                 timeout=300
             )
 
@@ -493,27 +520,28 @@ class NomadNetClientMixin:
                     nn_path = shutil.which('nomadnet')
                     print(f"NomadNet installed at: {nn_path}")
                 else:
-                    # Try pipx as fallback hint
                     print("\nnomadnet not found in PATH.")
-                    print("You may need to:")
-                    print("  - Restart your shell, or")
-                    print("  - Use: pipx install nomadnet")
+                    print("You may need to log out and back in,")
+                    print("or run: eval \"$(pipx ensurepath)\"")
             else:
                 print(f"\nInstallation failed (exit code {result.returncode}).")
-                print("\nAlternatives:")
-                print("  pip install --user nomadnet")
-                print("  pipx install nomadnet")
-                print("  pip3 install nomadnet")
+                print("Try manually: pipx install nomadnet")
         except FileNotFoundError:
-            print("pip not found. Try:")
-            print("  sudo apt install python3-pip")
-            print("  pip3 install nomadnet")
+            print("pipx not found.")
+            print("Try: sudo apt install pipx && pipx install nomadnet")
+        except KeyboardInterrupt:
+            print("\n\nInstallation cancelled.")
         except subprocess.TimeoutExpired:
             print("\nInstallation timed out. Check your internet connection.")
+            print("Try manually: pipx install nomadnet")
         except Exception as e:
             print(f"\nInstallation error: {e}")
+            print("Try manually: pipx install nomadnet")
 
-        input("\nPress Enter to continue...")
+        try:
+            input("\nPress Enter to continue...")
+        except (EOFError, KeyboardInterrupt):
+            pass
 
     # ------------------------------------------------------------------
     # Helpers
@@ -557,7 +585,7 @@ class NomadNetClientMixin:
             self.dialog.msgbox(
                 "Not Installed",
                 "NomadNet is not installed.\n\n"
-                "Install with: pip install nomadnet\n"
+                "Install with: pipx install nomadnet\n"
                 "Or use the Install option from this menu.",
             )
             return None

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -89,28 +89,28 @@ class SetupWizard:
             'display': 'Reticulum Network Stack',
             'check_cmd': ['rnsd', '--version'],
             'systemd': 'rnsd.service',
-            'install_hint': 'pip install rns',
+            'install_hint': 'pipx install rns',
         },
         {
             'name': 'nomadnet',
             'display': 'NomadNet',
             'check_cmd': ['nomadnet', '--version'],
             'systemd': None,
-            'install_hint': 'pip install nomadnet',
+            'install_hint': 'pipx install nomadnet',
         },
         {
             'name': 'meshchat',
             'display': 'MeshChat',
             'check_cmd': ['meshchat', '--version'],
             'systemd': None,
-            'install_hint': 'pip install meshchat',
+            'install_hint': 'pipx install meshchat',
         },
         {
             'name': 'lxmf',
             'display': 'LXMF (messaging)',
             'check_cmd': ['lxmd', '--version'],
             'systemd': None,
-            'install_hint': 'pip install lxmf',
+            'install_hint': 'pipx install lxmf',
         },
     ]
 

--- a/src/utils/dependency_guard.py
+++ b/src/utils/dependency_guard.py
@@ -175,7 +175,7 @@ DEPENDENCY_CONTRACTS: Dict[str, DependencyContract] = {
         min_version='0.6.0',
         required_attrs=['__version__', 'Reticulum', 'Identity', 'Destination', 'Transport'],
         required_callables=[],
-        fix_hint="pip install --upgrade rns"
+        fix_hint="pipx install rns  (or pipx upgrade rns)"
     ),
     'LXMF': DependencyContract(
         package_name='lxmf',

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -247,7 +247,7 @@ class GatewayDiagnostic:
                 name="RNS Installation",
                 status=CheckStatus.FAIL,
                 message="RNS not installed",
-                fix_hint="pip3 install --user rns"
+                fix_hint="pipx install rns"
             )
         except (SystemExit, KeyboardInterrupt, GeneratorExit):
             raise
@@ -257,7 +257,7 @@ class GatewayDiagnostic:
                 name="RNS Installation",
                 status=CheckStatus.WARN,
                 message=f"RNS installed but error: {e}",
-                fix_hint="Try: pip3 install --user --upgrade rns cffi"
+                fix_hint="Try: pipx install rns  (or pipx upgrade rns)"
             )
 
     def check_rns_config(self) -> CheckResult:

--- a/src/utils/knowledge_base.py
+++ b/src/utils/knowledge_base.py
@@ -1080,7 +1080,7 @@ Common Issues:
                     instruction="Verify Python RNS package is installed",
                     command="python3 -c 'import RNS; print(RNS.__version__)'",
                     expected_result="Version number printed (e.g., 0.7.3)",
-                    if_fail="Install: pip3 install rns",
+                    if_fail="Install: pipx install rns",
                 ),
                 TroubleshootingStep(
                     instruction="Check for port conflicts on AutoInterface",

--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -471,7 +471,7 @@ class NetworkDiagnostics:
                 self.update_health(
                     "rns", HealthStatus.UNHEALTHY,
                     "RNS not installed",
-                    fix_hint="Install RNS: pip install rns"
+                    fix_hint="Install RNS: pipx install rns"
                 )
         except Exception as e:
             self.update_health("rns", HealthStatus.UNKNOWN, f"Check failed: {e}")

--- a/src/utils/startup_health.py
+++ b/src/utils/startup_health.py
@@ -158,7 +158,7 @@ def check_rnsd() -> ServiceHealth:
             running=False,
             status_text="check failed",
             optional=True,
-            fix_hint="Install Reticulum: pip3 install rns"
+            fix_hint="Install Reticulum: pipx install rns"
         )
 
 


### PR DESCRIPTION
Modern Debian/Ubuntu systems enforce PEP 668 which blocks bare pip install into the system Python environment. The NomadNet installer now uses pipx (matching the existing meshtastic CLI pattern) to install into an isolated environment. Also updated all user-facing pip install hints for RNS, NomadNet, LXMF, and MeshChat to recommend pipx across 13 files.

https://claude.ai/code/session_01V1CStMTpEmS9BRtc2Fk9jo