### PR TITLE
fix: Bind map server to LAN IP and fix headless browser issue

### DIFF
--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -206,27 +206,41 @@ class AIToolsMixin:
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to generate live map: {e}")
 
+    def _is_headless(self) -> bool:
+        """Check if running without a display (headless/SSH)."""
+        import os
+        display = os.environ.get('DISPLAY')
+        wayland = os.environ.get('WAYLAND_DISPLAY')
+        ssh = os.environ.get('SSH_CONNECTION')
+        return (not display and not wayland) or bool(ssh)
+
     def _start_map_server(self):
         """Start the map HTTP server for live-updating browser access."""
         import socket
 
         port = 5000
 
+        # Get the LAN IP for display
+        from utils.map_data_service import get_lan_ip
+        lan_ip = get_lan_ip()
+        map_url = f"http://{lan_ip}:{port}"
+
         # Check if port is already in use
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1)
-            result = sock.connect_ex(('localhost', port))
+            result = sock.connect_ex((lan_ip, port))
             sock.close()
             if result == 0:
                 self.dialog.msgbox(
                     "Map Server",
                     f"Map server already running!\n\n"
-                    f"Local:  http://localhost:{port}\n"
-                    f"Remote: http://<this-ip>:{port}\n\n"
+                    f"URL: {map_url}\n\n"
+                    "Open this URL in your browser.\n"
                     "The map auto-refreshes every 30 seconds."
                 )
-                self._open_in_browser(f"http://localhost:{port}")
+                if not self._is_headless():
+                    self._open_in_browser(map_url)
                 return
         except OSError:
             pass
@@ -237,15 +251,21 @@ class AIToolsMixin:
             server = MapServer(port=port)
             server.start_background()
 
-            self.dialog.msgbox(
-                "Map Server Started",
+            # Store reference to prevent garbage collection
+            self._map_server = server
+
+            msg = (
                 f"Live map server running!\n\n"
-                f"Local:  http://localhost:{port}\n"
-                f"Remote: http://<this-ip>:{port}\n\n"
+                f"URL: {map_url}\n\n"
+                "Open this URL in your browser.\n"
                 "The map pulls fresh data every 30 seconds.\n"
                 "Server runs until MeshForge exits."
             )
-            self._open_in_browser(f"http://localhost:{port}")
+            self.dialog.msgbox("Map Server Started", msg)
+
+            # Only try to open browser if we have a display
+            if not self._is_headless():
+                self._open_in_browser(map_url)
 
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to start map server: {e}")
@@ -276,10 +296,12 @@ class AIToolsMixin:
                 f"Auto-open map: {state}\n\n"
             )
             if settings["auto_open_map"]:
+                from utils.map_data_service import get_lan_ip
+                lan_ip = get_lan_ip()
                 msg += (
                     "The map server will start automatically\n"
-                    "when MeshForge launches, and the map will\n"
-                    "be accessible locally and remotely on port 5000."
+                    "when MeshForge launches.\n\n"
+                    f"Access at: http://{lan_ip}:5000"
                 )
             else:
                 msg += "Map server will not start automatically."

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -32,6 +32,25 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+def get_lan_ip() -> str:
+    """Get the LAN IP address for this machine.
+
+    Returns the IP that would be used to reach external hosts,
+    which is the appropriate IP for LAN access.
+    Falls back to 127.0.0.1 if detection fails.
+    """
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.settimeout(2)
+        # Connect to external IP to determine which interface would be used
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "127.0.0.1"
+
+
 class MapDataCollector:
     """Collects node data from all available sources into unified GeoJSON.
 
@@ -1197,9 +1216,23 @@ class MapServer:
         server.start_background()  # Returns immediately
     """
 
-    def __init__(self, port: int = 5000, host: str = "0.0.0.0"):
+    def __init__(self, port: int = 5000, host: str = "auto"):
+        """Initialize map server.
+
+        Args:
+            port: Port to listen on (default 5000)
+            host: Bind address. Options:
+                  - "auto": Bind to LAN IP (default, allows LAN access)
+                  - "localhost" or "127.0.0.1": Local only
+                  - "0.0.0.0": All interfaces (use with caution)
+                  - Specific IP: Bind to that IP only
+        """
         self.port = port
-        self.host = host
+        # Resolve "auto" to actual LAN IP
+        if host == "auto":
+            self.host = get_lan_ip()
+        else:
+            self.host = host
         self.collector = MapDataCollector()
         self._server: Optional[HTTPServer] = None
         self._thread: Optional[threading.Thread] = None
@@ -1215,11 +1248,12 @@ class MapServer:
 
         self._server = HTTPServer((self.host, self.port), MapRequestHandler)
         logger.info(f"Map server starting on http://{self.host}:{self.port}")
-        print(f"MeshForge Map Server running on port {self.port}")
-        print(f"  Local:  http://localhost:{self.port}/")
-        if self.host == "0.0.0.0":
-            print(f"  Remote: http://<your-ip>:{self.port}/")
-        print(f"  API:    http://localhost:{self.port}/api/nodes/geojson")
+        print(f"MeshForge Map Server running on {self.host}:{self.port}")
+        if self.host in ("127.0.0.1", "localhost"):
+            print(f"  URL: http://localhost:{self.port}/")
+        else:
+            print(f"  URL: http://{self.host}:{self.port}/")
+        print(f"  API: http://{self.host}:{self.port}/api/nodes/geojson")
         print("  Press Ctrl+C to stop")
 
         try:
@@ -1250,7 +1284,7 @@ class MapServer:
     @property
     def url(self) -> str:
         """Get the server URL."""
-        return f"http://localhost:{self.port}"
+        return f"http://{self.host}:{self.port}"
 
 
 def main():
@@ -1259,7 +1293,7 @@ def main():
 
     parser = argparse.ArgumentParser(description="MeshForge Live Map Server")
     parser.add_argument("-p", "--port", type=int, default=5000, help="Port (default: 5000)")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0, use 127.0.0.1 for local only)")
+    parser.add_argument("--host", default="auto", help="Bind address: 'auto' (LAN IP), 'localhost', '0.0.0.0' (all), or specific IP")
     parser.add_argument("--collect-only", action="store_true", help="Just collect and print GeoJSON")
     args = parser.parse_args()
 


### PR DESCRIPTION
Map Server:
- Add get_lan_ip() to detect the machine's LAN IP address
- Default bind to LAN IP (not 0.0.0.0) for safer LAN-only access
- Support "auto" (LAN IP), "localhost", "0.0.0.0", or specific IP
- Show actual IP in startup messages

TUI:
- Add _is_headless() to detect SSH/no-display environments
- Skip browser launch when headless - just display URL
- Show actual LAN IP in all map server messages
- Users can now access map remotely without lynx taking over

https://claude.ai/code/session_01Pm3V3RovQYg2mF95A7qqqF