### PR TITLE
fix: Use TopologyVisualizer.from_topology() for data export

### DIFF
--- a/.claude/foundations/missing_features.md
+++ b/.claude/foundations/missing_features.md
@@ -1,0 +1,163 @@
+# MeshForge Missing TUI Features
+
+> **Purpose**: Track features that exist in code but aren't accessible via TUI
+> **Created**: 2026-01-30
+> **For**: Alpha release planning
+
+---
+
+## Command Modules Not Exposed in TUI
+
+### HIGH PRIORITY (Alpha blockers)
+
+#### 1. Device Backup/Restore
+- **Module**: `commands/device_backup.py`
+- **Functions**: `create_backup()`, `list_backups()`, `restore_backup()`, `export_backup()`, `compare_backups()`
+- **Why Important**: Users need to backup configs before updates/changes
+- **Suggested Location**: Configuration menu
+- **Effort**: LOW (module ready, just need menu)
+
+#### 2. Message History
+- **Module**: `commands/messaging.py`
+- **Functions**: `get_messages()`, `get_conversations()`, `search_messages()`, `export_messages()`
+- **Why Important**: Messages are stored but users can't view history
+- **Suggested Location**: Dashboard or new Messages submenu
+- **Effort**: LOW (module ready, just need menu)
+
+### MEDIUM PRIORITY (Should have)
+
+#### 3. HamClock Space Weather
+- **Module**: `commands/hamclock.py`
+- **Functions**: `get_space_weather()`, `get_band_conditions()`, `get_voacap()`, `get_noaa_solar_data()`
+- **Why Important**: RF propagation data for HAMs
+- **Suggested Location**: RF & SDR Tools or new HamClock submenu
+- **Effort**: LOW (module ready)
+- **Note**: Only useful if HamClock service running
+
+#### 4. RNode Configuration
+- **Module**: `commands/rnode.py`
+- **Functions**: `detect_rnode_devices()`, `get_device_info()`, `get_recommended_config()`, `configure_rnode()`
+- **Why Important**: RNodes are common LoRa devices
+- **Suggested Location**: Hardware menu or Configuration
+- **Effort**: MEDIUM (needs device selection UI)
+
+#### 5. Advanced Diagnostics
+- **Module**: `commands/diagnostics.py`
+- **Functions**: `get_system_health()`, `run_gateway_diagnostics()`, `check_mesh_connectivity()`
+- **Why Important**: Troubleshooting without CLI
+- **Suggested Location**: System menu
+- **Effort**: LOW (module ready)
+- **Note**: Some diagnostics already in system_tools_mixin
+
+### LOW PRIORITY (Post-alpha)
+
+#### 6. Gateway Control
+- **Module**: `commands/gateway.py`
+- **Functions**: `get_status()`, `start()`, `stop()`, `get_bridge_stats()`
+- **Why Important**: Direct gateway control
+- **Note**: May overlap with service control
+- **Effort**: MEDIUM
+
+---
+
+## Utility Modules Not Exposed
+
+### Network Health
+- **Module**: `utils/network_health.py`
+- **Functions**: `get_health_score()`, `get_component_health()`
+- **Suggested Location**: Dashboard widget
+- **Effort**: LOW
+
+### Predictive Maintenance
+- **Module**: `utils/predictive_maintenance.py`
+- **Functions**: `predict_battery_life()`, `predict_failures()`
+- **Suggested Location**: Metrics menu
+- **Effort**: MEDIUM
+
+### Firmware Flasher
+- **Module**: `utils/firmware_flasher.py`
+- **Functions**: `check_updates()`, `flash_firmware()`
+- **Suggested Location**: Hardware menu
+- **Effort**: HIGH (risky operation needs careful UI)
+
+---
+
+## Implementation Templates
+
+### Adding Device Backup to Configuration Menu
+
+```python
+# In configuration_menu or new submenu
+def _device_backup_menu(self):
+    """Device backup and restore menu."""
+    choices = [
+        ("create", "Create Backup"),
+        ("list", "List Backups"),
+        ("restore", "Restore Backup"),
+        ("export", "Export Backup"),
+        ("back", "Back"),
+    ]
+
+    while True:
+        choice = self.dialog.menu("Device Backup", "Manage device backups:", choices)
+
+        if choice is None or choice == "back":
+            break
+
+        if choice == "create":
+            from commands import device_backup
+            result = device_backup.create_backup(name=f"backup_{datetime.now():%Y%m%d}")
+            if result.success:
+                self.dialog.msgbox("Backup Created", f"Saved: {result.data['path']}")
+            else:
+                self.dialog.msgbox("Backup Failed", result.error)
+```
+
+### Adding Message History
+
+```python
+def _message_history_menu(self):
+    """View message history."""
+    from commands import messaging
+
+    result = messaging.get_messages(limit=50)
+    if not result.success:
+        self.dialog.msgbox("Error", result.error)
+        return
+
+    messages = result.data.get("messages", [])
+    if not messages:
+        self.dialog.msgbox("No Messages", "No message history found.")
+        return
+
+    # Format for display
+    lines = []
+    for msg in messages:
+        lines.append(f"[{msg['timestamp']}] {msg['from']} -> {msg['to']}")
+        lines.append(f"  {msg['text'][:60]}...")
+        lines.append("")
+
+    self.dialog.msgbox("Message History", "\n".join(lines))
+```
+
+---
+
+## Tracking
+
+| Feature | PR | Session | Status |
+|---------|----|---------|---------|
+| Device Backup | | | Not started |
+| Message History | | | Not started |
+| HamClock Data | | | Not started |
+| RNode Config | | | Not started |
+| Advanced Diagnostics | | | Not started |
+| Network Health | | | Not started |
+
+---
+
+## Notes
+
+- All HIGH priority features have modules ready - just need TUI menus
+- Focus on features that support meshtasticd + rnsd (required services)
+- HamClock features only matter if service is running
+- Firmware flashing is risky - save for post-alpha

--- a/.claude/foundations/pre_alpha_checklist.md
+++ b/.claude/foundations/pre_alpha_checklist.md
@@ -1,0 +1,216 @@
+# MeshForge Pre-Alpha Checklist
+
+> **Purpose**: Track work required for alpha release
+> **Created**: 2026-01-30
+> **Status**: In Progress
+> **Target**: Raspberry Pi 4/5
+> **Timeline**: When ready
+> **Required Services**: meshtasticd, rnsd
+> **Optional Services**: MQTT, HamClock
+
+---
+
+## Session Workflow
+
+Each session should:
+1. Pick a category/task from this checklist
+2. Mark task as `[~]` (in progress)
+3. Complete and verify the work
+4. Mark as `[x]` (done) and commit
+5. Watch for session entropy - make notes and start fresh if needed
+
+---
+
+## Critical Bugs
+
+### Fixed
+- [x] **Export topology bug** - `main.py:692` created empty TopologyVisualizer (Session 2026-01-30)
+
+### Pending
+- [ ] **MF004 subprocess timeout** - `main.py:804` interactive shell without timeout (low priority - acceptable for interactive)
+
+---
+
+## TUI Feature Completeness
+
+### Core Menus (Must Work)
+| Menu | Status | Notes |
+|------|--------|-------|
+| Dashboard | [ ] | Verify node list, status display |
+| Mesh Networks | [ ] | Meshtastic + RNS submenus |
+| RF & SDR Tools | [ ] | RF calculator, site planner |
+| Maps & Visualization | [ ] | Map server, topology viz, exports |
+| Configuration | [ ] | Settings, channel config |
+| System & Logs | [ ] | Service control, logs |
+
+### Feature Verification Checklist
+Each feature needs testing on target hardware:
+
+#### Dashboard
+- [ ] Shows connected node count
+- [ ] Shows service status (meshtasticd, rnsd)
+- [ ] Quick actions work
+- [ ] Refresh updates data
+
+#### Meshtastic
+- [ ] Radio menu opens
+- [ ] Node list displays
+- [ ] Send message works (if device connected)
+- [ ] Channel config loads/saves
+
+#### RNS (Reticulum)
+- [ ] RNS menu opens
+- [ ] Interface list displays
+- [ ] NomadNet integration works
+- [ ] Path discovery works
+
+#### Maps & Visualization
+- [ ] Map server starts
+- [ ] Browser opens map
+- [ ] Topology view renders
+- [ ] **Export works with real data** (fixed 2026-01-30)
+
+#### Configuration
+- [ ] Settings load correctly
+- [ ] Settings save to correct location (not /root)
+- [ ] First-run wizard triggers on fresh install
+
+#### Services
+- [ ] Service status detection accurate
+- [ ] Start/stop services works (with sudo)
+- [ ] Service logs viewable
+
+---
+
+## Missing Features (By Priority)
+
+### High Priority - Should have for Alpha
+| Feature | Module Exists | TUI Accessible | Session |
+|---------|---------------|----------------|---------|
+| Device Backup/Restore | `commands/device_backup.py` | [ ] | |
+| Message History | `commands/messaging.py` | [ ] | |
+| Network Health Score | `utils/network_health.py` | [ ] | |
+
+### Medium Priority - Nice to have
+| Feature | Module Exists | TUI Accessible | Session |
+|---------|---------------|----------------|---------|
+| HamClock Space Weather | `gtk_ui/panels/hamclock.py` | [ ] | |
+| Firmware Update | `utils/firmware_flasher.py` | [ ] | |
+| RNode Configuration | `commands/rnode.py` | [ ] | |
+| Predictive Maintenance | `utils/predictive_maintenance.py` | [ ] | |
+
+### Low Priority - Post-Alpha
+| Feature | Module Exists | TUI Accessible | Session |
+|---------|---------------|----------------|---------|
+| Full Hardware Detection | `utils/hardware_*.py` | Partial | |
+| AREDN Integration | `launcher_tui/aredn_mixin.py` | [ ] | |
+| Advanced Diagnostics | `utils/diagnostic_engine.py` | Partial | |
+
+---
+
+## Installation & First Run
+
+### Fresh Install Test
+- [ ] Clone repo on fresh Pi
+- [ ] Run install script
+- [ ] TUI launches without errors
+- [ ] First-run wizard appears
+- [ ] Settings saved to ~/.config/meshforge/
+
+### Dependencies Check
+- [ ] whiptail/dialog available
+- [ ] Python 3.9+ available
+- [ ] Required packages install correctly
+
+---
+
+## Service Integration
+
+### Required Services (Alpha)
+| Service | Detection | Control | Verified | Notes |
+|---------|-----------|---------|----------|-------|
+| meshtasticd | systemctl | Start/Stop | [ ] | Single client limitation |
+| rnsd | Port 37428 | Start/Stop | [ ] | RNS shared instance |
+
+### Optional Services
+| Service | Detection | Control | Verified | Notes |
+|---------|-----------|---------|----------|-------|
+| nomadnet | Port check | Start/Stop | [ ] | RNS messaging |
+| MQTT | Port 1883 | External | [ ] | Monitoring |
+| HamClock | Port 8080 | External | [ ] | Space weather |
+
+---
+
+## Known Limitations (Document for Users)
+
+1. **WebKit disabled with sudo** - Browser fallback always used
+2. **Meshtasticd single client** - Only one TCP connection at a time
+3. **Root required** - Many features need sudo for hardware access
+4. **Path.home() bug** - Fixed in code, verify no regressions
+
+---
+
+## Test Scenarios
+
+### Scenario 1: Standalone RF Tools (No Hardware)
+```
+1. Launch TUI without any devices
+2. Open RF & SDR Tools
+3. Run RF calculator
+4. Verify calculations display
+```
+Expected: Works offline, no errors
+
+### Scenario 2: Meshtastic Connected
+```
+1. Connect USB Meshtastic device
+2. Launch TUI with sudo
+3. Open Mesh Networks > Meshtastic
+4. View node list
+5. Send test message
+```
+Expected: Shows nodes, message sends
+
+### Scenario 3: Gateway Mode
+```
+1. Start meshtasticd and rnsd
+2. Launch TUI
+3. Open Dashboard
+4. Verify both networks visible
+5. Export topology
+```
+Expected: Shows unified topology, export contains data
+
+---
+
+## Acceptance Criteria for Alpha
+
+### Must Pass
+- [ ] TUI launches on Raspberry Pi 4/5
+- [ ] All core menus accessible
+- [ ] No crashes on basic navigation
+- [ ] Export produces valid files with data
+- [ ] Settings persist between sessions
+- [ ] Service status accurate
+
+### Should Pass
+- [ ] First-run wizard helpful
+- [ ] Error messages actionable
+- [ ] Documentation accurate
+
+---
+
+## Session Log
+
+| Date | Session ID | Work Done | Notes |
+|------|------------|-----------|-------|
+| 2026-01-30 | KMjRH | Fixed export bug, created checklist | |
+
+---
+
+## Notes for Next Session
+
+- pytest not installed in environment - tests can't run
+- Linter only found 1 warning (MF004 on interactive shell)
+- 55+ utility modules exist; many not exposed in TUI
+- Previous session work was on different branch (export-modules-docs-i4jRW)

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -694,26 +694,46 @@ class MeshForgeLauncher(
         try:
             from utils.topology_visualizer import TopologyVisualizer
 
-            viz = TopologyVisualizer()
-            # TODO: Populate with actual data
-            output_dir = get_real_user_home() / ".config" / "meshforge" / "exports"
-            output_dir.mkdir(parents=True, exist_ok=True)
+            # Get topology from TopologyMixin (properly populated)
+            topology = self._get_topology()
+            if topology is None:
+                self.dialog.msgbox(
+                    "Export Unavailable",
+                    "Network topology not loaded.\n\n"
+                    "The gateway service may need to be running."
+                )
+                return
+
+            # Create visualizer from actual topology data
+            viz = TopologyVisualizer.from_topology(topology)
 
             if format_type == "geojson":
-                path = output_dir / "topology.geojson"
-                viz.export_geojson(str(path))
+                path, count = viz.export_geojson()
+                self.dialog.msgbox(
+                    "GeoJSON Export",
+                    f"Exported {count} features.\n\nFile: {path}"
+                )
             elif format_type == "csv":
-                path = output_dir / "topology.csv"
-                viz.export_csv(str(path))
+                nodes_path, edges_path = viz.export_csv()
+                self.dialog.msgbox(
+                    "CSV Export",
+                    f"Exported CSV files:\n\nNodes: {nodes_path}\nEdges: {edges_path}"
+                )
             elif format_type == "graphml":
-                path = output_dir / "topology.graphml"
-                viz.export_graphml(str(path))
+                path, count = viz.export_graphml()
+                self.dialog.msgbox(
+                    "GraphML Export",
+                    f"Exported {count} edges.\n\nFile: {path}"
+                )
             elif format_type == "d3":
-                path = output_dir / "topology.json"
-                viz.export_d3_json(str(path))
+                path, count = viz.export_d3_json()
+                self.dialog.msgbox(
+                    "D3.js Export",
+                    f"Exported {count} nodes + links.\n\nFile: {path}"
+                )
 
-            self.dialog.msgbox("Export Complete", f"Exported to:\n{path}")
-
+        except ImportError:
+            self.dialog.msgbox("Export Failed", "Topology visualizer module not available.")
         except Exception as e:
             self.dialog.msgbox("Export Failed", f"Error: {e}")
 


### PR DESCRIPTION
The _export_topology_data() method was creating an empty TopologyVisualizer without any data. Now properly uses from_topology() to populate from NetworkTopology, matching the pattern in TopologyMixin._export_topology().

Also adds pre-alpha checklist and missing features documentation for tracking alpha release readiness.

https://claude.ai/code/session_01EaNsMcKpd93KBNfc3VN8ZQ