### PR TITLE
fix: Drop privileges when opening browser in topology and site planner

### DIFF
--- a/.claude/session_notes/2026-01-31_privilege_extension.md
+++ b/.claude/session_notes/2026-01-31_privilege_extension.md
@@ -1,0 +1,102 @@
+# Session Notes: Privilege Extension Fixes
+
+**Date**: 2026-01-31
+**Branch**: `claude/nomadnet-privilege-fix-VYkyD`
+**Previous PR**: #597 (NomadNet privilege fix merged)
+
+## Summary
+
+Extended the privilege-dropping pattern from NomadNet to other xdg-open browser launches. This ensures browsers open as the real user when MeshForge runs with sudo.
+
+## Changes Made
+
+### 1. topology_mixin.py - Fixed browser opening
+
+**File**: `src/launcher_tui/topology_mixin.py`
+
+Before:
+```python
+def open_browser():
+    result = subprocess.run(
+        ["xdg-open", output_path],
+        capture_output=True,
+        timeout=10
+    )
+```
+
+After:
+```python
+def open_browser():
+    real_user = os.environ.get('SUDO_USER')
+    if os.geteuid() == 0 and real_user:
+        # Running as root via sudo - run browser as real user
+        result = subprocess.run(
+            ['sudo', '-u', real_user, 'xdg-open', output_path],
+            capture_output=True,
+            timeout=10
+        )
+    else:
+        result = subprocess.run(
+            ["xdg-open", output_path],
+            capture_output=True,
+            timeout=10
+        )
+```
+
+### 2. site_planner.py - Fixed URL opening
+
+**File**: `src/diagnostics/site_planner.py`
+
+Same pattern applied to `_open_url()` method.
+
+## Verification
+
+- Syntax check: PASS (py_compile)
+- Linter: PASS (only pre-existing MF004 warning in main.py)
+- Module import: TopologyMixin imports successfully
+
+## Related Context
+
+### Map "Text" Issue Investigation
+
+User reported maps "not loading and showing text instead". Investigation found:
+
+1. Map HTML (`web/node_map.html`) is properly structured with Leaflet.js
+2. Map depends on CDN resources (unpkg.com for Leaflet, D3, etc.)
+3. If browser doesn't load correctly (privilege issue), user might see raw HTML
+
+**Likely root cause**: The xdg-open privilege issue was preventing the browser from opening correctly when running as root. The fixes applied should resolve this.
+
+### Files That Already Had Correct Pattern
+
+- `src/launcher_tui/ai_tools_mixin.py` - `_open_in_browser()` already drops privileges correctly
+
+### Pattern Reference
+
+All xdg-open calls should follow this pattern:
+```python
+import os
+
+real_user = os.environ.get('SUDO_USER')
+if os.geteuid() == 0 and real_user:
+    subprocess.run(['sudo', '-u', real_user, 'xdg-open', url], ...)
+else:
+    subprocess.run(['xdg-open', url], ...)
+```
+
+## NomadNet Fix Verification (from previous session)
+
+The NomadNet privilege fix from PR #597 was verified:
+- `_launch_nomadnet_textui()` - drops privileges with `sudo -u $SUDO_USER -i`
+- `_launch_nomadnet_daemon()` - drops privileges with `sudo -u $SUDO_USER -i`
+- `_edit_nomadnet_config()` - drops privileges when generating config
+- `_fix_user_directory_ownership()` - fixes root-owned directories in user home
+
+## Files Changed
+
+- `src/launcher_tui/topology_mixin.py` - Added privilege dropping to browser open
+- `src/diagnostics/site_planner.py` - Added privilege dropping to URL open
+
+## Session Health
+
+Session remained focused and systematic. No entropy detected. All tasks completed successfully.

--- a/src/diagnostics/site_planner.py
+++ b/src/diagnostics/site_planner.py
@@ -575,17 +575,30 @@ class SitePlanner:
         console.print("[dim]Check your country's amateur/ISM band rules before transmitting.[/dim]")
 
     def _open_url(self, url: str):
-        """Open URL in browser or display for manual access"""
+        """Open URL in browser or display for manual access.
+
+        When running as root via sudo, drops privileges so the browser
+        runs as the real user with their session/display.
+        """
         # Check if we're in a graphical environment
         display = os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY')
 
         if display:
             try:
-                # Try xdg-open first (Linux with display)
-                result = subprocess.run(
-                    ['xdg-open', url],
-                    capture_output=True, timeout=5
-                )
+                # Drop privileges when running as root so browser runs as real user
+                real_user = os.environ.get('SUDO_USER')
+                if os.geteuid() == 0 and real_user:
+                    # Running as root via sudo - run browser as real user
+                    result = subprocess.run(
+                        ['sudo', '-u', real_user, 'xdg-open', url],
+                        capture_output=True, timeout=5
+                    )
+                else:
+                    # Not root - try xdg-open directly
+                    result = subprocess.run(
+                        ['xdg-open', url],
+                        capture_output=True, timeout=5
+                    )
                 if result.returncode == 0:
                     console.print(f"[green]Opened in browser[/green]")
                     return

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -10,6 +10,7 @@ Provides network topology visualization and analysis tools:
 """
 
 import logging
+import os
 import subprocess
 import threading
 import webbrowser
@@ -486,14 +487,24 @@ class TopologyMixin:
             output_path = visualizer.generate()
 
             # Try to open in browser (in background thread to not block)
+            # Drop privileges when running as root so browser runs as real user
             def open_browser():
                 try:
-                    # Try xdg-open first (Linux)
-                    result = subprocess.run(
-                        ["xdg-open", output_path],
-                        capture_output=True,
-                        timeout=10
-                    )
+                    real_user = os.environ.get('SUDO_USER')
+                    if os.geteuid() == 0 and real_user:
+                        # Running as root via sudo - run browser as real user
+                        result = subprocess.run(
+                            ['sudo', '-u', real_user, 'xdg-open', output_path],
+                            capture_output=True,
+                            timeout=10
+                        )
+                    else:
+                        # Not root - try xdg-open directly
+                        result = subprocess.run(
+                            ["xdg-open", output_path],
+                            capture_output=True,
+                            timeout=10
+                        )
                     if result.returncode != 0:
                         # Fallback to webbrowser module
                         webbrowser.open(f"file://{output_path}")


### PR DESCRIPTION
Extends the privilege-dropping pattern from NomadNet fix to other xdg-open browser calls. When running MeshForge with sudo:
- topology_mixin.py: Browser now opens as real user
- site_planner.py: URLs now open as real user

This fixes browser not opening correctly when running as root, which could cause maps to not display properly.

https://claude.ai/code/session_01Sb4PP7MwPGDBUCRpExnZAV