### PR TITLE
fix: Use centralized find_meshtastic_cli() for CLI path resolution

### DIFF
--- a/src/cli/meshtastic_cli.py
+++ b/src/cli/meshtastic_cli.py
@@ -261,7 +261,8 @@ class MeshtasticCLI:
         console.print("\n[bold cyan]Meshtastic CLI Help[/bold cyan]\n")
         # Run without connection args for help
         try:
-            result = subprocess.run(["meshtastic", "-h"], capture_output=True, text=True, timeout=15)
+            cli_path = self._cli_path or 'meshtastic'
+            result = subprocess.run([cli_path, "-h"], capture_output=True, text=True, timeout=15)
             console.print(result.stdout)
         except Exception as e:
             console.print(f"[red]Error: {e}[/red]")

--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -110,12 +110,25 @@ def get_local_ip():
         return "localhost"
 
 
+def _find_cli():
+    """Find meshtastic CLI path using centralized resolver."""
+    try:
+        from utils.cli import find_meshtastic_cli
+        return find_meshtastic_cli()
+    except ImportError:
+        import shutil
+        return shutil.which('meshtastic')
+
+
 def get_radio_info():
     """Get meshtastic radio info via CLI."""
     info = {}
     try:
+        cli_path = _find_cli()
+        if not cli_path:
+            return info
         result = subprocess.run(
-            ['meshtastic', '--info'],
+            [cli_path, '--info'],
             capture_output=True, text=True, timeout=15
         )
         if result.returncode == 0:
@@ -140,8 +153,11 @@ def get_radio_info():
 def get_node_count():
     """Get number of known nodes."""
     try:
+        cli_path = _find_cli()
+        if not cli_path:
+            return None
         result = subprocess.run(
-            ['meshtastic', '--nodes'],
+            [cli_path, '--nodes'],
             capture_output=True, text=True, timeout=15
         )
         if result.returncode == 0:

--- a/src/commands/device_backup.py
+++ b/src/commands/device_backup.py
@@ -141,6 +141,18 @@ def create_backup(
     }
 
     try:
+        # Find meshtastic CLI
+        try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+        except ImportError:
+            import shutil
+            cli_path = shutil.which('meshtastic')
+
+        if not cli_path:
+            result['error'] = "meshtastic CLI not found - install with: pipx install meshtastic[cli]"
+            return result
+
         # Determine connection args
         if connection.startswith('/dev/'):
             conn_args = ['--port', connection]
@@ -151,7 +163,7 @@ def create_backup(
 
         # Get device info first
         info_result = subprocess.run(
-            ['meshtastic'] + conn_args + ['--info'],
+            [cli_path] + conn_args + ['--info'],
             capture_output=True, text=True, timeout=30
         )
 
@@ -182,7 +194,7 @@ def create_backup(
 
         # Export full config
         export_result = subprocess.run(
-            ['meshtastic'] + conn_args + ['--export-config'],
+            [cli_path] + conn_args + ['--export-config'],
             capture_output=True, text=True, timeout=30
         )
 
@@ -320,6 +332,18 @@ def restore_backup(
                 result['restored_items'].append(f"Would restore: {len(backup.channels)} channel(s)")
             return result
 
+        # Find meshtastic CLI
+        try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+        except ImportError:
+            import shutil
+            cli_path = shutil.which('meshtastic')
+
+        if not cli_path:
+            result['error'] = "meshtastic CLI not found - install with: pipx install meshtastic[cli]"
+            return result
+
         # Determine connection args
         if connection.startswith('/dev/'):
             conn_args = ['--port', connection]
@@ -334,7 +358,7 @@ def restore_backup(
                 if 'url' in channel:
                     url = channel['url']
                     cmd_result = subprocess.run(
-                        ['meshtastic'] + conn_args + ['--seturl', url],
+                        [cli_path] + conn_args + ['--seturl', url],
                         capture_output=True, text=True, timeout=30
                     )
                     if cmd_result.returncode == 0:
@@ -349,7 +373,7 @@ def restore_backup(
 
             if long_name:
                 cmd_result = subprocess.run(
-                    ['meshtastic'] + conn_args + ['--set-owner', long_name],
+                    [cli_path] + conn_args + ['--set-owner', long_name],
                     capture_output=True, text=True, timeout=30
                 )
                 if cmd_result.returncode == 0:
@@ -357,7 +381,7 @@ def restore_backup(
 
             if short_name:
                 cmd_result = subprocess.run(
-                    ['meshtastic'] + conn_args + ['--set-owner-short', short_name],
+                    [cli_path] + conn_args + ['--set-owner-short', short_name],
                     capture_output=True, text=True, timeout=30
                 )
                 if cmd_result.returncode == 0:

--- a/src/config/config_file_manager.py
+++ b/src/config/config_file_manager.py
@@ -1174,7 +1174,14 @@ Logging:
         console.print(f"\n[cyan]Setting position to {latitude}, {longitude}...[/cyan]")
 
         try:
-            cmd = ['meshtastic', '--host', 'localhost', '--setlat', str(latitude), '--setlon', str(longitude)]
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+            if not cli_path:
+                console.print("[red]meshtastic CLI not found[/red]")
+                console.print("[dim]Install with: pipx install meshtastic[cli][/dim]")
+                return False
+
+            cmd = [cli_path, '--host', 'localhost', '--setlat', str(latitude), '--setlon', str(longitude)]
             if altitude is not None:
                 cmd.extend(['--setalt', str(altitude)])
 
@@ -1191,12 +1198,12 @@ Logging:
                     console.print(f"[dim]{result.stderr.strip()}[/dim]")
                 console.print("\n[yellow]Troubleshooting:[/yellow]")
                 console.print("  - Is meshtasticd running? Check: systemctl status meshtasticd")
-                console.print("  - Is meshtastic CLI installed? pip install meshtastic")
+                console.print("  - Is meshtastic CLI installed? pipx install meshtastic[cli]")
                 return False
 
         except FileNotFoundError:
             console.print("[red]meshtastic CLI not found[/red]")
-            console.print("[dim]Install with: pip install meshtastic[/dim]")
+            console.print("[dim]Install with: pipx install meshtastic[cli][/dim]")
             return False
         except subprocess.TimeoutExpired:
             console.print("[red]Command timed out (30s)[/red]")

--- a/src/config/radio.py
+++ b/src/config/radio.py
@@ -322,7 +322,14 @@ class RadioConfigurator:
         console.print(f"\n[cyan]Setting position to {lat}, {lon}...[/cyan]")
 
         try:
-            cmd = ['meshtastic', '--host', host, '--setlat', str(lat), '--setlon', str(lon)]
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+            if not cli_path:
+                console.print("[red]meshtastic CLI not found[/red]")
+                console.print("[dim]Install with: pipx install meshtastic[cli][/dim]")
+                return False
+
+            cmd = [cli_path, '--host', host, '--setlat', str(lat), '--setlon', str(lon)]
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
 
             if result.returncode == 0:
@@ -335,7 +342,7 @@ class RadioConfigurator:
 
         except FileNotFoundError:
             console.print("[red]meshtastic CLI not found[/red]")
-            console.print("[dim]Install with: pip install meshtastic[/dim]")
+            console.print("[dim]Install with: pipx install meshtastic[cli][/dim]")
             return False
         except subprocess.TimeoutExpired:
             console.print("[red]Command timed out[/red]")

--- a/src/core/meshtastic_cli.py
+++ b/src/core/meshtastic_cli.py
@@ -82,8 +82,12 @@ class MeshtasticCLI:
             logger.warning("meshtastic CLI not found in PATH")
 
     def _find_cli(self) -> Optional[str]:
-        """Find meshtastic CLI in PATH."""
-        return shutil.which('meshtastic')
+        """Find meshtastic CLI using centralized path resolver."""
+        try:
+            from utils.cli import find_meshtastic_cli
+            return find_meshtastic_cli()
+        except ImportError:
+            return shutil.which('meshtastic')
 
     def _build_base_args(self) -> List[str]:
         """Build base CLI arguments for connection."""

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -393,7 +393,11 @@ General:
 
     def is_python_cli_installed(self) -> bool:
         """Check if Python meshtastic CLI is installed."""
-        return shutil.which("meshtastic") is not None
+        try:
+            from utils.cli import find_meshtastic_cli
+            return find_meshtastic_cli() is not None
+        except ImportError:
+            return shutil.which("meshtastic") is not None
 
     def get_native_deb_url(self, arch: str = "arm64") -> str:
         """

--- a/src/gateway/profiles/__init__.py
+++ b/src/gateway/profiles/__init__.py
@@ -244,8 +244,23 @@ class ProfileManager:
                 'command': None
             }
 
+        # Find meshtastic CLI
+        try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+        except ImportError:
+            import shutil
+            cli_path = shutil.which('meshtastic')
+
+        if not cli_path:
+            return {
+                'success': False,
+                'message': "meshtastic CLI not found. Install with: pipx install meshtastic[cli]",
+                'command': None
+            }
+
         # Build command
-        cmd = ['meshtastic', '--configure', str(path)]
+        cmd = [cli_path, '--configure', str(path)]
 
         if port:
             cmd.extend(['--port', port])

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -1468,8 +1468,14 @@ class RNSMeshtasticBridge:
     def _test_meshtastic_cli(self) -> bool:
         """Test Meshtastic CLI availability"""
         try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+            if not cli_path:
+                logger.debug("Meshtastic CLI not found")
+                return False
+
             result = subprocess.run(
-                ['meshtastic', '--info'],
+                [cli_path, '--info'],
                 capture_output=True,
                 timeout=10
             )
@@ -1489,7 +1495,9 @@ class RNSMeshtasticBridge:
     def _send_via_cli(self, message: str, destination: str = None, channel: int = 0) -> bool:
         """Send via Meshtastic CLI as fallback"""
         try:
-            cmd = ['meshtastic', '--host', self.config.meshtastic.host, '--sendtext', message]
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli() or 'meshtastic'
+            cmd = [cli_path, '--host', self.config.meshtastic.host, '--sendtext', message]
             if destination:
                 cmd.extend(['--dest', destination])
             if channel > 0:

--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -666,8 +666,9 @@ class AIToolsMixin:
                 return []
 
             # Try to get node list via meshtastic CLI
+            cli_path = self._get_meshtastic_cli()
             result = subprocess.run(
-                ['meshtastic', '--host', 'localhost', '--info'],
+                [cli_path, '--host', 'localhost', '--info'],
                 capture_output=True, text=True, timeout=30
             )
 

--- a/src/launcher_tui/emergency_mode_mixin.py
+++ b/src/launcher_tui/emergency_mode_mixin.py
@@ -88,8 +88,9 @@ class EmergencyModeMixin:
         subprocess.run(['clear'], check=False, timeout=5)
         print(f"Broadcasting: {full_msg}\n")
         try:
+            cli_path = self._get_meshtastic_cli()
             subprocess.run(
-                ['meshtastic', '--sendtext', full_msg],
+                [cli_path, '--sendtext', full_msg],
                 timeout=30
             )
             print("\nMessage sent.")
@@ -151,8 +152,9 @@ class EmergencyModeMixin:
         subprocess.run(['clear'], check=False, timeout=5)
         print(f"Sending to {dest_clean}: {full_msg}\n")
         try:
+            cli_path = self._get_meshtastic_cli()
             subprocess.run(
-                ['meshtastic', '--dest', dest_clean, '--sendtext', full_msg],
+                [cli_path, '--dest', dest_clean, '--sendtext', full_msg],
                 timeout=30
             )
             print("\nMessage sent.")
@@ -170,13 +172,14 @@ class EmergencyModeMixin:
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== NODES ONLINE ===\n")
         try:
+            cli_path = self._get_meshtastic_cli()
             subprocess.run(
-                ['meshtastic', '--nodes'],
+                [cli_path, '--nodes'],
                 timeout=30
             )
         except FileNotFoundError:
             print("ERROR: meshtastic CLI not available.")
-            print("Install: pip install meshtastic")
+            print("Install: pipx install meshtastic[cli]")
         except subprocess.TimeoutExpired:
             print("ERROR: Command timed out.")
         except Exception as e:
@@ -228,8 +231,9 @@ class EmergencyModeMixin:
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== MY POSITION ===\n")
         try:
+            cli_path = self._get_meshtastic_cli()
             subprocess.run(
-                ['meshtastic', '--get', 'position'],
+                [cli_path, '--get', 'position'],
                 timeout=30
             )
         except FileNotFoundError:
@@ -282,8 +286,9 @@ class EmergencyModeMixin:
                 count += 1
                 print(f"  [{count}] Sending beacon... ", end="", flush=True)
                 try:
+                    cli_path = self._get_meshtastic_cli()
                     result = subprocess.run(
-                        ['meshtastic', '--sendtext', beacon_msg],
+                        [cli_path, '--sendtext', beacon_msg],
                         capture_output=True, timeout=30
                     )
                     if result.returncode == 0:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -123,7 +123,11 @@ class MeshForgeLauncher(
     def _get_meshtastic_cli(self) -> str:
         """Find the meshtastic CLI binary path, with caching."""
         if self._meshtastic_path is None:
-            self._meshtastic_path = shutil.which('meshtastic') or 'meshtastic'
+            try:
+                from utils.cli import find_meshtastic_cli
+                self._meshtastic_path = find_meshtastic_cli() or 'meshtastic'
+            except ImportError:
+                self._meshtastic_path = shutil.which('meshtastic') or 'meshtastic'
         return self._meshtastic_path
 
     @staticmethod
@@ -353,7 +357,7 @@ class MeshForgeLauncher(
         """Radio tools using meshtastic CLI directly."""
         while True:
             # Check if CLI is available and show install option if not
-            has_cli = shutil.which('meshtastic') is not None
+            has_cli = self._get_meshtastic_cli() != 'meshtastic'
 
             choices = []
             if not has_cli:
@@ -487,8 +491,8 @@ class MeshForgeLauncher(
             if result.returncode == 0:
                 # Clear cached path so it gets re-resolved
                 self._meshtastic_path = None
-                cli_path = shutil.which('meshtastic')
-                if cli_path:
+                cli_path = self._get_meshtastic_cli()
+                if cli_path and cli_path != 'meshtastic':
                     print(f"\n** meshtastic CLI installed: {cli_path} **")
                 else:
                     print("\n** meshtastic installed but not found in PATH **")

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -358,8 +358,9 @@ Press Cancel to keep current values."""
         except ImportError:
             # Fallback: direct subprocess call
             try:
+                cli_path = self._get_meshtastic_cli()
                 result = subprocess.run(
-                    ['meshtastic', '--host', 'localhost:4403',
+                    [cli_path, '--host', 'localhost:4403',
                      '--set', 'lora.modem_preset', preset],
                     capture_output=True, text=True, timeout=30
                 )
@@ -369,7 +370,7 @@ Press Cancel to keep current values."""
                     return
 
                 subprocess.run(
-                    ['meshtastic', '--host', 'localhost:4403',
+                    [cli_path, '--host', 'localhost:4403',
                      '--set', 'lora.channel_num', str(freq_slot)],
                     capture_output=True, text=True, timeout=30
                 )

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -110,13 +110,14 @@ class QuickActionsMixin:
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== Node List ===\n")
         try:
+            cli_path = self._get_meshtastic_cli()
             subprocess.run(
-                ['meshtastic', '--nodes'],
+                [cli_path, '--nodes'],
                 timeout=30
             )
         except FileNotFoundError:
             print("Error: 'meshtastic' CLI not installed.")
-            print("Install with: pip install meshtastic")
+            print("Install with: pipx install meshtastic[cli]")
         except subprocess.TimeoutExpired:
             print("Error: Command timed out. Is meshtasticd running?")
         except Exception as e:

--- a/src/utils/channel_scan.py
+++ b/src/utils/channel_scan.py
@@ -238,8 +238,14 @@ class ChannelMonitor:
         """
         channels = []
         try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+            if not cli_path:
+                logger.debug("meshtastic CLI not available")
+                return channels
+
             result = subprocess.run(
-                ['meshtastic', '--info'],
+                [cli_path, '--info'],
                 capture_output=True, text=True, timeout=15
             )
             if result.returncode == 0:

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -19,8 +19,10 @@ def find_meshtastic_cli():
 
     Checks multiple locations where meshtastic CLI might be installed:
     - System PATH (via shutil.which)
-    - pipx installation paths (/root/.local/bin, /home/pi/.local/bin, ~/.local/bin)
-    - Common installation locations
+    - SUDO_USER's ~/.local/bin (pip/pipx install as user, run with sudo)
+    - /root/.local/bin (pip install as root)
+    - All /home/*/.local/bin directories (fallback scan)
+    - /usr/local/bin (system-wide pip install)
 
     Returns:
         str: Full path to meshtastic CLI, or None if not found
@@ -30,21 +32,36 @@ def find_meshtastic_cli():
     if cli_path:
         return cli_path
 
-    # Check common pipx installation paths
-    pipx_paths = [
+    # Priority: check the real user's home first (handles sudo case)
+    # When running with sudo, the CLI is usually in the invoking user's ~/.local/bin
+    sudo_user = os.environ.get('SUDO_USER')
+    if sudo_user and sudo_user != 'root':
+        user_path = f'/home/{sudo_user}/.local/bin/meshtastic'
+        if os.path.isfile(user_path) and os.access(user_path, os.X_OK):
+            return user_path
+
+    # Check common known locations
+    known_paths = [
         '/root/.local/bin/meshtastic',
-        '/home/pi/.local/bin/meshtastic',
         os.path.expanduser('~/.local/bin/meshtastic'),
+        '/usr/local/bin/meshtastic',
     ]
 
-    # Also check for the original user's home if running with sudo
-    sudo_user = os.environ.get('SUDO_USER')
-    if sudo_user:
-        pipx_paths.append(f'/home/{sudo_user}/.local/bin/meshtastic')
-
-    for path in pipx_paths:
+    for path in known_paths:
         if os.path.isfile(path) and os.access(path, os.X_OK):
             return path
+
+    # Fallback: scan all user home directories in /home/
+    try:
+        home_base = Path('/home')
+        if home_base.is_dir():
+            for user_dir in home_base.iterdir():
+                if user_dir.is_dir():
+                    candidate = user_dir / '.local' / 'bin' / 'meshtastic'
+                    if candidate.is_file() and os.access(str(candidate), os.X_OK):
+                        return str(candidate)
+    except (PermissionError, OSError):
+        pass
 
     return None
 

--- a/src/utils/device_backup.py
+++ b/src/utils/device_backup.py
@@ -249,7 +249,18 @@ class DeviceBackupManager:
 
     def _run_meshtastic_cmd(self, args: List[str], host: str, port: int) -> str:
         """Run meshtastic CLI command and return output."""
-        cmd = ["meshtastic", "--host", host, "--port", str(port)] + args
+        try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+        except ImportError:
+            import shutil
+            cli_path = shutil.which('meshtastic')
+
+        if not cli_path:
+            logger.error("[Backup] meshtastic CLI not found")
+            return ""
+
+        cmd = [cli_path, "--host", host, "--port", str(port)] + args
         logger.debug(f"[Backup] Running: {' '.join(cmd)}")
 
         try:

--- a/src/utils/lora_presets.py
+++ b/src/utils/lora_presets.py
@@ -477,12 +477,14 @@ def detect_meshtastic_settings(verbose: bool = False) -> Optional[Dict]:
     except Exception as e:
         log_attempt("meshtasticd systemd service", False, str(e))
 
-    # Check if meshtastic CLI is available
-    meshtastic_cli_available = True
+    # Check if meshtastic CLI is available using centralized finder
     try:
-        subprocess.run(['which', 'meshtastic'], capture_output=True, timeout=5)
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        meshtastic_cli_available = False
+        from utils.cli import find_meshtastic_cli as _find_cli
+        _meshtastic_cli_path = _find_cli()
+    except ImportError:
+        import shutil
+        _meshtastic_cli_path = shutil.which('meshtastic')
+    meshtastic_cli_available = _meshtastic_cli_path is not None
 
     def run_meshtastic_cmd(args: list, timeout: int = 10) -> tuple:
         """Run meshtastic CLI with detailed error handling.
@@ -495,7 +497,7 @@ def detect_meshtastic_settings(verbose: bool = False) -> Optional[Dict]:
 
         try:
             result = subprocess.run(
-                ['meshtastic'] + args,
+                [_meshtastic_cli_path] + args,
                 capture_output=True,
                 text=True,
                 timeout=timeout

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -293,8 +293,14 @@ class MapDataCollector:
     def _collect_via_cli(self) -> List[Dict]:
         """Fall back to CLI parsing when Python TCP interface unavailable."""
         try:
+            from utils.cli import find_meshtastic_cli
+            cli_path = find_meshtastic_cli()
+            if not cli_path:
+                logger.debug("meshtastic CLI not found")
+                return []
+
             result = subprocess.run(
-                ['meshtastic', '--host', 'localhost', '--info'],
+                [cli_path, '--host', 'localhost', '--info'],
                 capture_output=True, text=True, timeout=15
             )
             if result.returncode != 0:

--- a/src/utils/startup_health.py
+++ b/src/utils/startup_health.py
@@ -221,9 +221,13 @@ def detect_hardware() -> HardwareHealth:
 def get_node_count() -> int:
     """Get count of visible nodes."""
     try:
-        # Try to get node count from meshtastic CLI
+        from utils.cli import find_meshtastic_cli
+        cli_path = find_meshtastic_cli()
+        if not cli_path:
+            return 0
+
         result = subprocess.run(
-            ['meshtastic', '--host', 'localhost', '--info'],
+            [cli_path, '--host', 'localhost', '--info'],
             capture_output=True, text=True, timeout=10
         )
         if result.returncode == 0:


### PR DESCRIPTION
When meshtastic CLI is installed via pip/pipx as a regular user (e.g. to ~/.local/bin/meshtastic), running MeshForge with sudo causes shutil.which() to fail because root's PATH doesn't include the user's ~/.local/bin directory.

The centralized find_meshtastic_cli() in utils/cli.py already handled this by checking SUDO_USER, pipx paths, and common install locations, but most of the codebase bypassed it using shutil.which() directly or hardcoded 'meshtastic' strings in subprocess calls.

Changes:
- Enhanced find_meshtastic_cli() to also scan /home/*/.local/bin/ as a fallback and check /usr/local/bin
- Updated 20 files across the codebase to use the centralized path resolver instead of bare shutil.which('meshtastic')
- Replaced all hardcoded ['meshtastic', ...] subprocess calls with resolved CLI path
- Standardized install instructions to pipx install meshtastic[cli]

https://claude.ai/code/session_01JZfnYJv3h52trLYWqDTE9q