### PR TITLE
refactor: Unify service checking to use service_check.py module

### DIFF
--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -18,6 +18,17 @@ import socket
 import subprocess
 from pathlib import Path
 
+# Use centralized service checking
+try:
+    from utils.service_check import (
+        check_port as _check_port,
+        check_systemd_service,
+        check_process_running,
+    )
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 
 # ANSI colors
 class C:
@@ -51,13 +62,21 @@ class C:
 
 
 def check_service(name):
-    """Check if a systemd service is running."""
+    """Check if a systemd service is running.
+
+    Uses centralized service_check module when available.
+    """
     try:
-        result = subprocess.run(
-            ['systemctl', 'is-active', name],
-            capture_output=True, text=True, timeout=5
-        )
-        status = result.stdout.strip()
+        if _HAS_SERVICE_CHECK:
+            is_running, is_enabled = check_systemd_service(name)
+            status = 'active' if is_running else 'inactive'
+        else:
+            # Fallback to direct systemctl call
+            result = subprocess.run(
+                ['systemctl', 'is-active', name],
+                capture_output=True, text=True, timeout=5
+            )
+            status = result.stdout.strip()
 
         # If meshforge systemd service isn't active, check for interactive process
         if name == 'meshforge' and status != 'active':
@@ -70,7 +89,11 @@ def check_service(name):
 
 
 def _is_meshforge_process_running():
-    """Check if MeshForge is running as an interactive process (not systemd)."""
+    """Check if MeshForge is running as an interactive process (not systemd).
+
+    Note: This is a specialized check that filters out the status script itself,
+    so it doesn't use the generic check_process_running() from service_check.
+    """
     try:
         result = subprocess.run(
             ['pgrep', '-af', 'python.*meshforge|python.*launcher'],
@@ -87,7 +110,14 @@ def _is_meshforge_process_running():
 
 
 def check_port(port):
-    """Check if a TCP port is listening."""
+    """Check if a TCP port is listening.
+
+    Uses centralized service_check module when available.
+    """
+    if _HAS_SERVICE_CHECK:
+        return _check_port(port, host='127.0.0.1', timeout=1.0)
+
+    # Fallback to direct socket check
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -24,6 +24,13 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Import centralized service checking
+try:
+    from utils.service_check import check_process_running
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 # Import for sudo-safe home directory - see persistent_issues.md Issue #1
 try:
     from utils.paths import get_real_user_home
@@ -185,11 +192,17 @@ class NomadNetClientMixin:
         print()
         print("--- RNS Connectivity ---")
         try:
-            result = subprocess.run(
-                ['pgrep', '-f', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            if result.returncode == 0:
+            if _HAS_SERVICE_CHECK:
+                rnsd_running = check_process_running('rnsd')
+            else:
+                # Fallback to direct pgrep call
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                rnsd_running = result.returncode == 0
+
+            if rnsd_running:
                 print("  rnsd:      RUNNING (shared instance available)")
             else:
                 print("  rnsd:      NOT running")
@@ -669,7 +682,17 @@ downloads_path = ~/Downloads
             print("  https://github.com/markqvist/NomadNet#configuration")
 
     def _is_nomadnet_running(self) -> bool:
-        """Check if NomadNet process is running."""
+        """Check if NomadNet process is running.
+
+        Uses centralized service_check module when available, with fallback
+        to direct pgrep for custom filtering.
+        """
+        # Try unified check first (faster and standardized)
+        if _HAS_SERVICE_CHECK:
+            if check_process_running('nomadnet'):
+                return True
+
+        # Fallback to direct pgrep with custom filtering
         try:
             result = subprocess.run(
                 ['pgrep', '-f', 'bin/nomadnet'],
@@ -729,14 +752,19 @@ downloads_path = ~/Downloads
     def _check_rns_for_nomadnet(self) -> bool:
         """Check that RNS/rnsd is available before launching NomadNet.
 
+        Uses centralized service_check module when available.
         Returns True if OK to proceed, False if user cancelled.
         """
         try:
-            result = subprocess.run(
-                ['pgrep', '-f', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            rnsd_running = result.returncode == 0
+            if _HAS_SERVICE_CHECK:
+                rnsd_running = check_process_running('rnsd')
+            else:
+                # Fallback to direct pgrep call
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                rnsd_running = result.returncode == 0
         except Exception:
             rnsd_running = False
 

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -25,6 +25,17 @@ from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
+# Import centralized service checking
+try:
+    from utils.service_check import (
+        check_systemd_service,
+        check_process_running,
+        check_port as _check_port,
+    )
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 
 # Quick action definitions: (tag, description, method_name)
 QUICK_ACTIONS = [
@@ -69,7 +80,10 @@ class QuickActionsMixin:
                     break
 
     def _qa_service_status(self):
-        """Quick: show all service statuses."""
+        """Quick: show all service statuses.
+
+        Uses centralized service_check module when available.
+        """
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== Quick Service Status ===\n")
 
@@ -77,27 +91,28 @@ class QuickActionsMixin:
         warnings = []
         for svc in services:
             try:
-                result = subprocess.run(
-                    ['systemctl', 'is-active', svc],
-                    capture_output=True, text=True, timeout=5
-                )
-                status = result.stdout.strip()
-
-                # Check boot persistence
-                boot_info = ""
-                try:
+                if _HAS_SERVICE_CHECK:
+                    is_running, is_enabled = check_systemd_service(svc)
+                    status = 'active' if is_running else 'inactive'
+                else:
+                    # Fallback to direct systemctl call
+                    result = subprocess.run(
+                        ['systemctl', 'is-active', svc],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    status = result.stdout.strip()
+                    # Check boot persistence via fallback
                     enabled_result = subprocess.run(
                         ['systemctl', 'is-enabled', svc],
                         capture_output=True, text=True, timeout=5
                     )
                     is_enabled = enabled_result.returncode == 0
-                    if status == 'active' and not is_enabled:
-                        boot_info = "  (not enabled at boot)"
-                        warnings.append(svc)
-                    elif status == 'active' and is_enabled:
-                        boot_info = ""
-                except Exception:
-                    pass
+
+                # Check boot persistence
+                boot_info = ""
+                if status == 'active' and not is_enabled:
+                    boot_info = "  (not enabled at boot)"
+                    warnings.append(svc)
 
                 if status == 'active':
                     print(f"  * {svc:<18} running{boot_info}")
@@ -110,12 +125,18 @@ class QuickActionsMixin:
 
         # Bridge process (not a systemd service — no boot persistence check)
         try:
-            result = subprocess.run(
-                ['pgrep', '-f', 'rns_bridge'],
-                capture_output=True, timeout=3
-            )
-            bridge_status = "running" if result.returncode == 0 else "not running"
-            sym = "*" if result.returncode == 0 else "-"
+            if _HAS_SERVICE_CHECK:
+                bridge_running = check_process_running('rns_bridge')
+            else:
+                # Fallback to direct pgrep call
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rns_bridge'],
+                    capture_output=True, timeout=3
+                )
+                bridge_running = result.returncode == 0
+
+            bridge_status = "running" if bridge_running else "not running"
+            sym = "*" if bridge_running else "-"
             print(f"  {sym} {'rns_bridge':<18} {bridge_status}")
         except Exception:
             print(f"  ? {'rns_bridge':<18} unknown")
@@ -212,7 +233,10 @@ class QuickActionsMixin:
         self._wait_for_enter("Press Enter to continue...")
 
     def _qa_port_check(self):
-        """Quick: check network ports."""
+        """Quick: check network ports.
+
+        Uses centralized service_check module when available.
+        """
         import socket as sock
         subprocess.run(['clear'], check=False, timeout=5)
         print("=== Port Check ===\n")
@@ -226,13 +250,19 @@ class QuickActionsMixin:
 
         for port, desc in ports:
             try:
-                with sock.socket(sock.AF_INET, sock.SOCK_STREAM) as s:
-                    s.settimeout(1)
-                    result = s.connect_ex(('127.0.0.1', port))
-                    if result == 0:
-                        print(f"  * {port:<6} {desc}")
-                    else:
-                        print(f"  - {port:<6} {desc} (not listening)")
+                if _HAS_SERVICE_CHECK:
+                    port_open = _check_port(port, host='127.0.0.1', timeout=1.0)
+                else:
+                    # Fallback to direct socket check
+                    with sock.socket(sock.AF_INET, sock.SOCK_STREAM) as s:
+                        s.settimeout(1)
+                        result = s.connect_ex(('127.0.0.1', port))
+                        port_open = result == 0
+
+                if port_open:
+                    print(f"  * {port:<6} {desc}")
+                else:
+                    print(f"  - {port:<6} {desc} (not listening)")
             except Exception:
                 print(f"  ? {port:<6} {desc} (check failed)")
 

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -11,6 +11,13 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+# Import centralized service checking
+try:
+    from utils.service_check import check_process_running
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 # Import centralized path utility
 try:
     from utils.paths import get_real_user_home, ReticulumPaths

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -11,6 +11,16 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 
+# Import centralized service checking
+try:
+    from utils.service_check import (
+        check_systemd_service,
+        check_process_running,
+    )
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 # Import centralized path utility
 try:
     from utils.paths import get_real_user_home
@@ -71,8 +81,15 @@ class ServiceMenuMixin:
                 self._show_bridge_logs()
 
     def _is_bridge_running(self) -> bool:
-        """Check if the gateway bridge process is running."""
+        """Check if the gateway bridge process is running.
+
+        Uses centralized service_check module when available.
+        """
         try:
+            if _HAS_SERVICE_CHECK:
+                return check_process_running('bridge_cli.py')
+
+            # Fallback to direct pgrep call
             result = subprocess.run(
                 ['pgrep', '-f', 'bridge_cli.py'],
                 capture_output=True, text=True, timeout=5
@@ -268,25 +285,28 @@ class ServiceMenuMixin:
                         continue
 
                     try:
-                        result = subprocess.run(
-                            ['systemctl', 'is-active', svc],
-                            capture_output=True, text=True, timeout=5
-                        )
-                        status = result.stdout.strip()
-
-                        # Check boot persistence
-                        boot_info = ""
-                        try:
+                        if _HAS_SERVICE_CHECK:
+                            is_running, is_enabled = check_systemd_service(svc)
+                            status = 'active' if is_running else 'inactive'
+                        else:
+                            # Fallback to direct systemctl call
+                            result = subprocess.run(
+                                ['systemctl', 'is-active', svc],
+                                capture_output=True, text=True, timeout=5
+                            )
+                            status = result.stdout.strip()
+                            # Check boot persistence via fallback
                             enabled_result = subprocess.run(
                                 ['systemctl', 'is-enabled', svc],
                                 capture_output=True, text=True, timeout=5
                             )
                             is_enabled = enabled_result.returncode == 0
-                            if status == 'active' and not is_enabled:
-                                boot_info = "  (not enabled at boot)"
-                                warnings.append(svc)
-                        except Exception:
-                            pass
+
+                        # Check boot persistence
+                        boot_info = ""
+                        if status == 'active' and not is_enabled:
+                            boot_info = "  (not enabled at boot)"
+                            warnings.append(svc)
 
                         if status == 'active':
                             print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
@@ -636,8 +656,15 @@ WantedBy=multi-user.target
             return False
 
     def _is_rnsd_running(self) -> bool:
-        """Check if rnsd is running as a process."""
+        """Check if rnsd is running as a process.
+
+        Uses centralized service_check module when available.
+        """
         try:
+            if _HAS_SERVICE_CHECK:
+                return check_process_running('rnsd')
+
+            # Fallback to direct pgrep call
             result = subprocess.run(
                 ['pgrep', '-x', 'rnsd'],
                 capture_output=True,

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -25,6 +25,13 @@ from typing import Dict, Optional, List
 
 logger = logging.getLogger(__name__)
 
+# Import centralized service checking
+try:
+    from utils.service_check import check_systemd_service, check_process_running
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+
 # Import startup checker for enhanced status
 try:
     from startup_checks import StartupChecker, EnvironmentState, ServiceRunState
@@ -137,6 +144,8 @@ class StatusBar:
     def _check_systemd_active(self, service: str) -> str:
         """Check if a systemd service is active.
 
+        Uses centralized service_check module when available.
+
         Args:
             service: Service unit name.
 
@@ -144,6 +153,11 @@ class StatusBar:
             Status symbol character.
         """
         try:
+            if _HAS_SERVICE_CHECK:
+                is_running, _ = check_systemd_service(service)
+                return SYM_RUNNING if is_running else SYM_STOPPED
+
+            # Fallback to direct systemctl call
             result = subprocess.run(
                 ['systemctl', 'is-active', service],
                 capture_output=True, text=True, timeout=3
@@ -155,8 +169,16 @@ class StatusBar:
             return SYM_UNKNOWN
 
     def _check_bridge(self) -> None:
-        """Check if the RNS-Meshtastic bridge process is running."""
+        """Check if the RNS-Meshtastic bridge process is running.
+
+        Uses centralized service_check module when available.
+        """
         try:
+            if _HAS_SERVICE_CHECK:
+                self._bridge_running = check_process_running('rns_bridge')
+                return
+
+            # Fallback to direct pgrep call
             result = subprocess.run(
                 ['pgrep', '-f', 'rns_bridge'],
                 capture_output=True, timeout=3


### PR DESCRIPTION
Refactor 6 files to use the centralized service_check.py module instead of direct subprocess calls for service status checking. This improves consistency and maintainability by having a single source of truth for service detection logic.

Changes:
- cli/status.py: Use check_systemd_service() and check_port()
- launcher_tui/status_bar.py: Use check_systemd_service() and check_process_running()
- launcher_tui/quick_actions_mixin.py: Use unified module for service status and port checks
- launcher_tui/service_menu_mixin.py: Use unified module for bridge and rnsd checks
- launcher_tui/nomadnet_client_mixin.py: Use check_process_running() for rnsd detection
- launcher_tui/rns_menu_mixin.py: Add import for future use

All files include fallbacks to direct subprocess calls if the unified module import fails, ensuring backward compatibility.

Part of Alpha Reliability Priority #1: Unify service checking.

https://claude.ai/code/session_01QtVEt2gT2ssTdS9hnmFvDg