### PR TITLE
fix: Add try/except fallback for utils.paths imports in gateway module

### DIFF
--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -113,7 +113,20 @@ def validate_speed_hop_combination(speed: int, hop_limit: int) -> Optional[Confi
     return None
 
 # Import centralized path utility for sudo compatibility
-from utils.paths import get_real_user_home
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        """Fallback for when utils.paths is not in Python path."""
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            candidate = Path(f'/home/{sudo_user}')
+            return candidate
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            candidate = Path(f'/home/{logname}')
+            return candidate
+        return Path('/root')
 
 
 @dataclass

--- a/src/gateway/message_queue.py
+++ b/src/gateway/message_queue.py
@@ -30,7 +30,19 @@ from typing import Dict, List, Optional, Callable, Any
 from contextlib import contextmanager
 
 # Import centralized path utility for sudo compatibility
-from utils.paths import get_real_user_home
+import os
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        """Fallback for when utils.paths is not in Python path."""
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f'/home/{sudo_user}')
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f'/home/{logname}')
+        return Path('/root')
 
 logger = logging.getLogger(__name__)
 

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -16,7 +16,18 @@ import json
 logger = logging.getLogger(__name__)
 
 # Import centralized path utility
-from utils.paths import get_real_user_home
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        """Fallback for when utils.paths is not in Python path."""
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f'/home/{sudo_user}')
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f'/home/{logname}')
+        return Path('/root')
 
 
 @dataclass

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -43,7 +43,34 @@ logger = logging.getLogger(__name__)
 # Import centralized path utility
 # get_real_user_home: for MeshForge-specific files (identity, LXMF storage)
 # ReticulumPaths: for RNS config paths (mirrors RNS's own resolution)
-from utils.paths import get_real_user_home, ReticulumPaths
+import os
+try:
+    from utils.paths import get_real_user_home, ReticulumPaths
+except ImportError:
+    def get_real_user_home() -> Path:
+        """Fallback for when utils.paths is not in Python path."""
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f'/home/{sudo_user}')
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f'/home/{logname}')
+        return Path('/root')
+
+    class ReticulumPaths:
+        @classmethod
+        def get_config_dir(cls) -> Path:
+            if Path('/etc/reticulum/config').is_file():
+                return Path('/etc/reticulum')
+            home = get_real_user_home()
+            xdg = home / '.config' / 'reticulum'
+            if (xdg / 'config').is_file():
+                return xdg
+            return home / '.reticulum'
+
+        @classmethod
+        def get_config_file(cls) -> Path:
+            return cls.get_config_dir() / 'config'
 
 # Import service checker for pre-flight checks (Issue #3)
 try:


### PR DESCRIPTION
The gateway module files (config.py, node_tracker.py, message_queue.py, rns_bridge.py) used bare imports of utils.paths without fallback handlers. This caused ModuleNotFoundError when running from production paths where the src directory isn't in PYTHONPATH.

Added try/except ImportError blocks with fallback implementations matching the pattern used elsewhere in the codebase (e.g., launcher_tui/main.py).

https://claude.ai/code/session_01SBB657k7Sw7Mxeyre3TwUi