### PR TITLE
feat: Add dual-radio gateway template (Short Turbo <> Long Fast)

### DIFF
--- a/templates/reticulum.conf
+++ b/templates/reticulum.conf
@@ -130,6 +130,28 @@
   #   # tcp_port = 127.0.0.1:4403
   #   data_speed = 0
 
+  # --- Dual-Radio Gateway: Short Turbo <> MeshForge <> Long Fast ---
+  # Bridges two Meshtastic networks on different presets.
+  # Requires two radios, each running meshtasticd on a separate TCP port.
+  # RNS routes traffic between interfaces automatically.
+  #
+  # Radio 1: meshtasticd --host 127.0.0.1 --port 4403 (Short Turbo)
+  # Radio 2: meshtasticd --host 127.0.0.1 --port 4404 (Long Fast)
+
+  # [[Meshtastic Short Turbo]]
+  #   type = Meshtastic_Interface
+  #   enabled = true
+  #   mode = gateway
+  #   tcp_port = 127.0.0.1:4403
+  #   data_speed = 8
+
+  # [[Meshtastic Long Fast]]
+  #   type = Meshtastic_Interface
+  #   enabled = true
+  #   mode = gateway
+  #   tcp_port = 127.0.0.1:4404
+  #   data_speed = 0
+
 
   # ===========================================================================
   # TCP SERVER INTERFACE - Host an RNS entry point


### PR DESCRIPTION
Added commented-out example for bridging two Meshtastic networks on different presets through a single MeshForge gateway. Two radios run separate meshtasticd instances on different TCP ports, and RNS routes traffic between the interfaces automatically.

https://claude.ai/code/session_01GdTbaGYtjvYQhbzovfQWcZ