### PR TITLE
fix: Use TopologyMixin for export, document map architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ src/
 ├── gtk_ui/            # GTK4 Desktop — FROZEN (not actively developed)
 ├── gateway/           # RNS-Meshtastic bridge
 │   ├── rns_bridge.py  # Main gateway bridge
+│   ├── node_tracker.py # Unified node tracking (RNS + Meshtastic)
+│   ├── network_topology.py # Network graph and path tracking
 │   └── message_queue.py # Persistent message queue (SQLite)
 ├── monitoring/        # Network monitoring
 │   └── mqtt_subscriber.py # Nodeless MQTT monitoring
@@ -53,10 +55,15 @@ src/
 │   ├── diagnostic_engine.py # Intelligent diagnostics
 │   ├── knowledge_base.py    # Mesh networking knowledge
 │   ├── claude_assistant.py  # AI assistant (Standalone + PRO)
-│   └── coverage_map.py      # Folium map generator
+│   ├── map_data_service.py  # Node map server (MapServer class)
+│   ├── topology_visualizer.py # D3.js topology visualization
+│   └── coverage_map.py      # Folium coverage map generator
 ├── launcher.py        # Auto-detect (falls through to TUI)
 ├── standalone.py      # Zero-dependency RF tools
 └── __version__.py     # Version and changelog
+
+web/
+└── node_map.html      # Live node map (Leaflet.js) — PRIMARY MAP UI
 ```
 
 ## Code Standards
@@ -197,6 +204,42 @@ from utils.coverage_map import CoverageMapGenerator
 gen = CoverageMapGenerator()
 gen.add_nodes_from_geojson(geojson_data)
 gen.generate("coverage_map.html")
+```
+
+### Node Map Server (Primary Visualization)
+The live node map (`web/node_map.html`) is the primary visualization for mesh nodes:
+```python
+from utils.map_data_service import MapServer, MapDataCollector
+
+# Start HTTP server (accessible from other devices)
+server = MapServer(port=5000)
+server.start_background()  # Serves at http://localhost:5000
+
+# Or just collect node data without server
+collector = MapDataCollector()
+geojson = collector.collect()  # Unified GeoJSON from all sources
+```
+
+Data sources merged by MapDataCollector:
+- meshtasticd TCP (localhost:4403) — local mesh nodes
+- MQTT subscriber — global/regional nodes
+- Node tracker cache — RNS + Meshtastic nodes
+
+### Topology Visualization
+Export network topology in various formats:
+```python
+from utils.topology_visualizer import TopologyVisualizer
+from gateway.network_topology import get_network_topology
+
+# Create from live topology data
+topology = get_network_topology()
+viz = TopologyVisualizer.from_topology(topology)
+
+# Export options
+viz.generate("topology.html")           # Interactive D3.js graph
+viz.export_geojson("nodes.geojson")     # For mapping tools
+viz.export_graphml("topology.graphml")  # For Gephi
+viz.export_csv(".")                     # nodes.csv + edges.csv
 ```
 
 ## Contact

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -666,56 +666,13 @@ class MeshForgeLauncher(
         self._ai_tools_menu()
 
     def _export_data_menu(self):
-        """Export data in various formats."""
-        while True:
-            choices = [
-                ("geojson", "GeoJSON             For mapping tools"),
-                ("csv", "CSV                 Spreadsheet format"),
-                ("graphml", "GraphML             For graph analysis"),
-                ("d3", "D3.js JSON          For web visualization"),
-                ("back", "Back"),
-            ]
+        """Export data in various formats.
 
-            choice = self.dialog.menu(
-                "Export Data",
-                "Export network data:",
-                choices
-            )
-
-            if choice is None or choice == "back":
-                break
-
-            # Delegate to topology export functions
-            if choice in ["geojson", "csv", "graphml", "d3"]:
-                self._export_topology_data(choice)
-
-    def _export_topology_data(self, format_type: str):
-        """Export topology data in specified format."""
-        try:
-            from utils.topology_visualizer import TopologyVisualizer
-
-            viz = TopologyVisualizer()
-            # TODO: Populate with actual data
-            output_dir = get_real_user_home() / ".config" / "meshforge" / "exports"
-            output_dir.mkdir(parents=True, exist_ok=True)
-
-            if format_type == "geojson":
-                path = output_dir / "topology.geojson"
-                viz.export_geojson(str(path))
-            elif format_type == "csv":
-                path = output_dir / "topology.csv"
-                viz.export_csv(str(path))
-            elif format_type == "graphml":
-                path = output_dir / "topology.graphml"
-                viz.export_graphml(str(path))
-            elif format_type == "d3":
-                path = output_dir / "topology.json"
-                viz.export_d3_json(str(path))
-
-            self.dialog.msgbox("Export Complete", f"Exported to:\n{path}")
-
-        except Exception as e:
-            self.dialog.msgbox("Export Failed", f"Error: {e}")
+        Delegates to TopologyMixin._export_topology() which properly populates
+        the visualizer from NetworkTopology data.
+        """
+        # Use the properly implemented export from TopologyMixin
+        self._export_topology()
 
     # =========================================================================
     # NEW Submenu: Configuration (5)


### PR DESCRIPTION
- Remove duplicate _export_topology_data() that exported empty data
- Delegate to TopologyMixin._export_topology() which properly populates the visualizer from NetworkTopology data
- Update CLAUDE.md architecture to include:
  - gateway/node_tracker.py - Unified node tracking
  - gateway/network_topology.py - Network graph tracking
  - utils/map_data_service.py - Node map server
  - utils/topology_visualizer.py - D3.js visualization
  - web/node_map.html - Primary map UI
- Add usage examples for MapServer, MapDataCollector, TopologyVisualizer

https://claude.ai/code/session_01HGuxX41rYTvZpJdvq2vJfp