### PR TITLE
docs: Verify service unification is complete

### DIFF
--- a/.claude/sessions/2026-01-31_service_unification_verification.md
+++ b/.claude/sessions/2026-01-31_service_unification_verification.md
@@ -1,0 +1,118 @@
+# Session Notes: Service Unification Verification
+
+**Date**: 2026-01-31
+**Branch**: `claude/service-unification-continued-LADhN`
+**Version**: `0.4.8-alpha`
+
+---
+
+## Summary
+
+Verified that all files identified as having "fragmented" service checking patterns already have proper centralized imports with fallbacks, or have valid reasons for direct systemctl/pgrep calls.
+
+**Conclusion**: Service unification work is complete. No further refactoring needed.
+
+---
+
+## Files Verified
+
+### nomadnet_client_mixin.py - PROPERLY IMPLEMENTED
+
+All three service-checking locations already use centralized helpers:
+
+1. **`_nomadnet_status()`** (line ~195-203)
+   - Uses `check_process_running('rnsd')` when `_HAS_SERVICE_CHECK=True`
+   - Proper fallback to direct pgrep
+
+2. **`_is_nomadnet_running()`** (lines 646-670)
+   - Uses `check_process_running('nomadnet')` first
+   - Also runs pgrep with custom filtering (`bin/nomadnet`) as extension
+   - This is intentional - need custom filtering for NomadNet detection
+
+3. **`_check_rns_for_nomadnet()`** (lines 714-731)
+   - Uses `check_process_running('rnsd')` when `_HAS_SERVICE_CHECK=True`
+   - Proper fallback to direct pgrep
+
+**Import block** (lines 27-32):
+```python
+try:
+    from utils.service_check import check_process_running
+    _HAS_SERVICE_CHECK = True
+except ImportError:
+    _HAS_SERVICE_CHECK = False
+```
+
+---
+
+### startup_health.py - PROPERLY IMPLEMENTED
+
+Both service-checking functions already use centralized helpers:
+
+1. **`check_meshtasticd()`** (lines 87-123)
+   - Uses `check_service('meshtasticd')` when `HAS_SERVICE_CHECK=True`
+   - Proper fallback to `systemctl is-active`
+
+2. **`check_rnsd()`** (lines 126-162)
+   - Uses `check_service('rnsd')` when `HAS_SERVICE_CHECK=True`
+   - Proper fallback to pgrep
+
+**Import block** (lines 25-32):
+```python
+try:
+    from utils.service_check import check_service, ServiceState
+    HAS_SERVICE_CHECK = True
+except ImportError:
+    HAS_SERVICE_CHECK = False
+```
+
+---
+
+### startup_checks.py - INTENTIONAL DIRECT CALLS
+
+Uses direct systemctl calls because it needs detailed info not provided by centralized helpers:
+
+1. **`_check_systemd_service()`** (lines 289-332)
+   - `systemctl is-active` - needs detailed status (active, failed, inactive, dead)
+   - `systemctl is-enabled` - needs boot enable status
+   - `systemctl show -p MainPID` - needs actual PID
+
+2. **`_check_process_service()`** (lines 334-361)
+   - Uses pgrep with port fallback for non-systemd services
+   - Returns PID for display purposes
+
+**Decision**: Leave as-is. The centralized helpers (`check_service`, `check_process_running`) don't return this level of detail.
+
+---
+
+## Unification Status Summary
+
+| Module | Status | Notes |
+|--------|--------|-------|
+| `service_check.py` | COMPLETE | All helpers implemented |
+| `gateway_diagnostic.py` | COMPLETE | Uses `check_process_with_pid()` |
+| `rns_menu_mixin.py` | COMPLETE | Uses `check_process_running()` |
+| `network_diagnostics.py` | COMPLETE | Uses `check_process_running()` |
+| `nomadnet_client_mixin.py` | COMPLETE | Already had proper patterns |
+| `startup_health.py` | COMPLETE | Already had proper patterns |
+| `startup_checks.py` | N/A | Needs detailed systemd info |
+| `system_tools_mixin.py` | N/A | Display commands only |
+| `hardware_config.py` | N/A | Intentional sudo prefix |
+
+---
+
+## Related PRs (Merged)
+
+- PR #593: `claude/review-session-notes-AJP0A` - Added `check_process_with_pid()`
+- PR #594: `claude/session-management-setup-bzUDu` - Refactored network_diagnostics.py
+
+---
+
+## Previous Session Documentation
+
+- `.claude/sessions/2026-01-31_service_unification.md`
+- `.claude/sessions/2026-01-31_service_unification_continued.md`
+- `.claude/session_notes/systemctl_refactor_next.md`
+
+---
+
+*Session ID: claude/service-unification-continued-LADhN*


### PR DESCRIPTION
Reviewed all files identified as having "fragmented" service checking:
- nomadnet_client_mixin.py: Already uses check_process_running()
- startup_health.py: Already uses check_service()
- startup_checks.py: Needs detailed systemd info (leave as-is)

Conclusion: Service unification work is complete.

https://claude.ai/code/session_017XV9rxLbScbmnNRxJsnSvU