### PR TITLE
fix: Handle KeyboardInterrupt gracefully in launcher TUI input() calls

### DIFF
--- a/src/launcher_tui/emergency_mode_mixin.py
+++ b/src/launcher_tui/emergency_mode_mixin.py
@@ -101,7 +101,7 @@ class EmergencyModeMixin:
         except Exception as e:
             print(f"ERROR: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _emcomm_direct(self):
         """Send a direct message to a specific node."""
@@ -165,7 +165,7 @@ class EmergencyModeMixin:
         except Exception as e:
             print(f"ERROR: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _emcomm_status(self):
         """Show which nodes are currently online."""
@@ -186,7 +186,7 @@ class EmergencyModeMixin:
             print(f"ERROR: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _emcomm_messages(self):
         """Show recent messages from the mesh."""
@@ -224,7 +224,7 @@ class EmergencyModeMixin:
             print(f"  Error: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _emcomm_position(self):
         """Show current GPS position."""
@@ -244,7 +244,7 @@ class EmergencyModeMixin:
             print(f"ERROR: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _emcomm_sos_beacon(self):
         """Send repeating SOS beacon messages."""
@@ -308,4 +308,4 @@ class EmergencyModeMixin:
         except KeyboardInterrupt:
             print(f"\n\nSOS Beacon stopped after {count} transmission(s).")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -120,6 +120,14 @@ class MeshForgeLauncher(
         self._meshtastic_path = None  # Cached CLI path
         self._bridge_log_path = None  # Path to active bridge log file
 
+    @staticmethod
+    def _wait_for_enter(msg: str = "\nPress Enter to continue...") -> None:
+        """Wait for user to press Enter, handling Ctrl+C gracefully."""
+        try:
+            input(msg)
+        except (KeyboardInterrupt, EOFError):
+            print()  # Clean newline after ^C
+
     def _get_meshtastic_cli(self) -> str:
         """Find the meshtastic CLI binary path, with caching."""
         if self._meshtastic_path is None:
@@ -425,7 +433,7 @@ class MeshForgeLauncher(
         except KeyboardInterrupt:
             print("\n\nAborted.")
         try:
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
         except KeyboardInterrupt:
             print()
 
@@ -458,7 +466,7 @@ class MeshForgeLauncher(
                 if result.returncode != 0:
                     print("\nFailed to install pipx.")
                     print("Try manually: sudo apt install pipx")
-                    input("\nPress Enter to continue...")
+                    self._wait_for_enter()
                     return
 
             # Ensure pipx bin dir is in PATH for this session
@@ -515,7 +523,7 @@ class MeshForgeLauncher(
             print("Try manually: pipx install meshtastic")
 
         try:
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
         except KeyboardInterrupt:
             print()
 
@@ -742,32 +750,32 @@ class MeshForgeLauncher(
                     ['journalctl', '-p', 'err', '--since', '1 hour ago', '--no-pager'],
                     timeout=30
                 )
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "mesh-50":
                 print("=== meshtasticd (last 50 lines) ===\n")
                 subprocess.run(
                     ['journalctl', '-u', 'meshtasticd', '-n', '50', '--no-pager'],
                     timeout=15
                 )
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "rns-50":
                 print("=== rnsd (last 50 lines) ===\n")
                 subprocess.run(
                     ['journalctl', '-u', 'rnsd', '-n', '50', '--no-pager'],
                     timeout=15
                 )
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "boot":
                 print("=== Boot messages (this boot) ===\n")
                 subprocess.run(
                     ['journalctl', '-b', '-n', '100', '--no-pager'],
                     timeout=15
                 )
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "kernel":
                 print("=== Kernel messages (dmesg) ===\n")
                 subprocess.run(['dmesg', '--time-format=reltime'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "meshforge":
                 self._view_meshforge_logs()
 
@@ -805,22 +813,22 @@ class MeshForgeLauncher(
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Listening Ports ===\n")
                 subprocess.run(['ss', '-tlnp'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "ifaces":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Network Interfaces ===\n")
                 subprocess.run(['ip', '-c', 'addr'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "conns":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Active Connections ===\n")
                 subprocess.run(['ss', '-tunp'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "routes":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Routing Table ===\n")
                 subprocess.run(['ip', 'route'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "ping":
                 self._ping_test()
             elif choice == "dns":
@@ -864,12 +872,12 @@ class MeshForgeLauncher(
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== RNS Status ===\n")
                 self._run_rns_tool(['rnstatus'], 'rnstatus')
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "paths":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== RNS Path Table ===\n")
                 self._run_rns_tool(['rnpath', '-t'], 'rnpath')
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "probe":
                 self._rns_probe_destination()
             elif choice == "identity":
@@ -898,19 +906,23 @@ class MeshForgeLauncher(
         print("Probe tests reachability of a destination on the RNS network.")
         print("Enter the full destination hash (32 hex chars), or a partial hash.\n")
 
-        dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+        try:
+            dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
         if not dest_hash or dest_hash.lower() == 'q':
             return
 
         # Validate hex format to prevent flag injection
         if not re.match(r'^[0-9a-fA-F]+$', dest_hash):
             print("Error: Hash must contain only hex characters (0-9, a-f).")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         print(f"\nProbing {dest_hash}...\n")
         self._run_rns_tool(['rnprobe', dest_hash], 'rnprobe')
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _rns_identity_info(self):
         """Show RNS identity information."""
@@ -951,7 +963,7 @@ class MeshForgeLauncher(
                         print("  Status: not created (starts on first bridge run)")
                 except ImportError:
                     pass
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
 
             elif choice == "path":
                 subprocess.run(['clear'], check=False, timeout=5)
@@ -981,20 +993,24 @@ class MeshForgeLauncher(
                         print("  Not created yet")
                 except ImportError:
                     pass
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
 
             elif choice == "recall":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Recall RNS Identity ===\n")
                 print("Look up a known identity by its destination hash.\n")
-                dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+                try:
+                    dest_hash = input("Destination hash (or 'q' to cancel): ").strip()
+                except (KeyboardInterrupt, EOFError):
+                    print()
+                    continue
                 if dest_hash and dest_hash.lower() != 'q':
                     # Validate hex format to prevent flag injection
                     if not re.match(r'^[0-9a-fA-F]+$', dest_hash):
                         print("Error: Hash must contain only hex characters (0-9, a-f).")
                     else:
                         self._run_rns_tool(['rnid', '--recall', dest_hash], 'rnid')
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
 
     def _rns_known_destinations(self):
         """Show known RNS destinations from the running rnsd instance."""
@@ -1034,7 +1050,7 @@ class MeshForgeLauncher(
             print("Commands module not available, falling back to rnstatus...\n")
             self._run_rns_tool(['rnstatus', '-a'], 'rnstatus')
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _rns_diagnostics(self):
         """Run comprehensive RNS diagnostics."""
@@ -1046,7 +1062,7 @@ class MeshForgeLauncher(
         except ImportError:
             print("RNS commands module not available.")
             print("Run from MeshForge root: sudo python3 src/launcher_tui/main.py")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         # 1. Service status
@@ -1104,7 +1120,7 @@ class MeshForgeLauncher(
             else:
                 print(f"  {tool}: not found")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     @staticmethod
     def _is_root_owned_rns_config(config_path: Path) -> bool:
@@ -1338,7 +1354,7 @@ class MeshForgeLauncher(
             print(f"  Source: https://github.com/landandair/RNS_Over_Meshtastic")
             print(f"  Use 'Install Meshtastic Interface' from the RNS menu to install.")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _edit_rns_config(self):
         """Edit Reticulum config with available editor. Deploys template if no config exists."""
@@ -1712,7 +1728,7 @@ class MeshForgeLauncher(
                 print("No AREDN node found on local network.")
                 print("\nTried: localnode.local.mesh, 10.0.0.1")
                 print("\nIs your AREDN node connected?")
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
                 return
 
             print(f"Connecting to {node_ip}...\n")
@@ -1741,7 +1757,7 @@ class MeshForgeLauncher(
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _aredn_neighbors(self):
         """Show AREDN neighbor links."""
@@ -1754,7 +1770,7 @@ class MeshForgeLauncher(
             node_ip = self._aredn_get_node_ip()
             if not node_ip:
                 print("No AREDN node found. Is it connected?")
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
                 return
 
             client = AREDNClient(node_ip)
@@ -1776,7 +1792,7 @@ class MeshForgeLauncher(
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _aredn_services(self):
         """Show AREDN advertised services."""
@@ -1789,7 +1805,7 @@ class MeshForgeLauncher(
             node_ip = self._aredn_get_node_ip()
             if not node_ip:
                 print("No AREDN node found.")
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
                 return
 
             client = AREDNClient(node_ip)
@@ -1816,7 +1832,7 @@ class MeshForgeLauncher(
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _aredn_web(self):
         """Show AREDN web UI URL."""
@@ -1864,7 +1880,7 @@ class MeshForgeLauncher(
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Config Menu - meshtasticd config.d/ management
@@ -1929,7 +1945,7 @@ class MeshForgeLauncher(
             print("  sudo apt install meshtasticd")
             print("  # or run the MeshForge installer")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _view_config_overlays(self):
         """Show config.d/ overlay files."""
@@ -1940,7 +1956,7 @@ class MeshForgeLauncher(
         if not config_d.exists():
             print("config.d/ directory not found.")
             print("Create it: sudo mkdir -p /etc/meshtasticd/config.d")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         overlays = sorted(config_d.glob('*.yaml'))
@@ -1963,7 +1979,7 @@ class MeshForgeLauncher(
                 except PermissionError:
                     print("  (permission denied)")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _view_available_hats(self):
         """Show available HAT configurations from meshtasticd package."""
@@ -1975,7 +1991,7 @@ class MeshForgeLauncher(
             print("available.d/ not found.")
             print("meshtasticd package should provide this.")
             print("\nInstall: sudo apt install meshtasticd")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         configs = sorted(available_d.glob('*.yaml'))
@@ -1992,7 +2008,7 @@ class MeshForgeLauncher(
             print("  sudo systemctl restart meshtasticd")
             print("\nWARNING: Only ONE Lora config should be in config.d/")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _open_web_client(self):
         """Show/open meshtasticd web client for full radio configuration."""
@@ -2078,13 +2094,13 @@ class MeshForgeLauncher(
             else:
                 print("No status output available.")
                 try:
-                    input("\nPress Enter to continue...")
+                    self._wait_for_enter()
                 except KeyboardInterrupt:
                     print()
         except subprocess.TimeoutExpired:
             print("\n\nStatus check timed out (30s).")
             try:
-                input("\nPress Enter to return to menu...")
+                self._wait_for_enter("\nPress Enter to return to menu...")
             except KeyboardInterrupt:
                 print()
         except KeyboardInterrupt:
@@ -2156,7 +2172,7 @@ class MeshForgeLauncher(
         print()
         print("-" * 50)
         try:
-            input("\nPress Enter to return to menu...")
+            self._wait_for_enter("\nPress Enter to return to menu...")
         except KeyboardInterrupt:
             print()
 
@@ -2184,7 +2200,7 @@ class MeshForgeLauncher(
             print(f"=== MeshForge Log: {latest_log.name} ===\n")
             print('\n'.join(lines))
             print("\n" + "=" * 50)
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to read log: {e}")
 
@@ -2418,7 +2434,7 @@ class MeshForgeLauncher(
         except KeyboardInterrupt:
             print("\nBridge stopped.")
         try:
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
         except KeyboardInterrupt:
             print()
 
@@ -2557,19 +2573,19 @@ class MeshForgeLauncher(
                             print()
                     except Exception:
                         pass
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "restart-mesh":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("Restarting meshtasticd...\n")
                 subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30)
                 subprocess.run(['systemctl', 'status', 'meshtasticd', '--no-pager', '-l'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "restart-rns":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("Restarting rnsd...\n")
                 subprocess.run(['systemctl', 'restart', 'rnsd'], timeout=30)
                 subprocess.run(['systemctl', 'status', 'rnsd', '--no-pager', '-l'], timeout=10)
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
             elif choice == "install":
                 self._install_native_meshtasticd()
             else:
@@ -2840,7 +2856,7 @@ WantedBy=multi-user.target
                 ['systemctl', 'status', service_name, '--no-pager', '-l'],
                 timeout=10
             )
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif action == "start":
             print(f"Starting {service_name}...\n")
@@ -2849,7 +2865,7 @@ WantedBy=multi-user.target
                 ['systemctl', 'status', service_name, '--no-pager', '-l'],
                 timeout=10
             )
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif action == "stop":
             if self.dialog.yesno("Confirm", f"Stop {service_name}?", default_no=True):
@@ -2857,7 +2873,7 @@ WantedBy=multi-user.target
                 print(f"Stopping {service_name}...\n")
                 subprocess.run(['systemctl', 'stop', service_name], timeout=30)
                 print(f"{service_name} stopped.")
-                input("\nPress Enter to continue...")
+                self._wait_for_enter()
 
         elif action == "restart":
             print(f"Restarting {service_name}...\n")
@@ -2866,7 +2882,7 @@ WantedBy=multi-user.target
                 ['systemctl', 'status', service_name, '--no-pager', '-l'],
                 timeout=10
             )
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif action == "logs":
             print(f"=== {service_name} logs (last 30) ===\n")
@@ -2874,7 +2890,7 @@ WantedBy=multi-user.target
                 ['journalctl', '-u', service_name, '-n', '30', '--no-pager'],
                 timeout=15
             )
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
     def _hardware_menu(self):
         """Hardware detection and configuration menu."""
@@ -2946,7 +2962,7 @@ WantedBy=multi-user.target
         else:
             print("  (not found)")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _enable_spi(self):
         """Enable SPI interface for HAT-based radios."""
@@ -3187,8 +3203,12 @@ Made with aloha for the mesh community
 
 def main():
     """Main entry point."""
-    launcher = MeshForgeLauncher()
-    launcher.run()
+    try:
+        launcher = MeshForgeLauncher()
+        launcher.run()
+    except KeyboardInterrupt:
+        print("\n\nExiting MeshForge...")
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -197,7 +197,7 @@ class NomadNetClientMixin:
         except Exception:
             print("  rnsd:      (check failed)")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # ------------------------------------------------------------------
     # Launch text UI
@@ -380,7 +380,7 @@ class NomadNetClientMixin:
             print(f"  3. {user_home}/.nomadnetwork/config")
             print("\nRun 'Launch Text UI' to create the default config.")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _edit_nomadnet_config(self):
         """Edit NomadNet config with available editor."""
@@ -491,7 +491,7 @@ class NomadNetClientMixin:
                 if result.returncode != 0:
                     print("\nFailed to install pipx.")
                     print("Try manually: sudo apt install pipx")
-                    input("\nPress Enter to continue...")
+                    self._wait_for_enter()
                     return
 
             # Ensure pipx bin dir is in PATH for this session
@@ -539,7 +539,7 @@ class NomadNetClientMixin:
             print("Try manually: pipx install nomadnet")
 
         try:
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
         except (EOFError, KeyboardInterrupt):
             pass
 

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -103,7 +103,7 @@ class QuickActionsMixin:
             print(f"  ? {'rns_bridge':<18} unknown")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_node_list(self):
         """Quick: show meshtastic node list."""
@@ -123,7 +123,7 @@ class QuickActionsMixin:
         except Exception as e:
             print(f"Error: {e}")
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_follow_logs(self):
         """Quick: follow meshtasticd journal logs."""
@@ -140,7 +140,7 @@ class QuickActionsMixin:
             pass  # User pressed Ctrl+C
         except Exception as e:
             print(f"Error: {e}")
-            input("Press Enter to continue...")
+            self._wait_for_enter("Press Enter to continue...")
 
     def _qa_restart_meshtasticd(self):
         """Quick: restart meshtasticd service."""
@@ -163,7 +163,7 @@ class QuickActionsMixin:
             self._status_bar.invalidate()
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_restart_rnsd(self):
         """Quick: restart rnsd service."""
@@ -186,7 +186,7 @@ class QuickActionsMixin:
             self._status_bar.invalidate()
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_port_check(self):
         """Quick: check network ports."""
@@ -214,7 +214,7 @@ class QuickActionsMixin:
                 print(f"  ? {port:<6} {desc} (check failed)")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_generate_report(self):
         """Quick: generate and display a status report."""
@@ -230,7 +230,11 @@ class QuickActionsMixin:
                 print(line)
                 # Pause every 40 lines
                 if (i + 1) % 40 == 0 and i + 1 < len(lines):
-                    resp = input("\n--- More (Enter=continue, q=quit) ---\n")
+                    try:
+                        resp = input("\n--- More (Enter=continue, q=quit) ---\n")
+                    except (KeyboardInterrupt, EOFError):
+                        print()
+                        break
                     if resp.strip().lower() == 'q':
                         break
         except ImportError:
@@ -239,7 +243,7 @@ class QuickActionsMixin:
             print(f"Error generating report: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_node_inventory(self):
         """Quick: show tracked node inventory."""
@@ -291,7 +295,7 @@ class QuickActionsMixin:
             print(f"Error: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_gps_position(self):
         """Quick: show GPS position and distance to nodes."""
@@ -342,7 +346,7 @@ class QuickActionsMixin:
             print(f"Error: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_run_diagnostics(self):
         """Quick: run diagnostic engine health check."""
@@ -376,7 +380,7 @@ class QuickActionsMixin:
             print(f"Error: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")
 
     def _qa_channel_scan(self):
         """Quick: show channel activity scan."""
@@ -406,4 +410,4 @@ class QuickActionsMixin:
             print(f"Error: {e}")
 
         print()
-        input("Press Enter to continue...")
+        self._wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/rns_interfaces_mixin.py
+++ b/src/launcher_tui/rns_interfaces_mixin.py
@@ -70,14 +70,14 @@ class RNSInterfacesMixin:
 
         result = self._rns_cmd_list_interfaces()
         if result is None:
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         interfaces = result.data.get('interfaces', [])
         if not interfaces:
             print("No interfaces found in the Reticulum config.\n")
             print("Use 'Add Interface from Template' to create one.")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
             return
 
         for idx, iface in enumerate(interfaces, 1):
@@ -96,7 +96,7 @@ class RNSInterfacesMixin:
             print()
 
         print(f"Total: {len(interfaces)} interface(s)")
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # ------------------------------------------------------------------
     # Add interface (template-based)

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -177,7 +177,7 @@ class SystemToolsMixin:
         except Exception as e:
             print(f"\nError: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Process Management
@@ -256,7 +256,7 @@ class SystemToolsMixin:
             print(f"Error: {e}")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _show_mesh_processes(self):
         """Show mesh-related processes."""
@@ -293,7 +293,7 @@ class SystemToolsMixin:
             print(f"Error: {e}")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _fuser_port_check(self):
         """Check what's using a specific port."""
@@ -347,7 +347,7 @@ class SystemToolsMixin:
             print(f"Error: {e}")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Network Diagnostics
@@ -415,7 +415,7 @@ class SystemToolsMixin:
                 print(f"Error: {e}")
 
             print("\n" + "=" * 60)
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif cmd_type == 'dns':
             self._dns_lookup()
@@ -470,7 +470,7 @@ class SystemToolsMixin:
                 print(f"Resolution failed: {e}")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _traceroute(self):
         """Run traceroute to a host."""
@@ -504,7 +504,7 @@ class SystemToolsMixin:
         else:
             print("No traceroute tool found. Install: sudo apt install traceroute")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _ping_test(self):
         """Interactive ping test."""
@@ -546,7 +546,7 @@ class SystemToolsMixin:
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _wifi_status(self):
         """Show WiFi status."""
@@ -568,7 +568,7 @@ class SystemToolsMixin:
             print("No WiFi tools found. Install: sudo apt install iw")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Hardware Information
@@ -636,7 +636,7 @@ class SystemToolsMixin:
                 print(f"Error: {e}")
 
             print("\n" + "=" * 60)
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif cmd_type == 'gpio':
             self._gpio_status()
@@ -669,7 +669,7 @@ class SystemToolsMixin:
             print("No GPIO interface found.")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     def _spi_i2c_status(self):
         """Show SPI and I2C status."""
@@ -706,7 +706,7 @@ class SystemToolsMixin:
             print("  No I2C devices found")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Performance Tools
@@ -764,7 +764,7 @@ class SystemToolsMixin:
                 print(f"Error: {e}")
 
             print("\n" + "=" * 60)
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif cmd_type == 'vmstat_live':
             print("=== vmstat 1 (Live - Ctrl+C to stop) ===\n")
@@ -772,7 +772,7 @@ class SystemToolsMixin:
                 subprocess.run(['vmstat', '1'], timeout=None)
             except KeyboardInterrupt:
                 print("\n\nStopped.")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()
 
         elif cmd_type == 'stress':
             self._stress_test_menu()
@@ -822,7 +822,7 @@ class SystemToolsMixin:
         except Exception as e:
             print(f"Error: {e}")
 
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Storage Tools
@@ -912,7 +912,7 @@ class SystemToolsMixin:
                 print("ncdu not found. Install: sudo apt install ncdu")
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Service Management
@@ -1010,7 +1010,7 @@ class SystemToolsMixin:
                     subprocess.run(['systemctl', 'status', unit, '--no-pager'], timeout=10)
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Advanced Log Analysis
@@ -1133,7 +1133,7 @@ class SystemToolsMixin:
                 subprocess.run(['sudo', 'journalctl', '--vacuum-time=2d'], timeout=60)
 
         print("\n" + "=" * 60)
-        input("\nPress Enter to continue...")
+        self._wait_for_enter()
 
     # =========================================================================
     # Drop to Shell
@@ -1164,4 +1164,4 @@ class SystemToolsMixin:
             subprocess.run([shell], timeout=None)
         except Exception as e:
             print(f"Shell error: {e}")
-            input("\nPress Enter to continue...")
+            self._wait_for_enter()

--- a/tests/test_emergency_mode.py
+++ b/tests/test_emergency_mode.py
@@ -69,6 +69,10 @@ class MockLauncher(EmergencyModeMixin):
     def __init__(self):
         self.dialog = MockDialog()
 
+    @staticmethod
+    def _wait_for_enter(msg: str = "\nPress Enter to continue...") -> None:
+        pass
+
 
 class TestEmergencyModeMenu:
     """Test emergency mode menu structure."""

--- a/tests/test_quick_actions.py
+++ b/tests/test_quick_actions.py
@@ -46,6 +46,10 @@ class MockLauncher(QuickActionsMixin):
         self.dialog = MockDialog()
         self._status_bar = None
 
+    @staticmethod
+    def _wait_for_enter(msg: str = "\nPress Enter to continue...") -> None:
+        pass
+
 
 class TestQuickActionDefinitions:
     """Test QUICK_ACTIONS list structure."""


### PR DESCRIPTION
Ctrl+C during any "Press Enter to continue..." prompt caused an unhandled KeyboardInterrupt traceback. Added _wait_for_enter() helper method that catches KeyboardInterrupt/EOFError, and replaced all ~95 bare input() pause calls across 6 launcher_tui files. Also wrapped user-input calls (dest_hash prompts) and added top-level handler in main() for clean exit.

https://claude.ai/code/session_01Lt3eu6F6689NffvhAgzPqA