### PR TITLE
feat: Add dual-radio Meshtastic gateway config template

### DIFF
--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -996,6 +996,33 @@ def get_interface_templates() -> CommandResult:
                 'hop_limit': '3'
             }
         },
+        'meshtastic_dual': {
+            'name': 'Meshtastic Dual-Radio Gateway',
+            'description': 'Two radios: Short Turbo + Long Fast',
+            'multi_interface': True,
+            'interfaces': [
+                {
+                    'default_name': 'Meshtastic Short Turbo',
+                    'type': 'Meshtastic_Interface',
+                    'settings': {
+                        'mode': 'gateway',
+                        'tcp_port': '127.0.0.1:4403',
+                        'data_speed': '8',
+                        'hop_limit': '3',
+                    }
+                },
+                {
+                    'default_name': 'Meshtastic Long Fast',
+                    'type': 'Meshtastic_Interface',
+                    'settings': {
+                        'mode': 'gateway',
+                        'tcp_port': '127.0.0.1:4404',
+                        'data_speed': '0',
+                        'hop_limit': '3',
+                    }
+                }
+            ]
+        },
         'rnode': {
             'name': 'RNode LoRa',
             'description': 'Direct LoRa via RNode hardware',
@@ -1039,6 +1066,13 @@ def apply_template(template_name: str, interface_name: str, overrides: Dict[str,
         )
 
     template = templates[template_name]
+
+    if template.get('multi_interface'):
+        return CommandResult.fail(
+            f"Template '{template_name}' is a multi-interface template. "
+            f"Use apply_multi_template() instead."
+        )
+
     settings = template['settings'].copy()
 
     # Apply overrides
@@ -1046,6 +1080,70 @@ def apply_template(template_name: str, interface_name: str, overrides: Dict[str,
         settings.update(overrides)
 
     return add_interface(interface_name, template['type'], settings)
+
+
+def apply_multi_template(
+    template_name: str,
+    interface_configs: List[Dict[str, Any]],
+) -> CommandResult:
+    """
+    Apply a multi-interface template to create several interfaces at once.
+
+    Args:
+        template_name: Name of template (e.g. meshtastic_dual)
+        interface_configs: List of dicts with 'name' and optional 'overrides'
+            for each interface defined in the template.
+
+    Returns:
+        CommandResult indicating success (all added) or failure
+    """
+    templates_result = get_interface_templates()
+    templates = templates_result.data.get('templates', {})
+
+    if template_name not in templates:
+        return CommandResult.fail(
+            f"Unknown template: {template_name}",
+            data={'available': list(templates.keys())}
+        )
+
+    template = templates[template_name]
+    if not template.get('multi_interface'):
+        return CommandResult.fail(
+            f"Template '{template_name}' is not a multi-interface template. "
+            f"Use apply_template() instead."
+        )
+
+    iface_defs = template.get('interfaces', [])
+    if len(interface_configs) != len(iface_defs):
+        return CommandResult.fail(
+            f"Expected {len(iface_defs)} interface configs, got {len(interface_configs)}"
+        )
+
+    added = []
+    for iface_def, user_cfg in zip(iface_defs, interface_configs):
+        name = user_cfg.get('name', iface_def['default_name'])
+        settings = iface_def['settings'].copy()
+        overrides = user_cfg.get('overrides')
+        if overrides:
+            settings.update(overrides)
+
+        result = add_interface(name, iface_def['type'], settings)
+        if not result.success:
+            cleanup_hint = ""
+            if added:
+                cleanup_hint = (
+                    f"\n\nAlready added: {', '.join(added)}"
+                    f"\nTo clean up, remove them via Manage Interfaces > Remove."
+                )
+            return CommandResult.fail(
+                f"Failed adding [[{name}]]: {result.message}{cleanup_hint}"
+            )
+        added.append(name)
+
+    return CommandResult.ok(
+        f"Added {len(added)} interfaces: {', '.join(added)}",
+        data={'added': added}
+    )
 
 
 # ============================================================================

--- a/src/launcher_tui/rns_interfaces_mixin.py
+++ b/src/launcher_tui/rns_interfaces_mixin.py
@@ -5,7 +5,7 @@ Provides TUI handlers to list, add, remove, enable/disable, and apply
 templates for Reticulum network interfaces.  All heavy lifting is
 delegated to the backend in commands.rns (add_interface, remove_interface,
 enable_interface, disable_interface, list_interfaces, get_interface_templates,
-apply_template).
+apply_template, apply_multi_template).
 """
 
 import re
@@ -121,7 +121,10 @@ class RNSInterfacesMixin:
         # Build menu of templates
         choices = []
         for key, tpl in templates.items():
-            label = f"{tpl['type']} - {tpl['description']}"
+            if tpl.get('multi_interface'):
+                label = f"Multi - {tpl['description']}"
+            else:
+                label = f"{tpl['type']} - {tpl['description']}"
             # Truncate long descriptions for whiptail
             if len(label) > 60:
                 label = label[:57] + "..."
@@ -138,6 +141,11 @@ class RNSInterfacesMixin:
             return
 
         template = templates[tpl_choice]
+
+        # Multi-interface templates have a different flow
+        if template.get('multi_interface'):
+            self._rns_add_multi_interface(rns_mod, tpl_choice, template)
+            return
 
         # Ask for a name
         default_name = template.get('name', tpl_choice)
@@ -175,6 +183,72 @@ class RNSInterfacesMixin:
             )
         else:
             self.dialog.msgbox("Error", f"Failed to add interface:\n{result.message}")
+
+    def _rns_add_multi_interface(self, rns_mod, tpl_key: str, template: dict):
+        """Handle adding a multi-interface template (e.g. dual-radio Meshtastic)."""
+        iface_defs = template.get('interfaces', [])
+        if not iface_defs:
+            self.dialog.msgbox("Error", "Template has no interface definitions.")
+            return
+
+        # Show overview of what will be created
+        overview_lines = [f"{template['name']}\n"]
+        for i, idef in enumerate(iface_defs, 1):
+            overview_lines.append(f"  Radio {i}: {idef['default_name']}")
+            overview_lines.append(f"    type = {idef['type']}")
+            for k, v in idef['settings'].items():
+                overview_lines.append(f"    {k} = {v}")
+            overview_lines.append("")
+        overview_lines.append("Proceed? (settings can be customised next)")
+
+        if not self.dialog.yesno(template['name'], "\n".join(overview_lines)):
+            return
+
+        # Collect user config for each interface
+        interface_configs = []
+        for i, idef in enumerate(iface_defs, 1):
+            default_name = idef['default_name']
+            iface_name = self.dialog.inputbox(
+                f"Radio {i} Name",
+                f"Name for radio {i} ({idef['type']}):\n"
+                f"(alphanumeric, spaces, dashes allowed)",
+                default_name,
+            )
+            if not iface_name:
+                return
+            iface_name = iface_name.strip()
+            if not iface_name or not re.match(r'^[\w\s\-]+$', iface_name):
+                self.dialog.msgbox(
+                    "Invalid Name",
+                    "Name must contain only alphanumeric characters,\n"
+                    "spaces, and dashes.",
+                )
+                return
+
+            # Let user customise this radio's settings
+            settings = dict(idef.get('settings', {}))
+            settings = self._rns_edit_interface_settings(idef['type'], settings)
+            if settings is None:
+                return  # user cancelled
+
+            interface_configs.append({
+                'name': iface_name,
+                'overrides': settings,
+            })
+
+        # Apply all interfaces
+        result = rns_mod.apply_multi_template(tpl_key, interface_configs)
+        if result.success:
+            added = result.data.get('added', [])
+            names_str = "\n".join(f"  - [[{n}]]" for n in added)
+            self.dialog.msgbox(
+                "Interfaces Added",
+                f"Added {len(added)} interfaces:\n{names_str}\n\n"
+                f"Restart rnsd to apply:\n"
+                f"  sudo systemctl restart rnsd",
+            )
+        else:
+            self.dialog.msgbox("Error", f"Failed:\n{result.message}")
 
     def _rns_edit_interface_settings(self, iface_type: str, settings: dict):
         """Let the user edit key settings for an interface template.


### PR DESCRIPTION
Adds a 'meshtastic_dual' template to RNS Interfaces > Add that deploys both Short Turbo (port 4403, data_speed=8) and Long Fast (port 4404, data_speed=0) interfaces in one step. All settings are user-modifiable.

- New multi-interface template architecture (multi_interface flag)
- apply_multi_template() backend for creating N interfaces at once
- TUI flow shows overview, lets user name/customize each radio
- Guard in apply_template() to reject multi-interface templates
- Partial-failure cleanup hint in error messages

https://claude.ai/code/session_01P1KZzDmPPXE11nwf4QH8oy