### PR TITLE
feat: Add meshforge-map standalone systemd service

### DIFF
--- a/.claude/sessions/2026-01-31_meshforge_map_service.md
+++ b/.claude/sessions/2026-01-31_meshforge_map_service.md
@@ -1,0 +1,135 @@
+# Session Notes: MeshForge Map Service Standalone
+
+**Date**: 2026-01-31
+**Branch**: `claude/radio-geojson-integration-eKnp7`
+**Focus**: Make MeshForge web UI a standalone systemd service for reliability
+
+## Summary
+
+Upgraded the MeshForge web UI from an in-process TUI component to a standalone systemd service. This improves reliability - the map server now persists independently of the TUI lifecycle and starts automatically on boot.
+
+## Problem
+
+The previous architecture had the web UI (port 5000) running as a background thread inside the TUI process:
+- Server died when TUI exited
+- No auto-start on boot
+- Connectivity issues when TUI crashed/restarted
+- Not suitable for NOC operations requiring 24/7 uptime
+
+## Solution
+
+Created `meshforge-map` as a first-class systemd service:
+
+### 1. Enhanced CLI Entry Point (`src/utils/map_data_service.py`)
+
+Extended `main()` with service-friendly features:
+- `--daemon` mode for systemd
+- `--status` to check if running
+- `--pid-file` for service management
+- Signal handlers (SIGTERM, SIGINT) for graceful shutdown
+- Port conflict detection
+
+### 2. Systemd Service (`scripts/meshforge-map.service`)
+
+```ini
+[Unit]
+Description=MeshForge Map Server - NOC Web Interface
+After=network.target meshtasticd.service
+Wants=meshtasticd.service
+
+[Service]
+Type=simple
+ExecStart=/opt/meshforge/venv/bin/python -m utils.map_data_service --daemon --port 5000
+Restart=on-failure
+```
+
+### 3. CLI Command (`/usr/local/bin/meshforge-map`)
+
+Wrapper script for easy management:
+```bash
+meshforge-map start    # Start service
+meshforge-map stop     # Stop service
+meshforge-map status   # Check status
+meshforge-map url      # Show access URL
+meshforge-map enable   # Enable on boot
+```
+
+### 4. Installer Integration (`scripts/install_noc.sh`)
+
+- Installs service file to `/etc/systemd/system/`
+- Creates `/usr/local/bin/meshforge-map` command
+- Enables and starts service on install
+- Updated summary output to show new commands
+
+### 5. TUI Integration (`src/launcher_tui/ai_tools_mixin.py`)
+
+Modified `_start_map_server()` and `_maybe_auto_start_map()`:
+- First tries systemd service (preferred)
+- Falls back to in-process if systemd unavailable
+- Shows service status in dialogs
+- New helper methods: `_try_start_map_service()`, `_get_map_service_status()`
+
+## Architecture
+
+```
+BEFORE:
+┌─────────────────────────────────────┐
+│  TUI Process                        │
+│  ├── Whiptail dialogs               │
+│  └── MapServer thread (port 5000)   │  ← Dies with TUI
+└─────────────────────────────────────┘
+
+AFTER:
+┌─────────────────────────────────────┐
+│  systemd                            │
+│  ├── meshforge-map.service          │  ← Persistent, auto-start
+│  │   └── python -m utils.map_data_service
+│  │       └── HTTPServer :5000       │
+│  │                                  │
+│  └── (optional) meshforge.service   │
+└─────────────────────────────────────┘
+          │
+          │ TUI detects existing service
+          ▼
+┌─────────────────────────────────────┐
+│  TUI Process                        │
+│  └── Uses existing service OR       │
+│      falls back to in-process       │
+└─────────────────────────────────────┘
+```
+
+## Files Modified
+
+| File | Changes |
+|------|---------|
+| `src/utils/map_data_service.py` | Enhanced main() with daemon mode, status check, signal handling |
+| `src/launcher_tui/ai_tools_mixin.py` | Added systemd service detection and fallback logic |
+| `scripts/install_noc.sh` | Added meshforge-map service installation |
+| `scripts/meshforge-map.service` | NEW - systemd unit file |
+
+## Testing
+
+- `python3 -m utils.map_data_service --help` - CLI works
+- `python3 -m utils.map_data_service --status` - Status check works
+- `python3 -m utils.map_data_service --collect-only` - Data collection works
+- Syntax validation passed for all modified files
+
+## Commands Added
+
+```bash
+meshforge-map start      # Start map server
+meshforge-map stop       # Stop map server
+meshforge-map restart    # Restart
+meshforge-map status     # Check status
+meshforge-map enable     # Enable on boot
+meshforge-map disable    # Disable on boot
+meshforge-map url        # Show access URL
+meshforge-map -p 8080    # Run on custom port (interactive)
+```
+
+## Next Steps
+
+1. **Test on real hardware** - Verify systemd service starts correctly
+2. **Add to meshforge-noc orchestrator** - Service coordination
+3. **Health checks** - Add /api/health endpoint for monitoring
+4. **Nginx integration** - Optional reverse proxy for HTTPS

--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -1190,6 +1190,88 @@ fi
 WEB_CMD
 chmod +x /usr/local/bin/meshforge-web
 
+# MeshForge Map Server command (NOC web UI on port 5000)
+cat > /usr/local/bin/meshforge-map << 'MAP_CMD'
+#!/bin/bash
+# MeshForge Map Server - NOC Web Interface
+# Serves the live node map on port 5000
+
+PYTHON_CMD="/opt/meshforge/venv/bin/python"
+[ ! -x "$PYTHON_CMD" ] && PYTHON_CMD="python3"
+
+case "${1:-}" in
+    start)
+        echo "Starting MeshForge Map Server..."
+        sudo systemctl start meshforge-map
+        ;;
+    stop)
+        echo "Stopping MeshForge Map Server..."
+        sudo systemctl stop meshforge-map
+        ;;
+    restart)
+        echo "Restarting MeshForge Map Server..."
+        sudo systemctl restart meshforge-map
+        ;;
+    status)
+        systemctl status meshforge-map --no-pager
+        cd /opt/meshforge/src && $PYTHON_CMD -m utils.map_data_service --status
+        ;;
+    enable)
+        echo "Enabling MeshForge Map Server on boot..."
+        sudo systemctl enable meshforge-map
+        ;;
+    disable)
+        echo "Disabling MeshForge Map Server on boot..."
+        sudo systemctl disable meshforge-map
+        ;;
+    url)
+        LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+        [ -z "$LOCAL_IP" ] && LOCAL_IP="localhost"
+        echo "MeshForge Map: http://${LOCAL_IP}:5000/"
+        ;;
+    *)
+        # Default: run interactively (for debugging)
+        cd /opt/meshforge/src
+        exec $PYTHON_CMD -m utils.map_data_service "$@"
+        ;;
+esac
+MAP_CMD
+chmod +x /usr/local/bin/meshforge-map
+
+# Install MeshForge Map Server systemd service
+if [[ -f "$INSTALL_DIR/scripts/meshforge-map.service" ]]; then
+    cp "$INSTALL_DIR/scripts/meshforge-map.service" /etc/systemd/system/
+    echo -e "  ${GREEN}✓ meshforge-map.service installed${NC}"
+else
+    # Inline service definition (fallback)
+    cat > /etc/systemd/system/meshforge-map.service << 'MAP_SERVICE'
+[Unit]
+Description=MeshForge Map Server - NOC Web Interface
+Documentation=https://github.com/Nursedude/meshforge
+After=network.target meshtasticd.service
+Wants=meshtasticd.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/meshforge/src
+RuntimeDirectory=meshforge
+ExecStart=/bin/bash -c 'if [ -x /opt/meshforge/venv/bin/python ]; then exec /opt/meshforge/venv/bin/python -m utils.map_data_service --daemon --port 5000; else exec python3 -m utils.map_data_service --daemon --port 5000; fi'
+ExecStop=/bin/kill -TERM $MAINPID
+TimeoutStopSec=10
+Restart=on-failure
+RestartSec=5
+Environment=PYTHONUNBUFFERED=1
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=meshforge-map
+
+[Install]
+WantedBy=multi-user.target
+MAP_SERVICE
+    echo -e "  ${GREEN}✓ meshforge-map.service created${NC}"
+fi
+
 # Update systemd service to use orchestrator
 cat > /etc/systemd/system/meshforge.service << 'MESHFORGE_SERVICE'
 [Unit]
@@ -1257,6 +1339,7 @@ if $INSTALL_RNS; then
     echo -e "  ${GREEN}✓${NC} Reticulum (RNS)"
 fi
 echo -e "  ${GREEN}✓${NC} MeshForge NOC"
+echo -e "  ${GREEN}✓${NC} MeshForge Map Server (port 5000)"
 echo ""
 echo -e "${CYAN}Configuration:${NC}"
 echo -e "  NOC Mode:    ${BOLD}$NOC_MODE${NC}"
@@ -1273,17 +1356,20 @@ echo "  /etc/meshtasticd/available.d/     - Radio templates"
 echo "  /etc/meshtasticd/config.d/        - Active configs"
 echo ""
 echo -e "${CYAN}Commands:${NC}"
-echo -e "  ${GREEN}meshforge-status${NC}            - Quick system status (no sudo needed)"
-echo -e "  ${GREEN}meshforge-web${NC}              - Open radio web client (config)"
-echo -e "  ${GREEN}sudo meshforge${NC}             - Launch interface wizard"
-echo -e "  ${GREEN}sudo meshforge-noc --start${NC}  - Start NOC services"
-echo -e "  ${GREEN}sudo meshforge-noc --status${NC} - Check service status"
-echo -e "  ${GREEN}sudo meshforge-noc --stop${NC}   - Stop NOC services"
+echo -e "  ${GREEN}meshforge-status${NC}             - Quick system status (no sudo needed)"
+echo -e "  ${GREEN}meshforge-web${NC}                - Open radio web client (config)"
+echo -e "  ${GREEN}meshforge-map url${NC}            - Show NOC map URL (port 5000)"
+echo -e "  ${GREEN}meshforge-map status${NC}         - Check map server status"
+echo -e "  ${GREEN}sudo meshforge${NC}               - Launch interface wizard"
+echo -e "  ${GREEN}sudo meshforge-noc --start${NC}   - Start NOC services"
+echo -e "  ${GREEN}sudo meshforge-noc --status${NC}  - Check service status"
+echo -e "  ${GREEN}sudo meshforge-noc --stop${NC}    - Stop NOC services"
 echo ""
 echo -e "${CYAN}Systemd Services:${NC}"
-echo -e "  ${GREEN}sudo systemctl enable meshforge${NC}   - Enable on boot"
-echo -e "  ${GREEN}sudo systemctl start meshforge${NC}    - Start now"
-echo -e "  ${GREEN}sudo systemctl status meshtasticd${NC} - Check meshtasticd"
+echo -e "  ${GREEN}sudo systemctl enable meshforge${NC}       - Enable NOC on boot"
+echo -e "  ${GREEN}sudo systemctl enable meshforge-map${NC}   - Enable Map Server on boot"
+echo -e "  ${GREEN}sudo systemctl start meshforge-map${NC}    - Start Map Server now"
+echo -e "  ${GREEN}sudo systemctl status meshtasticd${NC}     - Check meshtasticd"
 echo ""
 
 # ─────────────────────────────────────────────────────────────────
@@ -1348,6 +1434,22 @@ if [[ -x "$VERIFY_SCRIPT" ]]; then
 else
     echo -e "${YELLOW}⚠ Verification script not found: $VERIFY_SCRIPT${NC}"
     echo -e "${YELLOW}  Skipping verification${NC}"
+fi
+
+# Enable and start MeshForge Map Server (NOC web UI)
+echo ""
+echo -e "${CYAN}Enabling MeshForge Map Server...${NC}"
+systemctl daemon-reload
+systemctl enable meshforge-map 2>/dev/null || true
+systemctl start meshforge-map 2>/dev/null || true
+
+# Check if map server started
+sleep 2
+if systemctl is-active --quiet meshforge-map; then
+    LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "localhost")
+    echo -e "  ${GREEN}✓ Map Server running: http://${LOCAL_IP}:5000/${NC}"
+else
+    echo -e "  ${YELLOW}⚠ Map Server not running (check: journalctl -u meshforge-map)${NC}"
 fi
 
 # Offer to start services (only if services can actually run)

--- a/scripts/meshforge-map.service
+++ b/scripts/meshforge-map.service
@@ -1,0 +1,46 @@
+[Unit]
+Description=MeshForge Map Server - NOC Web Interface
+Documentation=https://github.com/Nursedude/meshforge
+After=network.target meshtasticd.service
+Wants=meshtasticd.service
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/meshforge/src
+RuntimeDirectory=meshforge
+
+# Use venv if available, fall back to system Python
+ExecStart=/bin/bash -c '\
+    if [ -x /opt/meshforge/venv/bin/python ]; then \
+        exec /opt/meshforge/venv/bin/python -m utils.map_data_service --daemon --port 5000; \
+    else \
+        exec python3 -m utils.map_data_service --daemon --port 5000; \
+    fi'
+
+# Graceful shutdown
+ExecStop=/bin/kill -TERM $MAINPID
+TimeoutStopSec=10
+
+# Restart policy
+Restart=on-failure
+RestartSec=5
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+# Environment
+Environment=PYTHONUNBUFFERED=1
+Environment=PYTHONDONTWRITEBYTECODE=1
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=meshforge-map
+
+# Security hardening (relaxed for access to user dirs and radio)
+ProtectSystem=false
+PrivateTmp=false
+NoNewPrivileges=false
+
+[Install]
+WantedBy=multi-user.target

--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -57,8 +57,8 @@ class AIToolsMixin:
     def _maybe_auto_start_map(self):
         """Start map server on TUI launch if user has enabled auto-open.
 
-        Note: Server initialization is wrapped to suppress stdout/stderr output
-        that could interfere with the whiptail/dialog TUI during startup.
+        Prefers systemd service (meshforge-map) for reliability.
+        Falls back to in-process server if systemd unavailable.
         """
         import json
         import socket
@@ -76,7 +76,7 @@ class AIToolsMixin:
         if not settings.get("auto_open_map", False):
             return
 
-        # Check if server already running
+        # Check if server already running (port 5000)
         try:
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(1)
@@ -87,15 +87,17 @@ class AIToolsMixin:
         except OSError:
             pass
 
-        # Start map server in background (no dialog, quiet)
+        # Try to start via systemd service first (preferred for reliability)
+        if self._try_start_map_service_quiet():
+            return  # Successfully started via systemd
+
+        # Fall back to in-process server (non-systemd environments)
         # Suppress stdout/stderr AND logging to prevent TUI corruption
         try:
             import logging
-            import sys
             from contextlib import redirect_stdout, redirect_stderr
             from io import StringIO
 
-            # Temporarily raise logging level to suppress all log output
             root_logger = logging.getLogger()
             old_level = root_logger.level
             root_logger.setLevel(logging.CRITICAL + 1)
@@ -106,13 +108,52 @@ class AIToolsMixin:
                     server = MapServer(port=5000)
                     server.start_background()
             finally:
-                # Restore logging level
                 root_logger.setLevel(old_level)
 
-            # Store reference to prevent garbage collection
             self._map_server = server
         except Exception:
             pass  # Non-fatal, don't interrupt startup
+
+    def _try_start_map_service_quiet(self) -> bool:
+        """Try to start map server via systemd (quiet, no TUI output).
+
+        Returns True if service started successfully.
+        """
+        import subprocess
+        import socket
+        import time
+
+        try:
+            # Check if systemd is available
+            result = subprocess.run(
+                ['systemctl', 'is-enabled', 'meshforge-map'],
+                capture_output=True, timeout=5
+            )
+            if result.returncode != 0:
+                return False  # Service not installed
+
+            # Start the service
+            subprocess.run(
+                ['systemctl', 'start', 'meshforge-map'],
+                capture_output=True, timeout=10
+            )
+
+            # Wait briefly for service to start
+            for _ in range(5):
+                time.sleep(0.5)
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(1)
+                    result = sock.connect_ex(('localhost', 5000))
+                    sock.close()
+                    if result == 0:
+                        return True
+                except OSError:
+                    pass
+
+            return False
+        except Exception:
+            return False
 
     def _get_map_settings_file(self) -> Path:
         """Get the map settings file path."""
@@ -238,8 +279,8 @@ class AIToolsMixin:
     def _start_map_server(self):
         """Start the map HTTP server for live-updating browser access.
 
-        Note: Server initialization is wrapped to suppress stdout/stderr output
-        that could interfere with the whiptail/dialog TUI.
+        Prefers systemd service (meshforge-map) for reliability.
+        Falls back to in-process server if systemd unavailable.
         """
         import socket
         import time
@@ -258,10 +299,12 @@ class AIToolsMixin:
             sock.close()
             if result == 0:
                 urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
+                service_status = self._get_map_service_status()
                 self.dialog.msgbox(
                     "Map Server",
                     f"Map server already running!\n\n"
                     f"Access via:\n{urls}\n\n"
+                    f"Service: {service_status}\n\n"
                     "Open any URL in your browser.\n"
                     "The map auto-refreshes every 30 seconds."
                 )
@@ -269,20 +312,31 @@ class AIToolsMixin:
         except OSError:
             pass
 
+        # Try systemd service first (preferred for reliability)
+        service_started = self._try_start_map_service()
+
+        if service_started:
+            urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
+            self.dialog.msgbox(
+                "Map Server Started",
+                f"Map server running as system service!\n\n"
+                f"Access via:\n{urls}\n\n"
+                "Open any URL in your browser.\n"
+                "The map pulls fresh data every 30 seconds.\n\n"
+                "Service persists after TUI exits.\n"
+                "Manage with: meshforge-map start|stop|status"
+            )
+            return
+
+        # Fall back to in-process server
         try:
-            # Suppress stdout/stderr AND logging during server init to prevent
-            # TUI corruption. The meshtastic library, HTTP server, and various
-            # loggers can output during initialization.
             import logging
-            import sys
             from contextlib import redirect_stdout, redirect_stderr
             from io import StringIO
 
-            # Capture any output during initialization
             captured_out = StringIO()
             captured_err = StringIO()
 
-            # Temporarily raise logging level to suppress all log output
             root_logger = logging.getLogger()
             old_level = root_logger.level
             root_logger.setLevel(logging.CRITICAL + 1)
@@ -294,27 +348,85 @@ class AIToolsMixin:
                     server = MapServer(port=port)  # Binds to 0.0.0.0
                     server.start_background()
 
-                    # Small delay to let server thread stabilize
                     time.sleep(0.1)
             finally:
-                # Restore logging level
                 root_logger.setLevel(old_level)
 
-            # Store reference to prevent garbage collection
             self._map_server = server
 
             urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
             msg = (
-                f"Live map server running!\n\n"
+                f"Live map server running (in-process)!\n\n"
                 f"Access via:\n{urls}\n\n"
                 "Open any URL in your browser.\n"
                 "The map pulls fresh data every 30 seconds.\n"
-                "Server runs until MeshForge exits."
+                "Server runs until MeshForge exits.\n\n"
+                "Tip: Install meshforge-map service for\n"
+                "persistent operation."
             )
             self.dialog.msgbox("Map Server Started", msg)
 
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to start map server: {e}")
+
+    def _try_start_map_service(self) -> bool:
+        """Try to start map server via systemd service.
+
+        Returns True if service started successfully.
+        """
+        import subprocess
+        import socket
+        import time
+
+        try:
+            # Check if systemd service is available
+            result = subprocess.run(
+                ['systemctl', 'is-enabled', 'meshforge-map'],
+                capture_output=True, timeout=5
+            )
+            if result.returncode != 0:
+                return False  # Service not installed
+
+            # Start the service
+            subprocess.run(
+                ['systemctl', 'start', 'meshforge-map'],
+                capture_output=True, timeout=10
+            )
+
+            # Wait for service to start (up to 3 seconds)
+            for _ in range(6):
+                time.sleep(0.5)
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(1)
+                    result = sock.connect_ex(('localhost', 5000))
+                    sock.close()
+                    if result == 0:
+                        return True
+                except OSError:
+                    pass
+
+            return False
+        except Exception:
+            return False
+
+    def _get_map_service_status(self) -> str:
+        """Get map server service status for display."""
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ['systemctl', 'is-active', 'meshforge-map'],
+                capture_output=True, text=True, timeout=5
+            )
+            status = result.stdout.strip()
+            if status == "active":
+                return "systemd service (active)"
+            elif result.returncode != 0:
+                return "in-process (TUI)"
+            return f"systemd ({status})"
+        except Exception:
+            return "in-process (TUI)"
 
     def _toggle_auto_map(self):
         """Toggle the auto-open map on launch setting."""

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -1957,24 +1957,173 @@ class MapServer:
 
 
 def main():
-    """Run the map server standalone."""
-    import argparse
+    """Run the map server standalone.
 
-    parser = argparse.ArgumentParser(description="MeshForge Live Map Server")
-    parser.add_argument("-p", "--port", type=int, default=5000, help="Port (default: 5000)")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address (default: 0.0.0.0 for all interfaces)")
-    parser.add_argument("--collect-only", action="store_true", help="Just collect and print GeoJSON")
+    Designed for both interactive use and systemd service deployment.
+
+    Examples:
+        # Interactive
+        python -m utils.map_data_service
+
+        # As service
+        python -m utils.map_data_service --daemon
+
+        # Collect GeoJSON only
+        python -m utils.map_data_service --collect-only
+    """
+    import argparse
+    import signal
+
+    parser = argparse.ArgumentParser(
+        description="MeshForge Live Map Server - NOC Web Interface",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python -m utils.map_data_service           # Start on port 5000
+  python -m utils.map_data_service -p 8080   # Use custom port
+  python -m utils.map_data_service --daemon  # Run as background service
+  python -m utils.map_data_service --status  # Check if running
+  python -m utils.map_data_service --collect-only  # Just get GeoJSON
+        """
+    )
+    parser.add_argument("-p", "--port", type=int, default=5000,
+                        help="Port (default: 5000)")
+    parser.add_argument("--host", default="0.0.0.0",
+                        help="Bind address (default: 0.0.0.0 for all interfaces)")
+    parser.add_argument("--collect-only", action="store_true",
+                        help="Just collect and print GeoJSON, then exit")
+    parser.add_argument("--daemon", action="store_true",
+                        help="Run in daemon mode (for systemd)")
+    parser.add_argument("--status", action="store_true",
+                        help="Check if map server is running")
+    parser.add_argument("--pid-file", type=str,
+                        default="/run/meshforge/map-server.pid",
+                        help="PID file location (default: /run/meshforge/map-server.pid)")
+    parser.add_argument("-v", "--verbose", action="store_true",
+                        help="Enable verbose logging")
     args = parser.parse_args()
 
+    # Configure logging
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(
+        level=log_level,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S"
+    )
+
+    # Status check
+    if args.status:
+        return _check_server_status(args.port)
+
+    # Collect-only mode
     if args.collect_only:
         collector = MapDataCollector()
         geojson = collector.collect()
         print(json.dumps(geojson, indent=2))
-        print(f"\n# {len(geojson['features'])} nodes collected", flush=True)
-    else:
-        server = MapServer(port=args.port, host=args.host)
+
+        # Summary to stderr so it doesn't pollute JSON output
+        import sys
+        props = geojson.get("properties", {})
+        print(f"\n# {len(geojson['features'])} nodes with position", file=sys.stderr)
+        print(f"# {props.get('nodes_without_position_count', 0)} nodes without position", file=sys.stderr)
+        print(f"# Sources: {props.get('sources', {})}", file=sys.stderr)
+        return 0
+
+    # Check if port is already in use
+    if _is_port_in_use(args.port):
+        print(f"ERROR: Port {args.port} is already in use")
+        print(f"  Check: lsof -i :{args.port}")
+        print(f"  Or use: --port <different_port>")
+        return 1
+
+    # Daemon mode - write PID file for service management
+    if args.daemon:
+        _write_pid_file(args.pid_file)
+
+    # Create and start server
+    server = MapServer(port=args.port, host=args.host)
+
+    # Signal handlers for graceful shutdown
+    def handle_signal(signum, frame):
+        sig_name = signal.Signals(signum).name
+        print(f"\nReceived {sig_name}, shutting down...")
+        server.stop()
+        _remove_pid_file(args.pid_file)
+        import sys
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
         server.start()
+    finally:
+        _remove_pid_file(args.pid_file)
+
+    return 0
+
+
+def _is_port_in_use(port: int) -> bool:
+    """Check if a port is already in use."""
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(1)
+        result = sock.connect_ex(('localhost', port))
+        sock.close()
+        return result == 0
+    except Exception:
+        return False
+
+
+def _check_server_status(port: int) -> int:
+    """Check if map server is running and report status."""
+    if _is_port_in_use(port):
+        print(f"✓ MeshForge Map Server is running on port {port}")
+        # Try to get status from API
+        try:
+            import urllib.request
+            with urllib.request.urlopen(f"http://localhost:{port}/api/status", timeout=2) as resp:
+                data = json.loads(resp.read().decode())
+                print(f"  Collector: {'active' if data.get('collector') else 'inactive'}")
+                if data.get('radio'):
+                    radio = data['radio']
+                    print(f"  Radio: {radio.get('mode', 'unknown')} "
+                          f"({'connected' if radio.get('connected') else 'disconnected'})")
+        except Exception:
+            pass
+        return 0
+    else:
+        print(f"✗ MeshForge Map Server is not running on port {port}")
+        return 1
+
+
+def _write_pid_file(pid_file: str) -> None:
+    """Write PID file for service management."""
+    try:
+        pid_dir = Path(pid_file).parent
+        pid_dir.mkdir(parents=True, exist_ok=True)
+        with open(pid_file, 'w') as f:
+            f.write(str(os.getpid()))
+        logger.debug(f"PID file written: {pid_file}")
+    except PermissionError:
+        # Running as non-root, use alternative location
+        alt_pid = Path("/tmp/meshforge-map-server.pid")
+        with open(alt_pid, 'w') as f:
+            f.write(str(os.getpid()))
+        logger.debug(f"PID file written: {alt_pid}")
+    except Exception as e:
+        logger.warning(f"Could not write PID file: {e}")
+
+
+def _remove_pid_file(pid_file: str) -> None:
+    """Remove PID file on shutdown."""
+    for path in [pid_file, "/tmp/meshforge-map-server.pid"]:
+        try:
+            Path(path).unlink(missing_ok=True)
+        except Exception:
+            pass
 
 
 if __name__ == "__main__":
-    main()
+    import sys
+    sys.exit(main() or 0)


### PR DESCRIPTION
Upgrades the MeshForge web UI from an in-process TUI component to a standalone systemd service for improved reliability:

- Enhanced map_data_service.py with daemon mode, status check, signal handling, and PID file support
- Created meshforge-map.service systemd unit file
- Added meshforge-map CLI command (start/stop/status/enable/url)
- Updated install_noc.sh to install and enable service on boot
- Modified TUI to prefer systemd service, fallback to in-process

The map server now:
- Persists independently of TUI lifecycle
- Auto-starts on boot
- Provides reliable 24/7 operation for NOC use cases
- Can be managed via: meshforge-map start|stop|status

https://claude.ai/code/session_01FUQ5xK4oHTsqJDdd2KPAhs