### PR TITLE
feat: Add MQTT setup wizard and local broker mode to TUI

### DIFF
--- a/.claude/session_notes/2026-02-03_mqtt_setup_wizard.md
+++ b/.claude/session_notes/2026-02-03_mqtt_setup_wizard.md
@@ -1,0 +1,129 @@
+# Session Notes: MQTT Setup Wizard
+
+**Date**: 2026-02-03
+**Branch**: `claude/fix-mesh-message-display-lKBWq`
+**Status**: Ready for commit
+
+## Context
+
+Continuation of local MQTT integration work from previous session. The PR #666 (local MQTT broker support) was merged. This session adds TUI automation for the MQTT setup process.
+
+## Completed This Session
+
+### 1. MQTT Setup Wizard in Service Menu
+**File**: `src/launcher_tui/service_menu_mixin.py`
+
+Added comprehensive MQTT setup wizard accessible from:
+`Configuration → Service Config → MQTT Setup`
+
+Features:
+- **Install mosquitto**: Detects if installed, offers one-click installation
+- **Start mosquitto service**: Enables and starts the systemd service
+- **Configure meshtasticd**: Automatically configures:
+  - `mqtt.enabled = true`
+  - `mqtt.address = localhost`
+  - `mqtt.json_enabled = true`
+  - Primary channel uplink enabled
+- **Auto-detect channel**: Parses channel name from meshtasticd for correct topic
+
+Methods added:
+```python
+_mqtt_setup_wizard()           # Main wizard flow
+_is_mosquitto_installed()      # Check installation
+_install_mosquitto()           # apt install mosquitto
+_ensure_mosquitto_running()    # systemd enable/start
+_auto_detect_primary_channel() # Get channel name for topic
+_configure_meshtasticd_mqtt_local()  # CLI configuration
+```
+
+### 2. Local/Public Mode Toggle in MQTT Monitor
+**File**: `src/launcher_tui/mqtt_mixin.py`
+
+Enhanced MQTT monitoring menu with:
+- **Quick mode switch**: "Use Local Broker" / "Use Public Broker" options
+- **Auto-detection**: Detects channel name for local topic construction
+- **Mode display**: Menu shows current mode (Local/Public) and broker
+
+Changes:
+- Updated `_configure_mqtt()` with local/public quick options
+- Added `_detect_local_channel()` helper method
+- Updated `_mqtt_menu()` to show current mode in subtitle
+
+## Architecture Summary
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                          MeshForge TUI                               │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│  Service Config Menu                    MQTT Monitor Menu            │
+│  ├── Service Status                     ├── Status                  │
+│  ├── Manage meshtasticd                 ├── Start/Stop Subscriber   │
+│  ├── Manage rnsd                        ├── Configure (Local/Public)│
+│  ├── Install meshtasticd                │   ├── Use Local Broker ←──│
+│  └── MQTT Setup ←─────────────┐         │   └── Use Public Broker   │
+│                               │         └── View Nodes/Stats        │
+│                               │                                      │
+│                   ┌───────────▼───────────┐                         │
+│                   │   MQTT Setup Wizard   │                         │
+│                   ├───────────────────────┤                         │
+│                   │ 1. Install mosquitto  │                         │
+│                   │ 2. Start service      │                         │
+│                   │ 3. Configure radio    │                         │
+│                   │    - mqtt.enabled     │                         │
+│                   │    - mqtt.address     │                         │
+│                   │    - json_enabled     │                         │
+│                   │    - uplink_enabled   │                         │
+│                   └───────────────────────┘                         │
+│                                                                      │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `src/launcher_tui/service_menu_mixin.py` | +180 lines: MQTT setup wizard |
+| `src/launcher_tui/mqtt_mixin.py` | +70 lines: Local mode support |
+
+## WebSocket Status
+
+Gateway Bridge WebSocket (PR #664) was reviewed:
+- Implementation complete in `src/utils/websocket_server.py`
+- Integrated in `src/gateway/rns_bridge.py`
+- Port 5001, JSON message format
+- Requires hardware testing on Pi
+
+## Testing Notes
+
+### MQTT Setup Wizard
+```bash
+# Run TUI
+sudo python3 src/launcher_tui/main.py
+
+# Navigate to: Configuration → Service Config → MQTT Setup
+# Follow wizard prompts
+
+# Verify manually:
+systemctl status mosquitto
+mosquitto_sub -h localhost -t 'msh/#' -v
+```
+
+### MQTT Monitor Local Mode
+```bash
+# In TUI: Mesh Networks → MQTT Monitor → Configure → Use Local Broker
+# Verify: Start Subscriber should connect to localhost:1883
+```
+
+## Next Steps
+
+1. **Hardware testing**: Run MQTT setup wizard on Pi with meshtasticd
+2. **WebSocket testing**: Verify real-time message display in web client
+3. **Create PR**: Push changes and create pull request
+
+## Handoff Notes
+
+- All code changes are syntactically verified
+- Follows existing patterns from meshtasticd installation wizard
+- Uses service_check.py helpers for service management
+- Channel auto-detection matches session note topic discovery: `msh/2/json/{channel}/#`

--- a/src/launcher_tui/mqtt_mixin.py
+++ b/src/launcher_tui/mqtt_mixin.py
@@ -50,24 +50,32 @@ class MQTTMixin:
     def _mqtt_menu(self):
         """MQTT monitoring menu - nodeless mesh observation."""
         while True:
-            # Get current status
+            # Get current status and mode
             status = self._get_mqtt_status()
+            config = self._load_mqtt_config()
+            broker = config.get('broker', 'mqtt.meshtastic.org')
+            mode = "Local" if broker == "localhost" else "Public"
 
             choices = [
                 ("status", f"Status              {status}"),
                 ("start", "Start Subscriber    Connect to MQTT broker"),
                 ("stop", "Stop Subscriber     Disconnect from broker"),
-                ("config", "Configure           Broker settings"),
+                ("config", f"Configure           Mode: {mode}"),
                 ("nodes", "View Nodes          Show discovered nodes"),
                 ("stats", "Statistics          Node counts, activity"),
                 ("export", "Export Data         Save nodes to file"),
                 ("back", "Back"),
             ]
 
+            subtitle = f"MQTT Mode: {mode} ({broker})\n"
+            if mode == "Local":
+                subtitle += "Multi-consumer: shares messages with other apps"
+            else:
+                subtitle += "Nodeless monitoring without local radio"
+
             choice = self.dialog.menu(
                 "MQTT Monitoring",
-                "Nodeless mesh observation via MQTT.\n"
-                "Monitor mesh networks without local radio.",
+                subtitle,
                 choices
             )
 
@@ -214,12 +222,16 @@ class MQTTMixin:
             port = config.get('port', 8883)
             topic = config.get('topic', 'msh/US/2/e/LongFast/#')
 
+            # Determine current mode
+            mode = "Local" if broker == "localhost" else "Public"
+
             choices = [
+                ("local", f"Use Local Broker    Quick: localhost:1883"),
+                ("public", f"Use Public Broker   Quick: mqtt.meshtastic.org"),
                 ("broker", f"Broker              {broker}"),
                 ("port", f"Port                {port}"),
                 ("topic", f"Topic               {topic[:30]}..."),
                 ("auth", "Authentication      Username/password"),
-                ("reset", "Reset to Defaults   Use public broker"),
                 ("save", "Save & Exit"),
                 ("back", "Cancel"),
             ]
@@ -233,7 +245,54 @@ class MQTTMixin:
             if choice is None or choice == "back":
                 break
 
-            if choice == "broker":
+            if choice == "local":
+                # Quick setup for local mosquitto broker
+                channel = self._detect_local_channel()
+                topic = f"msh/2/json/{channel}/#" if channel else "msh/2/json/+/#"
+                config = {
+                    'broker': 'localhost',
+                    'port': 1883,
+                    'topic': topic,
+                    'username': None,
+                    'password': None,
+                    'use_tls': False
+                }
+                self._save_mqtt_config(config)
+                self.dialog.msgbox(
+                    "Local Mode Set",
+                    f"Configured for local mosquitto broker:\n\n"
+                    f"  Broker: localhost:1883\n"
+                    f"  Topic: {topic}\n"
+                    f"  TLS: disabled\n\n"
+                    "Make sure:\n"
+                    "  1. Mosquitto is running (systemctl status mosquitto)\n"
+                    "  2. Meshtasticd MQTT is configured\n\n"
+                    "Use Service Config → MQTT Setup for full setup."
+                )
+                break
+
+            elif choice == "public":
+                # Quick setup for public Meshtastic broker
+                config = {
+                    'broker': 'mqtt.meshtastic.org',
+                    'port': 8883,
+                    'topic': 'msh/US/2/e/LongFast/#',
+                    'username': 'meshdev',
+                    'password': 'large4cats',
+                    'use_tls': True
+                }
+                self._save_mqtt_config(config)
+                self.dialog.msgbox(
+                    "Public Mode Set",
+                    "Configured for public Meshtastic broker:\n\n"
+                    "  Broker: mqtt.meshtastic.org:8883\n"
+                    "  Topic: msh/US/2/e/LongFast/#\n"
+                    "  TLS: enabled\n\n"
+                    "This is nodeless monitoring - no local radio needed."
+                )
+                break
+
+            elif choice == "broker":
                 new_broker = self.dialog.inputbox(
                     "MQTT Broker",
                     "Enter MQTT broker hostname:",
@@ -277,15 +336,6 @@ class MQTTMixin:
                 )
                 if password is not None:
                     config['password'] = password if password else None
-
-            elif choice == "reset":
-                config = {
-                    'broker': 'mqtt.meshtastic.org',
-                    'port': 8883,
-                    'topic': 'msh/US/2/e/LongFast/#',
-                    'username': None,
-                    'password': None
-                }
 
             elif choice == "save":
                 self._save_mqtt_config(config)
@@ -442,3 +492,32 @@ class MQTTMixin:
         except Exception as e:
             logger.debug(f"Error loading MQTT cache: {e}")
         return []
+
+    def _detect_local_channel(self) -> Optional[str]:
+        """Detect primary channel name from local meshtasticd.
+
+        Returns channel name or None if detection fails.
+        Used to construct correct MQTT topic for local broker.
+        """
+        import shutil
+        try:
+            cli = shutil.which('meshtastic') or 'meshtastic'
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--ch-index', '0', '--info'],
+                capture_output=True, text=True, timeout=15
+            )
+
+            if result.returncode == 0:
+                # Parse channel name from output
+                for line in result.stdout.split('\n'):
+                    if 'name' in line.lower():
+                        parts = line.split(':')
+                        if len(parts) >= 2:
+                            name = parts[1].strip().strip('"\'')
+                            if name and name.lower() not in ('none', ''):
+                                logger.debug(f"Detected channel: {name}")
+                                return name
+        except Exception as e:
+            logger.debug(f"Could not detect channel: {e}")
+
+        return None

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -263,6 +263,7 @@ class ServiceMenuMixin:
                 ("start-rns", "Start rnsd"),
                 ("restart-rns", "Restart rnsd"),
                 ("install", "Install meshtasticd"),
+                ("mqtt-setup", "MQTT Setup           Install & configure broker"),
                 ("back", "Back"),
             ]
 
@@ -400,6 +401,8 @@ class ServiceMenuMixin:
                 self._wait_for_enter()
             elif choice == "install":
                 self._install_native_meshtasticd()
+            elif choice == "mqtt-setup":
+                self._mqtt_setup_wizard()
             else:
                 self._manage_service(choice)
 
@@ -879,3 +882,276 @@ WantedBy=multi-user.target
                     timeout=15
                 )
             self._wait_for_enter()
+
+    # =========================================================================
+    # MQTT Setup Wizard - Local broker for multi-consumer architecture
+    # =========================================================================
+
+    def _mqtt_setup_wizard(self):
+        """MQTT setup wizard - install mosquitto and configure meshtasticd.
+
+        This enables the local MQTT architecture where meshtasticd publishes
+        to a local mosquitto broker, allowing multiple consumers (MeshForge,
+        meshing-around, Grafana, etc.) to receive mesh messages.
+        """
+        # Introduction
+        if not self.dialog.yesno(
+            "MQTT Setup Wizard",
+            "This wizard will set up local MQTT architecture:\n\n"
+            "1. Install mosquitto MQTT broker\n"
+            "2. Configure meshtasticd to publish to local broker\n"
+            "3. Enable uplink on primary channel\n\n"
+            "Benefits:\n"
+            "• Multiple apps can receive mesh messages\n"
+            "• No more TCP one-client limitation\n"
+            "• Works with meshing-around, Grafana, etc.\n\n"
+            "Continue with setup?"
+        ):
+            return
+
+        # Step 1: Check/Install mosquitto
+        self.dialog.infobox("MQTT Setup", "Step 1/3: Checking mosquitto...")
+
+        if not self._is_mosquitto_installed():
+            if self.dialog.yesno(
+                "Install Mosquitto",
+                "Mosquitto MQTT broker is not installed.\n\n"
+                "Install it now?\n\n"
+                "This will run: apt install mosquitto mosquitto-clients"
+            ):
+                if not self._install_mosquitto():
+                    return
+            else:
+                self.dialog.msgbox(
+                    "Setup Cancelled",
+                    "MQTT setup requires mosquitto.\n\n"
+                    "Install manually with:\n"
+                    "  sudo apt install mosquitto mosquitto-clients"
+                )
+                return
+        else:
+            self.dialog.infobox("MQTT Setup", "Mosquitto is already installed.")
+
+        # Step 2: Ensure mosquitto is running
+        self.dialog.infobox("MQTT Setup", "Step 2/3: Starting mosquitto service...")
+        if not self._ensure_mosquitto_running():
+            self.dialog.msgbox(
+                "Warning",
+                "Could not start mosquitto service.\n\n"
+                "Check: sudo systemctl status mosquitto"
+            )
+            # Continue anyway - user might fix manually
+
+        # Step 3: Configure meshtasticd
+        self.dialog.infobox("MQTT Setup", "Step 3/3: Configuring meshtasticd...")
+
+        # Auto-detect channel name
+        channel_name = self._auto_detect_primary_channel()
+
+        if not self._configure_meshtasticd_mqtt_local(channel_name):
+            self.dialog.msgbox(
+                "Warning",
+                "Could not fully configure meshtasticd MQTT.\n\n"
+                "You may need to configure manually:\n"
+                "  meshtastic --set mqtt.enabled true\n"
+                "  meshtastic --set mqtt.address localhost\n"
+                "  meshtastic --set mqtt.json_enabled true\n"
+                "  meshtastic --ch-index 0 --ch-set uplink_enabled true"
+            )
+            return
+
+        # Success!
+        topic_pattern = f"msh/2/json/{channel_name}/#" if channel_name else "msh/2/json/+/#"
+        self.dialog.msgbox(
+            "MQTT Setup Complete",
+            "Local MQTT architecture is ready!\n\n"
+            "Services:\n"
+            f"  • Mosquitto: localhost:1883\n"
+            f"  • Topic: {topic_pattern}\n\n"
+            "Test with:\n"
+            f"  mosquitto_sub -h localhost -t 'msh/#' -v\n\n"
+            "MeshForge will now receive messages via MQTT\n"
+            "alongside other consumers like meshing-around."
+        )
+
+    def _is_mosquitto_installed(self) -> bool:
+        """Check if mosquitto is installed."""
+        try:
+            result = subprocess.run(
+                ['which', 'mosquitto'],
+                capture_output=True, text=True, timeout=5
+            )
+            return result.returncode == 0
+        except Exception:
+            return False
+
+    def _install_mosquitto(self) -> bool:
+        """Install mosquitto MQTT broker.
+
+        Returns True if installation succeeded.
+        """
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Installing Mosquitto MQTT Broker ===\n")
+
+        try:
+            # Update package list
+            print("Updating package list...")
+            result = subprocess.run(
+                ['apt-get', 'update'],
+                timeout=120
+            )
+
+            # Install mosquitto and clients
+            print("\nInstalling mosquitto and mosquitto-clients...")
+            result = subprocess.run(
+                ['apt-get', 'install', '-y', 'mosquitto', 'mosquitto-clients'],
+                timeout=300
+            )
+
+            if result.returncode != 0:
+                print("\n\033[0;31mError:\033[0m Installation failed.")
+                self._wait_for_enter()
+                return False
+
+            print("\n\033[0;32m✓\033[0m Mosquitto installed successfully.")
+            self._wait_for_enter()
+            return True
+
+        except subprocess.TimeoutExpired:
+            print("\n\033[0;31mError:\033[0m Installation timed out.")
+            self._wait_for_enter()
+            return False
+        except Exception as e:
+            print(f"\n\033[0;31mError:\033[0m {e}")
+            self._wait_for_enter()
+            return False
+
+    def _ensure_mosquitto_running(self) -> bool:
+        """Ensure mosquitto service is running and enabled.
+
+        Returns True if mosquitto is running.
+        """
+        try:
+            # Enable and start mosquitto
+            if _HAS_SERVICE_CHECK:
+                success, msg = enable_service('mosquitto', start=True)
+                return success
+            else:
+                # Fallback to direct systemctl calls
+                subprocess.run(
+                    ['systemctl', 'enable', 'mosquitto'],
+                    timeout=30, check=False
+                )
+                subprocess.run(
+                    ['systemctl', 'start', 'mosquitto'],
+                    timeout=30, check=False
+                )
+
+                # Check if running
+                result = subprocess.run(
+                    ['systemctl', 'is-active', 'mosquitto'],
+                    capture_output=True, text=True, timeout=5
+                )
+                return result.stdout.strip() == 'active'
+
+        except Exception:
+            return False
+
+    def _auto_detect_primary_channel(self) -> Optional[str]:
+        """Auto-detect primary channel name from meshtasticd.
+
+        Returns channel name or None if detection fails.
+        """
+        try:
+            # Try meshtastic CLI
+            cli = shutil.which('meshtastic') or 'meshtastic'
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--ch-index', '0', '--info'],
+                capture_output=True, text=True, timeout=15
+            )
+
+            if result.returncode == 0:
+                # Parse channel name from output
+                for line in result.stdout.split('\n'):
+                    if 'name' in line.lower():
+                        parts = line.split(':')
+                        if len(parts) >= 2:
+                            name = parts[1].strip().strip('"\'')
+                            if name and name.lower() != 'none':
+                                return name
+
+        except Exception:
+            pass
+
+        return None
+
+    def _configure_meshtasticd_mqtt_local(self, channel_name: Optional[str] = None) -> bool:
+        """Configure meshtasticd to use local mosquitto broker.
+
+        Args:
+            channel_name: Optional channel name for display (auto-detected)
+
+        Returns True if configuration succeeded.
+        """
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Configuring meshtasticd for Local MQTT ===\n")
+
+        cli = shutil.which('meshtastic') or 'meshtastic'
+        success = True
+
+        try:
+            # Enable MQTT
+            print("Enabling MQTT...")
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.enabled', 'true'],
+                timeout=15
+            )
+            if result.returncode != 0:
+                success = False
+
+            # Set broker to localhost
+            print("Setting broker to localhost...")
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.address', 'localhost'],
+                timeout=15
+            )
+            if result.returncode != 0:
+                success = False
+
+            # Enable JSON mode for human-readable messages
+            print("Enabling JSON mode...")
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.json_enabled', 'true'],
+                timeout=15
+            )
+            if result.returncode != 0:
+                success = False
+
+            # Enable uplink on primary channel
+            print("Enabling uplink on primary channel...")
+            result = subprocess.run(
+                [cli, '--host', 'localhost',
+                 '--ch-index', '0', '--ch-set', 'uplink_enabled', 'true'],
+                timeout=15
+            )
+            if result.returncode != 0:
+                success = False
+
+            if success:
+                print(f"\n\033[0;32m✓\033[0m Configuration complete!")
+                if channel_name:
+                    print(f"  Channel: {channel_name}")
+                print(f"  Broker: localhost:1883")
+                print(f"  JSON mode: enabled")
+                print(f"  Uplink: enabled (channel 0)")
+            else:
+                print("\n\033[0;33mWarning:\033[0m Some settings may have failed.")
+                print("Check meshtasticd is running: sudo systemctl status meshtasticd")
+
+            self._wait_for_enter()
+            return success
+
+        except Exception as e:
+            print(f"\n\033[0;31mError:\033[0m {e}")
+            self._wait_for_enter()
+            return False


### PR DESCRIPTION
- Add one-click MQTT setup wizard in Service Config menu
  - Installs mosquitto broker if not present
  - Configures meshtasticd for local MQTT publishing
  - Auto-detects primary channel name for topic
  - Enables uplink on primary channel

- Enhance MQTT Monitor with Local/Public mode toggle
  - Quick switch between local (localhost:1883) and public broker
  - Auto-detects channel for correct topic pattern
  - Shows current mode in menu subtitle

This enables the multi-consumer architecture where multiple apps (MeshForge, meshing-around, Grafana) can receive mesh messages simultaneously via local MQTT broker.

https://claude.ai/code/session_013G1s8iq3gPUqeG4Xc4ySVV