### PR TITLE
feat: Add Meshtastic 2.6+ relay node discovery for improved node visi…

### DIFF
--- a/.claude/session_notes/2026-02-03_meshtastic_node_visibility.md
+++ b/.claude/session_notes/2026-02-03_meshtastic_node_visibility.md
@@ -1,0 +1,118 @@
+# Session Notes: Meshtastic Node Visibility Investigation
+
+**Date**: 2026-02-03
+**Session ID**: fix-meshtastic-node-visibility-x5MEv
+**Objective**: Investigate why some Meshtastic nodes aren't visible and improve telemetry capture
+
+## Root Cause Analysis
+
+### Problem Statement
+Some Meshtastic nodes were not appearing in MeshForge's maps, topology graphs, and monitoring displays despite being active in the mesh network.
+
+### Key Discovery: Meshtastic 2.6+ Relay Node Fields
+
+After reviewing the [Meshtastic Mesh Algorithm documentation](https://meshtastic.org/docs/overview/mesh-algo/) and the [Managed Flood Routing blog post](https://meshtastic.org/blog/why-meshtastic-uses-managed-flood-routing/), I discovered that Meshtastic 2.6+ introduced two critical new fields in the packet header:
+
+| Offset | Field | Purpose |
+|--------|-------|---------|
+| 0x0E | `relay_node` | Last byte of node ID that relayed this packet |
+| 0x0F | `next_hop` | Last byte of expected next-hop node for routing |
+
+### Why Nodes Were Missing
+
+1. **Managed Flood Routing Suppression**: Nodes listen before rebroadcasting. If they hear another node already rebroadcasting, they suppress their own rebroadcast. This means many nodes "witness" packets but never send their own telemetry.
+
+2. **SNR-based Prioritization**: Nodes further away (lower SNR) rebroadcast first. Closer nodes hear this and suppress, making them less visible.
+
+3. **Traffic Scaling (>40 nodes)**: In meshes with >40 nodes, NodeInfo/Position/Telemetry intervals are scaled back significantly:
+   ```
+   ScaledInterval = Interval * (1.0 + ((NumberOfOnlineNodes - 40) * 0.075))
+   ```
+
+4. **MeshForge Gap**: The codebase was NOT extracting the `relayNode` field from packets, so relay-only nodes were completely invisible.
+
+## Changes Made
+
+### 1. MQTT Subscriber (`src/monitoring/mqtt_subscriber.py`)
+
+- **Added fields to `MQTTNode` dataclass**:
+  - `relay_node: Optional[int]` - Last byte of relay node ID
+  - `next_hop: Optional[int]` - Last byte of expected next-hop
+  - `discovered_via_relay: bool` - Flag for nodes found via relay activity
+
+- **Added `_discover_relay_node()` method**: Creates placeholder nodes when we see unknown relay nodes (partial ID format: `!????xx` where `xx` is the hex of the last byte)
+
+- **Added `_try_merge_relay_node()` method**: Merges partial relay nodes with full node IDs when the node eventually sends its own telemetry
+
+- **Added stats tracking**:
+  - `nodes_discovered_via_relay`
+  - `relay_nodes_merged`
+
+- **Updated GeoJSON output** to include relay tracking properties
+
+### 2. RNS Bridge (`src/gateway/rns_bridge.py`)
+
+- **Added relay node extraction** in `_on_meshtastic_receive()`:
+  ```python
+  relay_node = packet.get('relayNode')
+  if relay_node and relay_node > 0:
+      self._discover_relay_node(relay_node, from_id, packet)
+  ```
+
+- **Added `_discover_relay_node()` method**: Discovers relay nodes and creates topology edges showing relay relationships
+
+### 3. Node Tracker (`src/gateway/node_tracker.py`)
+
+- **Added fields to `UnifiedNode` dataclass**:
+  - `discovered_via_relay: bool`
+  - `relay_node: Optional[int]`
+  - `next_hop: Optional[int]`
+
+- **Updated `from_meshtastic()` method** to extract `relayNode` and `nextHop` fields
+
+### 4. Message Listener (`src/utils/message_listener.py`)
+
+- **Added relay tracking** to message data:
+  - `relay_node`
+  - `next_hop`
+
+### 5. Traffic Inspector (`src/monitoring/traffic_inspector.py`)
+
+- **Added fields to `MeshPacket` dataclass**:
+  - `relay_node: Optional[int]`
+  - `next_hop: Optional[int]`
+
+- **Updated `dissect()` method** to extract relay fields from metadata
+
+- **Updated protocol tree** to display relay info in the Routing section
+
+## Impact
+
+These changes enable MeshForge to:
+
+1. **Discover relay-only nodes** that never send their own telemetry
+2. **Track relay relationships** in the topology graph
+3. **Merge partial IDs** when nodes eventually identify themselves
+4. **Display relay path information** in packet inspection
+5. **Provide statistics** on relay-discovered nodes
+
+## Testing Notes
+
+- All modified files compile successfully
+- Changes follow existing code patterns and security guidelines
+- No breaking changes to existing APIs
+
+## Follow-up Recommendations
+
+1. **Web UI Update**: Add visual indicators for relay-discovered nodes (different icon or color)
+2. **Map Enhancement**: Show relay paths as dotted lines between nodes
+3. **Statistics Dashboard**: Display relay discovery stats in monitoring UI
+4. **Documentation**: Update user docs to explain relay node discovery
+
+## Sources
+
+- [Mesh Broadcast Algorithm | Meshtastic](https://meshtastic.org/docs/overview/mesh-algo/)
+- [Why Meshtastic Uses Managed Flood Routing | Meshtastic](https://meshtastic.org/blog/why-meshtastic-uses-managed-flood-routing/)
+- [Meshtastic 2.6 Preview: MUI and Next-Hop Routing](https://meshtastic.org/blog/meshtastic-2-6-preview/)
+- [MeshPacket Structure | DeepWiki](https://deepwiki.com/meshtastic/protobufs/2.1-meshpacket-structure)
+- [meshtastic Python library](https://python.meshtastic.org/)

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -297,6 +297,11 @@ class UnifiedNode:
     last_seen: Optional[datetime] = None
     first_seen: Optional[datetime] = None
 
+    # Relay tracking (Meshtastic 2.6+)
+    discovered_via_relay: bool = False  # Node discovered by seeing it relay packets
+    relay_node: Optional[int] = None  # Last byte of node that relayed to us
+    next_hop: Optional[int] = None  # Last byte of expected next-hop for our packets
+
     # State machine for granular status tracking
     # Initialized in __post_init__ if available
     _state_machine: Optional[Any] = field(default=None, repr=False)
@@ -596,9 +601,18 @@ class UnifiedNode:
 
         # Radio metrics
         node.snr = mesh_node.get('snr')
+        node.rssi = mesh_node.get('rssi') or mesh_node.get('rxRssi')
         node.hops = mesh_node.get('hopsAway')
         node.last_seen = datetime.now()
         node.is_online = True
+
+        # Relay tracking (Meshtastic 2.6+)
+        relay_node = mesh_node.get('relayNode')
+        if relay_node and relay_node > 0:
+            node.relay_node = relay_node
+        next_hop = mesh_node.get('nextHop')
+        if next_hop and next_hop > 0:
+            node.next_hop = next_hop
 
         # Update state machine with live data
         if node._state_machine is not None:

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -1136,6 +1136,12 @@ class RNSMeshtasticBridge:
                 })
                 self.node_tracker.add_node(node)
 
+            # Extract relay node (Meshtastic 2.6+)
+            # relayNode is the last byte of the node ID that relayed this packet
+            relay_node = packet.get('relayNode')
+            if relay_node and relay_node > 0:
+                self._discover_relay_node(relay_node, from_id, packet)
+
             # Handle text messages
             if portnum == 'TEXT_MESSAGE_APP':
                 payload = decoded.get('payload', b'')
@@ -1207,6 +1213,62 @@ class RNSMeshtasticBridge:
 
         except Exception as e:
             logger.error(f"Error processing Meshtastic message: {e}")
+
+    def _discover_relay_node(self, relay_byte: int, from_id: str, packet: dict):
+        """
+        Discover relay node from Meshtastic 2.6+ relayNode field.
+
+        The relayNode field only contains the last byte of the relay node's ID.
+        We try to match it against known nodes or create a placeholder.
+        """
+        try:
+            if relay_byte <= 0 or relay_byte > 255:
+                return
+
+            # Try to find existing node matching this last byte
+            for node in self.node_tracker.get_meshtastic_nodes():
+                if node.meshtastic_id:
+                    try:
+                        node_num = int(node.meshtastic_id[1:], 16)
+                        if (node_num & 0xFF) == relay_byte:
+                            # Found the relay node - update topology
+                            if self._network_topology and from_id:
+                                self._network_topology.add_edge(
+                                    source_id=node.id,
+                                    dest_id=from_id,
+                                    hops=1,  # Direct relay relationship
+                                    snr=packet.get('rxSnr'),
+                                    rssi=packet.get('rxRssi'),
+                                )
+                            logger.debug(f"Relay path: {node.meshtastic_id} -> {from_id}")
+                            return
+                    except (ValueError, TypeError):
+                        continue
+
+            # No match - create partial relay node for tracking
+            partial_id = f"!????{relay_byte:02x}"
+            node = UnifiedNode(
+                id=partial_id,
+                name=f"Relay-{relay_byte:02x}",
+                network="meshtastic",
+                meshtastic_id=partial_id,
+            )
+            self.node_tracker.add_node(node)
+
+            # Add topology edge from unknown relay to sender
+            if self._network_topology and from_id:
+                self._network_topology.add_edge(
+                    source_id=partial_id,
+                    dest_id=from_id,
+                    hops=1,
+                    snr=packet.get('rxSnr'),
+                    rssi=packet.get('rxRssi'),
+                )
+
+            logger.info(f"Discovered relay node via packet routing: {partial_id}")
+
+        except Exception as e:
+            logger.debug(f"Error discovering relay node: {e}")
 
     def _on_lxmf_receive(self, message):
         """Handle incoming LXMF message"""

--- a/src/monitoring/mqtt_subscriber.py
+++ b/src/monitoring/mqtt_subscriber.py
@@ -81,6 +81,10 @@ class MQTTNode:
     via_mqtt: bool = True
     hop_start: Optional[int] = None
     hops_away: Optional[int] = None
+    # Relay tracking (Meshtastic 2.6+)
+    relay_node: Optional[int] = None  # Last byte of relay node ID
+    next_hop: Optional[int] = None    # Last byte of expected next-hop node
+    discovered_via_relay: bool = False  # Node discovered by seeing it relay packets
 
     def is_online(self, threshold_minutes: int = 15) -> bool:
         """Check if node was seen recently."""
@@ -161,6 +165,8 @@ class MQTTNodelessSubscriber:
             "messages_received": 0,
             "messages_rejected": 0,
             "nodes_discovered": 0,
+            "nodes_discovered_via_relay": 0,  # Nodes found through relay_node field
+            "relay_nodes_merged": 0,  # Partial relay nodes matched to full IDs
             "nodes_pruned": 0,
             "connect_time": None,
             "last_message_time": None,
@@ -491,9 +497,123 @@ class MQTTNodelessSubscriber:
                 self._nodes[node_id] = MQTTNode(node_id=node_id)
                 with self._stats_lock:
                     self._stats["nodes_discovered"] += 1
+
+                # Check if this node matches a previously discovered relay node
+                if node_id.startswith("!") and not node_id.startswith("!????"):
+                    self._try_merge_relay_node(node_id)
             else:
                 self._nodes[node_id].last_seen = datetime.now()
             return self._nodes[node_id]
+
+    def _try_merge_relay_node(self, full_node_id: str) -> None:
+        """
+        Check if this full node ID matches a partial relay node and merge them.
+        Called under _nodes_lock.
+        """
+        try:
+            full_num = int(full_node_id[1:], 16)
+            last_byte = full_num & 0xFF
+            partial_id = f"!????{last_byte:02x}"
+
+            if partial_id in self._nodes:
+                # Found matching partial relay node - merge
+                partial_node = self._nodes[partial_id]
+                full_node = self._nodes[full_node_id]
+
+                # Transfer relay discovery flag
+                full_node.discovered_via_relay = True
+
+                # Remove partial entry
+                del self._nodes[partial_id]
+
+                with self._stats_lock:
+                    self._stats["relay_nodes_merged"] += 1
+
+                logger.info(
+                    f"Merged relay node {partial_id} -> {full_node_id} "
+                    f"({partial_node.long_name} -> {full_node.long_name or 'unknown'})"
+                )
+        except (ValueError, TypeError, KeyError):
+            pass
+
+    def _discover_relay_node(self, relay_byte: int, data: Dict) -> Optional[MQTTNode]:
+        """
+        Discover a relay node from its last byte (Meshtastic 2.6+ relay_node field).
+
+        The relay_node field only contains the last byte of the node ID. We try to:
+        1. Match it against existing nodes
+        2. If no match, create a partial entry that can be filled in later
+
+        This allows us to discover nodes that relay packets but never send their
+        own telemetry/position, which is common for managed flood routing.
+        """
+        if relay_byte <= 0 or relay_byte > 255:
+            return None
+
+        # Try to find an existing node matching this last byte
+        with self._nodes_lock:
+            for node_id, node in self._nodes.items():
+                if node_id.startswith("!"):
+                    try:
+                        # Extract last byte of node ID
+                        node_num = int(node_id[1:], 16)
+                        if (node_num & 0xFF) == relay_byte:
+                            # Found matching node - update last_seen
+                            node.last_seen = datetime.now()
+                            logger.debug(f"Relay activity from known node: {node_id}")
+                            return node
+                    except (ValueError, TypeError):
+                        continue
+
+            # No match found - create a placeholder node with partial ID
+            # Format: !????xxxx where xxxx is the hex of the last byte
+            partial_id = f"!????{relay_byte:02x}"
+
+            if partial_id not in self._nodes:
+                # Create new node discovered via relay
+                relay_node = MQTTNode(
+                    node_id=partial_id,
+                    discovered_via_relay=True,
+                    long_name=f"Relay-{relay_byte:02x}",
+                    short_name=f"R{relay_byte:02x}",
+                )
+                self._nodes[partial_id] = relay_node
+                with self._stats_lock:
+                    self._stats["nodes_discovered"] += 1
+                    self._stats["nodes_discovered_via_relay"] += 1
+                logger.info(f"Discovered relay node via packet routing: {partial_id}")
+                return relay_node
+            else:
+                # Update existing partial node
+                self._nodes[partial_id].last_seen = datetime.now()
+                return self._nodes[partial_id]
+
+    def _match_relay_to_full_node(self, partial_id: str, full_node_id: str) -> bool:
+        """
+        Match a partial relay node ID to a full node ID when we learn the full ID.
+
+        When a node that was discovered via relay sends its own telemetry,
+        we can merge the partial entry with the full node info.
+        """
+        if not partial_id.startswith("!????"):
+            return False
+
+        try:
+            relay_byte = int(partial_id[-2:], 16)
+            full_num = int(full_node_id[1:], 16)
+            if (full_num & 0xFF) == relay_byte:
+                # Match! Merge the nodes
+                with self._nodes_lock:
+                    if partial_id in self._nodes and full_node_id in self._nodes:
+                        # Copy relay discovery flag to full node
+                        self._nodes[full_node_id].discovered_via_relay = True
+                        # Remove partial entry
+                        del self._nodes[partial_id]
+                        logger.info(f"Merged relay node {partial_id} -> {full_node_id}")
+                        return True
+        except (ValueError, TypeError):
+            pass
+        return False
 
     def _safe_float(self, value: Any, min_val: float, max_val: float) -> Optional[float]:
         """Safely extract and validate a float value within range."""
@@ -540,6 +660,25 @@ class MQTTNodelessSubscriber:
             hops = self._safe_int(data["hops_away"], 0, 15)
             if hops is not None:
                 node.hops_away = hops
+
+        # Extract relay node info (Meshtastic 2.6+)
+        # relay_node is the last byte of the node ID that relayed this packet
+        if "relay_node" in data or "relayNode" in data:
+            relay = self._safe_int(
+                data.get("relay_node") or data.get("relayNode"), 0, 255
+            )
+            if relay is not None and relay > 0:
+                node.relay_node = relay
+                # Discover the relay node if we haven't seen it
+                self._discover_relay_node(relay, data)
+
+        # Extract next_hop info (Meshtastic 2.6+)
+        if "next_hop" in data or "nextHop" in data:
+            next_hop = self._safe_int(
+                data.get("next_hop") or data.get("nextHop"), 0, 255
+            )
+            if next_hop is not None and next_hop > 0:
+                node.next_hop = next_hop
 
         # Notify callbacks (snapshot for thread-safe iteration)
         for callback in list(self._node_callbacks):
@@ -715,6 +854,17 @@ class MQTTNodelessSubscriber:
             return [n for n in self._nodes.values()
                     if n.latitude is not None and n.longitude is not None]
 
+    def get_relay_discovered_nodes(self) -> List[MQTTNode]:
+        """Get nodes discovered via relay_node field (no direct telemetry yet)."""
+        with self._nodes_lock:
+            return [n for n in self._nodes.values() if n.discovered_via_relay]
+
+    def get_partial_relay_nodes(self) -> List[MQTTNode]:
+        """Get nodes with partial IDs (discovered via relay, not yet identified)."""
+        with self._nodes_lock:
+            return [n for n in self._nodes.values()
+                    if n.node_id.startswith("!????")]
+
     def get_messages(self, limit: int = 100) -> List[MQTTMessage]:
         """Get recent messages."""
         with self._messages_lock:
@@ -728,6 +878,8 @@ class MQTTNodelessSubscriber:
             "node_count": len(self._nodes),
             "online_count": len(self.get_online_nodes()),
             "with_position": len(self.get_nodes_with_position()),
+            "relay_discovered": len(self.get_relay_discovered_nodes()),
+            "partial_relay_nodes": len(self.get_partial_relay_nodes()),
             "message_count": len(self._messages),
         }
 
@@ -772,6 +924,10 @@ class MQTTNodelessSubscriber:
                         "hardware": node.hardware_model,
                         "role": node.role,
                         "hops_away": node.hops_away,
+                        # Relay tracking (Meshtastic 2.6+)
+                        "discovered_via_relay": node.discovered_via_relay,
+                        "relay_node": node.relay_node,
+                        "next_hop": node.next_hop,
                     }
                 }
                 features.append(feature)

--- a/src/monitoring/traffic_inspector.py
+++ b/src/monitoring/traffic_inspector.py
@@ -371,6 +371,10 @@ class MeshPacket:
     via_mqtt: bool = False    # Received via MQTT
     want_ack: bool = False    # ACK requested
 
+    # Relay tracking (Meshtastic 2.6+)
+    relay_node: Optional[int] = None  # Last byte of relay node ID
+    next_hop: Optional[int] = None    # Last byte of next-hop node ID
+
     # Payload
     portnum: int = 0          # Meshtastic port number
     port_name: str = ""       # Human-readable port name
@@ -627,10 +631,18 @@ class MeshtasticDissector(PacketDissector):
         if "airUtilTx" in metadata:
             packet.air_util_tx = metadata["airUtilTx"]
 
+        # Relay tracking (Meshtastic 2.6+)
+        relay_node = metadata.get("relayNode")
+        if relay_node and relay_node > 0:
+            packet.relay_node = relay_node
+        next_hop = metadata.get("nextHop")
+        if next_hop and next_hop > 0:
+            packet.next_hop = next_hop
+
         # Direction
         if metadata.get("direction") == "outbound":
             packet.direction = PacketDirection.OUTBOUND
-        elif metadata.get("relayed"):
+        elif metadata.get("relayed") or packet.relay_node:
             packet.direction = PacketDirection.RELAYED
         else:
             packet.direction = PacketDirection.INBOUND
@@ -673,6 +685,14 @@ class MeshtasticDissector(PacketDissector):
                        "Received via MQTT broker")
         tree.add_field(routing, "Want ACK", "mesh.ack", packet.want_ack, FieldType.BOOLEAN,
                        "Acknowledgement requested")
+
+        # Relay tracking (Meshtastic 2.6+)
+        if packet.relay_node is not None:
+            tree.add_field(routing, "Relay Node", "mesh.relay", f"!????{packet.relay_node:02x}",
+                           FieldType.STRING, "Last byte of relay node ID (Meshtastic 2.6+)")
+        if packet.next_hop is not None:
+            tree.add_field(routing, "Next Hop", "mesh.next_hop", f"!????{packet.next_hop:02x}",
+                           FieldType.STRING, "Expected next-hop relay (Meshtastic 2.6+)")
 
         # Payload
         payload_field = PacketField(name="Payload", abbrev="mesh.payload",

--- a/src/utils/message_listener.py
+++ b/src/utils/message_listener.py
@@ -408,6 +408,10 @@ class MessageListener:
         hop_limit = packet.get('hopLimit', 0)
         hops_away = hop_start - hop_limit if hop_start else 0
 
+        # Relay tracking (Meshtastic 2.6+)
+        relay_node = packet.get('relayNode')  # Last byte of relay node ID
+        next_hop = packet.get('nextHop')  # Last byte of next-hop node ID
+
         # Update status
         self._status.messages_received += 1
         self._status.last_message_time = datetime.now()
@@ -423,6 +427,8 @@ class MessageListener:
             'hops_away': hops_away,
             'hop_start': hop_start,
             'hop_limit': hop_limit,
+            'relay_node': relay_node,  # Meshtastic 2.6+
+            'next_hop': next_hop,  # Meshtastic 2.6+
             'timestamp': datetime.now().isoformat(),
             'is_broadcast': to_id in ('!ffffffff', '^all', None),
         }


### PR DESCRIPTION
…bility

Extract relayNode and nextHop fields from Meshtastic packets to discover nodes that relay traffic but don't send their own telemetry. This addresses the "invisible node" problem caused by managed flood routing suppression.

Key changes:
- MQTT subscriber: Discover relay nodes from relay_node field, create placeholder nodes with partial IDs (!????xx), merge when full ID known
- RNS bridge: Extract relayNode from packets, create topology edges showing relay relationships
- Node tracker: Add discovered_via_relay, relay_node, next_hop fields to UnifiedNode dataclass
- Traffic inspector: Display relay path info in packet dissection
- Message listener: Include relay fields in message data

This enables discovery of:
- Relay-only nodes that never send telemetry
- Nodes with scaled-back telemetry (meshes >40 nodes)
- Nodes suppressed by SNR-based flood routing

https://claude.ai/code/session_01Ji68nfGad45r3f2KL7w58m