### PR TITLE
fix: Auto-install meshtastic module when Meshtastic_Interface detected

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -994,6 +994,14 @@ RNSD_SERVICE
         systemctl daemon-reload
     fi
 
+    # Check if Meshtastic_Interface.py plugin exists - if so, install meshtastic module
+    # This is required for the RNS-over-Meshtastic bridge to work (Issue #24)
+    if [[ -f "/etc/reticulum/interfaces/Meshtastic_Interface.py" ]]; then
+        echo "  Meshtastic_Interface.py detected, installing meshtastic module..."
+        pip3 install $PIP_ARGS --ignore-installed -q meshtastic
+        echo -e "  ${GREEN}✓ meshtastic module installed for rnsd${NC}"
+    fi
+
     echo -e "  ${GREEN}✓ Reticulum installed${NC}"
 else
     echo -e "${CYAN}[4/8] Skipping Reticulum...${NC}"


### PR DESCRIPTION
During RNS installation, check if Meshtastic_Interface.py plugin exists in /etc/reticulum/interfaces/. If found, automatically install the meshtastic Python module system-wide so rnsd can load the interface.

This prevents the Issue #24 failure where rnsd crashes because the meshtastic module isn't available in root's Python environment.

https://claude.ai/code/session_01PgPmHKfDPYk5NjVbQmemLf