### PR TITLE
fix: Topology browser now displays nodes from node tracker

### DIFF
--- a/.claude/session_notes/2026-02-05_session_tracking_setup.md
+++ b/.claude/session_notes/2026-02-05_session_tracking_setup.md
@@ -68,7 +68,29 @@
 3. No radio connected
 4. Actual bug in node counting
 
-**Investigation Status:** In progress
+**Investigation Status:** RESOLVED
+
+---
+
+## Bug Fix: Topology Browser Not Showing Node Tracker Data
+
+**Problem:**
+The D3.js browser visualization showed "1 Node, 0 Links" even when nodes were available
+in the UnifiedNodeTracker.
+
+**Root Cause:**
+`_open_topology_browser()` in `topology_mixin.py` only read from `NetworkTopology`
+which is populated by RNS path table. It did NOT incorporate data from
+`UnifiedNodeTracker` which has richer Meshtastic node data.
+
+**Fix Applied:**
+Modified `_open_topology_browser()` to:
+1. Get both topology AND node tracker singletons
+2. Enrich the visualizer with nodes from tracker (name, GPS, SNR, RSSI, role)
+3. Add edges from local to each tracked node
+
+**File Modified:**
+- `src/launcher_tui/topology_mixin.py:639-704` - Enhanced browser visualization
 
 ---
 
@@ -84,11 +106,12 @@
 
 ## Handoff Notes (for next session)
 
-- **Current task status:** Investigating 0 node count issue
-- **Blockers encountered:** None yet
-- **Files modified:** This session notes file
-- **Commits made:** None yet
+- **Current task status:** COMPLETED - topology browser fix
+- **Blockers encountered:** None
+- **Files modified:**
+  - `src/launcher_tui/topology_mixin.py` - Fixed browser visualization to use node tracker data
+  - `.claude/session_notes/2026-02-05_session_tracking_setup.md` - This file
+- **Commits made:** 2 (session notes + topology fix)
 - **Next steps:**
-  - Determine if 0 nodes is expected (services not running)
-  - If bug, fix it
-  - Alpha branch work if user requests
+  - Test topology browser with live meshtasticd/rnsd services
+  - Alpha branch work: NanoVNA plugin, firmware flashing

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -644,12 +644,71 @@ class TopologyMixin:
             from utils.topology_visualizer import TopologyVisualizer
 
             topology = self._get_topology()
-            if topology is None:
+            tracker = self._get_node_tracker()
+
+            if topology is None and tracker is None:
                 self.dialog.msgbox("Unavailable", "Topology module not loaded.")
                 return
 
-            # Generate visualization
-            visualizer = TopologyVisualizer.from_topology(topology)
+            # Generate visualization - start with topology data
+            if topology:
+                visualizer = TopologyVisualizer.from_topology(topology)
+            else:
+                visualizer = TopologyVisualizer()
+                visualizer.add_node("local", name="Local Node", node_type="local", network="rns")
+
+            # Enrich with node tracker data (has richer Meshtastic node info)
+            if tracker and hasattr(tracker, 'get_all_nodes'):
+                try:
+                    for node in tracker.get_all_nodes():
+                        # Determine node type
+                        if node.network == "rns":
+                            node_type = "rns"
+                        elif node.network == "meshtastic":
+                            node_type = "meshtastic"
+                        elif node.network == "both":
+                            node_type = "both"
+                        else:
+                            node_type = "node"
+
+                        # Check if it's a router/gateway
+                        if node.role and "router" in node.role.lower():
+                            node_type = "router"
+                        elif node.role and "gateway" in node.role.lower():
+                            node_type = "gateway"
+
+                        # Add/update node with rich data
+                        visualizer.add_node(
+                            node_id=node.id,
+                            name=node.name or node.short_name or node.id,
+                            node_type=node_type,
+                            network=node.network,
+                            is_online=getattr(node, 'is_online', False),
+                            hops=node.hops or 0,
+                            latitude=node.latitude,
+                            longitude=node.longitude,
+                            altitude=node.altitude,
+                            metadata={
+                                "hardware": node.hardware_model,
+                                "firmware": node.firmware_version,
+                                "role": node.role,
+                                "snr": node.snr,
+                                "rssi": node.rssi,
+                            }
+                        )
+
+                        # Add edge from local to this node if not already present
+                        if node.id != "local":
+                            visualizer.add_edge(
+                                source="local",
+                                target=node.id,
+                                hops=node.hops or 1,
+                                snr=node.snr,
+                                rssi=node.rssi,
+                                is_active=getattr(node, 'is_online', False),
+                            )
+                except Exception as e:
+                    logger.debug(f"Error adding tracker nodes to visualizer: {e}")
             output_path = visualizer.generate()
 
             # Detect SSH/headless environment


### PR DESCRIPTION
The D3.js topology visualization was only reading from NetworkTopology (which only tracks RNS path table). Now also incorporates nodes from UnifiedNodeTracker with richer Meshtastic data (GPS, SNR, role, etc.)

https://claude.ai/code/session_011fCZMhbzV1ix7XYoqLvtrU