### PR TITLE
fix: Standardize service status messaging and surface boot persistence

### DIFF
--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -283,7 +283,7 @@ class FirstRunMixin:
             status = check_service(svc_id)
             if status.available:
                 lines.append(f"\n✓ {svc_name}")
-                lines.append(f"  Status: Running")
+                lines.append(f"  Status: running")
             else:
                 all_running = False
                 lines.append(f"\n✗ {svc_name}")

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -2543,6 +2543,7 @@ class MeshForgeLauncher(
             if choice == "status":
                 subprocess.run(['clear'], check=False, timeout=5)
                 print("=== Service Status ===\n")
+                warnings = []
                 for svc in ['meshtasticd', 'rnsd', 'meshforge']:
                     try:
                         result = subprocess.run(
@@ -2550,8 +2551,23 @@ class MeshForgeLauncher(
                             capture_output=True, text=True, timeout=5
                         )
                         status = result.stdout.strip()
+
+                        # Check boot persistence
+                        boot_info = ""
+                        try:
+                            enabled_result = subprocess.run(
+                                ['systemctl', 'is-enabled', svc],
+                                capture_output=True, text=True, timeout=5
+                            )
+                            is_enabled = enabled_result.returncode == 0
+                            if status == 'active' and not is_enabled:
+                                boot_info = "  (not enabled at boot)"
+                                warnings.append(svc)
+                        except Exception:
+                            pass
+
                         if status == 'active':
-                            print(f"  \033[0;32m●\033[0m {svc:<18} running")
+                            print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
                         elif status == 'failed':
                             print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
                         else:
@@ -2559,6 +2575,12 @@ class MeshForgeLauncher(
                     except Exception:
                         print(f"  ? {svc:<18} unknown")
                 print()
+
+                # Surface actionable warning
+                if warnings:
+                    print(f"  \033[0;33mWarning:\033[0m {', '.join(warnings)} won't start on reboot.")
+                    print(f"  Fix: sudo systemctl enable {' '.join(warnings)}\n")
+
                 # Show failed service logs
                 for svc in ['meshtasticd', 'rnsd']:
                     try:

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -130,8 +130,8 @@ class MeshtasticdConfigMixin:
 
             text = f"""Meshtasticd Service Status:
 
-Service: {'RUNNING' if is_running else 'STOPPED'}
-Enabled: {'Yes' if is_enabled else 'No'}
+Service: {'running' if is_running else 'stopped'}
+Boot:    {'enabled' if is_enabled else 'not enabled (will not start on reboot)'}
 
 Config File: {config_path}
 Config Exists: {'Yes' if config_exists else 'No'}

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -74,6 +74,7 @@ class QuickActionsMixin:
         print("=== Quick Service Status ===\n")
 
         services = ['meshtasticd', 'rnsd', 'mosquitto', 'meshforge']
+        warnings = []
         for svc in services:
             try:
                 result = subprocess.run(
@@ -81,8 +82,25 @@ class QuickActionsMixin:
                     capture_output=True, text=True, timeout=5
                 )
                 status = result.stdout.strip()
+
+                # Check boot persistence
+                boot_info = ""
+                try:
+                    enabled_result = subprocess.run(
+                        ['systemctl', 'is-enabled', svc],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    is_enabled = enabled_result.returncode == 0
+                    if status == 'active' and not is_enabled:
+                        boot_info = "  (not enabled at boot)"
+                        warnings.append(svc)
+                    elif status == 'active' and is_enabled:
+                        boot_info = ""
+                except Exception:
+                    pass
+
                 if status == 'active':
-                    print(f"  * {svc:<18} running")
+                    print(f"  * {svc:<18} running{boot_info}")
                 elif status == 'failed':
                     print(f"  ! {svc:<18} FAILED")
                 else:
@@ -90,7 +108,7 @@ class QuickActionsMixin:
             except Exception:
                 print(f"  ? {svc:<18} unknown")
 
-        # Bridge process
+        # Bridge process (not a systemd service — no boot persistence check)
         try:
             result = subprocess.run(
                 ['pgrep', '-f', 'rns_bridge'],
@@ -101,6 +119,11 @@ class QuickActionsMixin:
             print(f"  {sym} {'rns_bridge':<18} {bridge_status}")
         except Exception:
             print(f"  ? {'rns_bridge':<18} unknown")
+
+        # Surface actionable warning for services that won't survive reboot
+        if warnings:
+            print(f"\n  Warning: {', '.join(warnings)} running but won't start on reboot.")
+            print(f"  Fix: sudo systemctl enable {' '.join(warnings)}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/service_discovery_mixin.py
+++ b/src/launcher_tui/service_discovery_mixin.py
@@ -80,7 +80,7 @@ class ServiceDiscoveryMixin:
         mesh_status = check_service('meshtasticd')
         services.append(DiscoveredService(
             name="meshtasticd",
-            status="running" if mesh_status.running else "stopped",
+            status="running" if mesh_status.available else "stopped",
             address="localhost:4403",
             service_type="meshtastic",
             details=mesh_status.message or ""
@@ -90,7 +90,7 @@ class ServiceDiscoveryMixin:
         rns_status = check_service('rnsd')
         services.append(DiscoveredService(
             name="rnsd",
-            status="running" if rns_status.running else "stopped",
+            status="running" if rns_status.available else "stopped",
             address="UDP 37428",
             service_type="rns",
             details=rns_status.message or ""
@@ -100,7 +100,7 @@ class ServiceDiscoveryMixin:
         hc_status = check_service('hamclock')
         services.append(DiscoveredService(
             name="HamClock",
-            status="running" if hc_status.running else "stopped",
+            status="running" if hc_status.available else "stopped",
             address="localhost:8080",
             service_type="hamclock",
             details=hc_status.message or ""
@@ -271,17 +271,36 @@ class ServiceDiscoveryMixin:
         lines = ["MeshForge Service Status\n"]
         lines.append("=" * 40)
 
+        warnings = []
         for svc_id, svc_name in services:
             status = check_service(svc_id)
-            icon = "✓" if status.running else "✗"
-            state = "Running" if status.running else "Stopped"
+            icon = "✓" if status.available else "✗"
+            state = "running" if status.available else "stopped"
             lines.append(f"\n{icon} {svc_name}")
             lines.append(f"  Status: {state}")
+
+            # Check boot persistence for running services
+            if status.available:
+                try:
+                    from utils.service_check import check_systemd_service
+                    _, is_enabled = check_systemd_service(svc_id)
+                    if not is_enabled:
+                        lines.append(f"  Boot: not enabled (won't start on reboot)")
+                        warnings.append(svc_id)
+                    else:
+                        lines.append(f"  Boot: enabled")
+                except ImportError:
+                    pass
+
             if status.message:
                 lines.append(f"  Info: {status.message}")
 
-        # Add quick actions hint
-        lines.append("\n" + "-" * 40)
+        if warnings:
+            lines.append("\n" + "-" * 40)
+            lines.append(f"Fix: sudo systemctl enable {' '.join(warnings)}")
+        else:
+            lines.append("\n" + "-" * 40)
+
         lines.append("Use Service Manager to start/stop services")
 
         self.dialog.msgbox("Service Status", "\n".join(lines))


### PR DESCRIPTION
- Fix AttributeError crash in service_discovery_mixin.py: status.running does not exist, corrected to status.available
- Surface "not enabled at boot" warning in quick actions, service menu, service discovery, and meshtasticd config — running services that won't survive a reboot now show actionable fix command
- Standardize status wording: lowercase "running"/"stopped" across all displays (was inconsistent: RUNNING/Running/running)
- Standardize "Enabled: Yes/No" to "Boot: enabled/not enabled" with actionable context

https://claude.ai/code/session_01Lt3eu6F6689NffvhAgzPqA