### PR TITLE
fix: Create /etc/reticulum/storage directory during install

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -976,6 +976,17 @@ if $INSTALL_RNS; then
 
     pip3 install $PIP_ARGS --ignore-installed -q rns
 
+    # Create /etc/reticulum directory structure
+    # RNS stores data in a 'storage' subdirectory of its config directory.
+    # When using system-wide config (/etc/reticulum/config), rnsd needs
+    # the storage directory to exist with proper permissions.
+    echo "  Creating /etc/reticulum/ structure..."
+    mkdir -p /etc/reticulum/storage
+    mkdir -p /etc/reticulum/interfaces
+    chmod 755 /etc/reticulum
+    chmod 755 /etc/reticulum/storage
+    chmod 755 /etc/reticulum/interfaces
+
     # Create systemd service if not exists
     if ! systemctl list-unit-files | grep -q rnsd.service; then
         echo "  Creating rnsd systemd service..."

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -106,6 +106,33 @@ class ReticulumPaths:
       3. ~/.reticulum/config (traditional fallback)
     """
 
+    # System-wide paths
+    ETC_BASE = Path('/etc/reticulum')
+    ETC_STORAGE = ETC_BASE / 'storage'
+    ETC_INTERFACES = ETC_BASE / 'interfaces'
+
+    @classmethod
+    def ensure_system_dirs(cls) -> bool:
+        """Create system-wide Reticulum directories if they don't exist.
+
+        RNS requires a 'storage' subdirectory in its config directory.
+        When using /etc/reticulum/config, this means /etc/reticulum/storage
+        must exist with proper permissions before rnsd can start.
+
+        Returns:
+            True if directories exist or were created, False on permission error.
+
+        Note:
+            Requires root/sudo to create directories in /etc.
+        """
+        try:
+            cls.ETC_BASE.mkdir(mode=0o755, parents=True, exist_ok=True)
+            cls.ETC_STORAGE.mkdir(mode=0o755, parents=True, exist_ok=True)
+            cls.ETC_INTERFACES.mkdir(mode=0o755, parents=True, exist_ok=True)
+            return True
+        except PermissionError:
+            return False
+
     @classmethod
     def get_config_dir(cls) -> Path:
         """Get Reticulum config directory.


### PR DESCRIPTION
rnsd fails to start with "PermissionError: Permission denied: '/etc/reticulum/storage'" when using system-wide config because the storage subdirectory doesn't exist.

Changes:
- install_noc.sh: Create /etc/reticulum/storage and /etc/reticulum/interfaces directories with 755 permissions during RNS installation
- paths.py: Add ReticulumPaths.ensure_system_dirs() helper for runtime directory creation (useful for existing installations)

https://claude.ai/code/session_01NQYd6p9KYYoegPwsjkFhzb