### PR TITLE
feat: Add device persistence and node state machine

### DIFF
--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -3,9 +3,9 @@
 > **LoRa Mesh Network Development & Operations Suite**
 > *Build. Test. Deploy. Monitor.*
 
-## Current Version: 0.4.3-beta
-## Last Updated: 2026-01-15
-## Branch: `claude/review-and-report-rDUgX`
+## Current Version: 0.4.8-alpha
+## Last Updated: 2026-02-02
+## Branch: `claude/device-persistence-state-machine-oUfwu`
 
 ---
 
@@ -51,6 +51,85 @@ sudo ./scripts/install-desktop.sh
 ---
 
 ## Recent Work Summary
+
+### Session: 2026-02-02 - Device Persistence & Node State Machine
+
+**Features Implemented:**
+
+1. **Node State Machine** (`src/gateway/node_state.py`)
+   - Granular node states beyond simple online/offline
+   - States: DISCOVERED, ONLINE, WEAK_SIGNAL, INTERMITTENT, SUSPECTED_OFFLINE, OFFLINE, UNREACHABLE, STALE_CACHE
+   - State transition tracking with history
+   - Signal quality-based state transitions (weak signal detection)
+   - Timeout-based transitions (suspect -> offline)
+   - Integrated into UnifiedNode dataclass
+
+2. **Device Persistence** (`src/utils/device_persistence.py`)
+   - Remembers last successfully connected device
+   - Auto-reconnect to last known device on startup
+   - Connection history tracking (success/fail)
+   - Configurable auto-reconnect (enable/disable)
+   - Preferred connection type setting
+   - Reconnect config generation for DeviceController
+
+3. **DeviceController Integration** (`src/utils/device_controller.py`)
+   - Auto-connect now tries last known device first
+   - Records successful/failed connection attempts
+   - Integrated with DevicePersistence singleton
+
+4. **UnifiedNode Enhancements** (`src/gateway/node_tracker.py`)
+   - Added state machine to UnifiedNode
+   - New properties: state, state_name, state_icon
+   - check_timeout() method for state machine updates
+   - State history available via get_state_history()
+   - State data included in to_dict() serialization
+   - State machine persisted in node cache
+
+**Files Added:**
+| File | Description |
+|------|-------------|
+| `src/gateway/node_state.py` | NodeState enum and NodeStateMachine class |
+| `src/utils/device_persistence.py` | Device connection persistence |
+| `tests/test_node_state.py` | Tests for node state machine |
+| `tests/test_device_persistence.py` | Tests for device persistence |
+
+**Files Modified:**
+| File | Change |
+|------|--------|
+| `src/gateway/node_tracker.py` | State machine integration |
+| `src/utils/device_controller.py` | Persistence integration |
+
+**Node State Transitions:**
+```
+STALE_CACHE --> (response) --> DISCOVERED/ONLINE
+DISCOVERED --> (good signal) --> ONLINE
+ONLINE --> (weak signal) --> WEAK_SIGNAL
+WEAK_SIGNAL --> (strong signal) --> ONLINE
+ANY_ACTIVE --> (no response 5min) --> SUSPECTED_OFFLINE
+SUSPECTED_OFFLINE --> (no response 1hr) --> OFFLINE
+OFFLINE --> (response) --> ONLINE
+```
+
+**Usage Examples:**
+
+```python
+# Node state machine
+node = UnifiedNode(id="test", network="meshtastic")
+print(node.state_name)  # "Cached"
+node.update_seen()
+print(node.state_name)  # "Online"
+node.record_signal_quality(snr=-15.0)  # Weak signal
+print(node.state_name)  # May become "Weak Signal"
+
+# Device persistence
+from utils.device_persistence import get_device_persistence
+persistence = get_device_persistence()
+if persistence.has_last_device():
+    config = persistence.get_reconnect_config()
+    # Use config with DeviceController
+```
+
+---
 
 ### Session: 2026-01-15 - Auto-Review & Stability Milestone
 

--- a/src/gateway/node_state.py
+++ b/src/gateway/node_state.py
@@ -1,0 +1,398 @@
+"""
+Node State Machine for MeshForge
+
+Provides granular state tracking for mesh nodes beyond simple online/offline.
+
+States:
+- DISCOVERED: First time node seen, collecting initial data
+- ONLINE: Node responding normally with good signal
+- WEAK_SIGNAL: Low SNR/RSSI but still responding
+- INTERMITTENT: Sporadic responses, signal degrading
+- SUSPECTED_OFFLINE: No recent response but within grace period
+- OFFLINE: Confirmed offline after timeout
+- UNREACHABLE: No path available (RNS specific)
+- STALE_CACHE: Data loaded from cache, not yet verified
+
+State Transitions:
+- STALE_CACHE -> DISCOVERED (on first live update)
+- DISCOVERED -> ONLINE (after sufficient good responses)
+- ONLINE -> WEAK_SIGNAL (when signal drops below threshold)
+- ONLINE/WEAK_SIGNAL -> INTERMITTENT (irregular response pattern)
+- ANY -> SUSPECTED_OFFLINE (no response for SUSPECT_THRESHOLD)
+- SUSPECTED_OFFLINE -> OFFLINE (no response for OFFLINE_THRESHOLD)
+- ANY -> ONLINE (on good response after being offline)
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from enum import Enum, auto
+from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class NodeState(Enum):
+    """Granular node states for mesh network tracking."""
+
+    # Initial states
+    DISCOVERED = auto()      # First time seen, collecting data
+    STALE_CACHE = auto()     # Loaded from cache, not yet verified
+
+    # Active states
+    ONLINE = auto()          # Responding normally with good signal
+    WEAK_SIGNAL = auto()     # Low SNR/RSSI but still responding
+    INTERMITTENT = auto()    # Sporadic responses, degrading
+
+    # Inactive states
+    SUSPECTED_OFFLINE = auto()  # No response but within grace period
+    OFFLINE = auto()            # Confirmed offline after timeout
+    UNREACHABLE = auto()        # No path available (RNS)
+
+    def is_active(self) -> bool:
+        """Check if this state indicates the node is active."""
+        return self in (NodeState.ONLINE, NodeState.WEAK_SIGNAL,
+                       NodeState.INTERMITTENT, NodeState.DISCOVERED)
+
+    def is_healthy(self) -> bool:
+        """Check if this state indicates good connectivity."""
+        return self in (NodeState.ONLINE, NodeState.DISCOVERED)
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable state name."""
+        return {
+            NodeState.DISCOVERED: "Discovered",
+            NodeState.STALE_CACHE: "Cached",
+            NodeState.ONLINE: "Online",
+            NodeState.WEAK_SIGNAL: "Weak Signal",
+            NodeState.INTERMITTENT: "Intermittent",
+            NodeState.SUSPECTED_OFFLINE: "Checking...",
+            NodeState.OFFLINE: "Offline",
+            NodeState.UNREACHABLE: "Unreachable",
+        }.get(self, self.name)
+
+    @property
+    def icon(self) -> str:
+        """Status icon for UI display."""
+        return {
+            NodeState.DISCOVERED: "?",
+            NodeState.STALE_CACHE: "~",
+            NodeState.ONLINE: "+",
+            NodeState.WEAK_SIGNAL: "!",
+            NodeState.INTERMITTENT: "~",
+            NodeState.SUSPECTED_OFFLINE: "?",
+            NodeState.OFFLINE: "-",
+            NodeState.UNREACHABLE: "X",
+        }.get(self, "?")
+
+
+@dataclass
+class StateTransition:
+    """Record of a state transition for debugging/history."""
+    from_state: NodeState
+    to_state: NodeState
+    timestamp: datetime
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {
+            "from": self.from_state.name,
+            "to": self.to_state.name,
+            "timestamp": self.timestamp.isoformat(),
+            "reason": self.reason
+        }
+
+
+@dataclass
+class NodeStateConfig:
+    """Configuration for node state machine thresholds."""
+
+    # Time thresholds (in seconds)
+    suspect_threshold: float = 300.0     # 5 min: online -> suspected_offline
+    offline_threshold: float = 3600.0    # 1 hour: suspected -> offline
+    discovery_period: float = 60.0       # 1 min: stay in discovered state
+
+    # Signal thresholds
+    weak_signal_snr: float = -5.0        # Below this SNR = weak signal
+    weak_signal_rssi: int = -110         # Below this RSSI = weak signal
+
+    # Intermittent detection
+    intermittent_miss_ratio: float = 0.3  # 30% missed responses = intermittent
+    intermittent_window: int = 10         # Check last N expected responses
+
+    # History limits
+    max_transitions: int = 50             # Keep last N transitions
+
+
+class NodeStateMachine:
+    """
+    State machine for tracking node connectivity status.
+
+    Integrates with UnifiedNode to provide granular state tracking.
+    Tracks response patterns and signal quality for state decisions.
+    """
+
+    def __init__(self, config: Optional[NodeStateConfig] = None,
+                 initial_state: NodeState = NodeState.DISCOVERED):
+        self.config = config or NodeStateConfig()
+        self._state = initial_state
+        self._state_since = datetime.now()
+        self._transitions: List[StateTransition] = []
+
+        # Response tracking for intermittent detection
+        self._expected_responses: int = 0
+        self._actual_responses: int = 0
+        self._last_response: Optional[datetime] = None
+
+        # Signal tracking
+        self._recent_snr: List[float] = []
+        self._recent_rssi: List[int] = []
+
+    @property
+    def state(self) -> NodeState:
+        """Current node state."""
+        return self._state
+
+    @property
+    def state_since(self) -> datetime:
+        """Timestamp of last state change."""
+        return self._state_since
+
+    @property
+    def time_in_state(self) -> timedelta:
+        """Duration in current state."""
+        return datetime.now() - self._state_since
+
+    @property
+    def is_online(self) -> bool:
+        """Legacy compatibility: check if node is considered online."""
+        return self._state.is_active()
+
+    def transition_to(self, new_state: NodeState, reason: str = "") -> bool:
+        """
+        Transition to a new state.
+
+        Args:
+            new_state: Target state
+            reason: Human-readable reason for transition
+
+        Returns:
+            True if transition occurred, False if already in state
+        """
+        if new_state == self._state:
+            return False
+
+        transition = StateTransition(
+            from_state=self._state,
+            to_state=new_state,
+            timestamp=datetime.now(),
+            reason=reason
+        )
+
+        self._transitions.append(transition)
+
+        # Trim history
+        if len(self._transitions) > self.config.max_transitions:
+            self._transitions = self._transitions[-self.config.max_transitions:]
+
+        old_state = self._state
+        self._state = new_state
+        self._state_since = datetime.now()
+
+        logger.debug(f"State transition: {old_state.name} -> {new_state.name} ({reason})")
+        return True
+
+    def record_response(self, snr: Optional[float] = None,
+                        rssi: Optional[int] = None) -> NodeState:
+        """
+        Record a response from the node and update state.
+
+        Call this whenever the node is heard from (message, telemetry, etc.)
+
+        Args:
+            snr: Signal-to-Noise Ratio (dB)
+            rssi: Received Signal Strength (dBm)
+
+        Returns:
+            Current state after update
+        """
+        now = datetime.now()
+        self._last_response = now
+        self._actual_responses += 1
+
+        # Record signal quality
+        if snr is not None:
+            self._recent_snr.append(snr)
+            if len(self._recent_snr) > 10:
+                self._recent_snr = self._recent_snr[-10:]
+
+        if rssi is not None:
+            self._recent_rssi.append(rssi)
+            if len(self._recent_rssi) > 10:
+                self._recent_rssi = self._recent_rssi[-10:]
+
+        # Determine appropriate state based on signal quality
+        has_weak_signal = self._check_weak_signal(snr, rssi)
+
+        # State transitions on response
+        if self._state in (NodeState.STALE_CACHE, NodeState.DISCOVERED):
+            # First real response
+            if has_weak_signal:
+                self.transition_to(NodeState.WEAK_SIGNAL, "Initial response with weak signal")
+            else:
+                self.transition_to(NodeState.ONLINE, "Initial response received")
+
+        elif self._state in (NodeState.OFFLINE, NodeState.SUSPECTED_OFFLINE,
+                            NodeState.UNREACHABLE):
+            # Came back online
+            if has_weak_signal:
+                self.transition_to(NodeState.WEAK_SIGNAL, "Node responding again (weak)")
+            else:
+                self.transition_to(NodeState.ONLINE, "Node responding again")
+
+        elif self._state == NodeState.ONLINE:
+            # Check for signal degradation
+            if has_weak_signal:
+                self.transition_to(NodeState.WEAK_SIGNAL, "Signal degraded")
+
+        elif self._state == NodeState.WEAK_SIGNAL:
+            # Check for signal improvement
+            if not has_weak_signal:
+                self.transition_to(NodeState.ONLINE, "Signal improved")
+
+        elif self._state == NodeState.INTERMITTENT:
+            # Check if becoming stable again
+            if self._check_stable_responses():
+                if has_weak_signal:
+                    self.transition_to(NodeState.WEAK_SIGNAL, "Responses stabilized (weak)")
+                else:
+                    self.transition_to(NodeState.ONLINE, "Responses stabilized")
+
+        return self._state
+
+    def check_timeout(self, last_seen: Optional[datetime] = None) -> NodeState:
+        """
+        Check for timeout and update state if needed.
+
+        Call this periodically (e.g., in cleanup loop) to detect offline nodes.
+
+        Args:
+            last_seen: Override for last seen time (uses internal if None)
+
+        Returns:
+            Current state after check
+        """
+        last = last_seen or self._last_response
+        if last is None:
+            # Never seen - stay in current state
+            return self._state
+
+        now = datetime.now()
+        silence = (now - last).total_seconds()
+
+        # Check for timeout transitions
+        if self._state.is_active():
+            if silence > self.config.suspect_threshold:
+                self.transition_to(
+                    NodeState.SUSPECTED_OFFLINE,
+                    f"No response for {silence:.0f}s"
+                )
+
+        if self._state == NodeState.SUSPECTED_OFFLINE:
+            if silence > self.config.offline_threshold:
+                self.transition_to(
+                    NodeState.OFFLINE,
+                    f"Offline after {silence:.0f}s silence"
+                )
+
+        return self._state
+
+    def mark_unreachable(self, reason: str = "No path available") -> NodeState:
+        """Mark node as unreachable (no routing path)."""
+        self.transition_to(NodeState.UNREACHABLE, reason)
+        return self._state
+
+    def _check_weak_signal(self, snr: Optional[float],
+                           rssi: Optional[int]) -> bool:
+        """Check if current signal indicates weak connectivity."""
+        if snr is not None and snr < self.config.weak_signal_snr:
+            return True
+        if rssi is not None and rssi < self.config.weak_signal_rssi:
+            return True
+
+        # Also check recent averages
+        if self._recent_snr:
+            avg_snr = sum(self._recent_snr) / len(self._recent_snr)
+            if avg_snr < self.config.weak_signal_snr:
+                return True
+
+        if self._recent_rssi:
+            avg_rssi = sum(self._recent_rssi) / len(self._recent_rssi)
+            if avg_rssi < self.config.weak_signal_rssi:
+                return True
+
+        return False
+
+    def _check_stable_responses(self) -> bool:
+        """Check if response pattern has stabilized."""
+        # Simple check: at least 3 responses in last minute
+        if self._last_response is None:
+            return False
+
+        time_since = (datetime.now() - self._state_since).total_seconds()
+        if time_since < 60:
+            return False
+
+        # Rough heuristic: actual responses / expected > threshold
+        if self._expected_responses == 0:
+            return True
+
+        ratio = self._actual_responses / max(1, self._expected_responses)
+        return ratio > (1 - self.config.intermittent_miss_ratio)
+
+    def get_transitions(self, count: int = 10) -> List[StateTransition]:
+        """Get recent state transitions."""
+        return self._transitions[-count:]
+
+    def to_dict(self) -> dict:
+        """Serialize state machine for persistence."""
+        return {
+            "state": self._state.name,
+            "state_since": self._state_since.isoformat(),
+            "last_response": self._last_response.isoformat() if self._last_response else None,
+            "transitions": [t.to_dict() for t in self._transitions[-10:]]
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict, config: Optional[NodeStateConfig] = None) -> 'NodeStateMachine':
+        """Restore state machine from persisted data."""
+        try:
+            state = NodeState[data.get("state", "STALE_CACHE")]
+        except KeyError:
+            state = NodeState.STALE_CACHE
+
+        sm = cls(config=config, initial_state=state)
+
+        if data.get("state_since"):
+            try:
+                sm._state_since = datetime.fromisoformat(data["state_since"])
+            except (ValueError, TypeError):
+                pass
+
+        if data.get("last_response"):
+            try:
+                sm._last_response = datetime.fromisoformat(data["last_response"])
+            except (ValueError, TypeError):
+                pass
+
+        return sm
+
+
+# Default configuration instance
+_default_config = NodeStateConfig()
+
+
+def get_default_state_config() -> NodeStateConfig:
+    """Get the default state machine configuration."""
+    return _default_config

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -20,6 +20,18 @@ import json
 
 logger = logging.getLogger(__name__)
 
+# Import node state machine
+try:
+    from .node_state import (
+        NodeState, NodeStateMachine, NodeStateConfig,
+        StateTransition, get_default_state_config
+    )
+    NODE_STATE_AVAILABLE = True
+except ImportError:
+    NODE_STATE_AVAILABLE = False
+    NodeState = None  # type: ignore
+    NodeStateMachine = None  # type: ignore
+
 # Import RNS service registry and topology (optional - graceful fallback)
 try:
     from .rns_services import (
@@ -285,6 +297,10 @@ class UnifiedNode:
     last_seen: Optional[datetime] = None
     first_seen: Optional[datetime] = None
 
+    # State machine for granular status tracking
+    # Initialized in __post_init__ if available
+    _state_machine: Optional[Any] = field(default=None, repr=False)
+
     # Hardware info
     hardware_model: Optional[str] = None
     firmware_version: Optional[str] = None
@@ -298,11 +314,60 @@ class UnifiedNode:
     def __post_init__(self):
         if self.first_seen is None:
             self.first_seen = datetime.now()
+        # Initialize state machine if available
+        if NODE_STATE_AVAILABLE and self._state_machine is None:
+            from .node_state import NodeStateMachine, NodeState
+            initial = NodeState.DISCOVERED if self.is_online else NodeState.STALE_CACHE
+            self._state_machine = NodeStateMachine(initial_state=initial)
 
     def update_seen(self):
-        """Update last seen timestamp"""
+        """Update last seen timestamp and state machine"""
         self.last_seen = datetime.now()
         self.is_online = True
+        # Update state machine with current signal values
+        if self._state_machine is not None:
+            self._state_machine.record_response(snr=self.snr, rssi=self.rssi)
+
+    @property
+    def state(self) -> Optional['NodeState']:
+        """Get current node state (granular status)."""
+        if self._state_machine is not None:
+            return self._state_machine.state
+        # Fallback: derive from is_online
+        if NODE_STATE_AVAILABLE:
+            from .node_state import NodeState
+            return NodeState.ONLINE if self.is_online else NodeState.OFFLINE
+        return None
+
+    @property
+    def state_name(self) -> str:
+        """Get human-readable state name."""
+        if self._state_machine is not None:
+            return self._state_machine.state.display_name
+        return "Online" if self.is_online else "Offline"
+
+    @property
+    def state_icon(self) -> str:
+        """Get state icon for display."""
+        if self._state_machine is not None:
+            return self._state_machine.state.icon
+        return "+" if self.is_online else "-"
+
+    def check_timeout(self) -> bool:
+        """Check for timeout and update state. Returns True if state changed."""
+        if self._state_machine is not None:
+            old_state = self._state_machine.state
+            self._state_machine.check_timeout(self.last_seen)
+            # Sync is_online with state machine
+            self.is_online = self._state_machine.state.is_active()
+            return old_state != self._state_machine.state
+        return False
+
+    def get_state_history(self, count: int = 10) -> List[dict]:
+        """Get recent state transitions for debugging."""
+        if self._state_machine is not None:
+            return [t.to_dict() for t in self._state_machine.get_transitions(count)]
+        return []
 
     def record_signal_quality(self, snr: Optional[float] = None, rssi: Optional[int] = None):
         """Record signal quality measurements with timestamp for trending.
@@ -472,6 +537,10 @@ class UnifiedNode:
             "service_type": self.service_type,
             "service_aspect": self.service_aspect,
             "service_capabilities": self.service_capabilities if self.service_capabilities else None,
+            # Granular state
+            "state": self.state.name if self.state else None,
+            "state_display": self.state_name,
+            "state_icon": self.state_icon,
         }
 
         # Optionally include full signal history (for detailed views/caching)
@@ -480,6 +549,9 @@ class UnifiedNode:
                 result["snr_history"] = [s.to_dict() for s in self.snr_history]
             if self.rssi_history:
                 result["rssi_history"] = [s.to_dict() for s in self.rssi_history]
+            # Include state machine data for cache persistence
+            if self._state_machine is not None:
+                result["state_machine"] = self._state_machine.to_dict()
 
         return result
 
@@ -526,6 +598,11 @@ class UnifiedNode:
         node.snr = mesh_node.get('snr')
         node.hops = mesh_node.get('hopsAway')
         node.last_seen = datetime.now()
+        node.is_online = True
+
+        # Update state machine with live data
+        if node._state_machine is not None:
+            node._state_machine.record_response(snr=node.snr)
 
         return node
 
@@ -1144,7 +1221,7 @@ instance_control_port = 37429
                 logger.error(f"Callback error: {e}")
 
     def _cleanup_loop(self):
-        """Periodically mark offline nodes and save cache"""
+        """Periodically check node timeouts and save cache"""
         while self._running:
             if self._stop_event.wait(60):
                 break
@@ -1152,7 +1229,11 @@ instance_control_port = 37429
             with self._lock:
                 now = datetime.now()
                 for node in self._nodes.values():
-                    if node.last_seen:
+                    # Use state machine for timeout checking if available
+                    if node._state_machine is not None:
+                        node.check_timeout()
+                    elif node.last_seen:
+                        # Fallback to simple threshold check
                         age = (now - node.last_seen).total_seconds()
                         if age > self.OFFLINE_THRESHOLD:
                             node.is_online = False
@@ -1216,6 +1297,13 @@ instance_control_port = 37429
                     node.snr = node_data['snr']
                 if node_data.get('rssi') is not None:
                     node.rssi = node_data['rssi']
+                # Restore state machine from cache if available
+                if NODE_STATE_AVAILABLE and node_data.get('state_machine'):
+                    try:
+                        from .node_state import NodeStateMachine
+                        node._state_machine = NodeStateMachine.from_dict(node_data['state_machine'])
+                    except Exception as e:
+                        logger.debug(f"Could not restore state machine: {e}")
                 self._nodes[node.id] = node
 
             logger.info(f"Loaded {len(self._nodes)} nodes from cache")

--- a/src/utils/device_controller.py
+++ b/src/utils/device_controller.py
@@ -40,6 +40,14 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Import device persistence (optional - graceful fallback)
+try:
+    from utils.device_persistence import get_device_persistence, DevicePersistence
+    PERSISTENCE_AVAILABLE = True
+except ImportError:
+    PERSISTENCE_AVAILABLE = False
+    get_device_persistence = None  # type: ignore
+
 
 class ConnectionType(Enum):
     """Supported connection types."""
@@ -381,7 +389,24 @@ class DeviceController:
                 return self._connect_specific(self.config.connection_type)
 
     def _auto_connect(self) -> bool:
-        """Auto-detect and connect to best available device."""
+        """Auto-detect and connect to best available device.
+
+        Priority:
+        1. Last known successful device (if persistence enabled)
+        2. TCP to meshtasticd (most common)
+        3. Serial ports
+        4. BLE (slowest)
+        """
+        # Try last known device first (if available)
+        if PERSISTENCE_AVAILABLE:
+            persistence = get_device_persistence()
+            if persistence.has_last_device():
+                last = persistence.get_last_device()
+                logger.info(f"Trying last known device: {last.get('connection_type')}://{last.get('address')}")
+                if self._try_last_device(last):
+                    return True
+                logger.info("Last device unavailable, trying other options")
+
         # Try TCP first (meshtasticd is most common)
         if self._try_tcp():
             return True
@@ -396,6 +421,32 @@ class DeviceController:
 
         self._status.state = ConnectionState.ERROR
         self._status.error_message = "No Meshtastic device found"
+        return False
+
+    def _try_last_device(self, last: dict) -> bool:
+        """Try to connect to last known device."""
+        try:
+            conn_type = last.get("connection_type")
+            address = last.get("address")
+
+            if conn_type == "tcp":
+                parts = address.split(":")
+                host = parts[0] if parts else "localhost"
+                port = int(parts[1]) if len(parts) > 1 else 4403
+                self.config.host = host
+                self.config.port = port
+                return self._connect_specific(ConnectionType.TCP)
+
+            elif conn_type == "serial":
+                self.config.serial_port = address
+                return self._connect_specific(ConnectionType.SERIAL)
+
+            elif conn_type == "ble":
+                self.config.ble_address = address
+                return self._connect_specific(ConnectionType.BLE)
+
+        except Exception as e:
+            logger.debug(f"Failed to connect to last device: {e}")
         return False
 
     def _try_tcp(self) -> bool:
@@ -472,17 +523,57 @@ class DeviceController:
                 self._status.last_connected = time.time()
                 self._status.reconnect_attempts = 0
 
+                # Record successful connection for persistence
+                self._record_connection(conn_type, success=True)
+
                 self._fire_callback("on_connect", self._status)
                 return True
             else:
+                # Record failed connection attempt
+                self._record_connection(conn_type, success=False,
+                                       error_message="Connection refused")
                 return False
 
         except Exception as e:
             logger.error(f"Connection failed: {e}")
             self._status.state = ConnectionState.ERROR
             self._status.error_message = str(e)
+            # Record failed connection attempt
+            self._record_connection(conn_type, success=False, error_message=str(e))
             self._fire_callback("on_error", e)
             return False
+
+    def _record_connection(self, conn_type: ConnectionType, success: bool,
+                          error_message: Optional[str] = None) -> None:
+        """Record connection attempt for persistence."""
+        if not PERSISTENCE_AVAILABLE:
+            return
+
+        try:
+            persistence = get_device_persistence()
+
+            # Build address string based on connection type
+            if conn_type == ConnectionType.TCP:
+                address = f"{self.config.host}:{self.config.port}"
+                type_str = "tcp"
+            elif conn_type == ConnectionType.SERIAL:
+                address = self.config.serial_port or ""
+                type_str = "serial"
+            elif conn_type == ConnectionType.BLE:
+                address = self.config.ble_address or ""
+                type_str = "ble"
+            else:
+                return  # Don't record AUTO type
+
+            persistence.record_connection(
+                connection_type=type_str,
+                address=address,
+                device_info=self._status.device_info if success else {},
+                success=success,
+                error_message=error_message,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to record connection: {e}")
 
     def disconnect(self) -> None:
         """Disconnect from device."""

--- a/src/utils/device_persistence.py
+++ b/src/utils/device_persistence.py
@@ -1,0 +1,328 @@
+"""
+Device Persistence for MeshForge
+
+Remembers the last successfully connected device and allows auto-reconnection.
+
+Features:
+- Stores last successful connection (type, address, timestamp)
+- Provides quick reconnect to last known device
+- Tracks connection history for diagnostics
+- Integrates with DeviceController
+
+Usage:
+    from utils.device_persistence import DevicePersistence
+
+    # Get singleton instance
+    persistence = DevicePersistence.get_instance()
+
+    # Check for last device
+    if persistence.has_last_device():
+        last = persistence.get_last_device()
+        print(f"Last device: {last['connection_type']} at {last['address']}")
+
+    # Store successful connection
+    persistence.record_connection(
+        connection_type="tcp",
+        address="localhost:4403",
+        device_info={"firmware": "2.3.0"}
+    )
+
+    # Auto-connect helper
+    config = persistence.get_reconnect_config()
+    if config:
+        controller = DeviceController(config)
+        controller.connect()
+"""
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Import SettingsManager for persistence
+try:
+    from utils.common import SettingsManager
+except ImportError:
+    # Fallback for testing
+    SettingsManager = None  # type: ignore
+
+
+@dataclass
+class ConnectionRecord:
+    """Record of a device connection attempt."""
+    connection_type: str  # "tcp", "serial", "ble"
+    address: str          # "localhost:4403", "/dev/ttyUSB0", "AA:BB:CC:DD:EE:FF"
+    timestamp: float      # Unix timestamp
+    success: bool
+    device_info: Dict[str, Any]
+    error_message: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "connection_type": self.connection_type,
+            "address": self.address,
+            "timestamp": self.timestamp,
+            "success": self.success,
+            "device_info": self.device_info,
+            "error_message": self.error_message,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'ConnectionRecord':
+        return cls(
+            connection_type=data.get("connection_type", "unknown"),
+            address=data.get("address", ""),
+            timestamp=data.get("timestamp", 0),
+            success=data.get("success", False),
+            device_info=data.get("device_info", {}),
+            error_message=data.get("error_message"),
+        )
+
+
+# Default settings for device persistence
+DEVICE_PERSISTENCE_DEFAULTS = {
+    "last_connection": None,          # Last successful connection info
+    "connection_history": [],         # Recent connection attempts
+    "auto_reconnect_enabled": True,   # Whether to auto-reconnect
+    "max_history_entries": 20,        # Keep last N connection attempts
+    "preferred_connection_type": None,  # User preference: "tcp", "serial", "ble", None=auto
+}
+
+
+class DevicePersistence:
+    """
+    Manages device connection persistence for MeshForge.
+
+    Singleton pattern ensures consistent state across the application.
+    Uses SettingsManager for thread-safe JSON persistence.
+    """
+
+    _instance: Optional['DevicePersistence'] = None
+
+    @classmethod
+    def get_instance(cls) -> 'DevicePersistence':
+        """Get the singleton instance."""
+        if cls._instance is None:
+            cls._instance = cls()
+        return cls._instance
+
+    @classmethod
+    def reset_instance(cls) -> None:
+        """Reset singleton for testing."""
+        cls._instance = None
+
+    def __init__(self):
+        """Initialize device persistence (use get_instance() instead)."""
+        if SettingsManager is not None:
+            self._settings = SettingsManager(
+                "device_connection",
+                defaults=DEVICE_PERSISTENCE_DEFAULTS
+            )
+        else:
+            # Fallback for testing without full utils
+            self._settings = None
+            self._memory_store = DEVICE_PERSISTENCE_DEFAULTS.copy()
+            logger.warning("SettingsManager not available, using memory storage")
+
+    def _get(self, key: str, default: Any = None) -> Any:
+        """Get a setting value."""
+        if self._settings:
+            return self._settings.get(key, default)
+        return self._memory_store.get(key, default)
+
+    def _set(self, key: str, value: Any) -> None:
+        """Set a setting value."""
+        if self._settings:
+            self._settings.set(key, value)
+        else:
+            self._memory_store[key] = value
+
+    def _save(self) -> None:
+        """Save settings to disk."""
+        if self._settings:
+            self._settings.save()
+
+    # --- Last Device API ---
+
+    def has_last_device(self) -> bool:
+        """Check if there's a saved last device."""
+        last = self._get("last_connection")
+        return last is not None and isinstance(last, dict) and bool(last.get("address"))
+
+    def get_last_device(self) -> Optional[Dict[str, Any]]:
+        """
+        Get the last successfully connected device info.
+
+        Returns:
+            Dict with connection_type, address, timestamp, device_info
+            or None if no last device saved.
+        """
+        return self._get("last_connection")
+
+    def clear_last_device(self) -> None:
+        """Clear the saved last device."""
+        self._set("last_connection", None)
+        self._save()
+        logger.info("Cleared last device")
+
+    # --- Connection Recording ---
+
+    def record_connection(self, connection_type: str, address: str,
+                         device_info: Optional[Dict[str, Any]] = None,
+                         success: bool = True,
+                         error_message: Optional[str] = None) -> None:
+        """
+        Record a connection attempt.
+
+        Args:
+            connection_type: "tcp", "serial", or "ble"
+            address: Connection address (host:port, device path, BLE address)
+            device_info: Optional device information (firmware, node ID, etc.)
+            success: Whether connection succeeded
+            error_message: Error message if failed
+        """
+        record = ConnectionRecord(
+            connection_type=connection_type,
+            address=address,
+            timestamp=time.time(),
+            success=success,
+            device_info=device_info or {},
+            error_message=error_message,
+        )
+
+        # Update history
+        history = self._get("connection_history", [])
+        history.append(record.to_dict())
+
+        # Trim to max size
+        max_entries = self._get("max_history_entries", 20)
+        if len(history) > max_entries:
+            history = history[-max_entries:]
+
+        self._set("connection_history", history)
+
+        # Update last connection if successful
+        if success:
+            self._set("last_connection", {
+                "connection_type": connection_type,
+                "address": address,
+                "timestamp": time.time(),
+                "device_info": device_info or {},
+                "connected_at": datetime.now().isoformat(),
+            })
+            logger.info(f"Saved last device: {connection_type}://{address}")
+
+        self._save()
+
+    def get_connection_history(self, count: int = 10) -> List[ConnectionRecord]:
+        """
+        Get recent connection attempts.
+
+        Args:
+            count: Maximum number of records to return
+
+        Returns:
+            List of ConnectionRecord objects, most recent first
+        """
+        history = self._get("connection_history", [])
+        records = [ConnectionRecord.from_dict(r) for r in history[-count:]]
+        return list(reversed(records))
+
+    # --- Auto-Reconnect Configuration ---
+
+    @property
+    def auto_reconnect_enabled(self) -> bool:
+        """Check if auto-reconnect is enabled."""
+        return self._get("auto_reconnect_enabled", True)
+
+    @auto_reconnect_enabled.setter
+    def auto_reconnect_enabled(self, value: bool) -> None:
+        """Enable or disable auto-reconnect."""
+        self._set("auto_reconnect_enabled", value)
+        self._save()
+
+    @property
+    def preferred_connection_type(self) -> Optional[str]:
+        """Get user's preferred connection type."""
+        return self._get("preferred_connection_type")
+
+    @preferred_connection_type.setter
+    def preferred_connection_type(self, value: Optional[str]) -> None:
+        """Set preferred connection type (tcp, serial, ble, or None for auto)."""
+        if value not in (None, "tcp", "serial", "ble"):
+            raise ValueError(f"Invalid connection type: {value}")
+        self._set("preferred_connection_type", value)
+        self._save()
+
+    def get_reconnect_config(self) -> Optional[Dict[str, Any]]:
+        """
+        Get configuration for reconnecting to last device.
+
+        Returns a dict suitable for DeviceController initialization,
+        or None if no last device or auto-reconnect disabled.
+
+        Returns:
+            Dict with connection_type, host/port or serial_port, etc.
+            or None if not available
+        """
+        if not self.auto_reconnect_enabled:
+            return None
+
+        last = self.get_last_device()
+        if not last:
+            return None
+
+        conn_type = last.get("connection_type")
+        address = last.get("address")
+
+        if not conn_type or not address:
+            return None
+
+        config = {}
+
+        if conn_type == "tcp":
+            # Parse host:port
+            parts = address.split(":")
+            config["connection_type"] = "TCP"
+            config["host"] = parts[0] if parts else "localhost"
+            config["port"] = int(parts[1]) if len(parts) > 1 else 4403
+
+        elif conn_type == "serial":
+            config["connection_type"] = "SERIAL"
+            config["serial_port"] = address
+
+        elif conn_type == "ble":
+            config["connection_type"] = "BLE"
+            config["ble_address"] = address
+
+        else:
+            logger.warning(f"Unknown connection type: {conn_type}")
+            return None
+
+        return config
+
+    # --- Diagnostics ---
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get persistence statistics."""
+        history = self._get("connection_history", [])
+        success_count = sum(1 for r in history if r.get("success"))
+
+        return {
+            "has_last_device": self.has_last_device(),
+            "auto_reconnect_enabled": self.auto_reconnect_enabled,
+            "preferred_type": self.preferred_connection_type,
+            "history_entries": len(history),
+            "successful_connections": success_count,
+            "failed_connections": len(history) - success_count,
+        }
+
+
+# Convenience function for quick access
+def get_device_persistence() -> DevicePersistence:
+    """Get the device persistence singleton."""
+    return DevicePersistence.get_instance()

--- a/tests/test_device_persistence.py
+++ b/tests/test_device_persistence.py
@@ -1,0 +1,267 @@
+"""
+Tests for Device Persistence
+
+Tests auto-reconnect and device memory functionality.
+"""
+
+import pytest
+import time
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+import tempfile
+import json
+
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+class TestDevicePersistence:
+    """Tests for DevicePersistence class."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self):
+        """Reset singleton before each test."""
+        from utils.device_persistence import DevicePersistence
+        DevicePersistence.reset_instance()
+        yield
+        DevicePersistence.reset_instance()
+
+    @pytest.fixture
+    def persistence(self):
+        """Get a fresh DevicePersistence instance."""
+        from utils.device_persistence import DevicePersistence
+        return DevicePersistence.get_instance()
+
+    def test_singleton_pattern(self):
+        """Test that get_instance returns same instance."""
+        from utils.device_persistence import DevicePersistence
+        p1 = DevicePersistence.get_instance()
+        p2 = DevicePersistence.get_instance()
+        assert p1 is p2
+
+    def test_no_last_device_initially(self, persistence):
+        """Test that there's no last device initially."""
+        assert persistence.has_last_device() is False
+        assert persistence.get_last_device() is None
+
+    def test_record_successful_connection(self, persistence):
+        """Test recording a successful connection."""
+        persistence.record_connection(
+            connection_type="tcp",
+            address="localhost:4403",
+            device_info={"firmware": "2.3.0"},
+            success=True
+        )
+
+        assert persistence.has_last_device() is True
+        last = persistence.get_last_device()
+        assert last["connection_type"] == "tcp"
+        assert last["address"] == "localhost:4403"
+        assert last["device_info"]["firmware"] == "2.3.0"
+
+    def test_record_failed_connection(self, persistence):
+        """Test that failed connections don't become last device."""
+        persistence.record_connection(
+            connection_type="tcp",
+            address="badhost:4403",
+            success=False,
+            error_message="Connection refused"
+        )
+
+        # Should not have a last device
+        assert persistence.has_last_device() is False
+
+        # But should be in history
+        history = persistence.get_connection_history()
+        assert len(history) == 1
+        assert history[0].success is False
+        assert history[0].error_message == "Connection refused"
+
+    def test_connection_history(self, persistence):
+        """Test connection history tracking."""
+        # Record several connections
+        for i in range(5):
+            persistence.record_connection(
+                connection_type="tcp",
+                address=f"host{i}:4403",
+                success=i % 2 == 0  # Alternating success/fail
+            )
+
+        history = persistence.get_connection_history(count=10)
+        assert len(history) == 5
+
+        # Most recent should be first
+        assert "host4" in history[0].address
+
+    def test_clear_last_device(self, persistence):
+        """Test clearing last device."""
+        persistence.record_connection(
+            connection_type="tcp",
+            address="localhost:4403",
+            success=True
+        )
+
+        assert persistence.has_last_device() is True
+        persistence.clear_last_device()
+        assert persistence.has_last_device() is False
+
+    def test_auto_reconnect_enabled(self, persistence):
+        """Test auto-reconnect flag."""
+        # Should be enabled by default
+        assert persistence.auto_reconnect_enabled is True
+
+        persistence.auto_reconnect_enabled = False
+        assert persistence.auto_reconnect_enabled is False
+
+    def test_preferred_connection_type(self, persistence):
+        """Test preferred connection type setting."""
+        # Should be None (auto) by default
+        assert persistence.preferred_connection_type is None
+
+        persistence.preferred_connection_type = "tcp"
+        assert persistence.preferred_connection_type == "tcp"
+
+        # Invalid type should raise
+        with pytest.raises(ValueError):
+            persistence.preferred_connection_type = "invalid"
+
+    def test_get_reconnect_config_tcp(self, persistence):
+        """Test getting reconnect config for TCP."""
+        persistence.record_connection(
+            connection_type="tcp",
+            address="192.168.1.100:4403",
+            success=True
+        )
+
+        config = persistence.get_reconnect_config()
+        assert config is not None
+        assert config["connection_type"] == "TCP"
+        assert config["host"] == "192.168.1.100"
+        assert config["port"] == 4403
+
+    def test_get_reconnect_config_serial(self, persistence):
+        """Test getting reconnect config for serial."""
+        persistence.record_connection(
+            connection_type="serial",
+            address="/dev/ttyUSB0",
+            success=True
+        )
+
+        config = persistence.get_reconnect_config()
+        assert config is not None
+        assert config["connection_type"] == "SERIAL"
+        assert config["serial_port"] == "/dev/ttyUSB0"
+
+    def test_get_reconnect_config_ble(self, persistence):
+        """Test getting reconnect config for BLE."""
+        persistence.record_connection(
+            connection_type="ble",
+            address="AA:BB:CC:DD:EE:FF",
+            success=True
+        )
+
+        config = persistence.get_reconnect_config()
+        assert config is not None
+        assert config["connection_type"] == "BLE"
+        assert config["ble_address"] == "AA:BB:CC:DD:EE:FF"
+
+    def test_get_reconnect_config_disabled(self, persistence):
+        """Test that reconnect config returns None when disabled."""
+        persistence.record_connection(
+            connection_type="tcp",
+            address="localhost:4403",
+            success=True
+        )
+
+        persistence.auto_reconnect_enabled = False
+        config = persistence.get_reconnect_config()
+        assert config is None
+
+    def test_get_stats(self, persistence):
+        """Test getting persistence statistics."""
+        # Record some connections
+        persistence.record_connection("tcp", "host1:4403", success=True)
+        persistence.record_connection("tcp", "host2:4403", success=False)
+        persistence.record_connection("tcp", "host3:4403", success=True)
+
+        stats = persistence.get_stats()
+        assert stats["has_last_device"] is True
+        assert stats["history_entries"] == 3
+        assert stats["successful_connections"] == 2
+        assert stats["failed_connections"] == 1
+
+    def test_history_limit(self, persistence):
+        """Test that history is limited to max entries."""
+        # Record more than the limit
+        for i in range(30):
+            persistence.record_connection(
+                connection_type="tcp",
+                address=f"host{i}:4403",
+                success=True
+            )
+
+        history = persistence.get_connection_history(count=100)
+        # Default max is 20
+        assert len(history) <= 20
+
+
+class TestConnectionRecord:
+    """Tests for ConnectionRecord dataclass."""
+
+    def test_to_dict(self):
+        """Test serialization."""
+        from utils.device_persistence import ConnectionRecord
+
+        record = ConnectionRecord(
+            connection_type="tcp",
+            address="localhost:4403",
+            timestamp=1234567890.0,
+            success=True,
+            device_info={"firmware": "2.3.0"},
+            error_message=None
+        )
+
+        data = record.to_dict()
+        assert data["connection_type"] == "tcp"
+        assert data["address"] == "localhost:4403"
+        assert data["timestamp"] == 1234567890.0
+        assert data["success"] is True
+
+    def test_from_dict(self):
+        """Test deserialization."""
+        from utils.device_persistence import ConnectionRecord
+
+        data = {
+            "connection_type": "serial",
+            "address": "/dev/ttyUSB0",
+            "timestamp": 1234567890.0,
+            "success": False,
+            "device_info": {},
+            "error_message": "Device not found"
+        }
+
+        record = ConnectionRecord.from_dict(data)
+        assert record.connection_type == "serial"
+        assert record.address == "/dev/ttyUSB0"
+        assert record.success is False
+        assert record.error_message == "Device not found"
+
+
+class TestDevicePersistenceConvenience:
+    """Tests for convenience functions."""
+
+    @pytest.fixture(autouse=True)
+    def reset_singleton(self):
+        """Reset singleton before each test."""
+        from utils.device_persistence import DevicePersistence
+        DevicePersistence.reset_instance()
+        yield
+        DevicePersistence.reset_instance()
+
+    def test_get_device_persistence(self):
+        """Test convenience function returns singleton."""
+        from utils.device_persistence import get_device_persistence, DevicePersistence
+
+        p1 = get_device_persistence()
+        p2 = DevicePersistence.get_instance()
+        assert p1 is p2

--- a/tests/test_node_state.py
+++ b/tests/test_node_state.py
@@ -1,0 +1,254 @@
+"""
+Tests for Node State Machine
+
+Tests granular node state tracking and transitions.
+"""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from gateway.node_state import (
+    NodeState,
+    NodeStateMachine,
+    NodeStateConfig,
+    StateTransition,
+    get_default_state_config,
+)
+
+
+class TestNodeState:
+    """Tests for NodeState enum."""
+
+    def test_state_is_active(self):
+        """Test is_active() for different states."""
+        active_states = [
+            NodeState.ONLINE,
+            NodeState.WEAK_SIGNAL,
+            NodeState.INTERMITTENT,
+            NodeState.DISCOVERED,
+        ]
+        inactive_states = [
+            NodeState.OFFLINE,
+            NodeState.SUSPECTED_OFFLINE,
+            NodeState.UNREACHABLE,
+            NodeState.STALE_CACHE,
+        ]
+
+        for state in active_states:
+            assert state.is_active(), f"{state} should be active"
+
+        for state in inactive_states:
+            assert not state.is_active(), f"{state} should not be active"
+
+    def test_state_is_healthy(self):
+        """Test is_healthy() for different states."""
+        healthy_states = [NodeState.ONLINE, NodeState.DISCOVERED]
+        unhealthy_states = [
+            NodeState.WEAK_SIGNAL,
+            NodeState.INTERMITTENT,
+            NodeState.OFFLINE,
+            NodeState.SUSPECTED_OFFLINE,
+        ]
+
+        for state in healthy_states:
+            assert state.is_healthy(), f"{state} should be healthy"
+
+        for state in unhealthy_states:
+            assert not state.is_healthy(), f"{state} should not be healthy"
+
+    def test_state_display_name(self):
+        """Test human-readable display names."""
+        assert NodeState.ONLINE.display_name == "Online"
+        assert NodeState.WEAK_SIGNAL.display_name == "Weak Signal"
+        assert NodeState.SUSPECTED_OFFLINE.display_name == "Checking..."
+
+    def test_state_icon(self):
+        """Test state icons for UI."""
+        assert NodeState.ONLINE.icon == "+"
+        assert NodeState.OFFLINE.icon == "-"
+        assert NodeState.WEAK_SIGNAL.icon == "!"
+
+
+class TestNodeStateMachine:
+    """Tests for NodeStateMachine."""
+
+    def test_initial_state(self):
+        """Test initial state configuration."""
+        sm = NodeStateMachine()
+        assert sm.state == NodeState.DISCOVERED
+
+        sm_cached = NodeStateMachine(initial_state=NodeState.STALE_CACHE)
+        assert sm_cached.state == NodeState.STALE_CACHE
+
+    def test_transition_to_new_state(self):
+        """Test state transitions."""
+        sm = NodeStateMachine()
+
+        # Should return True on actual transition
+        result = sm.transition_to(NodeState.ONLINE, "test transition")
+        assert result is True
+        assert sm.state == NodeState.ONLINE
+
+        # Should return False if already in state
+        result = sm.transition_to(NodeState.ONLINE, "same state")
+        assert result is False
+
+    def test_transition_records_history(self):
+        """Test that transitions are recorded."""
+        sm = NodeStateMachine()
+        sm.transition_to(NodeState.ONLINE, "initial")
+        sm.transition_to(NodeState.WEAK_SIGNAL, "signal degraded")
+
+        history = sm.get_transitions(10)
+        assert len(history) == 2
+        assert history[0].from_state == NodeState.DISCOVERED
+        assert history[0].to_state == NodeState.ONLINE
+        assert history[1].from_state == NodeState.ONLINE
+        assert history[1].to_state == NodeState.WEAK_SIGNAL
+
+    def test_record_response_updates_state(self):
+        """Test that recording responses updates state."""
+        sm = NodeStateMachine(initial_state=NodeState.STALE_CACHE)
+
+        # First response should transition from STALE_CACHE
+        sm.record_response(snr=10.0, rssi=-60)
+        assert sm.state == NodeState.ONLINE
+
+    def test_record_response_weak_signal(self):
+        """Test weak signal detection."""
+        config = NodeStateConfig(weak_signal_snr=-5.0, weak_signal_rssi=-110)
+        sm = NodeStateMachine(config=config, initial_state=NodeState.ONLINE)
+
+        # Strong signal should stay online
+        sm.record_response(snr=5.0, rssi=-70)
+        assert sm.state == NodeState.ONLINE
+
+        # Weak signal should transition
+        sm.record_response(snr=-10.0, rssi=-120)
+        assert sm.state == NodeState.WEAK_SIGNAL
+
+    def test_record_response_recovery(self):
+        """Test recovery from offline state."""
+        sm = NodeStateMachine(initial_state=NodeState.OFFLINE)
+
+        # Response should bring it back online
+        sm.record_response(snr=10.0)
+        assert sm.state == NodeState.ONLINE
+
+    def test_check_timeout_to_suspected(self):
+        """Test timeout transitions to suspected offline."""
+        config = NodeStateConfig(suspect_threshold=10.0)  # 10 seconds
+        sm = NodeStateMachine(config=config)
+        sm.transition_to(NodeState.ONLINE, "initial")
+
+        # Fake an old last_seen time
+        old_time = datetime.now() - timedelta(seconds=15)
+        sm._last_response = old_time
+
+        sm.check_timeout()
+        assert sm.state == NodeState.SUSPECTED_OFFLINE
+
+    def test_check_timeout_to_offline(self):
+        """Test timeout transitions to confirmed offline."""
+        config = NodeStateConfig(suspect_threshold=10.0, offline_threshold=30.0)
+        sm = NodeStateMachine(config=config)
+        sm.transition_to(NodeState.SUSPECTED_OFFLINE, "initial")
+
+        # Fake a very old last_seen time
+        old_time = datetime.now() - timedelta(seconds=60)
+        sm._last_response = old_time
+
+        sm.check_timeout()
+        assert sm.state == NodeState.OFFLINE
+
+    def test_mark_unreachable(self):
+        """Test marking node as unreachable."""
+        sm = NodeStateMachine()
+        sm.mark_unreachable("No route found")
+        assert sm.state == NodeState.UNREACHABLE
+
+    def test_is_online_property(self):
+        """Test legacy is_online property."""
+        sm = NodeStateMachine(initial_state=NodeState.ONLINE)
+        assert sm.is_online is True
+
+        sm.transition_to(NodeState.OFFLINE, "timeout")
+        assert sm.is_online is False
+
+    def test_time_in_state(self):
+        """Test time_in_state calculation."""
+        sm = NodeStateMachine()
+        # Should be non-negative
+        assert sm.time_in_state.total_seconds() >= 0
+
+    def test_serialization(self):
+        """Test to_dict and from_dict."""
+        sm = NodeStateMachine()
+        sm.transition_to(NodeState.ONLINE, "test")
+        sm.record_response(snr=5.0)
+
+        data = sm.to_dict()
+        assert data["state"] == "ONLINE"
+        assert "state_since" in data
+
+        # Restore from dict
+        sm2 = NodeStateMachine.from_dict(data)
+        assert sm2.state == NodeState.ONLINE
+
+    def test_history_limit(self):
+        """Test that transition history is limited."""
+        config = NodeStateConfig(max_transitions=5)
+        sm = NodeStateMachine(config=config)
+
+        # Create many transitions
+        states = [NodeState.ONLINE, NodeState.WEAK_SIGNAL] * 10
+        for i, state in enumerate(states):
+            sm.transition_to(state, f"transition {i}")
+
+        history = sm.get_transitions(100)
+        assert len(history) <= 5
+
+
+class TestNodeStateConfig:
+    """Tests for NodeStateConfig."""
+
+    def test_default_config(self):
+        """Test default configuration values."""
+        config = get_default_state_config()
+        assert config.suspect_threshold == 300.0  # 5 min
+        assert config.offline_threshold == 3600.0  # 1 hour
+        assert config.weak_signal_snr == -5.0
+
+    def test_custom_config(self):
+        """Test custom configuration."""
+        config = NodeStateConfig(
+            suspect_threshold=60.0,
+            offline_threshold=300.0,
+            weak_signal_snr=-10.0,
+        )
+        assert config.suspect_threshold == 60.0
+        assert config.weak_signal_snr == -10.0
+
+
+class TestStateTransition:
+    """Tests for StateTransition dataclass."""
+
+    def test_to_dict(self):
+        """Test serialization."""
+        transition = StateTransition(
+            from_state=NodeState.ONLINE,
+            to_state=NodeState.WEAK_SIGNAL,
+            timestamp=datetime(2024, 1, 1, 12, 0, 0),
+            reason="Signal degraded"
+        )
+
+        data = transition.to_dict()
+        assert data["from"] == "ONLINE"
+        assert data["to"] == "WEAK_SIGNAL"
+        assert data["reason"] == "Signal degraded"
+        assert "2024-01-01" in data["timestamp"]


### PR DESCRIPTION
- Device Persistence (src/utils/device_persistence.py):
  - Remembers last successfully connected device
  - Auto-reconnect to last known device on startup
  - Connection history tracking with success/fail status
  - Configurable auto-reconnect (enable/disable)
  - Reconnect config generation for DeviceController

- Node State Machine (src/gateway/node_state.py):
  - Granular states: DISCOVERED, ONLINE, WEAK_SIGNAL, INTERMITTENT, SUSPECTED_OFFLINE, OFFLINE, UNREACHABLE, STALE_CACHE
  - State transition tracking with history
  - Signal quality-based state transitions
  - Timeout-based transitions for offline detection

- DeviceController integration:
  - Auto-connect tries last known device first
  - Records connection attempts for persistence

- UnifiedNode enhancements:
  - State machine integration with new properties
  - State data persisted in node cache

https://claude.ai/code/session_01NKq7839KqnZ3SKGRkeAgHu