### PR TITLE
docs: Update file size guidelines with current analysis (2026-02-04)

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -232,41 +232,73 @@ from utils.service_check import check_service, check_port, ServiceState
 ### Symptom
 Files exceed the 1,500 line guideline from CLAUDE.md, making them difficult to navigate, test, and maintain.
 
-### Current Status (2026-01-19)
+### Current Status (2026-02-04)
 
-**Python files over 1,500 lines:**
+**Python files over 1,500 lines (NEEDS ATTENTION):**
 
-| File | Lines | Priority | Status |
-|------|-------|----------|--------|
-| `src/core/diagnostics/engine.py` | 1,677 | LOW | Monitor |
-| `src/gtk_ui/panels/tools.py` | 1,562 | LOW | Monitor |
-| `src/gtk_ui/panels/diagnostics.py` | 1,560 | LOW | Monitor |
-| `src/gtk_ui/app.py` | 1,539 | LOW | Monitor |
-| `src/gtk_ui/panels/hamclock.py` | 1,525 | - | ✅ Refactored from 2,625 |
+| File | Lines | Priority | Extraction Plan |
+|------|-------|----------|-----------------|
+| `src/monitoring/traffic_inspector.py` | 2,194 | HIGH | Extract dissectors → `packet_dissectors.py`, models → `traffic_models.py`, storage → `traffic_storage.py` |
+| `src/gateway/rns_bridge.py` | 1,991 | HIGH | Extract Meshtastic connection handling → `meshtastic_handler.py` |
+| `src/gateway/node_tracker.py` | 1,808 | HIGH | Extract data classes → `node_models.py` (Position, PKIStatus, AirQualityMetrics, HealthMetrics, etc.) |
+| `src/launcher_tui/main.py` | 1,799 | HIGH | ⚠️ REGRESSED from 1,336! Extract: network tools → `network_tools_mixin.py`, web client → `web_client_mixin.py` |
+| `src/core/diagnostics/engine.py` | 1,767 | LOW | Already has models.py - monitor only |
+| `src/utils/metrics_export.py` | 1,762 | MEDIUM | Extract metric definitions → `metric_definitions.py` |
+| `src/utils/knowledge_content.py` | 1,688 | LOW | Content file by design - no split needed |
+| `src/launcher_tui/rns_menu_mixin.py` | 1,524 | LOW | Near threshold - monitor |
 
-**Successfully refactored:**
-- `launcher_tui/main.py`: 2,822 → 1,336 lines ✅
-- `hamclock.py`: 2,625 → 1,525 lines ✅
-- `rns.py`: 673 lines ✅
-- `mesh_tools.py`: Now under 1,500 lines ✅
+**Regression Alert:**
+- `launcher_tui/main.py` grew from 1,336 → 1,799 lines (+463 lines)
+- Methods added to main.py instead of mixins:
+  - `_ping_test`, `_meshtastic_discovery`, `_dns_lookup` → should be `network_tools_mixin.py`
+  - `_open_web_client`, `_launch_web_client_browser`, etc. → should be `web_client_mixin.py`
+  - `_data_path_diagnostic` (160 lines) → should be `data_path_mixin.py`
+
+**GTK files removed from tracking (GTK deprecated):**
+- `src/gtk_ui/panels/tools.py`, `diagnostics.py`, `app.py`, `hamclock.py`
+- GTK4 interface was removed; TUI is now the only interface
 
 **Markdown files over 1,000 lines:**
 
 | File | Lines | Action |
 |------|-------|--------|
+| `.claude/foundations/persistent_issues.md` | 1,451 | Growing - consider archiving resolved issues |
 | `.claude/dude_ai_university.md` | 1,206 | Consider splitting by topic |
 | `.claude/foundations/ai_development_practices.md` | 1,069 | Review for outdated content |
+
+### Extraction Priority Order
+
+1. **traffic_inspector.py** (2,194 lines) - Largest, clear extraction boundaries
+   - Extract: `traffic_models.py` (enums, PacketField, PacketTree, MeshPacket, HopInfo) ~450 lines
+   - Extract: `packet_dissectors.py` (PacketDissector, MeshtasticDissector, RNSDissector) ~500 lines
+   - Extract: `traffic_storage.py` (TrafficCapture, TrafficStats, TrafficAnalyzer) ~550 lines
+   - Remaining in main: DisplayFilter, TrafficLogger, TrafficInspector, globals ~700 lines
+
+2. **launcher_tui/main.py** (1,799 lines) - Regression fix
+   - Extract: `network_tools_mixin.py` (ping, discovery, DNS) ~150 lines
+   - Extract: `web_client_mixin.py` (web client, browser, URLs) ~200 lines
+   - Extract: `data_path_mixin.py` (_data_path_diagnostic) ~160 lines
+   - Target: <1,300 lines
+
+3. **node_tracker.py** (1,808 lines)
+   - Extract: `node_models.py` (Position, PKIStatus, AirQualityMetrics, HealthMetrics, Telemetry) ~400 lines
+   - Target: ~1,400 lines
+
+4. **rns_bridge.py** (1,991 lines)
+   - Extract: `meshtastic_handler.py` (Meshtastic connection/send/receive) ~400 lines
+   - Target: ~1,600 lines (or split RNS handler too)
 
 ### Proper Fix
 
 Files over 1,500 lines should be split when adding new features to them.
-Previously refactored: launcher_tui (extracted mixins), hamclock (extracted API client),
+Previously refactored: launcher_tui (extracted 29 mixins), hamclock (extracted API client),
 rns.py (extracted config editor + mixins). Web UI and Rich CLI were deleted in consolidation.
 
 ### Prevention
 - Check file length before adding new features
 - Split files proactively at 1,000 lines
 - Use `wc -l src/**/*.py | sort -rn | head -10` to monitor
+- When adding to launcher_tui/main.py, **always check if a mixin exists or should be created**
 
 ---
 

--- a/.claude/session_notes/2026-02-04_file_size_review.md
+++ b/.claude/session_notes/2026-02-04_file_size_review.md
@@ -1,0 +1,115 @@
+# Session Notes: File Size Guidelines Review
+**Date:** 2026-02-04
+**Branch:** `claude/review-file-size-guidelines-EFega`
+
+## Summary
+
+Comprehensive review of Python files exceeding the 1,500 line guideline.
+
+## Files Analyzed
+
+### High Priority (>1,800 lines)
+
+| File | Lines | Extraction Plan |
+|------|-------|-----------------|
+| `traffic_inspector.py` | 2,194 | 3-way split: models, dissectors, storage |
+| `rns_bridge.py` | 1,991 | Extract Meshtastic connection handler |
+| `node_tracker.py` | 1,808 | Extract data classes (Position, PKIStatus, etc.) |
+| `launcher_tui/main.py` | 1,799 | Extract network/web client mixins |
+
+### Medium Priority (1,500-1,800 lines)
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `diagnostics/engine.py` | 1,767 | Already has models.py - monitor |
+| `metrics_export.py` | 1,762 | Could extract metric definitions |
+| `knowledge_content.py` | 1,688 | Content file by design - no split |
+| `rns_menu_mixin.py` | 1,524 | Near threshold - monitor |
+
+## Key Findings
+
+### Regression Alert: launcher_tui/main.py
+- Previously refactored: 2,822 → 1,336 lines
+- Current: 1,799 lines (+463 lines regression)
+- Cause: New methods added to main.py instead of creating mixins
+- Methods to extract:
+  - `_ping_test`, `_meshtastic_discovery`, `_dns_lookup` → `network_tools_mixin.py`
+  - `_open_web_client`, `_launch_web_client_browser` → `web_client_mixin.py`
+  - `_data_path_diagnostic` (160 lines) → `data_path_mixin.py`
+
+### traffic_inspector.py Structure
+Already well-organized with clear boundaries:
+1. **Enums/Constants** (83-151) - 70 lines
+2. **Data Models** (158-535) - 380 lines (PacketField, PacketTree, MeshPacket, HopInfo)
+3. **Dissectors** (542-1045) - 500 lines (PacketDissector, Meshtastic, RNS)
+4. **DisplayFilter** (1052-1173) - 120 lines
+5. **TrafficCapture** (1180-1561) - 380 lines
+6. **TrafficStats/Analyzer** (1567-1737) - 170 lines
+7. **TrafficLogger** (1744-1856) - 110 lines
+8. **TrafficInspector** (1863-2087) - 225 lines
+9. **Globals** (2093-2194) - 100 lines
+
+Recommended extractions:
+- `traffic_models.py`: Enums + Data Models (~450 lines)
+- `packet_dissectors.py`: Dissectors (~500 lines)
+- `traffic_storage.py`: TrafficCapture + Stats (~550 lines)
+
+### node_tracker.py Structure
+Many data classes at the start:
+- Position (67-87)
+- PKIKeyState (90-100)
+- PKIStatus (103-148)
+- AirQualityMetrics (151-181)
+- HealthMetrics (184-199)
+- More...
+
+Recommended:
+- Extract all data classes to `node_models.py` (~400 lines)
+
+## Documents Updated
+
+1. `.claude/foundations/persistent_issues.md` - Issue #6 updated with:
+   - Current file sizes (2026-02-04)
+   - Extraction plans
+   - Regression alert for launcher_tui/main.py
+   - Priority order for refactoring
+
+2. `CLAUDE.md` - File Size Guidelines section updated
+
+## Next Steps (for future sessions)
+
+1. **Priority 1:** Extract from `traffic_inspector.py`
+   - Create `src/monitoring/traffic_models.py`
+   - Create `src/monitoring/packet_dissectors.py`
+   - Create `src/monitoring/traffic_storage.py`
+
+2. **Priority 2:** Fix `launcher_tui/main.py` regression
+   - Create `src/launcher_tui/network_tools_mixin.py`
+   - Create `src/launcher_tui/web_client_mixin.py`
+   - Create `src/launcher_tui/data_path_mixin.py`
+
+3. **Priority 3:** Extract from `node_tracker.py`
+   - Create `src/gateway/node_models.py`
+
+4. **Priority 4:** Extract from `rns_bridge.py`
+   - Create `src/gateway/meshtastic_handler.py`
+
+## Commands Used
+
+```bash
+# Check file sizes
+wc -l src/**/*.py src/**/**/*.py 2>/dev/null | sort -rn | head -30
+
+# Check markdown sizes
+wc -l .claude/**/*.md .claude/*.md 2>/dev/null | sort -rn | head -15
+
+# List methods in main.py
+grep -n "def _" src/launcher_tui/main.py | head -80
+```
+
+## Session Entropy
+
+No entropy detected. Clean analysis session.
+
+---
+*Session complete. Changes documented, ready for follow-up refactoring work.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,11 +211,19 @@ else:
 ## File Size Guidelines
 
 Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md` Issue #6):
-- `launcher_tui/main.py` (2,822) → Extract menu handlers
-- `hamclock.py` (2,625) → Extract API client
-- `mesh_tools.py` (1,953) → Monitor
 
-*Note: 7 UIs consolidated → TUI + browser maps. GTK4 removed.*
+**Current files needing attention (2026-02-04):**
+- `traffic_inspector.py` (2,194) → Extract dissectors, models, storage
+- `rns_bridge.py` (1,991) → Extract Meshtastic handler
+- `node_tracker.py` (1,808) → Extract data classes
+- `launcher_tui/main.py` (1,799) → **Regressed!** Extract network tools, web client mixins
+
+**Previously refactored:**
+- ✅ `launcher_tui/main.py` (was 2,822 → 1,336, now regressed to 1,799)
+- ✅ `hamclock.py` (2,625 → 1,525)
+- ✅ GTK4 panels removed (TUI is now only interface)
+
+*Note: Always check if a mixin exists before adding to main.py.*
 
 ## Commit Style
 


### PR DESCRIPTION
Review of Python files exceeding 1,500 line guideline:

Files needing attention:
- traffic_inspector.py (2,194) - HIGH: extract dissectors, models, storage
- rns_bridge.py (1,991) - HIGH: extract Meshtastic handler
- node_tracker.py (1,808) - HIGH: extract data classes
- launcher_tui/main.py (1,799) - HIGH: regressed from 1,336!

Key finding: launcher_tui/main.py regression (+463 lines)
- Methods added to main.py instead of mixins
- Need new mixins: network_tools, web_client, data_path

Updated:
- CLAUDE.md: Current file sizes and extraction plans
- persistent_issues.md: Issue #6 with detailed refactoring roadmap
- Added session notes for 2026-02-04

https://claude.ai/code/session_016Yj1VdTx2qjcn1gQaJLDpQ