### PR TITLE
refactor: Unify service checking with check_process_with_pid helper

### DIFF
--- a/.claude/sessions/2026-01-31_service_unification.md
+++ b/.claude/sessions/2026-01-31_service_unification.md
@@ -1,0 +1,104 @@
+# Session Notes: Service Checking Unification
+
+**Date**: 2026-01-31
+**Branch**: `claude/review-session-notes-AJP0A`
+**Version**: `0.4.8-alpha`
+
+---
+
+## Summary
+
+Continued service checking unification work to address the "service shows running in one UI, stopped in another" bug. Added new `check_process_with_pid()` helper to service_check.py and refactored key files to use centralized service checking.
+
+---
+
+## Changes This Session
+
+| File | Change |
+|------|--------|
+| `src/utils/service_check.py` | Added `check_process_with_pid()` function |
+| `src/utils/gateway_diagnostic.py` | Refactored 2 methods to use centralized checking |
+| `src/launcher_tui/rns_menu_mixin.py` | Refactored `_diagnose_rns_port_conflict()` |
+| `tests/test_service_check.py` | Added 5 tests for new function |
+
+---
+
+## New Helper Function
+
+```python
+def check_process_with_pid(process_name: str) -> Tuple[bool, Optional[str]]:
+    """
+    Check if a process is running and return its PID.
+
+    Returns:
+        Tuple of (is_running, pid) where pid is the first matching PID or None
+    """
+```
+
+This addresses cases where diagnostic functions need both the running status AND the PID for messaging.
+
+---
+
+## Files Refactored
+
+### gateway_diagnostic.py
+- `check_rnsd_running()` - now uses `check_process_with_pid('rnsd')`
+- `check_meshtasticd()` - now uses `check_process_with_pid('meshtasticd')`
+
+### rns_menu_mixin.py
+- `_diagnose_rns_port_conflict()` - now uses `check_process_running()` with fallback
+
+---
+
+## Remaining Fragmented Files
+
+The following files still have direct pgrep/systemctl calls. Some are acceptable (specialized use cases), others could be refactored in future sessions:
+
+### Acceptable (leave as-is)
+- `find_rns_processes()` in gateway_diagnostic.py - needs to enumerate ALL PIDs
+- `system_tools_mixin.py` - display commands (list-units, --failed)
+- `hardware_config.py` - intentional sudo prefix for standalone use
+
+### Could refactor (lower priority)
+- `nomadnet_client_mixin.py` - 2 places (already has fallback pattern)
+- `startup_checks.py` - 1 place
+- `startup_health.py` - 1 place
+- `network_diagnostics.py` - 1 place
+
+---
+
+## Testing
+
+- All modified files pass `py_compile` syntax check
+- New function verified working: `check_process_with_pid('bash')` returns `(True, 'PID')`
+- 5 unit tests added for new function (pytest not installed - tests ready for CI)
+
+---
+
+## Session Entropy Notes
+
+- Session was focused and limited to service unification
+- No breaking changes made
+- All changes are backward compatible (fallback patterns preserved)
+- Clear boundary: added one helper, refactored 3 methods, added tests
+
+---
+
+## Next Session Priorities
+
+1. **Commit and push** this branch
+2. **Pre-Alpha Checklist** - test core TUI menus on target hardware
+3. **More refactoring** - nomadnet_client_mixin.py if needed
+4. **pytest installation** - to run the test suite
+
+---
+
+## Related Documentation
+
+- Previous session: `.claude/sessions/2026-01-31_alpha_reliability_verify_install.md`
+- Systemctl refactor notes: `.claude/session_notes/systemctl_refactor_next.md`
+- Pre-alpha checklist: `.claude/foundations/pre_alpha_checklist.md`
+
+---
+
+*Session ID: claude/review-session-notes-AJP0A*

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -1025,12 +1025,27 @@ class RNSMenuMixin:
     def _diagnose_rns_port_conflict(self):
         """Print diagnostic info for RNS Address-in-use port conflicts."""
         try:
-            rnsd_check = subprocess.run(
-                ['pgrep', '-f', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            if rnsd_check.returncode == 0:
-                pid = rnsd_check.stdout.strip().split('\n')[0]
+            # Use centralized service check when available
+            if _HAS_SERVICE_CHECK:
+                rnsd_running = check_process_running('rnsd')
+            else:
+                # Fallback to direct pgrep
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                rnsd_running = result.returncode == 0
+
+            if rnsd_running:
+                # Get PID for diagnostic message
+                try:
+                    pid_result = subprocess.run(
+                        ['pgrep', '-f', 'rnsd'],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    pid = pid_result.stdout.strip().split('\n')[0] if pid_result.stdout else 'unknown'
+                except Exception:
+                    pid = 'unknown'
                 print(f"rnsd is running (PID: {pid}) but may need a restart:")
                 print("  sudo systemctl restart rnsd")
             else:

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -19,7 +19,9 @@ from utils.paths import get_real_user_home
 
 # Try to use centralized service checker
 try:
-    from utils.service_check import check_service, check_systemd_service, ServiceState
+    from utils.service_check import (
+        check_service, check_systemd_service, check_process_with_pid, ServiceState
+    )
     _HAS_SERVICE_CHECK = True
 except ImportError:
     _HAS_SERVICE_CHECK = False
@@ -316,16 +318,23 @@ class GatewayDiagnostic:
     def check_rnsd_running(self) -> CheckResult:
         """Check if rnsd daemon is running."""
         try:
-            result = subprocess.run(
-                ['pgrep', '-f', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                pids = result.stdout.strip().split('\n')
+            # Use centralized service check when available
+            if _HAS_SERVICE_CHECK:
+                running, pid = check_process_with_pid('rnsd')
+            else:
+                # Fallback to direct pgrep
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                running = result.returncode == 0 and result.stdout.strip()
+                pid = result.stdout.strip().split('\n')[0] if running else None
+
+            if running:
                 return CheckResult(
                     name="RNS Daemon (rnsd)",
                     status=CheckStatus.PASS,
-                    message=f"Running (PID: {pids[0]})"
+                    message=f"Running (PID: {pid})"
                 )
             else:
                 return CheckResult(
@@ -473,13 +482,19 @@ class GatewayDiagnostic:
 
     def check_meshtasticd(self) -> CheckResult:
         """Check if meshtasticd service is running."""
-        # Check process
         try:
-            result = subprocess.run(
-                ['pgrep', '-f', 'meshtasticd'],
-                capture_output=True, text=True, timeout=5
-            )
-            if result.returncode == 0 and result.stdout.strip():
+            # Use centralized service check when available
+            if _HAS_SERVICE_CHECK:
+                running, _ = check_process_with_pid('meshtasticd')
+            else:
+                # Fallback to direct pgrep
+                result = subprocess.run(
+                    ['pgrep', '-f', 'meshtasticd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                running = result.returncode == 0 and result.stdout.strip()
+
+            if running:
                 # Also check TCP port
                 if self.check_tcp_port('localhost', 4403):
                     return CheckResult(

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -303,6 +303,51 @@ def check_process_running(process_name: str) -> bool:
         return False
 
 
+def check_process_with_pid(process_name: str) -> Tuple[bool, Optional[str]]:
+    """
+    Check if a process is running and return its PID.
+
+    Args:
+        process_name: Name of the process to check (e.g., 'rnsd', 'meshtasticd')
+
+    Returns:
+        Tuple of (is_running, pid) where pid is the first matching PID or None
+
+    Example:
+        >>> running, pid = check_process_with_pid('rnsd')
+        >>> if running:
+        ...     print(f"rnsd is running (PID: {pid})")
+    """
+    try:
+        # First try exact process name match (most reliable)
+        result = subprocess.run(
+            ['pgrep', '-x', process_name],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            pid = result.stdout.strip().split('\n')[0]
+            return True, pid
+
+        # Also check with -f for processes run via interpreters
+        result = subprocess.run(
+            ['pgrep', '-f', process_name],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            # Filter out pgrep itself and get first real PID
+            pids = [p for p in result.stdout.strip().split('\n') if p]
+            if pids:
+                return True, pids[0]
+
+        return False, None
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+        return False, None
+
+
 def check_systemd_service(service_name: str) -> Tuple[bool, bool]:
     """
     Check if a systemd service is running and enabled.

--- a/tests/test_service_check.py
+++ b/tests/test_service_check.py
@@ -11,6 +11,7 @@ import subprocess
 
 from src.utils.service_check import (
     check_port,
+    check_process_with_pid,
     check_service,
     check_systemd_service,
     require_service,
@@ -456,3 +457,66 @@ class TestServiceHelpersIntegration:
                 assert len(result) == 2
                 assert isinstance(result[0], bool)
                 assert isinstance(result[1], str)
+
+
+class TestCheckProcessWithPid:
+    """Tests for check_process_with_pid function."""
+
+    def test_process_running_returns_pid(self):
+        """Test that running process returns (True, pid)."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="12345\n"
+            )
+
+            running, pid = check_process_with_pid('bash')
+
+            assert running is True
+            assert pid == "12345"
+
+    def test_process_not_running_returns_none(self):
+        """Test that non-running process returns (False, None)."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout=""
+            )
+
+            running, pid = check_process_with_pid('nonexistent_process')
+
+            assert running is False
+            assert pid is None
+
+    def test_multiple_pids_returns_first(self):
+        """Test that multiple PIDs return the first one."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout="12345\n67890\n"
+            )
+
+            running, pid = check_process_with_pid('multi_instance')
+
+            assert running is True
+            assert pid == "12345"
+
+    def test_timeout_returns_false(self):
+        """Test that timeout returns (False, None)."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = subprocess.TimeoutExpired('pgrep', 5)
+
+            running, pid = check_process_with_pid('slow_process')
+
+            assert running is False
+            assert pid is None
+
+    def test_pgrep_not_found_returns_false(self):
+        """Test graceful handling when pgrep is not available."""
+        with patch('subprocess.run') as mock_run:
+            mock_run.side_effect = FileNotFoundError()
+
+            running, pid = check_process_with_pid('any_process')
+
+            assert running is False
+            assert pid is None


### PR DESCRIPTION
- Add check_process_with_pid() to service_check.py for process+PID checks
- Refactor gateway_diagnostic.py to use centralized service checking
- Refactor rns_menu_mixin.py to use check_process_running
- Add 5 tests for new helper function

Addresses "service shows different status in different UIs" issue.

https://claude.ai/code/session_01Gq4RCcgM23wyVRhQAAcLzy