### PR TITLE
feat: Add terrain-aware coverage prediction (Phase 2)

### DIFF
--- a/.claude/research/maps_progress.md
+++ b/.claude/research/maps_progress.md
@@ -37,15 +37,14 @@ Upon code review, Phase 1 of the live map engine is **already complete**:
 
 ## Current Phase: 2 — RF-Aware Visualization
 
-Phase 1 is done. Next work should focus on Phase 2:
-
 ### Task Status
 
 | Task | Status | Notes |
 |------|--------|-------|
-| 5. Terrain-aware coverage | 🔴 Not started | Needs SRTM data integration |
-| 6. Link quality animation | 🟡 Partial | Colors exist, no pulse animation |
-| 7. Coverage prediction overlay | 🔴 Not started | Uses rf.py path loss models |
+| 5. Terrain-aware coverage | ✅ Done | `terrain.py` already exists with SRTM + LOS |
+| 5b. API integration | ✅ Done | `/api/coverage/` and `/api/los/` endpoints added |
+| 7. Coverage prediction overlay | ✅ Done | Click node → "Show Coverage" button |
+| 6. Link quality animation | 🔴 Not started | Colors exist, no pulse animation |
 | 8. Signal heatmap from real data | 🔴 Not started | Needs data collection over time |
 
 ### Files to Create (Phase 2)
@@ -70,12 +69,17 @@ src/utils/node_history.py    # SQLite time-series (may already exist)
 - [x] Updated README (removed GTK references)
 - [x] Discovered Phase 1 already implemented
 - [x] Updated roadmap for TUI-only architecture
-- [ ] Phase 2 work not started
+- [x] Phase 2: Added `/api/coverage/` and `/api/los/` endpoints
+- [x] Phase 2: Added terrain coverage overlay to map
+- [x] Phase 2: Node click → terrain analysis button
 
-**Next Steps:**
-1. Test existing live map (TUI > AI Tools > Live Network Map)
-2. Identify gaps in Phase 1 implementation
-3. Begin Phase 2: terrain-aware coverage modeling
+**Completed:**
+- Task 5: Terrain-aware coverage (API + map integration)
+- Task 7: Coverage prediction overlay
+
+**Next Steps (new session):**
+1. Task 6: Link quality animation (pulse on active links)
+2. Task 8: Signal heatmap from real measurements
 
 ---
 

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -584,6 +584,14 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         elif self.path.startswith('/api/nodes/trajectory/'):
             node_id = self.path.split('/api/nodes/trajectory/', 1)[1].rstrip('/')
             self._serve_trajectory(node_id)
+        elif self.path.startswith('/api/coverage/'):
+            # Coverage prediction for a node: /api/coverage/<lat>/<lon>/<alt>
+            parts = self.path.split('/api/coverage/', 1)[1].rstrip('/').split('/')
+            self._serve_coverage(parts)
+        elif self.path.startswith('/api/los/'):
+            # Line of sight check: /api/los/<lat1>/<lon1>/<lat2>/<lon2>
+            parts = self.path.split('/api/los/', 1)[1].rstrip('/').split('/')
+            self._serve_los(parts)
         else:
             # Serve static files from web/ directory
             if self.web_dir:
@@ -693,6 +701,160 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         self.send_header('Cache-Control', 'no-cache')
         self.end_headers()
         self.wfile.write(data)
+
+    def _serve_coverage(self, parts: List[str]):
+        """Serve terrain-aware coverage prediction for a location.
+
+        URL: /api/coverage/<lat>/<lon>/<antenna_height_m>
+        Optional query params: radius_km (default 10), freq_mhz (default 906)
+        """
+        try:
+            if len(parts) < 3:
+                self._serve_json({"error": "Usage: /api/coverage/<lat>/<lon>/<height_m>"})
+                return
+
+            lat = float(parts[0])
+            lon = float(parts[1])
+            alt = float(parts[2])
+
+            # Parse query params
+            from urllib.parse import parse_qs, urlparse
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            radius_km = float(params.get('radius_km', ['10'])[0])
+            freq_mhz = float(params.get('freq_mhz', ['906'])[0])
+            resolution = int(params.get('resolution', ['24'])[0])
+
+            # Limit resolution for performance
+            resolution = min(resolution, 48)
+            radius_km = min(radius_km, 50)
+
+            # Get coverage prediction from terrain analyzer
+            try:
+                from utils.terrain import SRTMProvider, LOSAnalyzer
+                provider = SRTMProvider()
+                analyzer = LOSAnalyzer(provider)
+                coverage = analyzer.coverage_grid(
+                    lat, lon, alt,
+                    radius_km=radius_km,
+                    freq_mhz=freq_mhz,
+                    resolution=resolution
+                )
+            except ImportError:
+                self._serve_json({"error": "terrain module not available"})
+                return
+            except Exception as e:
+                logger.error(f"Coverage calculation failed: {e}")
+                self._serve_json({"error": f"calculation failed: {str(e)}"})
+                return
+
+            # Convert to GeoJSON for map display
+            features = []
+            for point in coverage:
+                features.append({
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": [point["lon"], point["lat"]]
+                    },
+                    "properties": {
+                        "is_clear": point["is_clear"],
+                        "total_loss_db": point["total_loss_db"],
+                        "terrain_loss_db": point["terrain_loss_db"],
+                        "fresnel_pct": point["fresnel_clearance_pct"],
+                        "distance_m": point["distance_m"],
+                        "bearing": point["bearing"],
+                    }
+                })
+
+            result = {
+                "type": "FeatureCollection",
+                "features": features,
+                "properties": {
+                    "center": [lon, lat],
+                    "antenna_height_m": alt,
+                    "radius_km": radius_km,
+                    "freq_mhz": freq_mhz,
+                }
+            }
+            self._serve_json(result)
+
+        except ValueError as e:
+            self._serve_json({"error": f"Invalid parameters: {e}"})
+        except Exception as e:
+            logger.error(f"Coverage endpoint error: {e}")
+            self._serve_json({"error": str(e)})
+
+    def _serve_los(self, parts: List[str]):
+        """Serve line-of-sight analysis between two points.
+
+        URL: /api/los/<lat1>/<lon1>/<lat2>/<lon2>
+        Optional query params: alt1, alt2 (antenna heights, default 10m), freq_mhz (default 906)
+        """
+        try:
+            if len(parts) < 4:
+                self._serve_json({"error": "Usage: /api/los/<lat1>/<lon1>/<lat2>/<lon2>"})
+                return
+
+            lat1 = float(parts[0])
+            lon1 = float(parts[1])
+            lat2 = float(parts[2])
+            lon2 = float(parts[3])
+
+            # Parse query params
+            from urllib.parse import parse_qs, urlparse
+            parsed = urlparse(self.path)
+            params = parse_qs(parsed.query)
+            alt1 = float(params.get('alt1', ['10'])[0])
+            alt2 = float(params.get('alt2', ['10'])[0])
+            freq_mhz = float(params.get('freq_mhz', ['906'])[0])
+
+            # Calculate LOS
+            try:
+                from utils.terrain import SRTMProvider, LOSAnalyzer
+                provider = SRTMProvider()
+                analyzer = LOSAnalyzer(provider)
+                result = analyzer.analyze(lat1, lon1, alt1, lat2, lon2, alt2, freq_mhz)
+            except ImportError:
+                self._serve_json({"error": "terrain module not available"})
+                return
+            except Exception as e:
+                logger.error(f"LOS calculation failed: {e}")
+                self._serve_json({"error": f"calculation failed: {str(e)}"})
+                return
+
+            # Build elevation profile for visualization
+            profile = []
+            if hasattr(result, 'profile') and result.profile:
+                for p in result.profile:
+                    profile.append({
+                        "distance_m": p.distance_m,
+                        "elevation_m": p.ground_elevation,
+                        "los_height_m": p.los_height,
+                        "fresnel_top": p.los_height + p.fresnel_radius,
+                        "fresnel_bottom": p.los_height - p.fresnel_radius,
+                    })
+
+            response = {
+                "is_clear": result.is_clear,
+                "distance_m": result.distance_m,
+                "total_loss_db": result.total_loss_db,
+                "terrain_loss_db": result.terrain_loss_db,
+                "fresnel_clearance_pct": result.fresnel_clearance_pct,
+                "obstruction_count": len(result.obstructions) if hasattr(result, 'obstructions') else 0,
+                "profile": profile,
+                "endpoints": {
+                    "from": {"lat": lat1, "lon": lon1, "alt": alt1},
+                    "to": {"lat": lat2, "lon": lon2, "alt": alt2},
+                }
+            }
+            self._serve_json(response)
+
+        except ValueError as e:
+            self._serve_json({"error": f"Invalid parameters: {e}"})
+        except Exception as e:
+            logger.error(f"LOS endpoint error: {e}")
+            self._serve_json({"error": str(e)})
 
     def log_message(self, format, *args):
         """Suppress default request logging (too noisy)."""

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -471,6 +471,18 @@
             <button class="btn-action primary" onclick="refreshNodes()">Refresh</button>
             <button class="btn-action" onclick="fitAllNodes()">Fit All</button>
 
+            <div class="terrain-section" style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #2a3a4a;">
+                <div class="stat-row">
+                    <span class="label">Terrain Analysis</span>
+                </div>
+                <button class="btn-action" id="btn-terrain" onclick="showTerrainCoverage()" disabled>
+                    Show Coverage
+                </button>
+                <div id="terrain-status" style="font-size: 11px; color: #888; margin-top: 4px;">
+                    Click a node first
+                </div>
+            </div>
+
             <div class="cache-section" id="cache-section">
                 <div class="stat-row">
                     <span class="label">Cached:</span>
@@ -580,6 +592,10 @@
     const nodeLayer = L.layerGroup().addTo(map);
     const linkLayer = L.layerGroup().addTo(map);
     const coverageLayer = L.layerGroup().addTo(map);
+    const terrainLayer = L.layerGroup().addTo(map);
+
+    // Selected node for terrain analysis
+    let selectedNode = null;
 
     // ============================================
     // SVG Marker Icons
@@ -838,6 +854,7 @@
                     icon: createMarkerIcon(props, isNew)
                 });
                 marker.bindPopup(createPopupContent(props, coords));
+                marker.on('click', () => selectNodeForTerrain(feature));
                 nodeLayer.addLayer(marker);
 
                 // Coverage circle
@@ -1156,6 +1173,104 @@
                 maxZoom: Math.min(18, zoom + 2)
             }
         }, [channel.port2]);
+    }
+
+    // ============================================
+    // Terrain-Aware Coverage Prediction
+    // ============================================
+
+    function selectNodeForTerrain(feature) {
+        selectedNode = feature;
+        const btn = document.getElementById('btn-terrain');
+        const status = document.getElementById('terrain-status');
+        if (feature) {
+            btn.disabled = false;
+            const name = feature.properties.long_name || feature.properties.short_name || feature.properties.id;
+            status.textContent = `Selected: ${name}`;
+        } else {
+            btn.disabled = true;
+            status.textContent = 'Click a node first';
+        }
+    }
+
+    async function showTerrainCoverage() {
+        if (!selectedNode) return;
+
+        const btn = document.getElementById('btn-terrain');
+        const status = document.getElementById('terrain-status');
+        const coords = selectedNode.geometry.coordinates;
+        const lat = coords[1];
+        const lon = coords[0];
+        const alt = 10; // Default antenna height
+
+        btn.disabled = true;
+        status.textContent = 'Calculating terrain coverage...';
+        status.style.color = '#f39c12';
+
+        // Clear previous terrain overlay
+        terrainLayer.clearLayers();
+
+        try {
+            const response = await fetch(`/api/coverage/${lat}/${lon}/${alt}?radius_km=5&resolution=24`);
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+            const data = await response.json();
+            if (data.error) throw new Error(data.error);
+
+            // Display coverage points
+            data.features.forEach(feature => {
+                const fcoords = feature.geometry.coordinates;
+                const props = feature.properties;
+
+                // Color based on clearance
+                let color;
+                if (!props.is_clear) {
+                    color = '#ef5350'; // Red - obstructed
+                } else if (props.fresnel_pct >= 100) {
+                    color = '#66bb6a'; // Green - excellent
+                } else if (props.fresnel_pct >= 60) {
+                    color = '#ffca28'; // Yellow - marginal
+                } else {
+                    color = '#ff7043'; // Orange - poor
+                }
+
+                const circle = L.circleMarker([fcoords[1], fcoords[0]], {
+                    radius: 6,
+                    fillColor: color,
+                    color: color,
+                    weight: 1,
+                    opacity: 0.8,
+                    fillOpacity: 0.5,
+                }).bindPopup(`
+                    <div style="font-size: 12px;">
+                        <strong>Terrain Analysis</strong><br>
+                        Distance: ${(props.distance_m/1000).toFixed(2)} km<br>
+                        Bearing: ${props.bearing}&deg;<br>
+                        LOS Clear: ${props.is_clear ? 'Yes' : 'No'}<br>
+                        Fresnel: ${props.fresnel_pct.toFixed(0)}%<br>
+                        Path Loss: ${props.total_loss_db} dB<br>
+                        Terrain Loss: ${props.terrain_loss_db} dB
+                    </div>
+                `);
+
+                terrainLayer.addLayer(circle);
+            });
+
+            status.textContent = `Showing ${data.features.length} points`;
+            status.style.color = '#66bb6a';
+            btn.disabled = false;
+
+        } catch (e) {
+            console.error('Terrain coverage failed:', e);
+            status.textContent = `Error: ${e.message}`;
+            status.style.color = '#ef5350';
+            btn.disabled = false;
+        }
+    }
+
+    function clearTerrainCoverage() {
+        terrainLayer.clearLayers();
+        document.getElementById('terrain-status').textContent = 'Cleared';
     }
 
     // ============================================


### PR DESCRIPTION
- Add /api/coverage/<lat>/<lon>/<alt> endpoint for terrain prediction
- Add /api/los/<lat1>/<lon1>/<lat2>/<lon2> endpoint for LOS analysis
- Add terrain coverage overlay to live map (click node → Show Coverage)
- Color-coded coverage points (green=clear, yellow=marginal, red=blocked)
- Integrates existing terrain.py SRTM + LOSAnalyzer

Phase 2 Tasks Complete:
- Task 5: Terrain-aware coverage integration
- Task 7: Coverage prediction overlay

https://claude.ai/code/session_01QyhV1pJmQVRb2ncdCBYNXR