### PR TITLE
feat: Add Leaflet map to RF LOS calculator

### DIFF
--- a/web/los_visualization.html
+++ b/web/los_visualization.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>RF Line of Sight - MeshForge</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <style>
         * {
             margin: 0;
@@ -19,7 +21,7 @@
             padding: 20px;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1400px;
             margin: 0 auto;
         }
         h1 {
@@ -31,6 +33,27 @@
             text-align: center;
             color: #888;
             margin-bottom: 20px;
+        }
+        /* Two-column layout for map and chart */
+        .viz-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 20px;
+            margin-bottom: 20px;
+        }
+        @media (max-width: 900px) {
+            .viz-row {
+                grid-template-columns: 1fr;
+            }
+        }
+        /* Map container */
+        #rf-map {
+            height: 400px;
+            border-radius: 12px;
+            border: 1px solid #2a3a4a;
+        }
+        .leaflet-container {
+            background: #0a0e1a;
         }
         /* Preset selector */
         .preset-section {
@@ -276,24 +299,32 @@
                 </div>
             </div>
 
-            <div class="chart-container">
-                <canvas id="elevationChart"></canvas>
-                <div class="legend">
-                    <div class="legend-item">
-                        <div class="legend-color" style="background: #8B4513;"></div>
-                        <span>Terrain</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background: #4fc3f7;"></div>
-                        <span>Line of Sight</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background: rgba(76, 175, 80, 0.3); height: 12px;"></div>
-                        <span>60% Fresnel Zone</span>
-                    </div>
-                    <div class="legend-item">
-                        <div class="legend-color" style="background: #ff9800; border-style: dashed;"></div>
-                        <span>Earth Curvature</span>
+            <!-- Two-column: Map and Elevation Profile -->
+            <div class="viz-row">
+                <div class="chart-container" style="margin-bottom: 0;">
+                    <h4 style="color: #4fc3f7; margin-bottom: 10px;">RF Path Map</h4>
+                    <div id="rf-map"></div>
+                </div>
+                <div class="chart-container" style="margin-bottom: 0;">
+                    <h4 style="color: #4fc3f7; margin-bottom: 10px;">Elevation Profile</h4>
+                    <canvas id="elevationChart"></canvas>
+                    <div class="legend">
+                        <div class="legend-item">
+                            <div class="legend-color" style="background: #8B4513;"></div>
+                            <span>Terrain</span>
+                        </div>
+                        <div class="legend-item">
+                            <div class="legend-color" style="background: #4fc3f7;"></div>
+                            <span>Line of Sight</span>
+                        </div>
+                        <div class="legend-item">
+                            <div class="legend-color" style="background: rgba(76, 175, 80, 0.3); height: 12px;"></div>
+                            <span>60% Fresnel Zone</span>
+                        </div>
+                        <div class="legend-item">
+                            <div class="legend-color" style="background: #ff9800; border-style: dashed;"></div>
+                            <span>Earth Curvature</span>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -672,6 +703,103 @@
 
             // Resize chart container
             document.getElementById('elevationChart').parentElement.style.height = '400px';
+
+            // Initialize RF Path Map
+            initializeMap(params, elevationData, losStatus, statusClass);
+        }
+
+        // Leaflet map instance
+        let rfMap = null;
+
+        function initializeMap(params, elevationData, losStatus, statusClass) {
+            // Destroy existing map if present
+            if (rfMap) {
+                rfMap.remove();
+                rfMap = null;
+            }
+
+            // Create map centered between the two points
+            const centerLat = (params.latA + params.latB) / 2;
+            const centerLon = (params.lonA + params.lonB) / 2;
+
+            rfMap = L.map('rf-map', {
+                center: [centerLat, centerLon],
+                zoom: 10
+            });
+
+            // Dark theme tiles
+            L.tileLayer('https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png', {
+                attribution: '© OpenStreetMap, © CARTO',
+                maxZoom: 19
+            }).addTo(rfMap);
+
+            // Point A marker (green)
+            const markerA = L.circleMarker([params.latA, params.lonA], {
+                radius: 12,
+                fillColor: '#4caf50',
+                color: '#fff',
+                weight: 2,
+                fillOpacity: 0.9
+            }).addTo(rfMap);
+            markerA.bindPopup(`<b>Point A</b><br>${params.latA.toFixed(5)}, ${params.lonA.toFixed(5)}<br>Antenna: ${params.heightA}m`);
+
+            // Point B marker (blue)
+            const markerB = L.circleMarker([params.latB, params.lonB], {
+                radius: 12,
+                fillColor: '#2196f3',
+                color: '#fff',
+                weight: 2,
+                fillOpacity: 0.9
+            }).addTo(rfMap);
+            markerB.bindPopup(`<b>Point B</b><br>${params.latB.toFixed(5)}, ${params.lonB.toFixed(5)}<br>Antenna: ${params.heightB}m`);
+
+            // Draw RF path line with color based on LOS status
+            let pathColor = '#4caf50'; // Green for clear
+            if (statusClass === 'status-marginal') pathColor = '#ff9800'; // Orange
+            if (statusClass === 'status-bad') pathColor = '#f44336'; // Red
+
+            const pathLine = L.polyline([
+                [params.latA, params.lonA],
+                [params.latB, params.lonB]
+            ], {
+                color: pathColor,
+                weight: 4,
+                opacity: 0.8,
+                dashArray: statusClass === 'status-good' ? null : '10, 10'
+            }).addTo(rfMap);
+
+            // Add elevation sample points along the path
+            elevationData.forEach((point, i) => {
+                if (i === 0 || i === elevationData.length - 1) return; // Skip endpoints
+                L.circleMarker([point.lat, point.lon], {
+                    radius: 4,
+                    fillColor: '#888',
+                    color: '#666',
+                    weight: 1,
+                    fillOpacity: 0.6
+                }).addTo(rfMap).bindPopup(`Sample ${i}<br>Elev: ${point.elevation.toFixed(0)}m`);
+            });
+
+            // Fit map to show both points
+            const bounds = L.latLngBounds([
+                [params.latA, params.lonA],
+                [params.latB, params.lonB]
+            ]);
+            rfMap.fitBounds(bounds, { padding: [50, 50] });
+
+            // Add legend
+            const legend = L.control({ position: 'bottomright' });
+            legend.onAdd = function() {
+                const div = L.DomUtil.create('div', 'map-legend');
+                div.style.cssText = 'background: rgba(22, 33, 62, 0.9); padding: 10px; border-radius: 6px; color: #eee; font-size: 12px;';
+                div.innerHTML = `
+                    <div style="margin-bottom: 5px;"><span style="display:inline-block;width:12px;height:12px;background:#4caf50;border-radius:50%;margin-right:6px;"></span>Point A</div>
+                    <div style="margin-bottom: 5px;"><span style="display:inline-block;width:12px;height:12px;background:#2196f3;border-radius:50%;margin-right:6px;"></span>Point B</div>
+                    <div><span style="display:inline-block;width:20px;height:3px;background:${pathColor};margin-right:6px;vertical-align:middle;"></span>${losStatus}</div>
+                `;
+                return div;
+            };
+            legend.addTo(rfMap);
         }
 
         // Run visualization


### PR DESCRIPTION
The RF Calculator now has a two-column layout showing:
- LEFT: Interactive Leaflet map with RF path visualization
- RIGHT: Elevation profile chart with Fresnel zone

Map features:
- Dark theme CartoDB tiles
- Point A (green) and Point B (blue) markers
- RF path line colored by LOS status (green/orange/red)
- Dashed line for marginal/obstructed paths
- Elevation sample points along path
- Auto-fit bounds to show both endpoints
- Legend showing points and LOS status

Restored the GTK-style RF map visualization in browser form.

https://claude.ai/code/session_0117PYadidFBSfz9nqTEpcmx