### PR TITLE
refactor: Add ServiceState.FAILED and apply_config_and_restart helper

### DIFF
--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -463,10 +463,14 @@ def check_sdr():
     openwebrx = shutil.which('openwebrx')
     if openwebrx:
         try:
-            result = subprocess.run(['systemctl', 'is-active', 'openwebrx'],
-                                   capture_output=True, text=True, timeout=5)
-            status = result.stdout.strip()
-            print_status("OpenWebRX", status == 'active', status)
+            if SERVICE_CHECK_AVAILABLE:
+                svc_status = check_service('openwebrx')
+                print_status("OpenWebRX", svc_status.available, svc_status.state.value)
+            else:
+                result = subprocess.run(['systemctl', 'is-active', 'openwebrx'],
+                                       capture_output=True, text=True, timeout=5)
+                status = result.stdout.strip()
+                print_status("OpenWebRX", status == 'active', status)
         except Exception:
             print_status("OpenWebRX", True, "installed")
     else:

--- a/src/config/config_file_manager.py
+++ b/src/config/config_file_manager.py
@@ -17,7 +17,12 @@ from rich import box
 
 # Try to use centralized service checker
 try:
-    from utils.service_check import check_service, check_systemd_service, ServiceState
+    from utils.service_check import (
+        check_service,
+        check_systemd_service,
+        ServiceState,
+        apply_config_and_restart,
+    )
     _HAS_SERVICE_CHECK = True
 except ImportError:
     _HAS_SERVICE_CHECK = False

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -37,9 +37,11 @@ except ImportError:
 
 # Import service check
 try:
-    from utils.service_check import check_service
+    from utils.service_check import check_service, apply_config_and_restart
+    _HAS_APPLY_RESTART = True
 except ImportError:
     check_service = None
+    _HAS_APPLY_RESTART = False
 
 # Import device scanner
 try:
@@ -475,8 +477,11 @@ class FirstRunMixin:
             shutil.copy2(source, dest)
 
             # Restart meshtasticd
-            subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-            subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+            if _HAS_APPLY_RESTART:
+                success, msg = apply_config_and_restart('meshtasticd')
+            else:
+                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
+                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
 
             self.dialog.msgbox(
                 "Configuration Applied",
@@ -513,8 +518,11 @@ Serial:
             config_file.write_text(config_content)
 
             # Restart meshtasticd
-            subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-            subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+            if _HAS_APPLY_RESTART:
+                success, msg = apply_config_and_restart('meshtasticd')
+            else:
+                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
+                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
 
             self.dialog.msgbox(
                 "USB Configured",

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -12,11 +12,18 @@ from pathlib import Path
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH
 try:
-    from utils.service_check import check_service, check_systemd_service, ServiceState
+    from utils.service_check import (
+        check_service,
+        check_systemd_service,
+        ServiceState,
+        apply_config_and_restart,
+    )
+    _HAS_APPLY_RESTART = True
 except ImportError:
     check_service = None
     check_systemd_service = None
     ServiceState = None
+    _HAS_APPLY_RESTART = False
 
 
 class MeshtasticdConfigMixin:
@@ -467,10 +474,13 @@ Press Cancel to keep current values."""
             shutil.copy(src, dst)
 
             # Restart service
-            subprocess.run(['systemctl', 'daemon-reload'],
-                           capture_output=True, timeout=10)
-            subprocess.run(['systemctl', 'restart', 'meshtasticd'],
-                           capture_output=True, timeout=30)
+            if _HAS_APPLY_RESTART:
+                success, msg = apply_config_and_restart('meshtasticd')
+            else:
+                subprocess.run(['systemctl', 'daemon-reload'],
+                               capture_output=True, timeout=10)
+                subprocess.run(['systemctl', 'restart', 'meshtasticd'],
+                               capture_output=True, timeout=30)
 
             self.dialog.msgbox("Success",
                 f"Hardware config activated!\n\n"
@@ -610,21 +620,28 @@ Press Cancel to keep current values."""
         try:
             self.dialog.infobox("Restarting", "Restarting meshtasticd...")
 
-            subprocess.run(['systemctl', 'daemon-reload'],
-                           capture_output=True, timeout=10)
-
-            result = subprocess.run(
-                ['systemctl', 'restart', 'meshtasticd'],
-                capture_output=True,
-                text=True,
-                timeout=30
-            )
-
-            if result.returncode == 0:
-                self.dialog.msgbox("Success", "meshtasticd restarted successfully!")
+            if _HAS_APPLY_RESTART:
+                success, msg = apply_config_and_restart('meshtasticd')
+                if success:
+                    self.dialog.msgbox("Success", "meshtasticd restarted successfully!")
+                else:
+                    self.dialog.msgbox("Error", f"Restart failed:\n{msg}")
             else:
-                self.dialog.msgbox("Error",
-                    f"Restart failed:\n{result.stderr or result.stdout}")
+                subprocess.run(['systemctl', 'daemon-reload'],
+                               capture_output=True, timeout=10)
+
+                result = subprocess.run(
+                    ['systemctl', 'restart', 'meshtasticd'],
+                    capture_output=True,
+                    text=True,
+                    timeout=30
+                )
+
+                if result.returncode == 0:
+                    self.dialog.msgbox("Success", "meshtasticd restarted successfully!")
+                else:
+                    self.dialog.msgbox("Error",
+                        f"Restart failed:\n{result.stderr or result.stdout}")
 
         except subprocess.TimeoutExpired:
             self.dialog.msgbox("Error", "Restart timed out")

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -16,6 +16,8 @@ try:
     from utils.service_check import (
         check_systemd_service,
         check_process_running,
+        check_service,
+        ServiceState,
     )
     _HAS_SERVICE_CHECK = True
 except ImportError:
@@ -326,9 +328,14 @@ class ServiceMenuMixin:
                 # Show failed service logs (only for systemd services)
                 for svc in ['meshtasticd']:
                     try:
-                        r = subprocess.run(['systemctl', 'is-active', svc],
-                                           capture_output=True, text=True, timeout=5)
-                        if r.stdout.strip() == 'failed':
+                        if _HAS_SERVICE_CHECK:
+                            status = check_service(svc)
+                            is_failed = status.state == ServiceState.FAILED
+                        else:
+                            r = subprocess.run(['systemctl', 'is-active', svc],
+                                               capture_output=True, text=True, timeout=5)
+                            is_failed = r.stdout.strip() == 'failed'
+                        if is_failed:
                             print(f"\033[0;31m{svc} failure:\033[0m")
                             subprocess.run(
                                 ['journalctl', '-u', svc, '-n', '5', '--no-pager'],
@@ -341,9 +348,14 @@ class ServiceMenuMixin:
                 # Show rnsd failure logs if systemd-managed and failed
                 if not use_direct_rnsd:
                     try:
-                        r = subprocess.run(['systemctl', 'is-active', 'rnsd'],
-                                           capture_output=True, text=True, timeout=5)
-                        if r.stdout.strip() == 'failed':
+                        if _HAS_SERVICE_CHECK:
+                            status = check_service('rnsd')
+                            is_failed = status.state == ServiceState.FAILED
+                        else:
+                            r = subprocess.run(['systemctl', 'is-active', 'rnsd'],
+                                               capture_output=True, text=True, timeout=5)
+                            is_failed = r.stdout.strip() == 'failed'
+                        if is_failed:
                             print(f"\033[0;31mrnsd failure:\033[0m")
                             subprocess.run(
                                 ['journalctl', '-u', 'rnsd', '-n', '5', '--no-pager'],

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -44,9 +44,11 @@ __all__ = [
     'check_udp_port',       # UDP port check (utility)
     'check_process_running', # Process check via pgrep (utility)
     'check_systemd_service', # Systemd status check
+    # Service management
+    'apply_config_and_restart',  # Reload daemon + restart service
     # Data classes
     'ServiceStatus',        # Return type from check_service
-    'ServiceState',         # Status enum (AVAILABLE, DEGRADED, etc.)
+    'ServiceState',         # Status enum (AVAILABLE, DEGRADED, FAILED, etc.)
     # Configuration
     'KNOWN_SERVICES',       # Service configuration dict
 ]
@@ -56,6 +58,7 @@ class ServiceState(Enum):
     """Service availability states."""
     AVAILABLE = "available"
     DEGRADED = "degraded"       # Running but with issues
+    FAILED = "failed"           # Service crashed or failed to start
     NOT_RUNNING = "not_running"
     NOT_INSTALLED = "not_installed"
     UNKNOWN = "unknown"         # Cannot determine state
@@ -484,7 +487,7 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
                 return ServiceStatus(
                     name=name,
                     available=False,
-                    state=ServiceState.DEGRADED,
+                    state=ServiceState.FAILED,
                     message=f"{description} has failed",
                     fix_hint=f"Check logs: journalctl -u {systemd_name}",
                     port=check_port_num,
@@ -618,3 +621,64 @@ def require_service(name: str, port: Optional[int] = None) -> ServiceStatus:
     if not status.available:
         logger.warning(f"{status.message}. {status.fix_hint}")
     return status
+
+
+def apply_config_and_restart(service_name: str = 'meshtasticd', timeout: int = 30) -> Tuple[bool, str]:
+    """
+    Reload systemd daemon and restart a service.
+
+    This is the standard pattern after modifying service configuration files.
+    Always runs daemon-reload before restart to pick up changes.
+
+    Args:
+        service_name: Name of the systemd service to restart (default: meshtasticd)
+        timeout: Timeout in seconds for each command (default: 30)
+
+    Returns:
+        Tuple of (success: bool, message: str)
+
+    Example:
+        from utils.service_check import apply_config_and_restart
+
+        # After modifying /etc/meshtasticd/config.yaml:
+        success, msg = apply_config_and_restart('meshtasticd')
+        if not success:
+            show_error(msg)
+    """
+    try:
+        # Step 1: Reload systemd daemon to pick up any service file changes
+        daemon_reload = subprocess.run(
+            ['systemctl', 'daemon-reload'],
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        if daemon_reload.returncode != 0:
+            error_msg = daemon_reload.stderr.strip() or "daemon-reload failed"
+            logger.error(f"daemon-reload failed: {error_msg}")
+            return False, f"daemon-reload failed: {error_msg}"
+
+        # Step 2: Restart the service
+        restart = subprocess.run(
+            ['systemctl', 'restart', service_name],
+            capture_output=True,
+            text=True,
+            timeout=timeout
+        )
+        if restart.returncode != 0:
+            error_msg = restart.stderr.strip() or f"restart {service_name} failed"
+            logger.error(f"restart {service_name} failed: {error_msg}")
+            return False, f"restart {service_name} failed: {error_msg}"
+
+        logger.info(f"Successfully restarted {service_name}")
+        return True, f"{service_name} restarted successfully"
+
+    except subprocess.TimeoutExpired:
+        logger.error(f"Timeout while restarting {service_name}")
+        return False, f"Timeout while restarting {service_name}"
+    except FileNotFoundError:
+        logger.error("systemctl not found")
+        return False, "systemctl not found - is this a systemd system?"
+    except Exception as e:
+        logger.error(f"Error restarting {service_name}: {e}")
+        return False, f"Error: {e}"


### PR DESCRIPTION
Extends the unified service_check.py module with:
- ServiceState.FAILED enum for explicit failed state detection
- apply_config_and_restart() helper for daemon-reload + restart pattern

Refactors TUI mixins and CLI tools to use centralized functions:
- service_menu_mixin.py: Uses check_service() for failed state detection
- meshtasticd_config_mixin.py: Uses apply_config_and_restart()
- first_run_mixin.py: Uses apply_config_and_restart()
- diagnose.py: Uses check_service() for OpenWebRX status
- config_file_manager.py: Imports apply_config_and_restart (available)

All refactored code includes fallback to direct systemctl calls when the service_check module is not available.

https://claude.ai/code/session_01L7cYgYz7pLfUtui8U7o6dz