### PR TITLE
feat: Bump to v0.5.1-beta, deprecate alpha branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.5.0--beta-blue.svg" alt="Version"></a>
+  <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.5.1--beta-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-green.svg" alt="License"></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/python-3.9+-yellow.svg" alt="Python"></a>
   <a href="https://github.com/Nursedude/meshforge/actions"><img src="https://img.shields.io/badge/tests-2963%20functions-brightgreen.svg" alt="Tests"></a>
@@ -141,13 +141,10 @@ sudo git pull origin main
 
 ### Switch Branches
 
-The `main` and `alpha` branches are now synchronized. Both contain all features.
+All development is on `main`. The `alpha` branch is deprecated (135 commits behind).
 
 ```bash
-# Check current branch
-git branch
-
-# Switch if needed (both are equivalent)
+# If you're on alpha, switch to main:
 git checkout main
 sudo git pull origin main
 ```
@@ -663,19 +660,11 @@ See [CLAUDE.md](CLAUDE.md) for details.
 
 ---
 
-## Development Branches
+## Development
 
-MeshForge uses a unified development model:
-
-| Branch | Purpose | Status |
-|--------|---------|--------|
-| `main` | Production-ready, all features | **Stable** |
-| `alpha` | Synchronized with main | Unified |
-
-All features are now in `main`. The `alpha` branch tracks `main` for users who prefer the alpha naming convention.
+Single-branch model on `main`. Feature branches via `claude/` prefix, merged by PR.
 
 ```bash
-# Install (main branch)
 git clone https://github.com/Nursedude/meshforge.git
 cd meshforge
 sudo bash scripts/install_noc.sh

--- a/src/__version__.py
+++ b/src/__version__.py
@@ -3,9 +3,9 @@ MeshForge - LoRa Mesh Network Development & Operations Suite
 Version information and changelog
 """
 
-__version__ = "0.5.0-beta"
-__version_info__ = (0, 5, 0, 'beta')
-__release_date__ = "2026-02-01"
+__version__ = "0.5.1-beta"
+__version_info__ = (0, 5, 1, 'beta')
+__release_date__ = "2026-02-06"
 __app_name__ = "MeshForge"
 __app_description__ = "LoRa Mesh Network Development & Operations Suite"
 __app_tagline__ = "Build. Test. Deploy. Monitor."
@@ -14,6 +14,33 @@ __status__ = "beta"  # alpha=experimental, beta=testing, stable=production
 
 # Version history
 VERSION_HISTORY = [
+    {
+        "version": "0.5.1-beta",
+        "date": "2026-02-06",
+        "status": "beta",
+        "changes": [
+            "NEW: Full telemetry pipeline — sensor data through Prometheus, InfluxDB, Grafana",
+            "NEW: Gateway auto-starts metrics server, MQTT connect with timeout",
+            "NEW: Auto-fix RNS shared instance on 'no shared' error",
+            "NEW: Meshtastic 2.7+ favorites management, PKI status, health metrics",
+            "NEW: Wireshark-grade RNS packet sniffer",
+            "NEW: MQTT auto-start and local broker multi-consumer architecture",
+            "NEW: MQTT → WebSocket bridge for web UI access",
+            "NEW: Startup warning for root without SUDO_USER",
+            "FIX: Gateway bridge connects to RNS as shared instance client",
+            "FIX: MQTT subscriber hang on exit (4 root causes)",
+            "FIX: Bind metrics server to localhost only (security)",
+            "FIX: Path.home() violations in 6 files (MF001 audit)",
+            "FIX: shell=True in updates_mixin.py (MF002)",
+            "FIX: License mismatch in TUI about screen (MIT → GPL-3.0)",
+            "FIX: _frequency_calculator() undefined method → _calc_frequency_slot()",
+            "REFACTOR: TUI Maps & Viz menu routes directly to map functions",
+            "REFACTOR: Removed dead _handle_choice() and _network_tools_submenu()",
+            "REFACTOR: Extracted rns_sniffer_mixin, metrics modules, diagnostic checks",
+            "DOCS: README updated with TUI menu structure, code health, raspi-config patterns",
+            "DOCS: Single-branch model — alpha branch deprecated",
+        ]
+    },
     {
         "version": "0.5.0-beta",
         "date": "2026-02-01",


### PR DESCRIPTION
Version 0.5.1-beta captures 100+ commits since 0.5.0:
- Full telemetry pipeline (Prometheus/InfluxDB/Grafana)
- Gateway bridge RNS shared instance fix
- MQTT hang fix, auto-start, WebSocket bridge
- Meshtastic 2.7+ favorites, PKI, health metrics
- RNS packet sniffer, auto-fix shared instance
- MF001/MF002 audit fixes, TUI routing cleanup

Branch model: single-branch on main. Alpha is 135 commits behind and deprecated — README updated to reflect reality.

https://claude.ai/code/session_012LMthQcxwyzvn5rs7YJs3x