### PR TITLE
fix: Add --break-system-packages to meshtastic install instructions

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1390,7 +1390,8 @@ This happens even when the user has previously installed `meshtastic` via CLI.
 **Option 1: System-wide install (recommended for rnsd)**
 ```bash
 # Install to system site-packages where rnsd can find it
-sudo pip3 install meshtastic
+# --break-system-packages required on Debian 12+ / Pi OS Bookworm
+sudo pip3 install --break-system-packages meshtastic
 ```
 
 **Option 2: Install to same Python that rnsd uses**
@@ -1399,10 +1400,10 @@ sudo pip3 install meshtastic
 head -1 $(which rnsd 2>/dev/null || sudo find /usr -name rnsd 2>/dev/null | head -1)
 
 # If rnsd uses /usr/local/bin/python3:
-sudo /usr/local/bin/python3 -m pip install meshtastic
+sudo /usr/local/bin/python3 -m pip install --break-system-packages meshtastic
 
 # If rnsd uses /usr/bin/python3:
-sudo /usr/bin/python3 -m pip install meshtastic
+sudo /usr/bin/python3 -m pip install --break-system-packages meshtastic
 ```
 
 **Option 3: Disable the Meshtastic interface if not needed**

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -451,9 +451,10 @@ class GatewayDiagnostic:
                     name="Meshtastic Module (for rnsd)",
                     status=CheckStatus.FAIL,
                     message="meshtastic not importable by root's Python (rnsd will fail!)",
-                    fix_hint="sudo pip3 install meshtastic (system-wide install required)",
+                    fix_hint="sudo pip3 install --break-system-packages meshtastic",
                     details="The Meshtastic_Interface.py plugin requires meshtastic to be installed "
-                            "in root's Python path. pipx or --user installs won't work."
+                            "in root's Python path. pipx or --user installs won't work. "
+                            "Use --break-system-packages on Debian 12+ / Pi OS Bookworm."
                 )
         except subprocess.TimeoutExpired:
             return CheckResult(


### PR DESCRIPTION
On Debian 12+ / Raspberry Pi OS Bookworm, pip3 requires the --break-system-packages flag to install packages system-wide.

Updated Issue #24 docs and gateway_diagnostic.py fix_hint to include this flag so users don't hit the "externally-managed-environment" error.

https://claude.ai/code/session_01PgPmHKfDPYk5NjVbQmemLf