### PR TITLE
fix: Suppress expected AREDN/Folium errors during startup

### DIFF
--- a/src/utils/aredn.py
+++ b/src/utils/aredn.py
@@ -219,7 +219,9 @@ class AREDNClient:
             logger.error(f"AREDN HTTP error: {e.code} {e.reason}")
             return None
         except urllib.error.URLError as e:
-            logger.error(f"AREDN URL error: {e.reason}")
+            # URLError is expected when AREDN network is not available
+            # (DNS failure, connection refused, timeout, etc.)
+            logger.debug(f"AREDN URL error: {e.reason}")
             return None
         except json.JSONDecodeError as e:
             logger.error(f"AREDN JSON parse error: {e}")

--- a/src/utils/coverage_map.py
+++ b/src/utils/coverage_map.py
@@ -677,7 +677,8 @@ class CoverageMapGenerator:
             import folium
             from folium.plugins import MarkerCluster, HeatMap
         except ImportError:
-            logger.error("Folium not installed. Run: pip install folium")
+            # Folium not installed - use Leaflet.js fallback instead
+            logger.debug("Folium not installed, using Leaflet fallback")
             return self._generate_fallback(output_path)
 
         # Determine output path
@@ -1053,7 +1054,8 @@ class CoverageMapGenerator:
             import folium
             from folium.plugins import HeatMap
         except ImportError:
-            logger.error("Folium not installed for heatmap")
+            # Heatmap requires Folium - no fallback available
+            logger.warning("Folium not installed, heatmap unavailable")
             return ""
 
         if output_path is None:


### PR DESCRIPTION
- AREDN URL errors (DNS failures, connection refused) are expected when AREDN network is not available. Changed to debug level to avoid alarming users during normal startup.
- Folium import errors now use debug level since Leaflet fallback works fine. Users see a working map either way.
- Heatmap without Folium uses warning level since there's no fallback.

https://claude.ai/code/session_01MHN6DpgLkV7xu9T6jUz695