### PR TITLE
fix: RNS auto-fix only triggers for shared instance errors, View Node…

### DIFF
--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -1130,8 +1130,8 @@ class RNSMenuMixin(RNSSnifferMixin):
                 print("\nError: RNS port conflict (Address already in use)")
                 print("Another process is bound to the RNS AutoInterface port.\n")
                 self._diagnose_rns_port_conflict()
-            elif "no shared" in combined.lower() or "could not" in combined.lower():
-                # RNS connectivity issue - AUTO-FIX
+            elif "no shared" in combined.lower() or "could not connect" in combined.lower() or "shared instance" in combined.lower() or "authenticationerror" in combined.lower() or "digest" in combined.lower():
+                # RNS shared instance issue - AUTO-FIX
                 print(f"\nRNS connectivity issue detected.")
                 print("MeshForge will attempt to fix this automatically...\n")
 
@@ -1154,30 +1154,16 @@ class RNSMenuMixin(RNSSnifferMixin):
                     print("  2. Check rnsd logs: sudo journalctl -u rnsd -n 30")
                     print("  3. Restart rnsd: sudo systemctl restart rnsd")
             else:
-                # Other failure - still try auto-fix as RNS issues are usually config/service related
+                # Other error - DON'T auto-fix, just show output
+                # RNS tools may return non-zero for benign reasons (empty table, no paths)
                 if result.stdout:
                     print(result.stdout, end='')
-                print(f"\n{tool_name} returned an error. Attempting auto-fix...\n")
-
-                if self._auto_fix_rns_shared_instance():
-                    # Success - retry the original command
-                    print(f"\nRetrying {tool_name}...\n")
-                    retry_result = subprocess.run(
-                        cmd, capture_output=True, text=True, timeout=15
-                    )
-                    if retry_result.returncode == 0 and retry_result.stdout:
-                        print(retry_result.stdout, end='')
-                    elif retry_result.stdout:
-                        print(retry_result.stdout, end='')
-                else:
-                    print("\nAuto-fix did not resolve the issue.")
-                    print("Possible causes:")
-                    print("  - rnsd not running: sudo systemctl start rnsd")
-                    print("  - RNS not installed: pipx install rns")
-                    if result.stderr and result.stderr.strip():
-                        err_lines = result.stderr.strip().split('\n')[-3:]
-                        print("\nDetails:")
-                        for line in err_lines:
+                if result.stderr and result.stderr.strip():
+                    # Only show stderr if it contains actual error info
+                    stderr_lower = result.stderr.lower()
+                    if "error" in stderr_lower or "failed" in stderr_lower or "exception" in stderr_lower:
+                        print(f"\nNote: {tool_name} reported an issue:")
+                        for line in result.stderr.strip().split('\n')[-3:]:
                             print(f"  {line}")
         except FileNotFoundError:
             print(f"\n{tool_name} not found. Is RNS installed?")

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -188,42 +188,60 @@ class TopologyMixin:
     def _show_topology_nodes(self):
         """Show list of nodes in the topology."""
         topology = self._get_topology()
+        tracker = self._get_node_tracker()
 
-        if topology is None:
+        if topology is None and tracker is None:
             self.dialog.msgbox("Unavailable", "Topology module not loaded.")
             return
 
         try:
-            topo_dict = topology.to_dict()
-            nodes = topo_dict.get("nodes", [])
+            # Collect nodes from both topology and node tracker
+            all_nodes = {}  # node_id -> (display_name, node_type)
 
-            if not nodes:
-                self.dialog.msgbox("No Nodes", "No nodes discovered in the topology yet.")
+            # Get nodes from topology (RNS path table)
+            if topology:
+                topo_dict = topology.to_dict()
+                for node_id in topo_dict.get("nodes", []):
+                    if node_id == "local":
+                        all_nodes[node_id] = ("Local Node", "local")
+                    elif node_id.startswith("rns_"):
+                        all_nodes[node_id] = (node_id[:12], "RNS")
+                    else:
+                        all_nodes[node_id] = (node_id[:12], "Network")
+
+            # Get nodes from node tracker (has richer Meshtastic data)
+            if tracker and hasattr(tracker, 'get_all_nodes'):
+                for node in tracker.get_all_nodes():
+                    name = node.name or node.short_name or node.id
+                    if node.network == "meshtastic":
+                        node_type = "Mesh"
+                    elif node.network == "rns":
+                        node_type = "RNS"
+                    elif node.network == "both":
+                        node_type = "Bridge"
+                    else:
+                        node_type = "Node"
+                    # Add online indicator
+                    status = "+" if getattr(node, 'is_online', False) else "-"
+                    all_nodes[node.id] = (name, f"{node_type}{status}")
+
+            if not all_nodes:
+                self.dialog.msgbox("No Nodes", "No nodes discovered yet.\n\nNodes appear when:\n- RNS discovers paths\n- Meshtastic nodes are seen\n- Gateway bridge is running")
                 return
 
-            # Build node list for menu
+            # Build node list for menu (sort by name, limit to 50)
             node_choices = []
-            for node_id in sorted(nodes)[:50]:  # Limit to 50 for TUI
-                # Truncate long IDs
-                display_id = node_id[:30] if len(node_id) > 30 else node_id
-
-                # Determine node type
-                if node_id == "local":
-                    desc = "Local Node"
-                elif node_id.startswith("rns_"):
-                    desc = "RNS Destination"
-                elif node_id.startswith("mesh_") or node_id.startswith("!"):
-                    desc = "Meshtastic Node"
-                else:
-                    desc = "Network Node"
-
-                node_choices.append((node_id, f"{display_id} [{desc}]"))
+            sorted_nodes = sorted(all_nodes.items(), key=lambda x: x[1][0].lower())[:50]
+            for node_id, (name, node_type) in sorted_nodes:
+                # Truncate long names
+                display_name = name[:25] if len(name) > 25 else name
+                node_choices.append((node_id, f"{display_name} [{node_type}]"))
 
             node_choices.append(("back", "Back"))
 
             selected = self.dialog.menu(
                 "Network Nodes",
-                f"Found {len(nodes)} nodes:",
+                f"Found {len(all_nodes)} nodes:",
                 node_choices
             )
 


### PR DESCRIPTION
…s uses tracker

Two fixes:

1. RNS auto-fix was triggering on ANY non-zero exit code from RNS tools. This caused "Attempting auto-fix..." on every status check even when RNS was working fine but had empty data. Now auto-fix only triggers for:
   - "no shared instance" errors
   - "could not connect" errors
   - Authentication/digest errors Non-zero exit codes with no error indicators just show output normally.

2. View Nodes menu now shows nodes from both NetworkTopology (RNS paths) AND UnifiedNodeTracker (Meshtastic nodes), consistent with the topology browser. This fixes "No nodes discovered" when 372 nodes exist in tracker.

https://claude.ai/code/session_01WYPiYsPuFACHJMrkpFMbt1