### PR TITLE
fix: Auto-fix RNS for all failure types, not just 'no shared'

### DIFF
--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -1088,9 +1088,9 @@ class RNSMenuMixin(RNSSnifferMixin):
                 print("\nError: RNS port conflict (Address already in use)")
                 print("Another process is bound to the RNS AutoInterface port.\n")
                 self._diagnose_rns_port_conflict()
-            elif "no shared" in combined.lower():
-                # rnsd not running or share_instance not enabled - AUTO-FIX
-                print("\nNo shared RNS instance available.")
+            elif "no shared" in combined.lower() or "could not" in combined.lower():
+                # RNS connectivity issue - AUTO-FIX
+                print(f"\nRNS connectivity issue detected.")
                 print("MeshForge will attempt to fix this automatically...\n")
 
                 # Attempt automatic fix
@@ -1112,18 +1112,31 @@ class RNSMenuMixin(RNSSnifferMixin):
                     print("  2. Check rnsd logs: sudo journalctl -u rnsd -n 30")
                     print("  3. Restart rnsd: sudo systemctl restart rnsd")
             else:
-                # Generic failure - show output and suggestions
+                # Other failure - still try auto-fix as RNS issues are usually config/service related
                 if result.stdout:
                     print(result.stdout, end='')
-                print(f"\n{tool_name} failed. Possible causes:")
-                print("  - rnsd not running: sudo systemctl start rnsd")
-                print("  - RNS not installed: pipx install rns")
-                if result.stderr and result.stderr.strip():
-                    # Show last 3 lines of stderr for context
-                    err_lines = result.stderr.strip().split('\n')[-3:]
-                    print("\nDetails:")
-                    for line in err_lines:
-                        print(f"  {line}")
+                print(f"\n{tool_name} returned an error. Attempting auto-fix...\n")
+
+                if self._auto_fix_rns_shared_instance():
+                    # Success - retry the original command
+                    print(f"\nRetrying {tool_name}...\n")
+                    retry_result = subprocess.run(
+                        cmd, capture_output=True, text=True, timeout=15
+                    )
+                    if retry_result.returncode == 0 and retry_result.stdout:
+                        print(retry_result.stdout, end='')
+                    elif retry_result.stdout:
+                        print(retry_result.stdout, end='')
+                else:
+                    print("\nAuto-fix did not resolve the issue.")
+                    print("Possible causes:")
+                    print("  - rnsd not running: sudo systemctl start rnsd")
+                    print("  - RNS not installed: pipx install rns")
+                    if result.stderr and result.stderr.strip():
+                        err_lines = result.stderr.strip().split('\n')[-3:]
+                        print("\nDetails:")
+                        for line in err_lines:
+                            print(f"  {line}")
         except FileNotFoundError:
             print(f"\n{tool_name} not found. Is RNS installed?")
             print("Install: pipx install rns")


### PR DESCRIPTION
RNS tools can fail with various error messages (not just 'no shared'). Now attempts auto-fix for ANY RNS failure (except address conflicts), since the root cause is usually config/service issues.

https://claude.ai/code/session_011fCZMhbzV1ix7XYoqLvtrU