### PR TITLE
fix: Bind map server to 0.0.0.0 for remote access

### DIFF
--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -222,7 +222,8 @@ class AIToolsMixin:
                 self.dialog.msgbox(
                     "Map Server",
                     f"Map server already running!\n\n"
-                    f"Open: http://localhost:{port}\n\n"
+                    f"Local:  http://localhost:{port}\n"
+                    f"Remote: http://<this-ip>:{port}\n\n"
                     "The map auto-refreshes every 30 seconds."
                 )
                 self._open_in_browser(f"http://localhost:{port}")
@@ -239,7 +240,8 @@ class AIToolsMixin:
             self.dialog.msgbox(
                 "Map Server Started",
                 f"Live map server running!\n\n"
-                f"URL: http://localhost:{port}\n\n"
+                f"Local:  http://localhost:{port}\n"
+                f"Remote: http://<this-ip>:{port}\n\n"
                 "The map pulls fresh data every 30 seconds.\n"
                 "Server runs until MeshForge exits."
             )
@@ -277,7 +279,7 @@ class AIToolsMixin:
                 msg += (
                     "The map server will start automatically\n"
                     "when MeshForge launches, and the map will\n"
-                    "be accessible at http://localhost:5000"
+                    "be accessible locally and remotely on port 5000."
                 )
             else:
                 msg += "Map server will not start automatically."

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -1197,7 +1197,7 @@ class MapServer:
         server.start_background()  # Returns immediately
     """
 
-    def __init__(self, port: int = 5000, host: str = "127.0.0.1"):
+    def __init__(self, port: int = 5000, host: str = "0.0.0.0"):
         self.port = port
         self.host = host
         self.collector = MapDataCollector()
@@ -1215,9 +1215,11 @@ class MapServer:
 
         self._server = HTTPServer((self.host, self.port), MapRequestHandler)
         logger.info(f"Map server starting on http://{self.host}:{self.port}")
-        print(f"MeshForge Map Server: http://localhost:{self.port}")
-        print(f"  Map:  http://localhost:{self.port}/")
-        print(f"  API:  http://localhost:{self.port}/api/nodes/geojson")
+        print(f"MeshForge Map Server running on port {self.port}")
+        print(f"  Local:  http://localhost:{self.port}/")
+        if self.host == "0.0.0.0":
+            print(f"  Remote: http://<your-ip>:{self.port}/")
+        print(f"  API:    http://localhost:{self.port}/api/nodes/geojson")
         print("  Press Ctrl+C to stop")
 
         try:
@@ -1257,7 +1259,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="MeshForge Live Map Server")
     parser.add_argument("-p", "--port", type=int, default=5000, help="Port (default: 5000)")
-    parser.add_argument("--host", default="127.0.0.1", help="Bind address (default: 127.0.0.1)")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0, use 127.0.0.1 for local only)")
     parser.add_argument("--collect-only", action="store_true", help="Just collect and print GeoJSON")
     args = parser.parse_args()
 


### PR DESCRIPTION
- Change MapServer default host from 127.0.0.1 to 0.0.0.0
- Update CLI --host default to 0.0.0.0
- Update TUI messages to indicate remote access is available
- Allows accessing map from other devices on the network

https://claude.ai/code/session_01Pm3V3RovQYg2mF95A7qqqF