### PR TITLE
fix: Default to online status for nodes in meshtasticd nodedb

### DIFF
--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -427,8 +427,13 @@ class MapDataCollector:
         device_metrics = data.get('deviceMetrics', {})
 
         # Determine online status from lastHeard (configurable threshold)
+        # Default to online if node exists in nodedb but has no lastHeard
         last_heard = data.get('lastHeard', 0)
-        is_online = (now - last_heard) < online_threshold_seconds if last_heard else False
+        if last_heard:
+            is_online = (now - last_heard) < online_threshold_seconds
+        else:
+            # Node exists in nodedb - assume online (meshtasticd tracks it)
+            is_online = True
 
         # Format last_seen as human-readable
         if last_heard:
@@ -488,9 +493,12 @@ class MapDataCollector:
         else:
             formatted_id = str(node_id)
 
-        # Determine online status
+        # Determine online status - default to online if in nodedb
         last_heard = data.get('lastHeard', 0)
-        is_online = (now - last_heard) < online_threshold_seconds if last_heard else False
+        if last_heard:
+            is_online = (now - last_heard) < online_threshold_seconds
+        else:
+            is_online = True  # Node exists in nodedb
 
         # Format last_seen
         if last_heard:


### PR DESCRIPTION
When lastHeard is 0 or missing, assume node is online since meshtasticd is actively tracking it. Only mark offline if lastHeard exists AND exceeds the configurable threshold.

Fixes issue where all nodes showed offline on Hawaii mesh despite being actively tracked by meshtasticd.

https://claude.ai/code/session_01UuHLdHkbgPgWxQZELwvGwS