### PR TITLE
fix: Add detection for meshtastic module missing in rnsd's Python env

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1355,3 +1355,95 @@ fi
 - Never mark install "complete" until verification passes
 
 ---
+
+## Issue #24: Meshtastic Module Not Found by rnsd (Python Environment Mismatch)
+
+### Symptom
+NomadNet or rnsd fails to start with:
+```
+[Critical] Using this interface requires a meshtastic module to be installed.
+[Critical] You can install one with the command: python3 -m pip install meshtastic
+```
+
+rnsd repeatedly crashes with exit code 255/EXCEPTION:
+```
+systemd[1]: rnsd.service: Main process exited, code=exited, status=255/EXCEPTION
+```
+
+This happens even when the user has previously installed `meshtastic` via CLI.
+
+### Root Cause
+**Python environment mismatch.** The `Meshtastic_Interface.py` plugin in `/etc/reticulum/interfaces/` requires the `meshtastic` Python module. However:
+
+1. **pipx isolation**: Installing meshtastic CLI with `pipx install meshtastic` puts it in an isolated virtual environment that rnsd cannot access
+2. **Different Python version**: rnsd may use `/usr/bin/python3` while user installed meshtastic to `/usr/local/bin/python3`
+3. **User vs system site-packages**: `pip3 install --user meshtastic` installs to `~/.local/lib/python3.x/` which root's rnsd cannot access
+
+### Impact
+- rnsd enters restart loop (every 5 seconds per systemd restart policy)
+- NomadNet refuses to launch
+- RNS-Meshtastic gateway completely broken
+- User thinks system is broken when it's just a module path issue
+
+### Proper Fix
+
+**Option 1: System-wide install (recommended for rnsd)**
+```bash
+# Install to system site-packages where rnsd can find it
+sudo pip3 install meshtastic
+```
+
+**Option 2: Install to same Python that rnsd uses**
+```bash
+# Check which Python rnsd uses
+head -1 $(which rnsd 2>/dev/null || sudo find /usr -name rnsd 2>/dev/null | head -1)
+
+# If rnsd uses /usr/local/bin/python3:
+sudo /usr/local/bin/python3 -m pip install meshtastic
+
+# If rnsd uses /usr/bin/python3:
+sudo /usr/bin/python3 -m pip install meshtastic
+```
+
+**Option 3: Disable the Meshtastic interface if not needed**
+```bash
+# Edit RNS config to disable the interface
+sudo nano /etc/reticulum/config
+# Change 'enabled = yes' to 'enabled = no' under [[Meshtastic Interface]]
+
+# Or remove the interface file entirely
+sudo rm /etc/reticulum/interfaces/Meshtastic_Interface.py
+sudo systemctl restart rnsd
+```
+
+### Diagnosing the Issue
+```bash
+# Check if meshtastic is importable by root's Python
+sudo python3 -c "import meshtastic; print(f'OK: {meshtastic.__version__}')" 2>&1
+
+# If "No module named 'meshtastic'":
+# The module is not installed in root's Python path
+
+# Check where meshtastic is installed (if at all)
+pip3 show meshtastic 2>/dev/null && echo "User install found"
+sudo pip3 show meshtastic 2>/dev/null && echo "System install found"
+pipx list 2>/dev/null | grep meshtastic && echo "pipx install found (isolated!)"
+```
+
+### Files Involved
+- `/etc/reticulum/interfaces/Meshtastic_Interface.py` - The RNS plugin that requires meshtastic
+- `/etc/reticulum/config` - RNS configuration referencing the interface
+- RNS interface plugin from: https://github.com/landandair/RNS_Over_Meshtastic
+
+### MeshForge Detection
+The gateway diagnostic (`src/utils/gateway_diagnostic.py`) should be updated to:
+1. Check if Meshtastic_Interface.py exists
+2. If it exists, verify meshtastic is importable as root
+3. Show specific fix instructions if not
+
+### Prevention
+- When installing Meshtastic_Interface plugin, always verify meshtastic module is available
+- Add pre-flight check in TUI before enabling RNS-Meshtastic bridge
+- Document in installation wizard that meshtastic must be installed system-wide
+
+---

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -81,6 +81,7 @@ class GatewayDiagnostic:
         # Meshtastic checks
         self.results.append(self.check_meshtastic_installed())
         self.results.append(self.check_meshtastic_interface())
+        self.results.append(self.check_meshtastic_module_for_rnsd())
         self.results.append(self.check_meshtasticd())
 
         # Optional integrations
@@ -409,6 +410,64 @@ class GatewayDiagnostic:
                 status=CheckStatus.FAIL,
                 message="Not installed",
                 fix_hint="Install from MeshForge RNS panel → 'Install Interface' button"
+            )
+
+    def check_meshtastic_module_for_rnsd(self) -> CheckResult:
+        """
+        Check if meshtastic module is available in the Python environment that rnsd uses.
+
+        This is critical when Meshtastic_Interface.py is installed - rnsd will fail
+        to start if the meshtastic module isn't importable from root's Python.
+
+        See persistent_issues.md Issue #24 for details.
+        """
+        from utils.paths import ReticulumPaths
+        interface_path = ReticulumPaths.get_interfaces_dir() / "Meshtastic_Interface.py"
+
+        # Only check if the interface is installed - otherwise not relevant
+        if not interface_path.exists():
+            return CheckResult(
+                name="Meshtastic Module (for rnsd)",
+                status=CheckStatus.SKIP,
+                message="Meshtastic_Interface not installed, check not needed"
+            )
+
+        # Check if meshtastic is importable as root (how rnsd runs)
+        try:
+            result = subprocess.run(
+                ['sudo', 'python3', '-c', 'import meshtastic; print(meshtastic.__version__)'],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                version = result.stdout.strip()
+                return CheckResult(
+                    name="Meshtastic Module (for rnsd)",
+                    status=CheckStatus.PASS,
+                    message=f"meshtastic {version} available to rnsd"
+                )
+            else:
+                # Module not found - this is the Issue #24 problem
+                return CheckResult(
+                    name="Meshtastic Module (for rnsd)",
+                    status=CheckStatus.FAIL,
+                    message="meshtastic not importable by root's Python (rnsd will fail!)",
+                    fix_hint="sudo pip3 install meshtastic (system-wide install required)",
+                    details="The Meshtastic_Interface.py plugin requires meshtastic to be installed "
+                            "in root's Python path. pipx or --user installs won't work."
+                )
+        except subprocess.TimeoutExpired:
+            return CheckResult(
+                name="Meshtastic Module (for rnsd)",
+                status=CheckStatus.WARN,
+                message="Check timed out",
+                fix_hint="Run: sudo python3 -c 'import meshtastic' to test manually"
+            )
+        except FileNotFoundError:
+            # sudo not available (testing environment)
+            return CheckResult(
+                name="Meshtastic Module (for rnsd)",
+                status=CheckStatus.SKIP,
+                message="Cannot check (sudo not available)"
             )
 
     def check_meshtasticd(self) -> CheckResult:


### PR DESCRIPTION
When Meshtastic_Interface.py plugin is installed for RNS, rnsd will fail with exit code 255 if the meshtastic Python module isn't available in root's Python environment.

This commonly happens when users install meshtastic via pipx (isolated environment) or with pip --user (user site-packages), but rnsd runs as root and can't access those installations.

Changes:
- Added Issue #24 to persistent_issues.md documenting this problem
- Added check_meshtastic_module_for_rnsd() to gateway_diagnostic.py
- This check runs when Meshtastic_Interface.py exists and verifies meshtastic is importable as root
- Provides clear fix: sudo pip3 install meshtastic

https://claude.ai/code/session_01PgPmHKfDPYk5NjVbQmemLf