### PR TITLE
feat: Wire environment-aware path loss into multihop and preset_impact

### DIFF
--- a/src/launcher_tui/site_planner_mixin.py
+++ b/src/launcher_tui/site_planner_mixin.py
@@ -6,6 +6,24 @@ antenna guidelines, and external tool references.
 Extracted from main.py to reduce file size.
 """
 
+from utils.rf import DeployEnvironment, BuildingType
+
+
+# Menu labels for environment selection
+_ENV_CHOICES = [
+    ("free_space", "Free Space / Clear LOS"),
+    ("rural_open", "Rural Open Terrain"),
+    ("suburban", "Suburban / Residential"),
+    ("urban_elevated", "Urban w/ Elevated Gateway"),
+    ("urban_ground", "Urban Ground Level"),
+    ("dense_urban", "Dense Urban / Downtown"),
+    ("forest", "Forest / Heavy Vegetation"),
+    ("over_water", "Over Water / Coastal"),
+    ("indoor", "Indoor (same building)"),
+]
+
+_ENV_MAP = {v.value: v for v in DeployEnvironment}
+
 
 class SitePlannerMixin:
     """Mixin providing site planner methods for the launcher."""
@@ -48,112 +66,127 @@ class SitePlannerMixin:
             elif choice == "tools":
                 self._external_tools()
 
+    def _select_environment(self):
+        """Let the user pick a deployment environment.
+
+        Returns:
+            DeployEnvironment or None if cancelled.
+        """
+        choice = self.dialog.menu(
+            "Environment",
+            "Select deployment environment:",
+            _ENV_CHOICES,
+        )
+        if choice is None:
+            return None
+        return _ENV_MAP.get(choice, DeployEnvironment.SUBURBAN)
+
     def _estimate_range(self):
-        """Estimate communication range based on parameters."""
-        # Get TX power
-        tx_pwr = self.dialog.inputbox("Range Estimator", "TX Power (dBm):", "20")
+        """Estimate communication range using environment-aware model."""
+        from utils.preset_impact import PresetAnalyzer, PRESET_PARAMS
+
+        # TX power
+        tx_pwr = self.dialog.inputbox("Range Estimator", "TX Power (dBm):", "22")
         if not tx_pwr:
             return
 
-        # Get antenna gains
-        ant_gain = self.dialog.inputbox("Range Estimator", "Total Antenna Gain (dBi):", "4")
+        # Antenna gain
+        ant_gain = self.dialog.inputbox("Range Estimator", "Total Antenna Gain (dBi):", "4.3")
         if not ant_gain:
             return
 
-        # Get preset
-        presets = [
-            ("SHORT_TURBO", "-105 dBm sensitivity"),
-            ("SHORT_FAST", "-110 dBm sensitivity"),
-            ("MEDIUM_FAST", "-120 dBm sensitivity"),
-            ("LONG_FAST", "-125 dBm sensitivity"),
-            ("LONG_SLOW", "-132 dBm sensitivity"),
-        ]
+        # Antenna height
+        ant_height = self.dialog.inputbox("Range Estimator", "Antenna Height (m):", "2")
+        if not ant_height:
+            return
 
+        # Preset selection
+        preset_choices = [
+            (name, params['desc'])
+            for name, params in PRESET_PARAMS.items()
+        ]
         preset = self.dialog.menu(
             "Select Preset",
             "Choose LoRa modem preset:",
-            presets
+            preset_choices,
         )
-
         if not preset:
             return
 
-        # Sensitivity values
-        sens_map = {
-            "SHORT_TURBO": -105,
-            "SHORT_FAST": -110,
-            "MEDIUM_FAST": -120,
-            "LONG_FAST": -125,
-            "LONG_SLOW": -132,
-        }
+        # Environment selection
+        env = self._select_environment()
+        if env is None:
+            return
 
         try:
-            import math
             tx_p = float(tx_pwr)
             ant_g = float(ant_gain)
-            sens = sens_map.get(preset, -125)
+            ant_h = float(ant_height)
 
-            # Link budget
-            link_budget = tx_p + ant_g - sens
+            analyzer = PresetAnalyzer(
+                tx_power_dbm=int(tx_p),
+                tx_gain_dbi=ant_g / 2,
+                rx_gain_dbi=ant_g / 2,
+                environment=env,
+                antenna_height_m=ant_h,
+            )
+            impact = analyzer.analyze_preset(preset)
 
-            # Estimate range using FSPL formula (915 MHz)
-            # FSPL = 20*log10(d) + 20*log10(f) + 32.45
-            # d = 10^((FSPL - 20*log10(f) - 32.45) / 20)
-            freq_mhz = 915
-            max_fspl = link_budget
-            range_km = 10 ** ((max_fspl - 20 * math.log10(freq_mhz) - 32.45) / 20)
+            # Also show LOS reference
+            los_analyzer = PresetAnalyzer(
+                tx_power_dbm=int(tx_p),
+                tx_gain_dbi=ant_g / 2,
+                rx_gain_dbi=ant_g / 2,
+                environment=DeployEnvironment.FREE_SPACE,
+                antenna_height_m=ant_h,
+            )
+            los_impact = los_analyzer.analyze_preset(preset)
 
-            # Apply terrain factor (0.3-0.7 of theoretical)
-            los_range = range_km
-            urban_range = range_km * 0.3
-            rural_range = range_km * 0.5
+            env_label = dict(_ENV_CHOICES).get(env.value, env.value)
 
-            text = f"""Range Estimation:
+            text = f"""Range Estimation ({env_label}):
 
 Preset: {preset}
-TX Power: {tx_p} dBm
+TX Power: {tx_p:.0f} dBm
 Antenna Gain: {ant_g} dBi
-RX Sensitivity: {sens} dBm
+Antenna Height: {ant_h} m
+Sensitivity: {impact.sensitivity_dbm:.1f} dBm
+Link Budget: {impact.link_budget_db:.1f} dB
 
-Link Budget: {link_budget:.1f} dB
+Estimated Max Range (915 MHz):
+  {env_label}: {impact.max_range_km:.1f} km
+  Free Space (LOS ref): {los_impact.max_range_km:.1f} km
 
-Estimated Range (915 MHz):
-  Line of Sight: {los_range:.1f} km
-  Rural/Suburban: {rural_range:.1f} km
-  Urban/Dense: {urban_range:.1f} km
+Coverage Area: {impact.coverage_area_km2:.1f} km2
+Airtime: {impact.airtime_ms:.0f} ms
+Throughput: {impact.throughput_bps / 1000:.2f} kbps
 
-Note: Actual range depends on terrain,
-vegetation, and antenna height."""
+Note: Uses log-distance propagation model
+with environment-specific path loss exponent
+and fade margin."""
 
             self.dialog.msgbox("Range Estimation", text)
 
-        except ValueError:
+        except (ValueError, TypeError):
             self.dialog.msgbox("Error", "Invalid number entered")
 
     def _compare_presets(self):
-        """Compare LoRa modem presets."""
-        text = """LoRa Modem Preset Comparison:
+        """Compare LoRa modem presets with environment-aware range."""
+        from utils.preset_impact import PresetAnalyzer, format_comparison_table
 
-Preset          BW    SF  Range     Speed
-──────────────────────────────────────────
-SHORT_TURBO    500   7   <1 km     Fastest
-SHORT_FAST     250   7   1-5 km    Fast
-SHORT_SLOW     125   7   1-5 km    Medium
-MEDIUM_FAST    250   10  5-20 km   Medium
-MEDIUM_SLOW    125   10  5-20 km   Slower
-LONG_FAST      250   11  10-30 km  Default
-LONG_MODERATE  125   11  15-40 km  Slower
-LONG_SLOW      125   12  20-50 km  Slowest
+        # Let user pick environment
+        env = self._select_environment()
+        if env is None:
+            env = DeployEnvironment.FREE_SPACE
 
-Higher SF = Longer range, slower speed
-Lower BW = Better sensitivity, slower speed
+        analyzer = PresetAnalyzer(environment=env)
+        comp = analyzer.compare()
+        table = format_comparison_table(comp)
 
-Recommended:
-  Gateway: SHORT_TURBO or MEDIUM_FAST
-  Rural: LONG_FAST or LONG_MODERATE
-  Urban: SHORT_FAST or MEDIUM_FAST"""
+        env_label = dict(_ENV_CHOICES).get(env.value, env.value)
+        header = f"Preset Comparison ({env_label})"
 
-        self.dialog.msgbox("Preset Comparison", text)
+        self.dialog.msgbox(header, table)
 
     def _antenna_guidelines(self):
         """Show antenna guidelines."""

--- a/src/utils/multihop.py
+++ b/src/utils/multihop.py
@@ -38,6 +38,10 @@ from utils.preset_impact import (
     DEFAULT_FREQ_MHZ,
     DEFAULT_PAYLOAD_BYTES,
 )
+from utils.rf import (
+    DeployEnvironment,
+    log_distance_path_loss,
+)
 
 
 # Meshtastic protocol constants
@@ -198,8 +202,8 @@ def margin_to_probability(margin_db: float) -> float:
 class HopAnalyzer:
     """Analyzes multi-hop paths in a Meshtastic mesh network.
 
-    Combines FSPL propagation with LoRa preset parameters to determine
-    per-hop link quality and end-to-end path reliability.
+    Combines environment-aware propagation with LoRa preset parameters to
+    determine per-hop link quality and end-to-end path reliability.
 
     Args:
         preset: Meshtastic LoRa preset name (e.g., 'LONG_FAST').
@@ -208,6 +212,7 @@ class HopAnalyzer:
         payload_bytes: Payload size for airtime calculation.
         tx_gain_dbi: Transmit antenna gain.
         rx_gain_dbi: Receive antenna gain.
+        environment: Deployment environment for path loss modeling.
     """
 
     def __init__(self,
@@ -216,7 +221,8 @@ class HopAnalyzer:
                  freq_mhz: float = DEFAULT_FREQ_MHZ,
                  payload_bytes: int = DEFAULT_PAYLOAD_BYTES,
                  tx_gain_dbi: float = 2.15,
-                 rx_gain_dbi: float = 2.15):
+                 rx_gain_dbi: float = 2.15,
+                 environment: DeployEnvironment = DeployEnvironment.FREE_SPACE):
         if preset not in PRESET_PARAMS:
             raise ValueError(f"Unknown preset: {preset}")
 
@@ -226,6 +232,7 @@ class HopAnalyzer:
         self.payload_bytes = payload_bytes
         self.tx_gain_dbi = tx_gain_dbi
         self.rx_gain_dbi = rx_gain_dbi
+        self.environment = environment
 
         # Pre-calculate preset-dependent values
         self._analyzer = PresetAnalyzer(
@@ -250,8 +257,8 @@ class HopAnalyzer:
     def analyze_hop(self, from_node: RelayNode, to_node: RelayNode) -> HopResult:
         """Analyze a single hop between two nodes.
 
-        Calculates FSPL, link margin, and success probability for the
-        link between from_node and to_node.
+        Uses environment-aware log-distance path loss model when an
+        environment is set, falling back to FSPL for FREE_SPACE.
 
         Args:
             from_node: Transmitting node.
@@ -265,8 +272,9 @@ class HopAnalyzer:
                                to_node.lat, to_node.lon)
         dist_m = max(dist_km * 1000, 1.0)  # Minimum 1m to avoid log(0)
 
-        # FSPL
-        path_loss = fspl_db(dist_m, self.freq_mhz)
+        # Environment-aware path loss (log-distance model)
+        path_loss = log_distance_path_loss(dist_m, self.freq_mhz,
+                                           environment=self.environment)
 
         # Transmit power (node-specific or default)
         tx_power = from_node.tx_power_dbm or self.tx_power_dbm
@@ -401,6 +409,7 @@ class HopAnalyzer:
                 payload_bytes=self.payload_bytes,
                 tx_gain_dbi=self.tx_gain_dbi,
                 rx_gain_dbi=self.rx_gain_dbi,
+                environment=self.environment,
             )
             results.append(analyzer.analyze_path(nodes))
 
@@ -460,7 +469,7 @@ def format_path_report(result: PathResult) -> str:
         lines.append(
             f"  Hop {i}: {hop.from_node} → {hop.to_node}")
         lines.append(
-            f"         {hop.distance_km:.1f} km  |  FSPL {hop.fspl_db:.1f} dB  |  "
+            f"         {hop.distance_km:.1f} km  |  PL {hop.fspl_db:.1f} dB  |  "
             f"Margin {hop.link_margin_db:+.1f} dB [{margin_indicator}]  |  "
             f"P(success) {prob_pct:.0f}%")
         lines.append("")

--- a/src/utils/preset_impact.py
+++ b/src/utils/preset_impact.py
@@ -31,6 +31,13 @@ import math
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
+from utils.rf import (
+    DeployEnvironment,
+    BuildingType,
+    realistic_max_range,
+    radio_horizon_km,
+)
+
 
 # LoRa PHY constants
 NOISE_FIGURE_DB = 6.0  # Typical for SX1262/SX1276
@@ -153,8 +160,8 @@ PRESET_PARAMS = {
 class PresetAnalyzer:
     """Analyzes LoRa preset impact on coverage and performance.
 
-    Combines LoRa PHY calculations (sensitivity, airtime) with RF
-    propagation models (FSPL, link budget) to produce actionable
+    Combines LoRa PHY calculations (sensitivity, airtime) with
+    environment-aware propagation models to produce actionable
     coverage comparisons.
     """
 
@@ -163,7 +170,10 @@ class PresetAnalyzer:
                  tx_gain_dbi: float = DEFAULT_TX_GAIN_DBI,
                  rx_gain_dbi: float = DEFAULT_RX_GAIN_DBI,
                  freq_mhz: float = DEFAULT_FREQ_MHZ,
-                 payload_bytes: int = DEFAULT_PAYLOAD_BYTES):
+                 payload_bytes: int = DEFAULT_PAYLOAD_BYTES,
+                 environment: DeployEnvironment = DeployEnvironment.FREE_SPACE,
+                 building: BuildingType = BuildingType.NONE,
+                 antenna_height_m: float = 2.0):
         """Initialize analyzer with radio parameters.
 
         Args:
@@ -172,12 +182,18 @@ class PresetAnalyzer:
             rx_gain_dbi: Receive antenna gain in dBi.
             freq_mhz: Operating frequency in MHz.
             payload_bytes: Payload size for airtime calculation.
+            environment: Deployment environment for path loss modeling.
+            building: Building type at RX end (adds penetration loss).
+            antenna_height_m: Antenna height above ground in meters.
         """
         self.tx_power_dbm = tx_power_dbm
         self.tx_gain_dbi = tx_gain_dbi
         self.rx_gain_dbi = rx_gain_dbi
         self.freq_mhz = freq_mhz
         self.payload_bytes = payload_bytes
+        self.environment = environment
+        self.building = building
+        self.antenna_height_m = antenna_height_m
 
     def sensitivity(self, spreading_factor: int, bandwidth_hz: int) -> float:
         """Calculate receiver sensitivity for given LoRa parameters.
@@ -305,16 +321,22 @@ class PresetAnalyzer:
         # Link budget = TX power + gains - sensitivity
         lb = self.tx_power_dbm + self.tx_gain_dbi + self.rx_gain_dbi - sens
 
-        # Max range from FSPL
-        max_range_m = self.max_range_fspl(lb, self.freq_mhz)
+        # Max range using environment-aware log-distance model
+        if self.environment == DeployEnvironment.FREE_SPACE:
+            # Pure FSPL for backwards compatibility and LOS reference
+            max_range_m = self.max_range_fspl(lb, self.freq_mhz)
+        else:
+            max_range_m = realistic_max_range(
+                lb, self.freq_mhz,
+                environment=self.environment,
+                building=self.building,
+            )
         max_range_km = max_range_m / 1000.0
 
-        # Earth curvature limit (radio horizon for ground-level antennas)
-        # d_horizon = sqrt(2 * R * h) for 4/3 earth model
-        # At 10m antenna height: ~13 km radio horizon
-        # For elevated terrain, much further — so we just report FSPL range
-        # but cap at a practical limit
-        practical_limit_km = min(max_range_km, 200.0)  # Cap at 200 km
+        # Cap at radio horizon based on antenna heights
+        horizon_km = radio_horizon_km(self.antenna_height_m,
+                                      self.antenna_height_m)
+        practical_limit_km = min(max_range_km, horizon_km)
 
         # Coverage area (circular)
         coverage_km2 = math.pi * practical_limit_km ** 2

--- a/tests/test_rf_integration.py
+++ b/tests/test_rf_integration.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
 
 import pytest
 
+from utils.rf import DeployEnvironment, BuildingType
 from utils.preset_impact import (
     PresetAnalyzer, PresetComparison, compare_presets, format_comparison_table,
     PRESET_PARAMS,
@@ -505,3 +506,139 @@ class TestFormatOutputConsistency:
         parser = LogParser()
         entry = parser.parse_line("ERROR: test", LogSource.MESHTASTICD)
         json.dumps(entry.to_dict())
+
+
+# =============================================================================
+# Environment-Aware Propagation Integration
+# =============================================================================
+
+class TestEnvironmentAwareIntegration:
+    """Test environment-aware path loss wiring through multihop and preset_impact."""
+
+    def test_multihop_suburban_worse_than_free_space(self):
+        """Suburban environment gives lower success than free space on same path."""
+        nodes = [
+            RelayNode(lat=21.30, lon=-157.86, name="A"),
+            RelayNode(lat=21.40, lon=-157.75, name="B"),
+        ]
+        free = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.FREE_SPACE)
+        suburban = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.SUBURBAN)
+
+        path_free = free.analyze_path(nodes)
+        path_sub = suburban.analyze_path(nodes)
+
+        assert path_free.success_probability >= path_sub.success_probability
+        # Suburban path loss should be higher
+        assert path_sub.hops[0].fspl_db > path_free.hops[0].fspl_db
+
+    def test_multihop_forest_severely_limited(self):
+        """Forest environment makes even moderate hops difficult."""
+        nodes = [
+            RelayNode(lat=21.30, lon=-157.86, name="A"),
+            RelayNode(lat=21.35, lon=-157.82, name="B"),
+        ]
+        forest = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.FOREST)
+        path = forest.analyze_path(nodes)
+        # Forest PLE=5.0 should dramatically reduce margin vs free space
+        free = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.FREE_SPACE)
+        path_free = free.analyze_path(nodes)
+        margin_drop = path_free.hops[0].link_margin_db - path.hops[0].link_margin_db
+        assert margin_drop > 20  # Forest adds >20 dB loss at multi-km
+
+    def test_multihop_over_water_near_free_space(self):
+        """Over-water propagation is close to free space (PLE ~1.9)."""
+        nodes = [
+            RelayNode(lat=21.30, lon=-157.86, name="A"),
+            RelayNode(lat=21.35, lon=-157.82, name="B"),
+        ]
+        water = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.OVER_WATER)
+        free = HopAnalyzer(preset='LONG_FAST', environment=DeployEnvironment.FREE_SPACE)
+
+        path_water = water.analyze_path(nodes)
+        path_free = free.analyze_path(nodes)
+
+        # Over water should be within ~5 dB of free space for moderate distances
+        margin_diff = abs(path_free.hops[0].link_margin_db -
+                         path_water.hops[0].link_margin_db)
+        assert margin_diff < 10
+
+    def test_multihop_environment_propagates_to_compare(self):
+        """compare_presets_for_path uses the analyzer's environment."""
+        nodes = [
+            RelayNode(lat=21.30, lon=-157.86, name="A"),
+            RelayNode(lat=21.35, lon=-157.82, name="B"),
+        ]
+        analyzer = HopAnalyzer(
+            preset='LONG_FAST',
+            environment=DeployEnvironment.DENSE_URBAN,
+        )
+        results = analyzer.compare_presets_for_path(nodes)
+        # All presets should be significantly degraded in dense urban
+        for r in results:
+            assert r.success_probability < 1.0
+
+    def test_preset_impact_suburban_range_realistic(self):
+        """Suburban LONG_FAST should predict ~2-10 km, not 300 km."""
+        analyzer = PresetAnalyzer(
+            environment=DeployEnvironment.SUBURBAN,
+            antenna_height_m=2.0,
+        )
+        impact = analyzer.analyze_preset('LONG_FAST')
+        # Suburban with fade margin should be much less than free space
+        assert impact.max_range_km < 50
+        assert impact.max_range_km > 0.5
+
+    def test_preset_impact_free_space_backward_compat(self):
+        """Default FREE_SPACE environment matches old FSPL behavior."""
+        old = PresetAnalyzer()  # defaults to FREE_SPACE
+        impact = old.analyze_preset('LONG_FAST')
+        # Old behavior: max_range_los_km was the uncapped FSPL range
+        # New: still uses FSPL for FREE_SPACE
+        assert impact.max_range_los_km > 100  # Still shows theoretical LOS range
+
+    def test_preset_impact_building_reduces_range(self):
+        """Building penetration loss reduces range."""
+        outdoor = PresetAnalyzer(
+            environment=DeployEnvironment.SUBURBAN,
+            building=BuildingType.NONE,
+        )
+        indoor = PresetAnalyzer(
+            environment=DeployEnvironment.SUBURBAN,
+            building=BuildingType.CONCRETE,
+        )
+        range_out = outdoor.analyze_preset('LONG_FAST').max_range_km
+        range_in = indoor.analyze_preset('LONG_FAST').max_range_km
+        assert range_out > range_in
+
+    def test_preset_impact_radio_horizon_caps_range(self):
+        """Range is capped by radio horizon based on antenna height."""
+        low = PresetAnalyzer(
+            environment=DeployEnvironment.FREE_SPACE,
+            antenna_height_m=2.0,
+        )
+        high = PresetAnalyzer(
+            environment=DeployEnvironment.FREE_SPACE,
+            antenna_height_m=50.0,
+        )
+        range_low = low.analyze_preset('VERY_LONG_SLOW').max_range_km
+        range_high = high.analyze_preset('VERY_LONG_SLOW').max_range_km
+        # High antenna should allow longer range
+        assert range_high > range_low
+
+    def test_environment_ordering_consistency(self):
+        """More obstructed environments should give shorter range."""
+        envs = [
+            DeployEnvironment.FREE_SPACE,
+            DeployEnvironment.RURAL_OPEN,
+            DeployEnvironment.SUBURBAN,
+            DeployEnvironment.DENSE_URBAN,
+        ]
+        ranges = []
+        for env in envs:
+            a = PresetAnalyzer(environment=env, antenna_height_m=10.0)
+            impact = a.analyze_preset('LONG_FAST')
+            ranges.append(impact.max_range_km)
+        # Each should be less than or equal to the previous
+        for i in range(len(ranges) - 1):
+            assert ranges[i] >= ranges[i + 1], \
+                f"{envs[i].value} range {ranges[i]} should >= {envs[i+1].value} range {ranges[i+1]}"


### PR DESCRIPTION
Replace pure FSPL with log-distance propagation model using measured path loss exponents per deployment environment. Key changes:

- multihop.py: HopAnalyzer accepts environment parameter, uses log_distance_path_loss() instead of fspl_db() for per-hop analysis
- preset_impact.py: PresetAnalyzer uses realistic_max_range() with fade margin and building penetration loss, caps range at radio horizon instead of hardcoded 200 km
- site_planner_mixin.py: Range estimator and preset comparison now let users select deployment environment (9 options from free space to dense urban/forest), shows calculated vs LOS reference range
- 9 new integration tests validate environment ordering, backward compatibility, building loss, and radio horizon capping

214 tests pass. All existing tests unchanged (FREE_SPACE default).

https://claude.ai/code/session_01JoDjWS8ZRum5ixBfwC7Qit