### PR TITLE
feat: Gateway auto-starts metrics server, MQTT connect has timeout

### DIFF
--- a/src/gateway/bridge_cli.py
+++ b/src/gateway/bridge_cli.py
@@ -26,6 +26,9 @@ logging.basicConfig(
 )
 logger = logging.getLogger('gateway.cli')
 
+# Metrics server instance (auto-started with gateway)
+_metrics_server = None
+
 
 def preflight_checks(config: GatewayConfig) -> bool:
     """
@@ -119,6 +122,8 @@ def on_message(msg):
 
 def main():
     """Main entry point."""
+    global _metrics_server
+
     print("\n" + "="*50)
     print("  MeshForge Gateway Bridge")
     print("  RNS <-> Meshtastic Message Bridge")
@@ -167,6 +172,16 @@ def main():
 
         bridge_started = True
         print("Gateway started successfully!")
+
+        # Auto-start metrics server for Grafana integration
+        try:
+            from utils.metrics_export import start_metrics_server
+            _metrics_server = start_metrics_server(port=9090)
+            print("Metrics server started on http://localhost:9090/metrics")
+            print("  Grafana JSON API: http://localhost:9090/api/json/metrics")
+        except Exception as e:
+            logger.debug(f"Metrics server not started: {e}")
+
         print("Press Ctrl+C to stop\n")
 
         # Wait for connections before showing initial status
@@ -202,6 +217,15 @@ def main():
         traceback.print_exc()
 
     finally:
+        # Stop metrics server if running
+        if _metrics_server:
+            try:
+                _metrics_server.stop()
+                logger.debug("Metrics server stopped")
+            except Exception:
+                pass
+            _metrics_server = None
+
         # Only stop if we successfully started
         if bridge_started:
             print("Stopping gateway...")

--- a/src/monitoring/mqtt_subscriber.py
+++ b/src/monitoring/mqtt_subscriber.py
@@ -295,13 +295,29 @@ class MQTTNodelessSubscriber:
             if self._config.get("use_tls", True):
                 self._setup_tls()
 
-            # Connect
+            # Connect with timeout to prevent hanging
             broker = self._config.get("broker", DEFAULT_BROKER)
             port = self._config.get("port", DEFAULT_PORT_TLS)
+            connect_timeout = self._config.get("connect_timeout", 10)  # 10 second default
 
             logger.info(f"Connecting to MQTT broker {broker}:{port}")
-            self._client.connect(broker, port, keepalive=60)
+
+            # Set socket timeout before connecting
+            import socket
+            self._client.socket().settimeout(connect_timeout) if self._client.socket() else None
+
+            # Use connect_async for non-blocking connection
+            self._client.connect_async(broker, port, keepalive=60)
             self._client.loop_start()
+
+            # Wait for connection with timeout
+            start_time = time.time()
+            while not self._connected and (time.time() - start_time) < connect_timeout:
+                time.sleep(0.1)
+
+            if not self._connected:
+                logger.warning(f"Connection to {broker}:{port} timed out after {connect_timeout}s")
+                # Connection will continue trying in background due to loop_start()
 
             return True
 
@@ -335,11 +351,25 @@ class MQTTNodelessSubscriber:
                 )
 
     def _disconnect(self) -> None:
-        """Disconnect from MQTT broker."""
+        """Disconnect from MQTT broker with timeout."""
         if self._client:
             try:
-                self._client.loop_stop()
-                self._client.disconnect()
+                # loop_stop with wait=True can hang, use timeout thread
+                import threading
+
+                def stop_loop():
+                    try:
+                        self._client.loop_stop(force=True)
+                        self._client.disconnect()
+                    except Exception:
+                        pass
+
+                stop_thread = threading.Thread(target=stop_loop, daemon=True)
+                stop_thread.start()
+                stop_thread.join(timeout=5.0)  # 5 second max wait
+
+                if stop_thread.is_alive():
+                    logger.warning("MQTT disconnect timed out, forcing cleanup")
             except Exception as e:
                 logger.debug(f"Disconnect cleanup: {e}")
             self._client = None


### PR DESCRIPTION
Two improvements:

1. Gateway bridge now auto-starts Prometheus metrics server on port 9090 when the bridge starts. Grafana can now get data automatically via:
   - /metrics (Prometheus format)
   - /api/json/metrics (JSON for Infinity plugin) Metrics server stops cleanly when gateway stops.

2. MQTT subscriber now has connect timeout (default 10s) to prevent hangs when broker is unreachable. Uses connect_async for non-blocking connection. Disconnect also has 5s timeout to prevent shutdown hangs.

https://claude.ai/code/session_01WYPiYsPuFACHJMrkpFMbt1