### PR TITLE
fix: Add missing get_node_tracker() singleton and improve topology stats

### DIFF
--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -909,3 +909,22 @@ instance_control_port = 37429
         if self._service_registry:
             return self._service_registry.get_stats()
         return None
+
+
+# Global node tracker instance (singleton)
+_node_tracker: Optional[UnifiedNodeTracker] = None
+
+
+def get_node_tracker() -> UnifiedNodeTracker:
+    """Get the global node tracker instance.
+
+    Returns a singleton UnifiedNodeTracker that is shared across the application.
+    The tracker is created on first call and reused thereafter.
+
+    Returns:
+        UnifiedNodeTracker: The global node tracker instance
+    """
+    global _node_tracker
+    if _node_tracker is None:
+        _node_tracker = UnifiedNodeTracker()
+    return _node_tracker

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -82,9 +82,11 @@ class TopologyMixin:
 
     def _show_topology_stats(self):
         """Display topology statistics."""
+        # Prefer getting stats from node tracker (has richer data)
+        tracker = self._get_node_tracker()
         topology = self._get_topology()
 
-        if topology is None:
+        if topology is None and tracker is None:
             self.dialog.msgbox(
                 "Topology Unavailable",
                 "Network topology module not loaded.\n\n"
@@ -93,24 +95,69 @@ class TopologyMixin:
             return
 
         try:
-            stats = topology.get_topology_stats()
+            # Get topology stats from tracker if available, else direct
+            if tracker and hasattr(tracker, 'get_topology_stats'):
+                stats = tracker.get_topology_stats() or {}
+            elif topology:
+                stats = topology.get_topology_stats()
+            else:
+                stats = {}
+
+            # Get node counts from tracker for richer data
+            tracker_node_count = 0
+            online_count = 0
+            rns_count = 0
+            mesh_count = 0
+            if tracker and hasattr(tracker, 'get_all_nodes'):
+                try:
+                    all_nodes = tracker.get_all_nodes()
+                    tracker_node_count = len(all_nodes)
+                    for node in all_nodes:
+                        if getattr(node, 'is_online', False):
+                            online_count += 1
+                        network = getattr(node, 'network', '')
+                        if network == 'rns':
+                            rns_count += 1
+                        elif network == 'meshtastic':
+                            mesh_count += 1
+                        elif network == 'both':
+                            rns_count += 1
+                            mesh_count += 1
+                except Exception:
+                    pass
+
+            # Use the higher of topology nodes or tracker nodes
+            topo_node_count = stats.get('node_count', 0)
+            node_count = max(topo_node_count, tracker_node_count)
 
             # Format stats display
             lines = [
                 "NETWORK TOPOLOGY STATISTICS",
                 "=" * 40,
                 "",
-                f"Total Nodes:    {stats.get('node_count', 0)}",
+                f"Total Nodes:    {node_count}",
+            ]
+
+            # Show network breakdown if we have tracker data
+            if tracker_node_count > 0:
+                if online_count > 0:
+                    lines.append(f"  Online:       {online_count}")
+                if rns_count > 0:
+                    lines.append(f"  RNS:          {rns_count}")
+                if mesh_count > 0:
+                    lines.append(f"  Meshtastic:   {mesh_count}")
+
+            lines.extend([
+                "",
                 f"Total Edges:    {stats.get('edge_count', 0)}",
                 f"Active Edges:   {stats.get('active_edges', 0)}",
                 "",
                 f"Average Hops:   {stats.get('avg_hops', 0):.2f}",
                 f"Maximum Hops:   {stats.get('max_hops', 0)}",
                 "",
-            ]
+            ])
 
             # Add service stats if available from node tracker
-            tracker = self._get_node_tracker()
             if tracker and hasattr(tracker, 'get_service_stats'):
                 try:
                     svc_stats = tracker.get_service_stats()
@@ -122,6 +169,16 @@ class TopologyMixin:
                         lines.append("")
                 except Exception:
                     pass
+
+            # Show help if no data
+            if node_count == 0 and stats.get('edge_count', 0) == 0:
+                lines.append("No topology data available.")
+                lines.append("")
+                lines.append("Topology is populated when:")
+                lines.append("  - RNS discovers paths to destinations")
+                lines.append("  - Meshtastic nodes are seen")
+                lines.append("  - Gateway bridge is running")
+                lines.append("")
 
             self.dialog.msgbox("Topology Statistics", "\n".join(lines))
 


### PR DESCRIPTION
- Add get_node_tracker() singleton function that was being imported but didn't exist, causing topology stats to show zeros
- Enhance _show_topology_stats() to get richer data from node tracker including online/RNS/Meshtastic node breakdowns
- Show helpful message when no topology data is available explaining how topology is populated (RNS paths, Meshtastic nodes, gateway)

https://claude.ai/code/session_01BDwCbAMGtJPfYw9nZLivmF