### PR TITLE
fix: AREDN port 80→8080 (root cause of scanner never working), MQTT p…

### DIFF
--- a/src/launcher_tui/aredn_mixin.py
+++ b/src/launcher_tui/aredn_mixin.py
@@ -54,7 +54,7 @@ class AREDNMixin:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(2)
                 try:
-                    result = sock.connect_ex((host, 80))
+                    result = sock.connect_ex((host, 8080))  # AREDN serves on 8080
                     if result == 0:
                         return host
                 finally:

--- a/src/launcher_tui/mqtt_mixin.py
+++ b/src/launcher_tui/mqtt_mixin.py
@@ -466,6 +466,7 @@ class MQTTMixin:
             choices = [
                 ("local", f"Use Local Broker    Quick: localhost:1883"),
                 ("public", f"Use Public Broker   Quick: mqtt.meshtastic.org"),
+                ("private", "Use Private Broker  Custom: your own broker"),
                 ("broker", f"Broker              {broker}"),
                 ("port", f"Port                {port}"),
                 ("topic", f"Topic               {topic[:30]}..."),
@@ -530,6 +531,11 @@ class MQTTMixin:
                     "  TLS: enabled\n\n"
                     "This is nodeless monitoring - no local radio needed."
                 )
+                break
+
+            elif choice == "private":
+                # Guided setup for a private/custom MQTT broker
+                self._configure_private_broker(config)
                 break
 
             elif choice == "broker":
@@ -949,6 +955,109 @@ class MQTTMixin:
             'username': None,
             'password': None
         }
+
+    def _configure_private_broker(self, config: Dict[str, Any]):
+        """Guided setup for a private MQTT broker.
+
+        Walks through all required fields with sensible defaults for
+        a private/regional mesh broker (e.g. HawaiiNet, local Mosquitto).
+
+        Important: root_topic controls how many nodes you see.
+        Using 'msh' gets everything; 'msh/US/2/e' filters to US region.
+        """
+        broker = self.dialog.inputbox(
+            "Broker Address",
+            "Enter your private MQTT broker hostname or IP:\n\n"
+            "Examples:\n"
+            "  gt.wildc.net\n"
+            "  192.168.1.100\n"
+            "  mqtt.local",
+            init=config.get('broker', '')
+        )
+        if not broker:
+            return
+
+        port = self.dialog.inputbox(
+            "Broker Port",
+            "Enter MQTT port:\n\n"
+            "  1883 = Plain TCP\n"
+            "  1884 = Alternative plain TCP\n"
+            "  8883 = TLS encrypted",
+            init=str(config.get('port', 1883))
+        )
+        if not port or not port.isdigit():
+            return
+
+        username = self.dialog.inputbox(
+            "Username",
+            "MQTT username (blank for anonymous):",
+            init=config.get('username', '')
+        )
+
+        password = self.dialog.inputbox(
+            "Password",
+            "MQTT password (blank for none):",
+            init=''
+        )
+
+        # Root topic — this is the key to controlling node count
+        root_topic = self.dialog.inputbox(
+            "Root Topic",
+            "MQTT root topic — controls which nodes you see:\n\n"
+            "  msh           = ALL nodes (can be 5000+)\n"
+            "  msh/US        = US region only\n"
+            "  msh/US/2/e    = US encrypted channel\n"
+            "  msh/HI        = Hawaii only (if broker supports)\n\n"
+            "Your meshtasticd MQTT module must use the same root topic.",
+            init=config.get('root_topic', 'msh/US/2/e')
+        )
+        if not root_topic:
+            root_topic = "msh/US/2/e"
+
+        channel = self.dialog.inputbox(
+            "Channel Name",
+            "Meshtastic channel to subscribe to:\n\n"
+            "  LongFast   = Default Meshtastic channel\n"
+            "  HawaiiNet  = Regional channel\n"
+            "  meshforge  = Private MeshForge channel\n\n"
+            "Must match your radio's channel configuration.",
+            init=config.get('channel', 'LongFast')
+        )
+        if not channel:
+            channel = "LongFast"
+
+        # Build topic from root + channel
+        topic = f"{root_topic}/{channel}/#"
+
+        use_tls = int(port) == 8883
+
+        new_config = {
+            'broker': broker,
+            'port': int(port),
+            'topic': topic,
+            'root_topic': root_topic,
+            'channel': channel,
+            'username': username if username else None,
+            'password': password if password else None,
+            'use_tls': use_tls,
+        }
+
+        # Preserve auto-start settings
+        new_config['auto_start'] = config.get('auto_start', False)
+        new_config['auto_start_telemetry'] = config.get('auto_start_telemetry', True)
+
+        self._save_mqtt_config(new_config)
+        self.dialog.msgbox(
+            "Private Broker Configured",
+            f"Saved configuration:\n\n"
+            f"  Broker:   {broker}:{port}\n"
+            f"  Topic:    {topic}\n"
+            f"  Channel:  {channel}\n"
+            f"  Username: {username or '(anonymous)'}\n"
+            f"  TLS:      {'Yes' if use_tls else 'No'}\n\n"
+            f"Root topic '{root_topic}' determines node scope.\n"
+            f"Restart MQTT subscriber to apply."
+        )
 
     def _save_mqtt_config(self, config: Dict[str, Any]):
         """Save MQTT configuration to file."""

--- a/src/utils/aredn.py
+++ b/src/utils/aredn.py
@@ -127,8 +127,8 @@ class AREDNNode:
     @property
     def base_url(self) -> str:
         if self.ip:
-            return f"http://{self.ip}"
-        return f"http://{self.hostname}.local.mesh"
+            return f"http://{self.ip}:8080"
+        return f"http://{self.hostname}.local.mesh:8080"
 
     def to_dict(self) -> Dict:
         return {
@@ -166,24 +166,28 @@ class AREDNClient:
     """
 
     DEFAULT_TIMEOUT = 5
+    DEFAULT_PORT = 8080  # AREDN nodes serve HTTP on port 8080, not 80
 
-    def __init__(self, hostname_or_ip: str, timeout: int = DEFAULT_TIMEOUT):
+    def __init__(self, hostname_or_ip: str, timeout: int = DEFAULT_TIMEOUT,
+                 port: int = DEFAULT_PORT):
         """
         Initialize AREDN client.
 
         Args:
             hostname_or_ip: Node hostname (without .local.mesh) or IP address
             timeout: Request timeout in seconds
+            port: HTTP port (default 8080 — standard AREDN port)
         """
         self.hostname = hostname_or_ip
         self.timeout = timeout
+        self.port = port
 
-        # Determine base URL
+        # Determine base URL — AREDN uses port 8080
         if self._is_ip(hostname_or_ip):
-            self.base_url = f"http://{hostname_or_ip}"
+            self.base_url = f"http://{hostname_or_ip}:{port}"
             self.ip = hostname_or_ip
         else:
-            self.base_url = f"http://{hostname_or_ip}.local.mesh"
+            self.base_url = f"http://{hostname_or_ip}.local.mesh:{port}"
             self.ip = None
 
     def _is_ip(self, value: str) -> bool:

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -958,7 +958,8 @@ class MapDataCollector:
                 sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 sock.settimeout(2)
                 try:
-                    result = sock.connect_ex((host, 80))
+                    # AREDN nodes serve HTTP on port 8080, not 80
+                    result = sock.connect_ex((host, 8080))
                     if result == 0:
                         return host
                 finally:

--- a/tests/test_aredn_integration.py
+++ b/tests/test_aredn_integration.py
@@ -340,16 +340,16 @@ class TestAREDNClientIPDetection:
     """Test IP vs hostname detection."""
 
     def test_ip_detection(self):
-        """Test that IP addresses are correctly detected."""
+        """Test that IP addresses are correctly detected with port 8080."""
         client = AREDNClient("10.54.25.2")
         assert client.ip == "10.54.25.2"
-        assert client.base_url == "http://10.54.25.2"
+        assert client.base_url == "http://10.54.25.2:8080"
 
     def test_hostname_detection(self):
-        """Test that hostnames use .local.mesh suffix."""
+        """Test that hostnames use .local.mesh suffix with port 8080."""
         client = AREDNClient("WH6GXZ-meshforge")
         assert client.ip is None
-        assert client.base_url == "http://WH6GXZ-meshforge.local.mesh"
+        assert client.base_url == "http://WH6GXZ-meshforge.local.mesh:8080"
 
 
 class TestAREDNNodeDataclass:
@@ -371,14 +371,14 @@ class TestAREDNNodeDataclass:
         assert node.has_location() is False
 
     def test_base_url_with_ip(self):
-        """Test base_url uses IP when available."""
+        """Test base_url uses IP with port 8080."""
         node = AREDNNode(hostname="test", ip="10.54.25.2")
-        assert node.base_url == "http://10.54.25.2"
+        assert node.base_url == "http://10.54.25.2:8080"
 
     def test_base_url_without_ip(self):
-        """Test base_url uses .local.mesh when no IP."""
+        """Test base_url uses .local.mesh with port 8080."""
         node = AREDNNode(hostname="WH6GXZ-node")
-        assert node.base_url == "http://WH6GXZ-node.local.mesh"
+        assert node.base_url == "http://WH6GXZ-node.local.mesh:8080"
 
     def test_to_dict(self):
         """Test serialization to dict."""


### PR DESCRIPTION
…rivate broker

AREDN scanner has never found user's MikroTik routers because AREDNClient connected to port 80 while AREDN nodes serve on 8080.

- AREDNClient: base_url now includes :8080 (configurable via port param)
- AREDNNode.base_url property: includes :8080
- aredn_mixin._aredn_get_node_ip: probes port 8080 instead of 80
- map_data_collector._get_aredn_node_ip: probes port 8080
- Updated all tests to expect :8080 in URLs

MQTT: Added "Use Private Broker" guided setup to TUI config menu. Walks through broker/port/username/password/root_topic/channel with explanations of how root_topic controls node scope (msh = 5000+ nodes vs msh/US/2/e = regional). Preserves auto-start settings.

https://claude.ai/code/session_012LMthQcxwyzvn5rs7YJs3x