### PR TITLE
feat: Add MQTT → WebSocket bridge for web UI access

### DIFF
--- a/.claude/session_notes/2026-02-03_meshtasticd_architecture_audit.md
+++ b/.claude/session_notes/2026-02-03_meshtasticd_architecture_audit.md
@@ -198,10 +198,165 @@ Tests:
 |------|---------|
 | `scripts/test_meshtasticd_architecture.py` | Pi validation test script |
 
+## Test Checklists for Pi Validation
+
+### P1: TUI MQTT Monitor Test Checklist
+
+Run on Pi with meshtasticd + mosquitto running.
+
+**Prerequisites:**
+```bash
+sudo systemctl status meshtasticd   # must be active
+sudo systemctl status mosquitto     # must be active
+mosquitto_sub -h localhost -t 'msh/#' -v -C 1  # must see messages
+```
+
+**Test Sequence:**
+
+1. [ ] **Launch TUI**
+   ```bash
+   sudo python3 src/launcher_tui/main.py
+   ```
+
+2. [ ] **Navigate to MQTT Monitor**
+   - Mesh Networks → MQTT Monitor
+   - Status should show "Not running"
+
+3. [ ] **Configure for Local Broker**
+   - Configure → Use Local Broker
+   - Should show "Local Mode Set" confirmation
+   - Topic should be `msh/2/json/{channel}/#` (auto-detected channel)
+
+4. [ ] **Start Subscriber**
+   - Start Subscriber
+   - Should show "Connecting to MQTT broker..."
+   - After 2s, should show "MQTT Started" or "Connection Issue"
+   - Status should change to "Connected"
+
+5. [ ] **Verify Node Discovery**
+   - Wait 30-60 seconds for mesh activity
+   - View Nodes → Should populate with discovered nodes
+   - Statistics → Should show message count > 0
+
+6. [ ] **Stop and Restart**
+   - Stop Subscriber → Confirm
+   - Status should return to "Not running"
+   - Start Subscriber again → Should reconnect
+
+7. [ ] **Export Data**
+   - Export Data
+   - Verify file at `~/.local/share/meshforge/mqtt_export.json`
+
+**Pass Criteria:**
+- All steps complete without errors
+- Nodes discovered from local mesh traffic
+- Data persists in cache file
+
+---
+
+### P1: Gateway Bridge + MQTT Parallel Test Checklist
+
+Tests both data paths running simultaneously.
+
+**Prerequisites:**
+```bash
+sudo systemctl status meshtasticd   # must be active
+sudo systemctl status mosquitto     # must be active
+sudo systemctl status rnsd          # should be STOPPED (we'll use internal RNS)
+```
+
+**Test Sequence:**
+
+1. [ ] **Start MQTT Monitor First**
+   - TUI: Mesh Networks → MQTT Monitor
+   - Configure → Use Local Broker
+   - Start Subscriber
+   - Verify status "Connected"
+
+2. [ ] **Start Gateway Bridge (parallel)**
+   - TUI: Mesh Networks → Gateway Bridge → Start Bridge (background)
+   - Should start successfully
+   - Check logs: `tail -f /tmp/meshforge_gateway.log`
+
+3. [ ] **Verify Both Running**
+   - MQTT Monitor status: "Connected" ✓
+   - Gateway Bridge status: "Running" ✓
+   - `lsof -i :4403` - should show bridge_cli.py connection
+   - `mosquitto_sub -t 'msh/#' -C 1` - should still receive messages
+
+4. [ ] **Test Message Flow**
+   - Send a test message via Meshtastic radio
+   - Verify in MQTT Monitor (Statistics → message count increases)
+   - Verify in Gateway Bridge logs (message received)
+
+5. [ ] **Stop Gateway Bridge**
+   - Gateway Bridge → Stop
+   - MQTT Monitor should continue working
+
+6. [ ] **Stop MQTT Monitor**
+   - MQTT Monitor → Stop Subscriber
+   - Both paths now inactive
+
+**Architecture Validation:**
+```
+meshtasticd (TCP:4403) ──→ Gateway Bridge (exclusive)
+meshtasticd (MQTT)     ──→ mosquitto:1883 ──→ MQTT Monitor (parallel)
+                                          ──→ (other consumers)
+```
+
+**Pass Criteria:**
+- Both paths operate simultaneously without conflict
+- TCP:4403 exclusive to Gateway Bridge
+- MQTT continues working when Gateway Bridge stops
+- No resource contention
+
+---
+
+## P2 Implementation: MQTT → WebSocket Bridge
+
+**Completed**: MQTT → WebSocket bridge for web UI access without Gateway Bridge.
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `src/utils/mqtt_websocket_bridge.py` | Bridge MQTT subscriber data to WebSocket:5001 |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `src/launcher_tui/mqtt_mixin.py` | Added WebSocket Bridge toggle in MQTT menu |
+
+### How It Works
+
+```
+MQTT Subscriber ─┬─> TUI display (existing)
+                 ├─> Cache file (existing)
+                 └─> WebSocket Bridge ──> ws://0.0.0.0:5001 ──> Web UI (NEW)
+```
+
+### TUI Menu Path
+
+Mesh Networks → MQTT Monitor → WebSocket Bridge → Toggle On/Off
+
+### Requirements
+
+- MQTT subscriber must be running first
+- `websockets` Python package (usually already installed)
+
+### Web UI Integration
+
+When WebSocket bridge is enabled:
+1. Web UI connects to `ws://localhost:5001`
+2. Receives `mesh_message` events (text messages)
+3. Receives `node_update` events (node telemetry/position)
+4. Same format as Gateway Bridge WebSocket output
+
+---
+
 ## Handoff Notes
 
-- Branch: `claude/complete-meshtasticd-architecture-e3iVs`
-- Architecture is functionally complete
-- Test script created for Pi validation
-- Real-world testing on Pi confirmed working
-- Next: Run test script on Pi, verify TUI MQTT Monitor flow
+- Branch: `claude/complete-meshtasticd-architecture-SHBl3`
+- Architecture is functionally complete (including P2)
+- All data paths now have WebSocket output option
+- Test checklists added for systematic Pi validation
+- Next: Run test checklists on Pi, test WebSocket bridge with web UI

--- a/scripts/test_meshtasticd_architecture.py
+++ b/scripts/test_meshtasticd_architecture.py
@@ -122,6 +122,15 @@ def test_gateway_bridge_import() -> bool:
         return False
 
 
+def test_websocket_bridge_import() -> bool:
+    """Test that MQTT→WebSocket bridge can be imported."""
+    try:
+        from utils.mqtt_websocket_bridge import MQTTWebSocketBridge, is_bridge_available
+        return is_bridge_available()
+    except ImportError:
+        return False
+
+
 def main():
     print(f"\n{BLUE}═══════════════════════════════════════════════════════════════{RESET}")
     print(f"{BLUE}    MeshForge meshtasticd Architecture Test{RESET}")
@@ -193,6 +202,9 @@ def main():
     bridge_import = test_gateway_bridge_import()
     print(f"  {check_mark(bridge_import)} Gateway Bridge (gateway.rns_bridge)")
 
+    ws_bridge_import = test_websocket_bridge_import()
+    print(f"  {check_mark(ws_bridge_import)} WebSocket Bridge (utils.mqtt_websocket_bridge)")
+
     print()
 
     # =========================================================================
@@ -217,7 +229,8 @@ def main():
 
     if meshtasticd_running and mosquitto_running and mqtt_import:
         print(f"\n{GREEN}Architecture Status: READY{RESET}")
-        print("""
+        ws_note = "  • WebSocket Bridge: MQTT Monitor → WebSocket Bridge → Enable\n" if ws_bridge_import else ""
+        print(f"""
 Both data paths are available:
   • TCP:4403 → Gateway Bridge (exclusive, one client)
   • MQTT → mosquitto → multiple consumers
@@ -225,7 +238,7 @@ Both data paths are available:
 TUI Quick Start:
   • MQTT Monitor: Mesh Networks → MQTT Monitor → Configure → Use Local Broker
   • Gateway Bridge: Mesh Networks → Gateway Bridge
-""")
+{ws_note}""")
     else:
         print(f"\n{YELLOW}Architecture Status: PARTIAL{RESET}")
         print("\nMissing components:")

--- a/src/launcher_tui/mqtt_mixin.py
+++ b/src/launcher_tui/mqtt_mixin.py
@@ -5,6 +5,7 @@ Provides:
 - Start/stop MQTT subscriber
 - Configure MQTT broker settings
 - View MQTT node statistics
+- WebSocket bridge for web UI (MQTT → WebSocket:5001)
 """
 
 import json
@@ -39,6 +40,14 @@ except ImportError:
     _HAS_MQTT = False
     MQTTNodelessSubscriber = None
 
+# Try to import the MQTT→WebSocket bridge
+try:
+    from utils.mqtt_websocket_bridge import MQTTWebSocketBridge, is_bridge_available
+    _HAS_WS_BRIDGE = is_bridge_available()
+except ImportError:
+    _HAS_WS_BRIDGE = False
+    MQTTWebSocketBridge = None
+
 
 class MQTTMixin:
     """MQTT monitoring control for mesh networks."""
@@ -46,6 +55,7 @@ class MQTTMixin:
     # Class-level subscriber instance (shared across menu calls)
     _mqtt_subscriber: Optional[Any] = None
     _mqtt_thread: Optional[threading.Thread] = None
+    _mqtt_ws_bridge: Optional[Any] = None  # MQTT→WebSocket bridge
 
     def _mqtt_menu(self):
         """MQTT monitoring menu - nodeless mesh observation."""
@@ -56,6 +66,9 @@ class MQTTMixin:
             broker = config.get('broker', 'mqtt.meshtastic.org')
             mode = "Local" if broker == "localhost" else "Public"
 
+            # Check WebSocket bridge status
+            ws_status = self._get_ws_bridge_status()
+
             choices = [
                 ("status", f"Status              {status}"),
                 ("start", "Start Subscriber    Connect to MQTT broker"),
@@ -64,8 +77,13 @@ class MQTTMixin:
                 ("nodes", "View Nodes          Show discovered nodes"),
                 ("stats", "Statistics          Node counts, activity"),
                 ("export", "Export Data         Save nodes to file"),
-                ("back", "Back"),
             ]
+
+            # Add WebSocket bridge option if available
+            if _HAS_WS_BRIDGE:
+                choices.append(("websocket", f"WebSocket Bridge    {ws_status}"))
+
+            choices.append(("back", "Back"))
 
             subtitle = f"MQTT Mode: {mode} ({broker})\n"
             if mode == "Local":
@@ -96,6 +114,8 @@ class MQTTMixin:
                 self._show_mqtt_stats()
             elif choice == "export":
                 self._export_mqtt_data()
+            elif choice == "websocket":
+                self._toggle_ws_bridge()
 
     def _get_mqtt_status(self) -> str:
         """Get current MQTT subscriber status."""
@@ -104,6 +124,68 @@ class MQTTMixin:
         if self._mqtt_subscriber and self._mqtt_subscriber.is_connected():
             return "Connected"
         return "Not running"
+
+    def _get_ws_bridge_status(self) -> str:
+        """Get WebSocket bridge status."""
+        if not _HAS_WS_BRIDGE:
+            return "Unavailable"
+        if self._mqtt_ws_bridge and self._mqtt_ws_bridge.is_running:
+            clients = self._mqtt_ws_bridge.connected_clients
+            return f"Running ({clients} clients)"
+        return "Stopped"
+
+    def _toggle_ws_bridge(self):
+        """Toggle the MQTT→WebSocket bridge for web UI access."""
+        if not _HAS_WS_BRIDGE:
+            self.dialog.msgbox(
+                "WebSocket Unavailable",
+                "WebSocket bridge not available.\n\n"
+                "Install websockets: pip install websockets"
+            )
+            return
+
+        # Check if MQTT subscriber is running
+        if not self._mqtt_subscriber or not self._mqtt_subscriber.is_connected():
+            self.dialog.msgbox(
+                "MQTT Not Running",
+                "Start the MQTT subscriber first.\n\n"
+                "The WebSocket bridge forwards MQTT data to web clients."
+            )
+            return
+
+        # Toggle bridge state
+        if self._mqtt_ws_bridge and self._mqtt_ws_bridge.is_running:
+            # Stop the bridge
+            if self.dialog.yesno(
+                "Stop WebSocket Bridge",
+                "Stop the WebSocket bridge?\n\n"
+                "Web UI clients will disconnect."
+            ):
+                self._mqtt_ws_bridge.stop()
+                self._mqtt_ws_bridge = None
+                self.dialog.msgbox("Stopped", "WebSocket bridge stopped.")
+        else:
+            # Start the bridge
+            self.dialog.infobox("Starting", "Starting WebSocket bridge...")
+
+            try:
+                from utils.mqtt_websocket_bridge import MQTTWebSocketBridge
+                self._mqtt_ws_bridge = MQTTWebSocketBridge(self._mqtt_subscriber)
+
+                if self._mqtt_ws_bridge.start():
+                    self.dialog.msgbox(
+                        "WebSocket Bridge Started",
+                        "MQTT→WebSocket bridge is now running!\n\n"
+                        "Web UI can connect to: ws://localhost:5001\n\n"
+                        "This enables the web map and dashboard to\n"
+                        "receive mesh data via MQTT monitoring."
+                    )
+                else:
+                    self._mqtt_ws_bridge = None
+                    self.dialog.msgbox("Error", "Failed to start WebSocket bridge.")
+            except Exception as e:
+                logger.error(f"WebSocket bridge error: {e}")
+                self.dialog.msgbox("Error", f"WebSocket bridge error:\n{e}")
 
     def _show_mqtt_status(self):
         """Show detailed MQTT status."""
@@ -134,6 +216,20 @@ class MQTTMixin:
                 lines.append(f"  Broker: {config.get('broker', 'mqtt.meshtastic.org')}")
                 lines.append(f"  Port: {config.get('port', 8883)}")
                 lines.append(f"  Topic: {config.get('topic', 'msh/US/2/e/LongFast/#')}")
+
+            # WebSocket bridge status
+            if _HAS_WS_BRIDGE:
+                lines.append("")
+                lines.append("WEBSOCKET BRIDGE:")
+                if self._mqtt_ws_bridge and self._mqtt_ws_bridge.is_running:
+                    ws_stats = self._mqtt_ws_bridge.get_stats()
+                    lines.append(f"  Status: Running")
+                    lines.append(f"  Port: ws://0.0.0.0:{ws_stats.get('websocket_port', 5001)}")
+                    lines.append(f"  Clients: {ws_stats.get('websocket_clients', 0)}")
+                    lines.append(f"  Messages bridged: {ws_stats.get('messages_bridged', 0)}")
+                else:
+                    lines.append(f"  Status: Stopped")
+                    lines.append(f"  Enable for web UI access")
         else:
             lines.append("Status: Not running")
             lines.append("")
@@ -231,12 +327,21 @@ class MQTTMixin:
             self.dialog.msgbox("Not Running", "MQTT subscriber is not running.")
             return
 
+        # Note if WebSocket bridge is running
+        ws_running = self._mqtt_ws_bridge and self._mqtt_ws_bridge.is_running
+        ws_note = "\n\nWebSocket bridge will also be stopped." if ws_running else ""
+
         if self.dialog.yesno(
             "Stop MQTT",
-            "Stop the MQTT subscriber?\n\n"
-            "Node data will be preserved in cache."
+            f"Stop the MQTT subscriber?\n\n"
+            f"Node data will be preserved in cache.{ws_note}"
         ):
             try:
+                # Stop WebSocket bridge first if running
+                if self._mqtt_ws_bridge:
+                    self._mqtt_ws_bridge.stop()
+                    self._mqtt_ws_bridge = None
+
                 self._mqtt_subscriber.stop()
                 self._mqtt_subscriber = None
                 self.dialog.msgbox("Stopped", "MQTT subscriber stopped.")

--- a/src/utils/mqtt_websocket_bridge.py
+++ b/src/utils/mqtt_websocket_bridge.py
@@ -1,0 +1,263 @@
+"""
+MQTT to WebSocket Bridge for MeshForge.
+
+Connects the MQTT subscriber to the WebSocket server, enabling web UI
+to receive mesh data without the Gateway Bridge running.
+
+Architecture:
+    MQTT Subscriber ─┬─> TUI display
+                     └─> WebSocket Bridge ──> WebSocket:5001 ──> Web UI
+
+Usage:
+    from monitoring.mqtt_subscriber import create_local_subscriber
+    from utils.mqtt_websocket_bridge import MQTTWebSocketBridge
+
+    # Create MQTT subscriber
+    subscriber = create_local_subscriber()
+    subscriber.start()
+
+    # Enable WebSocket broadcast
+    bridge = MQTTWebSocketBridge(subscriber)
+    bridge.start()
+
+    # ... later ...
+    bridge.stop()
+"""
+
+import logging
+from datetime import datetime
+from typing import Optional, Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Lazy imports to avoid circular dependencies and optional deps
+MQTTNodelessSubscriber = None
+MessageWebSocketServer = None
+
+
+def _import_dependencies():
+    """Lazy import of dependencies."""
+    global MQTTNodelessSubscriber, MessageWebSocketServer
+
+    if MQTTNodelessSubscriber is None:
+        try:
+            from monitoring.mqtt_subscriber import MQTTNodelessSubscriber as _Sub
+            MQTTNodelessSubscriber = _Sub
+        except ImportError:
+            logger.warning("MQTT subscriber not available")
+
+    if MessageWebSocketServer is None:
+        try:
+            from utils.websocket_server import MessageWebSocketServer as _WS
+            MessageWebSocketServer = _WS
+        except ImportError:
+            logger.warning("WebSocket server not available")
+
+
+class MQTTWebSocketBridge:
+    """
+    Bridges MQTT subscriber data to WebSocket for web UI clients.
+
+    This allows the web UI to display mesh data when using MQTT monitoring
+    instead of the full Gateway Bridge (which uses TCP:4403).
+    """
+
+    def __init__(
+        self,
+        subscriber: Any,
+        websocket_port: int = 5001,
+        broadcast_messages: bool = True,
+        broadcast_nodes: bool = True,
+    ):
+        """
+        Initialize the MQTT to WebSocket bridge.
+
+        Args:
+            subscriber: MQTTNodelessSubscriber instance
+            websocket_port: WebSocket server port (default: 5001)
+            broadcast_messages: Whether to broadcast text messages
+            broadcast_nodes: Whether to broadcast node updates
+        """
+        _import_dependencies()
+
+        self._subscriber = subscriber
+        self._ws_port = websocket_port
+        self._ws_server: Optional[Any] = None
+        self._running = False
+
+        self._broadcast_messages = broadcast_messages
+        self._broadcast_nodes = broadcast_nodes
+
+        # Stats
+        self._messages_bridged = 0
+        self._nodes_bridged = 0
+
+    def start(self) -> bool:
+        """
+        Start the WebSocket server and register callbacks.
+
+        Returns:
+            True if started successfully, False otherwise
+        """
+        if self._running:
+            logger.warning("Bridge already running")
+            return True
+
+        if MessageWebSocketServer is None:
+            logger.error("WebSocket server not available - install websockets")
+            return False
+
+        try:
+            # Create and start WebSocket server
+            self._ws_server = MessageWebSocketServer(port=self._ws_port)
+            if not self._ws_server.start():
+                logger.error("Failed to start WebSocket server")
+                return False
+
+            # Register callbacks with MQTT subscriber
+            if self._broadcast_messages:
+                self._subscriber.register_message_callback(self._on_mqtt_message)
+            if self._broadcast_nodes:
+                self._subscriber.register_node_callback(self._on_mqtt_node)
+
+            self._running = True
+            logger.info(f"MQTT→WebSocket bridge started on ws://0.0.0.0:{self._ws_port}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to start bridge: {e}")
+            return False
+
+    def stop(self):
+        """Stop the WebSocket server."""
+        if not self._running:
+            return
+
+        self._running = False
+
+        if self._ws_server:
+            self._ws_server.stop()
+            self._ws_server = None
+
+        logger.info("MQTT→WebSocket bridge stopped")
+
+    def _on_mqtt_message(self, message: Any):
+        """Handle MQTT text message - broadcast to WebSocket."""
+        if not self._running or not self._ws_server:
+            return
+
+        try:
+            # Format message for WebSocket clients
+            ws_message = {
+                "type": "mesh_message",
+                "source": "mqtt",
+                "data": {
+                    "from_id": message.from_id,
+                    "to_id": message.to_id,
+                    "text": message.text,
+                    "channel": message.channel,
+                    "timestamp": message.timestamp.isoformat(),
+                    "snr": message.snr,
+                    "rssi": message.rssi,
+                    "hop_start": message.hop_start,
+                }
+            }
+
+            self._ws_server.broadcast(ws_message)
+            self._messages_bridged += 1
+
+        except Exception as e:
+            logger.debug(f"Message bridge error: {e}")
+
+    def _on_mqtt_node(self, node: Any):
+        """Handle MQTT node update - broadcast to WebSocket."""
+        if not self._running or not self._ws_server:
+            return
+
+        try:
+            # Format node update for WebSocket clients
+            ws_message = {
+                "type": "node_update",
+                "source": "mqtt",
+                "data": {
+                    "node_id": node.node_id,
+                    "name": node.long_name or node.short_name or node.node_id,
+                    "latitude": node.latitude,
+                    "longitude": node.longitude,
+                    "altitude": node.altitude,
+                    "battery_level": node.battery_level,
+                    "snr": node.snr,
+                    "rssi": node.rssi,
+                    "hardware_model": node.hardware_model,
+                    "role": node.role,
+                    "is_online": node.is_online(),
+                    "last_seen": node.get_age_string(),
+                    "via_mqtt": True,
+                }
+            }
+
+            self._ws_server.broadcast(ws_message)
+            self._nodes_bridged += 1
+
+        except Exception as e:
+            logger.debug(f"Node bridge error: {e}")
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get bridge statistics."""
+        ws_stats = self._ws_server.stats if self._ws_server else None
+
+        return {
+            "running": self._running,
+            "messages_bridged": self._messages_bridged,
+            "nodes_bridged": self._nodes_bridged,
+            "websocket_port": self._ws_port,
+            "websocket_clients": ws_stats.connected_clients if ws_stats else 0,
+            "websocket_total_connections": ws_stats.total_connections if ws_stats else 0,
+        }
+
+    @property
+    def is_running(self) -> bool:
+        """Check if bridge is running."""
+        return self._running
+
+    @property
+    def connected_clients(self) -> int:
+        """Get number of connected WebSocket clients."""
+        if self._ws_server:
+            return self._ws_server.stats.connected_clients
+        return 0
+
+
+# Singleton instance
+_bridge: Optional[MQTTWebSocketBridge] = None
+
+
+def get_mqtt_websocket_bridge(
+    subscriber: Any,
+    port: int = 5001
+) -> MQTTWebSocketBridge:
+    """Get or create the global MQTT→WebSocket bridge."""
+    global _bridge
+    if _bridge is None:
+        _bridge = MQTTWebSocketBridge(subscriber, websocket_port=port)
+    return _bridge
+
+
+def start_mqtt_websocket_bridge(subscriber: Any, port: int = 5001) -> bool:
+    """Start the global MQTT→WebSocket bridge."""
+    bridge = get_mqtt_websocket_bridge(subscriber, port)
+    return bridge.start()
+
+
+def stop_mqtt_websocket_bridge():
+    """Stop the global MQTT→WebSocket bridge."""
+    global _bridge
+    if _bridge:
+        _bridge.stop()
+        _bridge = None
+
+
+def is_bridge_available() -> bool:
+    """Check if MQTT→WebSocket bridge can be started."""
+    _import_dependencies()
+    return MQTTNodelessSubscriber is not None and MessageWebSocketServer is not None


### PR DESCRIPTION
Enables web UI to receive mesh data via MQTT monitoring path, without requiring the Gateway Bridge (which uses TCP:4403).

Architecture:
  MQTT Subscriber → WebSocket Bridge → ws://0.0.0.0:5001 → Web UI

New files:
- src/utils/mqtt_websocket_bridge.py: Bridge class connecting MQTT subscriber callbacks to WebSocket broadcast

Modified files:
- src/launcher_tui/mqtt_mixin.py: Added "WebSocket Bridge" toggle to MQTT Monitor menu with status display
- scripts/test_meshtasticd_architecture.py: Added bridge import test
- .claude/session_notes: Added P1 test checklists and P2 docs

TUI path: Mesh Networks → MQTT Monitor → WebSocket Bridge

https://claude.ai/code/session_01DGcvES6EoRCYUYrHHNRMqM