### PR TITLE
feat: Add Network Map to TUI main menu

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -292,6 +292,7 @@ class MeshForgeLauncher(
             choices = [
                 # Monitor
                 ("status", "Status Overview"),
+                ("map", "Network Map (live nodes)"),
                 ("quick", "Quick Actions (shortcuts)"),
                 ("logs", "Logs (live follow, errors, analysis)"),
                 ("network", "Network & Ports"),
@@ -328,6 +329,8 @@ class MeshForgeLauncher(
         """Handle menu selection."""
         if choice == "status":
             self._run_terminal_status()
+        elif choice == "map":
+            self._open_live_map()
         elif choice == "quick":
             self._quick_actions_menu()
         elif choice == "radio":


### PR DESCRIPTION
Maps were fully implemented (5 phases!) but buried in unreachable AI Tools submenu. Now directly accessible from main menu as "Network Map (live nodes)" - second item after Status Overview.

Supports:
- Browser snapshot mode (offline viewing)
- Live server mode (auto-refresh every 30s)
- Auto-open on TUI launch setting

https://claude.ai/code/session_01Xrt6wSWQ9ZTH9Sab6sVsXk