### PR TITLE
fix: Correctly detect rnsd enabled state via systemctl

### DIFF
--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -184,7 +184,7 @@ class StartupChecker:
     # Services to check with their expected ports
     SERVICES_TO_CHECK = {
         'meshtasticd': {'port': MESHTASTICD_PORT, 'port_type': 'tcp', 'systemd': True},
-        'rnsd': {'port': RNS_SHARED_INSTANCE_PORT, 'port_type': 'udp', 'systemd': False},
+        'rnsd': {'port': RNS_SHARED_INSTANCE_PORT, 'port_type': 'udp', 'systemd': True},
     }
 
     # Ports that MeshForge needs


### PR DESCRIPTION
rnsd was configured with 'systemd': False which caused the startup check to skip the systemctl is-enabled check. Since rnsd IS a systemd service, changed to 'systemd': True so enabled_at_boot is properly detected.

https://claude.ai/code/session_01PgPmHKfDPYk5NjVbQmemLf