### PR TITLE
docs: Add frequency slot/channel number reference to Meshtastic config

### DIFF
--- a/templates/reticulum.conf
+++ b/templates/reticulum.conf
@@ -97,8 +97,20 @@
   #   7 = LONG_MOD     (12.0s delay)
   #   0 = LONG_FAST    (8.0s delay)
   #   1 = LONG_SLOW    (15.0s delay)
+  #
+  # Frequency Slot / LoRa Channel Number:
+  #   Set on the Meshtastic device (not in this config).
+  #   All nodes on the same network must use the same slot + preset.
+  #
+  #   US 902-928 MHz common slots:
+  #     Slot 0  = 903.08 MHz (default)
+  #     Slot 12 = 906.08 MHz (HawaiiNet)
+  #     Slot 20 = 906.88 MHz (MtnMesh)
+  #
+  #   Set via CLI:  meshtastic --ch-set channel_num <slot>
+  #   Set preset:   meshtastic --set lora.modem_preset SHORT_TURBO
 
-  # --- Short Turbo config (recommended) ---
+  # --- Short Turbo config (recommended, slot 0) ---
   # [[Meshtastic Interface]]
   #   type = Meshtastic_Interface
   #   enabled = true
@@ -108,7 +120,7 @@
   #   # tcp_port = 127.0.0.1:4403
   #   data_speed = 8
 
-  # --- Long Fast config ---
+  # --- Long Fast config (slot 0) ---
   # [[Meshtastic Interface]]
   #   type = Meshtastic_Interface
   #   enabled = true


### PR DESCRIPTION
Added frequency slot documentation to the Meshtastic Interface section:
- US 902-928 MHz common slots (0=default, 12=HawaiiNet, 20=MtnMesh)
- CLI commands to set channel_num and modem_preset on device
- Note that frequency is set on the Meshtastic device, not in RNS config
- All nodes must use same slot + preset

https://claude.ai/code/session_01GdTbaGYtjvYQhbzovfQWcZ