### PR TITLE
fix: Add --ignore-installed to meshtastic pip install commands

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1391,7 +1391,8 @@ This happens even when the user has previously installed `meshtastic` via CLI.
 ```bash
 # Install to system site-packages where rnsd can find it
 # --break-system-packages required on Debian 12+ / Pi OS Bookworm
-sudo pip3 install --break-system-packages meshtastic
+# --ignore-installed avoids "Cannot uninstall packaging" errors
+sudo pip3 install --break-system-packages --ignore-installed meshtastic
 ```
 
 **Option 2: Install to same Python that rnsd uses**
@@ -1400,10 +1401,10 @@ sudo pip3 install --break-system-packages meshtastic
 head -1 $(which rnsd 2>/dev/null || sudo find /usr -name rnsd 2>/dev/null | head -1)
 
 # If rnsd uses /usr/local/bin/python3:
-sudo /usr/local/bin/python3 -m pip install --break-system-packages meshtastic
+sudo /usr/local/bin/python3 -m pip install --break-system-packages --ignore-installed meshtastic
 
 # If rnsd uses /usr/bin/python3:
-sudo /usr/bin/python3 -m pip install --break-system-packages meshtastic
+sudo /usr/bin/python3 -m pip install --break-system-packages --ignore-installed meshtastic
 ```
 
 **Option 3: Disable the Meshtastic interface if not needed**

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -451,10 +451,10 @@ class GatewayDiagnostic:
                     name="Meshtastic Module (for rnsd)",
                     status=CheckStatus.FAIL,
                     message="meshtastic not importable by root's Python (rnsd will fail!)",
-                    fix_hint="sudo pip3 install --break-system-packages meshtastic",
+                    fix_hint="sudo pip3 install --break-system-packages --ignore-installed meshtastic",
                     details="The Meshtastic_Interface.py plugin requires meshtastic to be installed "
                             "in root's Python path. pipx or --user installs won't work. "
-                            "Use --break-system-packages on Debian 12+ / Pi OS Bookworm."
+                            "Use --break-system-packages --ignore-installed on Debian 12+ / Pi OS Bookworm."
                 )
         except subprocess.TimeoutExpired:
             return CheckResult(


### PR DESCRIPTION
The "Cannot uninstall packaging" error occurs when pip tries to uninstall Debian-managed packages. Adding --ignore-installed skips the uninstall step and installs alongside the system package.

Updated:
- persistent_issues.md Issue #24 fix commands
- gateway_diagnostic.py fix_hint message

The install_noc.sh script already had this flag.

https://claude.ai/code/session_01PgPmHKfDPYk5NjVbQmemLf