### PR TITLE
feat: Expand RNS handler for multi-service discovery and topology tra…

### DIFF
--- a/src/gateway/network_topology.py
+++ b/src/gateway/network_topology.py
@@ -1,0 +1,616 @@
+"""
+Network Topology Graph for RNS/Meshtastic Networks
+
+Provides graph-based representation of mesh network topology with:
+- Edge tracking between nodes (with hop counts, metrics)
+- Path table change detection and event logging
+- Path tracing capabilities
+- Topology analysis utilities
+
+Reference: RNS uses destination hashes and hop counts for routing
+"""
+
+import logging
+import threading
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum, auto
+from typing import Dict, List, Optional, Set, Tuple, Callable, Any
+
+logger = logging.getLogger(__name__)
+
+
+class TopologyEventType(Enum):
+    """Types of topology change events"""
+    NODE_ADDED = auto()
+    NODE_REMOVED = auto()
+    NODE_UPDATED = auto()
+    EDGE_ADDED = auto()
+    EDGE_REMOVED = auto()
+    EDGE_UPDATED = auto()
+    PATH_DISCOVERED = auto()
+    PATH_LOST = auto()
+    HOP_COUNT_CHANGED = auto()
+
+
+@dataclass
+class TopologyEvent:
+    """Represents a change in network topology"""
+    event_type: TopologyEventType
+    timestamp: datetime = field(default_factory=datetime.now)
+    node_id: Optional[str] = None
+    dest_hash: Optional[bytes] = None
+    old_value: Any = None
+    new_value: Any = None
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "event_type": self.event_type.name,
+            "timestamp": self.timestamp.isoformat(),
+            "node_id": self.node_id,
+            "dest_hash": self.dest_hash.hex() if self.dest_hash else None,
+            "old_value": self.old_value,
+            "new_value": self.new_value,
+            "details": self.details,
+        }
+
+
+@dataclass
+class NetworkEdge:
+    """
+    Represents a connection/path between two nodes.
+
+    In RNS, edges are inferred from path table data which shows
+    how to reach a destination through the network.
+    """
+    source_id: str  # Node ID or "local" for our node
+    dest_id: str    # Target node ID
+    dest_hash: Optional[bytes] = None
+
+    # Path metrics
+    hops: int = 0           # Hop count from path table
+    interface: str = ""     # RNS interface name (if available)
+
+    # Timing
+    first_seen: datetime = field(default_factory=datetime.now)
+    last_seen: datetime = field(default_factory=datetime.now)
+    last_updated: datetime = field(default_factory=datetime.now)
+
+    # Signal metrics (when available - primarily Meshtastic)
+    snr: Optional[float] = None
+    rssi: Optional[int] = None
+
+    # Edge state
+    is_active: bool = True
+    announce_count: int = 0  # Number of announces received on this path
+
+    def update(self, hops: int = None, snr: float = None, rssi: int = None):
+        """Update edge metrics"""
+        self.last_seen = datetime.now()
+        self.last_updated = datetime.now()
+        self.announce_count += 1
+        self.is_active = True
+
+        if hops is not None:
+            self.hops = hops
+        if snr is not None:
+            self.snr = snr
+        if rssi is not None:
+            self.rssi = rssi
+
+    def get_weight(self) -> float:
+        """Calculate edge weight for pathfinding (lower is better).
+
+        Weight is based on:
+        - Hop count (primary factor)
+        - SNR/RSSI if available (secondary)
+        - Freshness of the path (tertiary)
+        """
+        weight = float(self.hops + 1)  # Base weight from hops
+
+        # Adjust for signal quality (if available)
+        if self.snr is not None:
+            # Better SNR = lower weight adjustment
+            # SNR typically -20 to +20 dB
+            snr_factor = max(0.5, 1.0 - (self.snr / 40.0))
+            weight *= snr_factor
+
+        # Penalize stale paths slightly
+        age_seconds = (datetime.now() - self.last_seen).total_seconds()
+        if age_seconds > 300:  # 5 minutes
+            staleness = min(2.0, 1.0 + (age_seconds / 3600))
+            weight *= staleness
+
+        return weight
+
+    def to_dict(self) -> dict:
+        return {
+            "source_id": self.source_id,
+            "dest_id": self.dest_id,
+            "dest_hash": self.dest_hash.hex() if self.dest_hash else None,
+            "hops": self.hops,
+            "interface": self.interface,
+            "first_seen": self.first_seen.isoformat(),
+            "last_seen": self.last_seen.isoformat(),
+            "snr": self.snr,
+            "rssi": self.rssi,
+            "is_active": self.is_active,
+            "announce_count": self.announce_count,
+            "weight": self.get_weight(),
+        }
+
+
+@dataclass
+class PathTableEntry:
+    """Snapshot of a path table entry for change detection"""
+    dest_hash: bytes
+    hops: int
+    interface_hash: Optional[bytes] = None
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    def __eq__(self, other):
+        if not isinstance(other, PathTableEntry):
+            return False
+        return (self.dest_hash == other.dest_hash and
+                self.hops == other.hops and
+                self.interface_hash == other.interface_hash)
+
+
+class PathTableMonitor:
+    """
+    Monitors RNS path table for changes and emits events.
+
+    Tracks additions, removals, and hop count changes in the
+    routing table to provide real-time topology updates.
+    """
+
+    def __init__(self, check_interval: float = 10.0):
+        self._lock = threading.RLock()
+        self._running = False
+        self._stop_event = threading.Event()
+        self._monitor_thread: Optional[threading.Thread] = None
+
+        self._check_interval = check_interval
+        self._last_snapshot: Dict[bytes, PathTableEntry] = {}
+        self._event_callbacks: List[Callable[[TopologyEvent], None]] = []
+        self._event_log: List[TopologyEvent] = []
+        self._max_log_size = 1000
+
+    def start(self):
+        """Start monitoring the path table"""
+        self._running = True
+        self._stop_event.clear()
+        self._monitor_thread = threading.Thread(target=self._monitor_loop, daemon=True)
+        self._monitor_thread.start()
+        logger.info(f"Path table monitor started (interval: {self._check_interval}s)")
+
+    def stop(self, timeout: float = 5.0):
+        """Stop monitoring"""
+        self._running = False
+        self._stop_event.set()
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self._monitor_thread.join(timeout=timeout)
+        logger.info("Path table monitor stopped")
+
+    def register_callback(self, callback: Callable[[TopologyEvent], None]):
+        """Register callback for topology events"""
+        with self._lock:
+            self._event_callbacks.append(callback)
+
+    def get_recent_events(self, count: int = 50) -> List[TopologyEvent]:
+        """Get recent topology events"""
+        with self._lock:
+            return list(self._event_log[-count:])
+
+    def _monitor_loop(self):
+        """Background loop checking for path table changes"""
+        while self._running:
+            if self._stop_event.wait(self._check_interval):
+                break
+
+            try:
+                self._check_path_table()
+            except Exception as e:
+                logger.debug(f"Path table check error: {e}")
+
+    def _check_path_table(self):
+        """Check path table for changes and emit events"""
+        try:
+            import RNS
+
+            if not hasattr(RNS.Transport, 'path_table') or not RNS.Transport.path_table:
+                return
+
+            current_snapshot: Dict[bytes, PathTableEntry] = {}
+
+            # Build current snapshot
+            for dest_hash, path_data in RNS.Transport.path_table.items():
+                if not isinstance(dest_hash, bytes) or len(dest_hash) != 16:
+                    continue
+
+                hops = 0
+                interface_hash = None
+
+                if isinstance(path_data, tuple):
+                    if len(path_data) > 1:
+                        hops = path_data[1] if isinstance(path_data[1], int) else 0
+                    if len(path_data) > 0 and path_data[0] is not None:
+                        # Interface reference - get hash if available
+                        try:
+                            if hasattr(path_data[0], 'hash'):
+                                interface_hash = path_data[0].hash
+                        except Exception:
+                            pass
+
+                current_snapshot[dest_hash] = PathTableEntry(
+                    dest_hash=dest_hash,
+                    hops=hops,
+                    interface_hash=interface_hash,
+                )
+
+            # Compare with last snapshot
+            with self._lock:
+                # Check for new paths
+                for dest_hash, entry in current_snapshot.items():
+                    if dest_hash not in self._last_snapshot:
+                        self._emit_event(TopologyEvent(
+                            event_type=TopologyEventType.PATH_DISCOVERED,
+                            dest_hash=dest_hash,
+                            new_value=entry.hops,
+                            details={"interface_hash": entry.interface_hash.hex() if entry.interface_hash else None},
+                        ))
+                    else:
+                        old_entry = self._last_snapshot[dest_hash]
+                        if entry.hops != old_entry.hops:
+                            self._emit_event(TopologyEvent(
+                                event_type=TopologyEventType.HOP_COUNT_CHANGED,
+                                dest_hash=dest_hash,
+                                old_value=old_entry.hops,
+                                new_value=entry.hops,
+                            ))
+
+                # Check for lost paths
+                for dest_hash in self._last_snapshot:
+                    if dest_hash not in current_snapshot:
+                        self._emit_event(TopologyEvent(
+                            event_type=TopologyEventType.PATH_LOST,
+                            dest_hash=dest_hash,
+                            old_value=self._last_snapshot[dest_hash].hops,
+                        ))
+
+                # Update snapshot
+                self._last_snapshot = current_snapshot
+
+        except ImportError:
+            pass  # RNS not installed
+        except Exception as e:
+            logger.debug(f"Path table check failed: {e}")
+
+    def _emit_event(self, event: TopologyEvent):
+        """Emit a topology event to callbacks and log"""
+        # Add to log
+        self._event_log.append(event)
+        if len(self._event_log) > self._max_log_size:
+            self._event_log = self._event_log[-self._max_log_size:]
+
+        # Log significant events
+        hash_short = event.dest_hash.hex()[:8] if event.dest_hash else "unknown"
+        if event.event_type == TopologyEventType.PATH_DISCOVERED:
+            logger.info(f"Path discovered: {hash_short} ({event.new_value} hops)")
+        elif event.event_type == TopologyEventType.PATH_LOST:
+            logger.info(f"Path lost: {hash_short}")
+        elif event.event_type == TopologyEventType.HOP_COUNT_CHANGED:
+            logger.debug(f"Hop count changed: {hash_short} {event.old_value} -> {event.new_value} hops")
+
+        # Notify callbacks
+        for callback in self._event_callbacks:
+            try:
+                callback(event)
+            except Exception as e:
+                logger.error(f"Topology event callback error: {e}")
+
+
+class NetworkTopology:
+    """
+    Graph representation of the mesh network topology.
+
+    Maintains nodes and edges with metrics, supports path tracing
+    and topology analysis.
+    """
+
+    def __init__(self):
+        self._lock = threading.RLock()
+        self._nodes: Dict[str, Dict[str, Any]] = {}  # node_id -> metadata
+        self._edges: Dict[Tuple[str, str], NetworkEdge] = {}  # (src, dst) -> edge
+        self._adjacency: Dict[str, Set[str]] = defaultdict(set)  # node_id -> neighbors
+
+        # Path table integration
+        self._path_monitor = PathTableMonitor()
+        self._path_monitor.register_callback(self._on_path_event)
+
+        # Topology event callbacks
+        self._callbacks: List[Callable[[TopologyEvent], None]] = []
+
+    def start(self):
+        """Start topology tracking"""
+        self._path_monitor.start()
+        logger.info("Network topology tracker started")
+
+    def stop(self, timeout: float = 5.0):
+        """Stop topology tracking"""
+        self._path_monitor.stop(timeout)
+        logger.info("Network topology tracker stopped")
+
+    def register_callback(self, callback: Callable[[TopologyEvent], None]):
+        """Register callback for topology changes"""
+        with self._lock:
+            self._callbacks.append(callback)
+
+    def add_node(self, node_id: str, metadata: Dict[str, Any] = None):
+        """Add or update a node in the topology"""
+        with self._lock:
+            is_new = node_id not in self._nodes
+            self._nodes[node_id] = metadata or {}
+
+            if is_new:
+                self._emit_event(TopologyEvent(
+                    event_type=TopologyEventType.NODE_ADDED,
+                    node_id=node_id,
+                    details=metadata or {},
+                ))
+
+    def remove_node(self, node_id: str):
+        """Remove a node and its edges"""
+        with self._lock:
+            if node_id not in self._nodes:
+                return
+
+            # Remove edges
+            edges_to_remove = []
+            for (src, dst), edge in self._edges.items():
+                if src == node_id or dst == node_id:
+                    edges_to_remove.append((src, dst))
+
+            for key in edges_to_remove:
+                del self._edges[key]
+                src, dst = key
+                self._adjacency[src].discard(dst)
+                self._adjacency[dst].discard(src)
+
+            del self._nodes[node_id]
+            self._emit_event(TopologyEvent(
+                event_type=TopologyEventType.NODE_REMOVED,
+                node_id=node_id,
+            ))
+
+    def add_edge(self, source_id: str, dest_id: str,
+                 dest_hash: bytes = None, hops: int = 0,
+                 snr: float = None, rssi: int = None,
+                 interface: str = "") -> NetworkEdge:
+        """Add or update an edge between nodes"""
+        with self._lock:
+            key = (source_id, dest_id)
+
+            if key in self._edges:
+                edge = self._edges[key]
+                old_hops = edge.hops
+                edge.update(hops=hops, snr=snr, rssi=rssi)
+
+                if hops != old_hops:
+                    self._emit_event(TopologyEvent(
+                        event_type=TopologyEventType.EDGE_UPDATED,
+                        node_id=dest_id,
+                        dest_hash=dest_hash,
+                        old_value=old_hops,
+                        new_value=hops,
+                    ))
+            else:
+                edge = NetworkEdge(
+                    source_id=source_id,
+                    dest_id=dest_id,
+                    dest_hash=dest_hash,
+                    hops=hops,
+                    interface=interface,
+                    snr=snr,
+                    rssi=rssi,
+                )
+                self._edges[key] = edge
+                self._adjacency[source_id].add(dest_id)
+                self._adjacency[dest_id].add(source_id)
+
+                # Ensure nodes exist
+                if source_id not in self._nodes:
+                    self._nodes[source_id] = {}
+                if dest_id not in self._nodes:
+                    self._nodes[dest_id] = {}
+
+                self._emit_event(TopologyEvent(
+                    event_type=TopologyEventType.EDGE_ADDED,
+                    node_id=dest_id,
+                    dest_hash=dest_hash,
+                    new_value=hops,
+                ))
+
+            return edge
+
+    def get_edge(self, source_id: str, dest_id: str) -> Optional[NetworkEdge]:
+        """Get edge between two nodes"""
+        with self._lock:
+            return self._edges.get((source_id, dest_id))
+
+    def get_neighbors(self, node_id: str) -> Set[str]:
+        """Get adjacent nodes"""
+        with self._lock:
+            return set(self._adjacency.get(node_id, set()))
+
+    def find_path(self, source_id: str, dest_id: str) -> Optional[List[str]]:
+        """Find path between two nodes using Dijkstra's algorithm.
+
+        Returns list of node IDs representing the path, or None if no path exists.
+        """
+        with self._lock:
+            if source_id not in self._nodes or dest_id not in self._nodes:
+                return None
+
+            if source_id == dest_id:
+                return [source_id]
+
+            # Dijkstra's algorithm
+            import heapq
+
+            distances: Dict[str, float] = {source_id: 0}
+            previous: Dict[str, Optional[str]] = {source_id: None}
+            visited: Set[str] = set()
+            heap = [(0, source_id)]
+
+            while heap:
+                current_dist, current = heapq.heappop(heap)
+
+                if current in visited:
+                    continue
+                visited.add(current)
+
+                if current == dest_id:
+                    # Reconstruct path
+                    path = []
+                    node = dest_id
+                    while node is not None:
+                        path.append(node)
+                        node = previous.get(node)
+                    return list(reversed(path))
+
+                # Check neighbors
+                for neighbor in self._adjacency.get(current, set()):
+                    if neighbor in visited:
+                        continue
+
+                    edge = self._edges.get((current, neighbor))
+                    if not edge or not edge.is_active:
+                        continue
+
+                    weight = edge.get_weight()
+                    new_dist = current_dist + weight
+
+                    if neighbor not in distances or new_dist < distances[neighbor]:
+                        distances[neighbor] = new_dist
+                        previous[neighbor] = current
+                        heapq.heappush(heap, (new_dist, neighbor))
+
+            return None  # No path found
+
+    def trace_path(self, dest_hash: bytes) -> Dict[str, Any]:
+        """Trace path to a destination hash through known topology.
+
+        Returns path information including intermediate hops if known.
+        """
+        with self._lock:
+            dest_id = f"rns_{dest_hash.hex()[:16]}"
+            result = {
+                "dest_hash": dest_hash.hex(),
+                "dest_id": dest_id,
+                "found": False,
+                "path": [],
+                "total_hops": 0,
+                "details": {},
+            }
+
+            # Find edge from local to destination
+            edge = self._edges.get(("local", dest_id))
+            if edge:
+                result["found"] = True
+                result["total_hops"] = edge.hops
+                result["path"] = ["local", dest_id]
+                result["details"] = {
+                    "interface": edge.interface,
+                    "last_seen": edge.last_seen.isoformat(),
+                    "announce_count": edge.announce_count,
+                }
+
+            return result
+
+    def get_topology_stats(self) -> Dict[str, Any]:
+        """Get topology statistics"""
+        with self._lock:
+            active_edges = sum(1 for e in self._edges.values() if e.is_active)
+            total_hops = sum(e.hops for e in self._edges.values() if e.is_active)
+
+            return {
+                "node_count": len(self._nodes),
+                "edge_count": len(self._edges),
+                "active_edges": active_edges,
+                "avg_hops": total_hops / active_edges if active_edges > 0 else 0,
+                "max_hops": max((e.hops for e in self._edges.values()), default=0),
+            }
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Export topology as dictionary"""
+        with self._lock:
+            return {
+                "nodes": list(self._nodes.keys()),
+                "edges": [e.to_dict() for e in self._edges.values()],
+                "stats": self.get_topology_stats(),
+            }
+
+    def get_recent_events(self, count: int = 50) -> List[Dict[str, Any]]:
+        """Get recent topology events"""
+        events = self._path_monitor.get_recent_events(count)
+        return [e.to_dict() for e in events]
+
+    def _on_path_event(self, event: TopologyEvent):
+        """Handle path table events and update topology"""
+        if event.dest_hash is None:
+            return
+
+        dest_id = f"rns_{event.dest_hash.hex()[:16]}"
+
+        if event.event_type == TopologyEventType.PATH_DISCOVERED:
+            self.add_edge(
+                source_id="local",
+                dest_id=dest_id,
+                dest_hash=event.dest_hash,
+                hops=event.new_value or 0,
+            )
+
+        elif event.event_type == TopologyEventType.PATH_LOST:
+            key = ("local", dest_id)
+            with self._lock:
+                if key in self._edges:
+                    self._edges[key].is_active = False
+
+        elif event.event_type == TopologyEventType.HOP_COUNT_CHANGED:
+            self.add_edge(
+                source_id="local",
+                dest_id=dest_id,
+                dest_hash=event.dest_hash,
+                hops=event.new_value or 0,
+            )
+
+        # Forward to registered callbacks
+        for callback in self._callbacks:
+            try:
+                callback(event)
+            except Exception as e:
+                logger.error(f"Topology callback error: {e}")
+
+    def _emit_event(self, event: TopologyEvent):
+        """Emit topology event to callbacks"""
+        for callback in self._callbacks:
+            try:
+                callback(event)
+            except Exception as e:
+                logger.error(f"Topology event callback error: {e}")
+
+
+# Global topology instance
+_topology: Optional[NetworkTopology] = None
+
+
+def get_network_topology() -> NetworkTopology:
+    """Get the global network topology instance"""
+    global _topology
+    if _topology is None:
+        _topology = NetworkTopology()
+    return _topology

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -1,6 +1,11 @@
 """
 Unified Node Tracker for RNS and Meshtastic Networks
-Tracks nodes from both networks with position and telemetry data
+Tracks nodes from both networks with position and telemetry data.
+
+Enhanced with:
+- Multi-service RNS announce parsing (LXMF, Nomad, generic)
+- Network topology graph with edge tracking
+- Path table change monitoring
 """
 
 import threading
@@ -9,11 +14,26 @@ import logging
 import os
 from datetime import datetime
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Callable, Any
+from typing import Dict, List, Optional, Callable, Any, TYPE_CHECKING
 from pathlib import Path
 import json
 
 logger = logging.getLogger(__name__)
+
+# Import RNS service registry and topology (optional - graceful fallback)
+try:
+    from .rns_services import (
+        RNSServiceType, ServiceInfo, AnnounceEvent,
+        get_service_registry, RNSServiceRegistry
+    )
+    from .network_topology import (
+        NetworkTopology, get_network_topology, TopologyEvent
+    )
+    RNS_SERVICES_AVAILABLE = True
+except ImportError:
+    RNS_SERVICES_AVAILABLE = False
+    RNSServiceType = None  # type: ignore
+    ServiceInfo = None  # type: ignore
 
 # Import centralized path utility
 try:
@@ -250,6 +270,11 @@ class UnifiedNode:
     firmware_version: Optional[str] = None
     role: Optional[str] = None
 
+    # RNS service info (enhanced tracking)
+    service_type: Optional[str] = None  # RNS service type (LXMF_DELIVERY, NOMAD_PAGE, etc.)
+    service_aspect: Optional[str] = None  # Raw aspect filter (lxmf.delivery, nomadnetwork.node, etc.)
+    service_capabilities: List[str] = field(default_factory=list)  # Service capabilities
+
     def __post_init__(self):
         if self.first_seen is None:
             self.first_seen = datetime.now()
@@ -298,6 +323,10 @@ class UnifiedNode:
             "hardware_model": self.hardware_model,
             "firmware_version": self.firmware_version,
             "role": self.role,
+            # RNS service info
+            "service_type": self.service_type,
+            "service_aspect": self.service_aspect,
+            "service_capabilities": self.service_capabilities if self.service_capabilities else None,
         }
 
     @classmethod
@@ -347,14 +376,25 @@ class UnifiedNode:
         return node
 
     @classmethod
-    def from_rns(cls, rns_hash: bytes, name: str = "", app_data: bytes = None) -> 'UnifiedNode':
+    def from_rns(cls, rns_hash: bytes, name: str = "", app_data: bytes = None,
+                 service_info: Any = None, aspect: str = None) -> 'UnifiedNode':
         """Create from RNS announce/discovery data.
 
-        Parses LXMF announce app_data which may contain:
+        Parses announce app_data which may contain:
         - Display name (first portion of app_data)
         - Telemetry data including position (msgpack encoded, if present)
 
-        Sideband and other LXMF apps can include GPS coordinates in announces.
+        Supports multiple RNS service types:
+        - LXMF (Sideband, NomadNet messaging)
+        - Nomad Network pages
+        - Generic services
+
+        Args:
+            rns_hash: 16-byte destination hash
+            name: Optional display name override
+            app_data: Raw announce app_data bytes
+            service_info: Optional ServiceInfo from RNS service registry
+            aspect: Optional aspect filter string (e.g., "lxmf.delivery")
         """
         hash_hex = rns_hash.hex()
 
@@ -366,8 +406,31 @@ class UnifiedNode:
             rns_hash=rns_hash,
         )
 
-        # Parse app_data if available (may contain name, position, telemetry)
-        if app_data and len(app_data) > 0:
+        # Use service registry if available and service_info provided
+        if RNS_SERVICES_AVAILABLE and service_info is not None:
+            # Extract data from ServiceInfo
+            if service_info.display_name:
+                node.name = service_info.display_name
+            if service_info.latitude is not None and service_info.longitude is not None:
+                lat, lon = service_info.latitude, service_info.longitude
+                if -90 <= lat <= 90 and -180 <= lon <= 180:
+                    node.position = Position(
+                        latitude=lat,
+                        longitude=lon,
+                        altitude=service_info.altitude or 0.0,
+                        timestamp=datetime.now()
+                    )
+                    logger.debug(f"RNS node {hash_hex[:8]} has position: {lat:.4f}, {lon:.4f}")
+            if service_info.battery is not None:
+                node.telemetry.battery_level = service_info.battery
+
+            # Store service info
+            node.service_type = service_info.service_type.name if hasattr(service_info.service_type, 'name') else str(service_info.service_type)
+            node.service_aspect = service_info.aspect
+            node.service_capabilities = list(service_info.capabilities)
+
+        elif app_data and len(app_data) > 0:
+            # Fallback to legacy parsing if service registry not available
             parsed = cls._parse_lxmf_app_data(app_data)
             if parsed:
                 if parsed.get("display_name"):
@@ -375,7 +438,6 @@ class UnifiedNode:
                 if parsed.get("latitude") is not None and parsed.get("longitude") is not None:
                     lat = parsed["latitude"]
                     lon = parsed["longitude"]
-                    # Validate coordinates
                     if -90 <= lat <= 90 and -180 <= lon <= 180:
                         node.position = Position(
                             latitude=lat,
@@ -384,6 +446,10 @@ class UnifiedNode:
                             timestamp=datetime.now()
                         )
                         logger.debug(f"RNS node {hash_hex[:8]} has position: {lat:.4f}, {lon:.4f}")
+
+        # Store aspect even without full service info
+        if aspect and not node.service_aspect:
+            node.service_aspect = aspect
 
         node.last_seen = datetime.now()
         return node
@@ -488,6 +554,11 @@ class UnifiedNodeTracker:
     """
     Tracks nodes from both RNS and Meshtastic networks.
     Provides unified view for map display and monitoring.
+
+    Enhanced features:
+    - Multi-service RNS announce parsing via RNSServiceRegistry
+    - Network topology graph via NetworkTopology
+    - Path table change monitoring with event logging
     """
 
     OFFLINE_THRESHOLD = 3600  # 1 hour
@@ -509,6 +580,16 @@ class UnifiedNodeTracker:
         self._reticulum = None
         self._rns_connected = False
 
+        # Enhanced RNS service tracking
+        self._service_registry: Optional[RNSServiceRegistry] = None
+        self._network_topology: Optional[NetworkTopology] = None
+        if RNS_SERVICES_AVAILABLE:
+            self._service_registry = get_service_registry()
+            self._network_topology = get_network_topology()
+            # Register for topology events
+            self._network_topology.register_callback(self._on_topology_event)
+            logger.debug("Enhanced RNS service tracking enabled")
+
         # Load cached nodes
         self._load_cache()
 
@@ -518,6 +599,10 @@ class UnifiedNodeTracker:
         self._stop_event.clear()
         self._cleanup_thread = threading.Thread(target=self._cleanup_loop, daemon=True)
         self._cleanup_thread.start()
+
+        # Start network topology tracking (includes path table monitor)
+        if self._network_topology:
+            self._network_topology.start()
 
         # Initialize RNS in the main thread to avoid signal handler issues
         # RNS.Reticulum() sets up signal handlers which only work in main thread
@@ -591,20 +676,39 @@ instance_control_port = 37429
                 self._rns_connected = True
                 logger.info("Connected to existing rnsd instance")
 
-                # Register announce handler to receive node announcements
-                class NodeAnnounceHandler:
-                    def __init__(self, tracker):
+                # Register announce handlers for node discovery
+                # We register handlers for specific aspects to get accurate service typing,
+                # plus a catch-all handler for unknown service types
+
+                class AspectAnnounceHandler:
+                    """Announce handler that passes aspect info to tracker"""
+                    def __init__(self, tracker, aspect: str = None):
                         self.tracker = tracker
-                        self.aspect_filter = None
+                        self.aspect_filter = aspect  # None = catch all
 
                     def received_announce(self, destination_hash, announced_identity, app_data):
                         try:
-                            self.tracker._on_rns_announce(destination_hash, announced_identity, app_data)
+                            self.tracker._on_rns_announce(
+                                destination_hash, announced_identity, app_data,
+                                aspect=self.aspect_filter
+                            )
                         except Exception as e:
                             logger.error(f"Error handling RNS announce: {e}")
 
-                RNS.Transport.register_announce_handler(NodeAnnounceHandler(self))
-                logger.info("Registered announce handler with rnsd")
+                # Register handlers for known service aspects
+                known_aspects = [
+                    "lxmf.delivery",       # LXMF messaging (Sideband, NomadNet)
+                    "lxmf.propagation",    # LXMF propagation nodes
+                    "nomadnetwork.node",   # Nomad Network pages
+                ]
+
+                for aspect in known_aspects:
+                    RNS.Transport.register_announce_handler(AspectAnnounceHandler(self, aspect))
+                    logger.debug(f"Registered announce handler for aspect: {aspect}")
+
+                # Also register a catch-all handler for unknown services
+                RNS.Transport.register_announce_handler(AspectAnnounceHandler(self, None))
+                logger.info(f"Registered {len(known_aspects) + 1} announce handlers with rnsd")
 
                 # Load known destinations from rnsd (may be empty initially)
                 self._load_known_rns_destinations(RNS)
@@ -695,6 +799,10 @@ instance_control_port = 37429
         logger.info("Stopping node tracker...")
         self._running = False
         self._stop_event.set()
+
+        # Stop network topology tracker
+        if self._network_topology:
+            self._network_topology.stop(timeout)
 
         # Wait for cleanup thread to finish
         if hasattr(self, '_cleanup_thread') and self._cleanup_thread and self._cleanup_thread.is_alive():
@@ -1097,27 +1205,145 @@ instance_control_port = 37429
         except Exception as e:
             logger.debug(f"Could not load known RNS destinations: {e}")
 
-    def _on_rns_announce(self, dest_hash, announced_identity, app_data):
-        """Handle RNS announce for node discovery"""
-        try:
-            # Parse display name from app_data if available
-            display_name = ""
-            if app_data:
-                try:
-                    # LXMF announces typically include display name
-                    # Try to decode as UTF-8 string
-                    display_name = app_data.decode('utf-8', errors='ignore').strip()
-                    # Clean up - remove non-printable characters
-                    display_name = ''.join(c for c in display_name if c.isprintable())
-                except Exception as e:
-                    logger.debug(f"Could not decode RNS display name: {e}")
+    def _on_rns_announce(self, dest_hash, announced_identity, app_data, aspect: str = None):
+        """Handle RNS announce for node discovery.
 
-            # Create node from announce
-            node = UnifiedNode.from_rns(dest_hash, name=display_name, app_data=app_data)
+        Uses the RNS service registry (if available) for multi-service parsing,
+        or falls back to legacy LXMF-only parsing.
+
+        Args:
+            dest_hash: 16-byte destination hash
+            announced_identity: RNS Identity object
+            app_data: Raw announce app_data bytes
+            aspect: Optional aspect filter from announce handler
+        """
+        try:
+            hash_short = dest_hash.hex()[:8]
+            service_info = None
+            display_name = ""
+
+            # Use service registry for enhanced parsing if available
+            if self._service_registry and RNS_SERVICES_AVAILABLE:
+                event = self._service_registry.parse_announce(
+                    dest_hash, announced_identity, app_data, aspect
+                )
+                service_info = event.service_info
+                display_name = event.raw_name
+
+                service_type_name = service_info.service_type.name if service_info else "UNKNOWN"
+                logger.debug(f"Parsed announce {hash_short}: type={service_type_name}, name={display_name or 'unnamed'}")
+            else:
+                # Legacy fallback: simple UTF-8 decode
+                if app_data:
+                    try:
+                        display_name = app_data.decode('utf-8', errors='ignore').strip()
+                        display_name = ''.join(c for c in display_name if c.isprintable())
+                    except Exception as e:
+                        logger.debug(f"Could not decode RNS display name: {e}")
+
+            # Create node from announce with service info
+            node = UnifiedNode.from_rns(
+                dest_hash,
+                name=display_name,
+                app_data=app_data,
+                service_info=service_info,
+                aspect=aspect
+            )
             self.add_node(node)
 
-            hash_short = dest_hash.hex()[:8]
-            logger.info(f"Discovered RNS node: {hash_short} ({display_name or 'unnamed'})")
+            # Update topology edge
+            if self._network_topology:
+                node_id = f"rns_{dest_hash.hex()[:16]}"
+                self._network_topology.add_edge(
+                    source_id="local",
+                    dest_id=node_id,
+                    dest_hash=dest_hash,
+                    hops=node.hops or 0,
+                )
+
+            service_desc = f"[{node.service_type}]" if node.service_type else ""
+            logger.info(f"Discovered RNS node: {hash_short} ({display_name or 'unnamed'}) {service_desc}")
 
         except Exception as e:
             logger.error(f"Error processing RNS announce: {e}")
+
+    def _on_topology_event(self, event: 'TopologyEvent'):
+        """Handle topology change events.
+
+        Updates node information when path table changes are detected.
+        """
+        if not RNS_SERVICES_AVAILABLE or event.dest_hash is None:
+            return
+
+        try:
+            node_id = f"rns_{event.dest_hash.hex()[:16]}"
+
+            with self._lock:
+                node = self._nodes.get(node_id)
+                if node:
+                    # Update hop count from topology event
+                    if event.new_value is not None and isinstance(event.new_value, int):
+                        node.hops = event.new_value
+                        node.update_seen()
+                        logger.debug(f"Updated node {node_id[:12]} hops: {event.new_value}")
+
+        except Exception as e:
+            logger.debug(f"Error handling topology event: {e}")
+
+    # --- Topology API methods ---
+
+    def get_topology_stats(self) -> Optional[Dict[str, Any]]:
+        """Get network topology statistics.
+
+        Returns:
+            Dict with node_count, edge_count, avg_hops, etc. or None if unavailable
+        """
+        if self._network_topology:
+            return self._network_topology.get_topology_stats()
+        return None
+
+    def get_topology(self) -> Optional[Dict[str, Any]]:
+        """Get full network topology as dictionary.
+
+        Returns:
+            Dict with nodes, edges, and stats or None if unavailable
+        """
+        if self._network_topology:
+            return self._network_topology.to_dict()
+        return None
+
+    def trace_path(self, dest_hash: bytes) -> Optional[Dict[str, Any]]:
+        """Trace path to a destination through the network.
+
+        Args:
+            dest_hash: 16-byte destination hash
+
+        Returns:
+            Dict with path info or None if unavailable
+        """
+        if self._network_topology:
+            return self._network_topology.trace_path(dest_hash)
+        return None
+
+    def get_recent_topology_events(self, count: int = 50) -> List[Dict[str, Any]]:
+        """Get recent topology change events.
+
+        Args:
+            count: Maximum number of events to return
+
+        Returns:
+            List of event dicts
+        """
+        if self._network_topology:
+            return self._network_topology.get_recent_events(count)
+        return []
+
+    def get_service_stats(self) -> Optional[Dict[str, int]]:
+        """Get counts of discovered services by type.
+
+        Returns:
+            Dict mapping service type names to counts or None if unavailable
+        """
+        if self._service_registry:
+            return self._service_registry.get_stats()
+        return None

--- a/src/gateway/rns_services.py
+++ b/src/gateway/rns_services.py
@@ -1,0 +1,390 @@
+"""
+RNS Service Registry and Announce Parsers
+
+Handles different RNS service types beyond LXMF, including:
+- LXMF messaging (Sideband, NomadNet)
+- Nomad Network pages
+- Propagation nodes
+- Generic/unknown services
+
+Reference: https://reticulum.network/manual/
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum, auto
+from typing import Dict, List, Optional, Callable, Any, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class RNSServiceType(Enum):
+    """Known RNS service types based on announce aspects"""
+    LXMF_DELIVERY = auto()       # lxmf.delivery - Sideband, NomadNet messaging
+    LXMF_PROPAGATION = auto()    # lxmf.propagation - LXMF propagation nodes
+    NOMAD_PAGE = auto()          # nomadnetwork.node - Nomad Network pages
+    PROPAGATION_NODE = auto()    # Reticulum propagation node
+    FILE_SHARE = auto()          # File sharing services
+    UNKNOWN = auto()             # Unknown service type
+
+
+# Aspect filter to service type mapping
+ASPECT_TO_SERVICE: Dict[str, RNSServiceType] = {
+    "lxmf.delivery": RNSServiceType.LXMF_DELIVERY,
+    "lxmf.propagation": RNSServiceType.LXMF_PROPAGATION,
+    "nomadnetwork.node": RNSServiceType.NOMAD_PAGE,
+    "nomadnetwork.page": RNSServiceType.NOMAD_PAGE,  # Alternative aspect
+}
+
+
+@dataclass
+class ServiceInfo:
+    """Information about a discovered RNS service"""
+    service_type: RNSServiceType
+    aspect: str
+    display_name: str = ""
+    description: str = ""
+    capabilities: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    # Telemetry extracted from app_data
+    latitude: Optional[float] = None
+    longitude: Optional[float] = None
+    altitude: Optional[float] = None
+    battery: Optional[int] = None
+    speed: Optional[float] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "service_type": self.service_type.name,
+            "aspect": self.aspect,
+            "display_name": self.display_name,
+            "description": self.description,
+            "capabilities": self.capabilities,
+            "metadata": self.metadata,
+            "latitude": self.latitude,
+            "longitude": self.longitude,
+            "altitude": self.altitude,
+            "battery": self.battery,
+            "speed": self.speed,
+        }
+
+
+@dataclass
+class AnnounceEvent:
+    """Represents an RNS announce event with parsed data"""
+    destination_hash: bytes
+    announced_identity: Any  # RNS.Identity
+    app_data: Optional[bytes]
+    aspect: Optional[str]
+    timestamp: datetime = field(default_factory=datetime.now)
+
+    # Parsed data
+    service_info: Optional[ServiceInfo] = None
+    raw_name: str = ""
+
+    @property
+    def hash_hex(self) -> str:
+        return self.destination_hash.hex()
+
+    @property
+    def short_hash(self) -> str:
+        return self.hash_hex[:8]
+
+
+class ServiceParser:
+    """Base class for service-specific announce parsers"""
+
+    @staticmethod
+    def parse(app_data: bytes, aspect: str) -> ServiceInfo:
+        """Parse app_data and return ServiceInfo. Override in subclasses."""
+        raise NotImplementedError
+
+
+class LXMFParser(ServiceParser):
+    """Parser for LXMF announce app_data (Sideband, NomadNet messaging)"""
+
+    @staticmethod
+    def parse(app_data: bytes, aspect: str) -> ServiceInfo:
+        """Parse LXMF app_data format.
+
+        LXMF app_data structure:
+        - Display name as UTF-8 string (variable length, usually < 128 bytes)
+        - Optional msgpack-encoded telemetry dict after the name
+
+        Msgpack telemetry keys (Sideband format):
+        - latitude/lat, longitude/lon/lng, altitude/alt
+        - speed, heading, accuracy, battery
+        """
+        info = ServiceInfo(
+            service_type=RNSServiceType.LXMF_DELIVERY if aspect == "lxmf.delivery"
+                        else RNSServiceType.LXMF_PROPAGATION,
+            aspect=aspect,
+        )
+
+        if not app_data or len(app_data) == 0:
+            return info
+
+        # Find msgpack boundary
+        msgpack_start = LXMFParser._find_msgpack_start(app_data)
+
+        # Extract display name (before msgpack or entire data)
+        name_bytes = app_data[:msgpack_start] if msgpack_start > 0 else app_data
+        if 0 < len(name_bytes) < 128:
+            try:
+                decoded = name_bytes.decode('utf-8', errors='ignore').strip('\x00').strip()
+                if decoded and len(decoded) >= 1:
+                    clean_name = ''.join(c for c in decoded if c.isprintable())
+                    if clean_name:
+                        info.display_name = clean_name[:64]
+            except UnicodeDecodeError:
+                pass
+
+        # Parse msgpack telemetry if found
+        if msgpack_start >= 0:
+            LXMFParser._parse_msgpack_telemetry(app_data[msgpack_start:], info)
+
+        return info
+
+    @staticmethod
+    def _find_msgpack_start(app_data: bytes) -> int:
+        """Find the start of msgpack data in app_data.
+
+        Scans for msgpack dict markers:
+        - fixmap: 0x80-0x8f (up to 15 entries)
+        - map16: 0xde
+        - map32: 0xdf
+        """
+        for i in range(len(app_data)):
+            byte = app_data[i]
+            if 0x80 <= byte <= 0x8f:  # fixmap
+                return i
+            elif byte in (0xde, 0xdf):  # map16 or map32
+                return i
+        return -1
+
+    @staticmethod
+    def _parse_msgpack_telemetry(data: bytes, info: ServiceInfo):
+        """Extract telemetry from msgpack data into ServiceInfo"""
+        try:
+            import msgpack
+            telemetry = msgpack.unpackb(data, raw=False, strict_map_key=False)
+            if not isinstance(telemetry, dict):
+                return
+
+            # Position extraction with multiple key formats
+            lat = telemetry.get('latitude') or telemetry.get('lat')
+            lon = telemetry.get('longitude') or telemetry.get('lon') or telemetry.get('lng')
+
+            if lat is not None and lon is not None:
+                try:
+                    info.latitude = float(lat)
+                    info.longitude = float(lon)
+                    info.altitude = float(telemetry.get('altitude') or telemetry.get('alt') or 0.0)
+                except (TypeError, ValueError):
+                    pass
+
+            # Other telemetry
+            if 'speed' in telemetry:
+                try:
+                    info.speed = float(telemetry['speed'])
+                except (TypeError, ValueError):
+                    pass
+
+            if 'battery' in telemetry:
+                try:
+                    info.battery = int(telemetry['battery'])
+                except (TypeError, ValueError):
+                    pass
+
+            # Store raw telemetry in metadata for debugging
+            info.metadata['raw_telemetry'] = {k: v for k, v in telemetry.items()
+                                               if k in ('latitude', 'lat', 'longitude', 'lon', 'lng',
+                                                       'altitude', 'alt', 'speed', 'heading',
+                                                       'accuracy', 'battery')}
+
+        except ImportError:
+            logger.debug("msgpack not installed - skipping telemetry parsing")
+        except Exception as e:
+            logger.debug(f"Failed to parse msgpack telemetry: {e}")
+
+
+class NomadParser(ServiceParser):
+    """Parser for Nomad Network node/page announces"""
+
+    @staticmethod
+    def parse(app_data: bytes, aspect: str) -> ServiceInfo:
+        """Parse Nomad Network app_data.
+
+        Nomad Network announces contain:
+        - Page name/title as UTF-8
+        - Optional page description
+        """
+        info = ServiceInfo(
+            service_type=RNSServiceType.NOMAD_PAGE,
+            aspect=aspect,
+            capabilities=["pages", "microns"],
+        )
+
+        if not app_data or len(app_data) == 0:
+            return info
+
+        try:
+            # Nomad typically sends plain UTF-8 for page info
+            decoded = app_data.decode('utf-8', errors='ignore').strip('\x00').strip()
+            if decoded:
+                # First line is usually the node/page name
+                lines = decoded.split('\n')
+                info.display_name = lines[0][:64] if lines else ""
+                if len(lines) > 1:
+                    info.description = '\n'.join(lines[1:])[:256]
+        except Exception as e:
+            logger.debug(f"Failed to parse Nomad app_data: {e}")
+
+        return info
+
+
+class GenericParser(ServiceParser):
+    """Parser for unknown/generic RNS announces"""
+
+    @staticmethod
+    def parse(app_data: bytes, aspect: str) -> ServiceInfo:
+        """Parse generic app_data - attempt basic name extraction"""
+        info = ServiceInfo(
+            service_type=RNSServiceType.UNKNOWN,
+            aspect=aspect or "unknown",
+        )
+
+        if not app_data or len(app_data) == 0:
+            return info
+
+        # Attempt UTF-8 decode for display name
+        try:
+            decoded = app_data.decode('utf-8', errors='ignore').strip('\x00').strip()
+            # Filter to printable chars only
+            clean = ''.join(c for c in decoded if c.isprintable())
+            if clean and len(clean) >= 2:
+                info.display_name = clean[:64]
+        except Exception:
+            pass
+
+        # Store raw app_data length for debugging
+        info.metadata['app_data_length'] = len(app_data)
+        info.metadata['app_data_hex_preview'] = app_data[:32].hex() if len(app_data) > 0 else ""
+
+        return info
+
+
+class RNSServiceRegistry:
+    """
+    Registry for RNS service parsers.
+
+    Manages aspect-to-parser mappings and handles announce parsing.
+    """
+
+    def __init__(self):
+        self._parsers: Dict[str, type] = {}
+        self._service_callbacks: List[Callable[[AnnounceEvent], None]] = []
+        self._discovered_services: Dict[str, ServiceInfo] = {}  # hash_hex -> ServiceInfo
+
+        # Register built-in parsers
+        self._register_builtin_parsers()
+
+    def _register_builtin_parsers(self):
+        """Register default parsers for known service types"""
+        # LXMF services
+        self.register_parser("lxmf.delivery", LXMFParser)
+        self.register_parser("lxmf.propagation", LXMFParser)
+
+        # Nomad Network
+        self.register_parser("nomadnetwork.node", NomadParser)
+        self.register_parser("nomadnetwork.page", NomadParser)
+
+    def register_parser(self, aspect: str, parser_class: type):
+        """Register a parser for a specific aspect"""
+        self._parsers[aspect] = parser_class
+        logger.debug(f"Registered parser for aspect: {aspect}")
+
+    def register_callback(self, callback: Callable[[AnnounceEvent], None]):
+        """Register callback for service discovery events"""
+        self._service_callbacks.append(callback)
+
+    def parse_announce(self, dest_hash: bytes, identity: Any,
+                      app_data: Optional[bytes], aspect: Optional[str] = None) -> AnnounceEvent:
+        """Parse an RNS announce and return structured event data.
+
+        Args:
+            dest_hash: 16-byte destination hash
+            identity: RNS Identity object
+            app_data: Raw announce app_data
+            aspect: Optional aspect filter (if known)
+
+        Returns:
+            AnnounceEvent with parsed ServiceInfo
+        """
+        event = AnnounceEvent(
+            destination_hash=dest_hash,
+            announced_identity=identity,
+            app_data=app_data,
+            aspect=aspect,
+        )
+
+        # Get appropriate parser
+        parser_class = self._parsers.get(aspect, GenericParser)
+
+        # Parse app_data
+        try:
+            event.service_info = parser_class.parse(app_data or b'', aspect or "")
+            if event.service_info.display_name:
+                event.raw_name = event.service_info.display_name
+        except Exception as e:
+            logger.error(f"Failed to parse announce for {event.short_hash}: {e}")
+            event.service_info = ServiceInfo(
+                service_type=RNSServiceType.UNKNOWN,
+                aspect=aspect or "unknown",
+            )
+
+        # Store discovered service
+        self._discovered_services[event.hash_hex] = event.service_info
+
+        # Notify callbacks
+        for callback in self._service_callbacks:
+            try:
+                callback(event)
+            except Exception as e:
+                logger.error(f"Service callback error: {e}")
+
+        return event
+
+    def get_service_type(self, aspect: str) -> RNSServiceType:
+        """Get service type for an aspect"""
+        return ASPECT_TO_SERVICE.get(aspect, RNSServiceType.UNKNOWN)
+
+    def get_discovered_service(self, hash_hex: str) -> Optional[ServiceInfo]:
+        """Get previously discovered service info by hash"""
+        return self._discovered_services.get(hash_hex)
+
+    def get_all_discovered(self) -> Dict[str, ServiceInfo]:
+        """Get all discovered services"""
+        return dict(self._discovered_services)
+
+    def get_stats(self) -> Dict[str, int]:
+        """Get counts by service type"""
+        stats: Dict[str, int] = {}
+        for service in self._discovered_services.values():
+            type_name = service.service_type.name
+            stats[type_name] = stats.get(type_name, 0) + 1
+        return stats
+
+
+# Global registry instance
+_registry: Optional[RNSServiceRegistry] = None
+
+
+def get_service_registry() -> RNSServiceRegistry:
+    """Get the global service registry instance"""
+    global _registry
+    if _registry is None:
+        _registry = RNSServiceRegistry()
+    return _registry

--- a/tests/test_rns_services.py
+++ b/tests/test_rns_services.py
@@ -1,0 +1,279 @@
+"""
+Tests for RNS service registry and announce parsers.
+"""
+
+import sys
+sys.path.insert(0, 'src')
+
+import unittest
+from datetime import datetime
+
+
+class TestRNSServiceTypes(unittest.TestCase):
+    """Test RNS service type definitions"""
+
+    def test_service_types_defined(self):
+        """Verify all expected service types exist"""
+        from gateway.rns_services import RNSServiceType
+
+        # Check all expected types
+        self.assertTrue(hasattr(RNSServiceType, 'LXMF_DELIVERY'))
+        self.assertTrue(hasattr(RNSServiceType, 'LXMF_PROPAGATION'))
+        self.assertTrue(hasattr(RNSServiceType, 'NOMAD_PAGE'))
+        self.assertTrue(hasattr(RNSServiceType, 'UNKNOWN'))
+
+    def test_aspect_mapping(self):
+        """Verify aspect to service type mapping"""
+        from gateway.rns_services import ASPECT_TO_SERVICE, RNSServiceType
+
+        self.assertEqual(ASPECT_TO_SERVICE['lxmf.delivery'], RNSServiceType.LXMF_DELIVERY)
+        self.assertEqual(ASPECT_TO_SERVICE['nomadnetwork.node'], RNSServiceType.NOMAD_PAGE)
+
+
+class TestLXMFParser(unittest.TestCase):
+    """Test LXMF announce parser"""
+
+    def test_parse_simple_name(self):
+        """Parse simple UTF-8 name"""
+        from gateway.rns_services import LXMFParser
+
+        app_data = b'TestUser'
+        info = LXMFParser.parse(app_data, 'lxmf.delivery')
+
+        self.assertEqual(info.display_name, 'TestUser')
+        self.assertEqual(info.service_type.name, 'LXMF_DELIVERY')
+
+    def test_parse_empty_data(self):
+        """Handle empty app_data gracefully"""
+        from gateway.rns_services import LXMFParser
+
+        info = LXMFParser.parse(b'', 'lxmf.delivery')
+        self.assertEqual(info.display_name, '')
+        self.assertIsNone(info.latitude)
+
+    def test_parse_unicode_name(self):
+        """Parse Unicode characters in name"""
+        from gateway.rns_services import LXMFParser
+
+        app_data = 'Tëst Üsér 日本語'.encode('utf-8')
+        info = LXMFParser.parse(app_data, 'lxmf.delivery')
+
+        self.assertIn('Tëst', info.display_name)
+
+    def test_msgpack_start_detection(self):
+        """Detect msgpack markers correctly"""
+        from gateway.rns_services import LXMFParser
+
+        # fixmap marker (0x80-0x8f)
+        idx = LXMFParser._find_msgpack_start(b'Name\x82\xa3lat\xcb@')
+        self.assertEqual(idx, 4)
+
+        # No msgpack
+        idx = LXMFParser._find_msgpack_start(b'JustAName')
+        self.assertEqual(idx, -1)
+
+
+class TestNomadParser(unittest.TestCase):
+    """Test Nomad Network parser"""
+
+    def test_parse_page_info(self):
+        """Parse Nomad page information"""
+        from gateway.rns_services import NomadParser
+
+        app_data = b'My Nomad Page\nWelcome to my page'
+        info = NomadParser.parse(app_data, 'nomadnetwork.node')
+
+        self.assertEqual(info.display_name, 'My Nomad Page')
+        self.assertEqual(info.description, 'Welcome to my page')
+        self.assertEqual(info.service_type.name, 'NOMAD_PAGE')
+        self.assertIn('pages', info.capabilities)
+
+
+class TestGenericParser(unittest.TestCase):
+    """Test generic/fallback parser"""
+
+    def test_parse_unknown_service(self):
+        """Parse unknown service type"""
+        from gateway.rns_services import GenericParser
+
+        app_data = b'SomeUnknownService'
+        info = GenericParser.parse(app_data, 'unknown.aspect')
+
+        self.assertEqual(info.display_name, 'SomeUnknownService')
+        self.assertEqual(info.service_type.name, 'UNKNOWN')
+        self.assertIn('app_data_length', info.metadata)
+
+
+class TestServiceRegistry(unittest.TestCase):
+    """Test RNS service registry"""
+
+    def test_registry_singleton(self):
+        """Service registry is a singleton"""
+        from gateway.rns_services import get_service_registry
+
+        reg1 = get_service_registry()
+        reg2 = get_service_registry()
+
+        self.assertIs(reg1, reg2)
+
+    def test_builtin_parsers_registered(self):
+        """Built-in parsers are registered"""
+        from gateway.rns_services import get_service_registry
+
+        registry = get_service_registry()
+
+        self.assertIn('lxmf.delivery', registry._parsers)
+        self.assertIn('nomadnetwork.node', registry._parsers)
+
+    def test_parse_announce_lxmf(self):
+        """Parse LXMF announce through registry"""
+        from gateway.rns_services import get_service_registry
+
+        registry = get_service_registry()
+        dest_hash = bytes.fromhex('0123456789abcdef0123456789abcdef')
+
+        event = registry.parse_announce(
+            dest_hash=dest_hash,
+            identity=None,
+            app_data=b'TestNode',
+            aspect='lxmf.delivery'
+        )
+
+        self.assertEqual(event.service_info.display_name, 'TestNode')
+        self.assertEqual(event.service_info.service_type.name, 'LXMF_DELIVERY')
+
+    def test_get_stats(self):
+        """Get service discovery statistics"""
+        from gateway.rns_services import RNSServiceRegistry
+
+        # Create fresh registry for stats test
+        registry = RNSServiceRegistry()
+
+        # Use valid 32-char hex strings (16 bytes each)
+        registry.parse_announce(bytes.fromhex('11111111111111111111111111111111'), None, b'Test1', 'lxmf.delivery')
+        registry.parse_announce(bytes.fromhex('22222222222222222222222222222222'), None, b'Test2', 'lxmf.delivery')
+        registry.parse_announce(bytes.fromhex('33333333333333333333333333333333'), None, b'Test3', 'nomadnetwork.node')
+
+        stats = registry.get_stats()
+
+        self.assertEqual(stats.get('LXMF_DELIVERY', 0), 2)
+        self.assertEqual(stats.get('NOMAD_PAGE', 0), 1)
+
+
+class TestNetworkTopology(unittest.TestCase):
+    """Test network topology graph"""
+
+    def test_add_nodes(self):
+        """Add nodes to topology"""
+        from gateway.network_topology import NetworkTopology
+
+        topo = NetworkTopology()
+        topo.add_node('node1', {'name': 'Node 1'})
+        topo.add_node('node2', {'name': 'Node 2'})
+
+        stats = topo.get_topology_stats()
+        self.assertEqual(stats['node_count'], 2)
+
+    def test_add_edge(self):
+        """Add edge between nodes"""
+        from gateway.network_topology import NetworkTopology
+
+        topo = NetworkTopology()
+        edge = topo.add_edge('local', 'node1', hops=3)
+
+        self.assertEqual(edge.source_id, 'local')
+        self.assertEqual(edge.dest_id, 'node1')
+        self.assertEqual(edge.hops, 3)
+
+    def test_find_path(self):
+        """Find path between nodes"""
+        from gateway.network_topology import NetworkTopology
+
+        topo = NetworkTopology()
+        topo.add_edge('A', 'B', hops=1)
+        topo.add_edge('B', 'C', hops=2)
+        topo.add_edge('A', 'C', hops=5)  # Direct but longer
+
+        # Should find A -> B -> C as shortest weighted path
+        path = topo.find_path('A', 'C')
+
+        self.assertIsNotNone(path)
+        self.assertEqual(path[0], 'A')
+        self.assertEqual(path[-1], 'C')
+
+    def test_edge_weight_calculation(self):
+        """Edge weight includes hops and freshness"""
+        from gateway.network_topology import NetworkEdge
+
+        edge = NetworkEdge(source_id='A', dest_id='B', hops=2)
+        weight = edge.get_weight()
+
+        # Weight should be >= hops + 1
+        self.assertGreaterEqual(weight, 3.0)
+
+    def test_topology_to_dict(self):
+        """Export topology as dictionary"""
+        from gateway.network_topology import NetworkTopology
+
+        topo = NetworkTopology()
+        topo.add_edge('local', 'dest1', hops=1)
+
+        data = topo.to_dict()
+
+        self.assertIn('nodes', data)
+        self.assertIn('edges', data)
+        self.assertIn('stats', data)
+        self.assertEqual(len(data['edges']), 1)
+
+
+class TestUnifiedNodeWithServices(unittest.TestCase):
+    """Test UnifiedNode with RNS service info"""
+
+    def test_node_from_rns_with_service_info(self):
+        """Create node from RNS with service info"""
+        from gateway.node_tracker import UnifiedNode
+        from gateway.rns_services import ServiceInfo, RNSServiceType
+
+        service_info = ServiceInfo(
+            service_type=RNSServiceType.LXMF_DELIVERY,
+            aspect='lxmf.delivery',
+            display_name='TestNode',
+            latitude=37.7749,
+            longitude=-122.4194,
+            battery=85,
+        )
+
+        node = UnifiedNode.from_rns(
+            rns_hash=bytes.fromhex('0123456789abcdef0123456789abcdef'),
+            name='',
+            app_data=None,
+            service_info=service_info,
+            aspect='lxmf.delivery',
+        )
+
+        self.assertEqual(node.name, 'TestNode')
+        self.assertEqual(node.service_type, 'LXMF_DELIVERY')
+        self.assertEqual(node.service_aspect, 'lxmf.delivery')
+        self.assertAlmostEqual(node.position.latitude, 37.7749, places=4)
+        self.assertEqual(node.telemetry.battery_level, 85)
+
+    def test_node_to_dict_includes_service(self):
+        """Node serialization includes service info"""
+        from gateway.node_tracker import UnifiedNode
+
+        node = UnifiedNode(
+            id='rns_test123',
+            network='rns',
+            name='Test',
+            service_type='LXMF_DELIVERY',
+            service_aspect='lxmf.delivery',
+        )
+
+        data = node.to_dict()
+
+        self.assertEqual(data['service_type'], 'LXMF_DELIVERY')
+        self.assertEqual(data['service_aspect'], 'lxmf.delivery')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
…cking

- Add RNSServiceRegistry for parsing different RNS service types (LXMF, Nomad Network pages, propagation nodes, generic)
- Create NetworkTopology graph model with edge tracking and path tracing
- Add PathTableMonitor for change detection and event logging
- Register aspect-specific announce handlers (lxmf.delivery, nomadnetwork.node, etc.)
- Add service_type, service_aspect fields to UnifiedNode
- Implement Dijkstra path finding through topology
- Add topology stats and event logging APIs

This addresses the gap where only LXMF announces were being parsed, missing other RNS service types and network topology information.

https://claude.ai/code/session_01EkuBrfrqStM85WMFiWb3pJ