### PR TITLE
fix: Add debug logging to swallowed exceptions and guard empty array …

### DIFF
--- a/src/commands/meshtastic.py
+++ b/src/commands/meshtastic.py
@@ -221,8 +221,8 @@ def auto_detect_connection() -> CommandResult:
                 "Using TCP connection to meshtasticd (port 4403)",
                 data={'type': 'localhost', 'value': '127.0.0.1', 'method': 'tcp'}
             )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"TCP connection check to meshtasticd failed: {e}")
 
     # Check for USB serial devices
     usb_paths = list(Path('/dev').glob('ttyUSB*')) + list(Path('/dev').glob('ttyACM*'))

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -2073,8 +2073,8 @@ class MeshForgeLauncher(
                 port_ok = sock.connect_ex((local_ip, 9443)) == 0
             finally:
                 sock.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Socket check for web client failed: {e}")
 
         if port_ok:
             msg = (
@@ -2306,8 +2306,8 @@ class MeshForgeLauncher(
                     devices.append("TCP: localhost:4403 (meshtasticd)")
             finally:
                 sock.close()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"Socket check for meshtasticd failed: {e}")
 
         # Check serial ports
         serial_ports = list(Path('/dev').glob('ttyUSB*')) + list(Path('/dev').glob('ttyACM*'))
@@ -3082,8 +3082,8 @@ WantedBy=multi-user.target
                             ['pgrep', '-a', '-x', 'rnsd'],
                             timeout=5
                         )
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"pgrep for rnsd failed: {e}")
                 else:
                     print(f"\033[0;31m○\033[0m rnsd is \033[0;31mnot running\033[0m")
                     print("\nTo start: Select 'Start Service' from the menu")

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -131,8 +131,8 @@ class NomadNetClientMixin:
                 version = result.stdout.strip() or result.stderr.strip()
                 if version:
                     print(f"  Version:   {version}")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"NomadNet version check failed: {e}")
         else:
             print("  NOT INSTALLED")
             print("  Install:   pipx install nomadnet")

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -275,8 +275,12 @@ class SystemToolsMixin:
 
             # Header
             lines = result.stdout.strip().split('\n')
-            print(lines[0])  # Header
-            print("-" * 80)
+            if lines and lines[0]:
+                print(lines[0])  # Header
+                print("-" * 80)
+            else:
+                print("No process information available")
+                print("-" * 80)
 
             found = False
             for line in lines[1:]:


### PR DESCRIPTION
…access

- Add logger.debug() to 5 exception handlers that were silently passing:
  - main.py: socket checks for web client and meshtasticd
  - main.py: pgrep for rnsd status
  - nomadnet_client_mixin.py: NomadNet version check
  - meshtastic.py: TCP connection check
- Add bounds check for empty process list in system_tools_mixin.py

Addresses reliability issues from auto-review (23 → 17, remaining are false positives on known-size tuple constant accesses).

https://claude.ai/code/session_01Xrt6wSWQ9ZTH9Sab6sVsXk