### PR TITLE
fix: Add socket timeouts to prevent TUI hang on network issues

### DIFF
--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -102,6 +102,7 @@ def get_local_ip():
     """Get the local IP address."""
     try:
         s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(2)  # 2 second timeout for network issues
         s.connect(("8.8.8.8", 80))
         ip = s.getsockname()[0]
         s.close()

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -2057,6 +2057,7 @@ class MeshForgeLauncher(
         local_ip = "localhost"
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            s.settimeout(2)
             try:
                 s.connect(("8.8.8.8", 80))
                 local_ip = s.getsockname()[0]
@@ -2184,6 +2185,7 @@ class MeshForgeLauncher(
         print()
         try:
             s = sock.socket(sock.AF_INET, sock.SOCK_DGRAM)
+            s.settimeout(2)
             try:
                 s.connect(("8.8.8.8", 80))
                 local_ip = s.getsockname()[0]

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -74,6 +74,7 @@ class MeshtasticdConfigMixin:
             if local_ip.startswith('127.'):
                 # Fallback: get IP from interface
                 s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                s.settimeout(2)
                 s.connect(("8.8.8.8", 80))
                 local_ip = s.getsockname()[0]
                 s.close()


### PR DESCRIPTION
Status Overview was hanging indefinitely when Pi had no internet - get_local_ip() socket.connect() to 8.8.8.8 had no timeout.

Added 2-second timeouts to all UDP socket connections used for local IP detection:
- cli/status.py: get_local_ip()
- main.py: _open_web_client(), _run_terminal_network()
- meshtasticd_config_mixin.py: _show_meshtasticd_web_client()

https://claude.ai/code/session_01Xrt6wSWQ9ZTH9Sab6sVsXk