### PR TITLE
feat: Decouple MeshForge from HamClock — NOAA primary, HamClock optional

### DIFF
--- a/.claude/research/hamclock_decoupling.md
+++ b/.claude/research/hamclock_decoupling.md
@@ -1,0 +1,107 @@
+# HamClock Decoupling — Session Notes
+
+> Session: 2026-02-08 | Branch: claude/decouple-meshforge-hamclock-52CXI
+
+## Context
+
+The original HamClock developer (Elwood Downey, WB0OEW) is SK. The original
+HamClock backend is scheduled to **sunset June 2026**. MeshForge needed to be
+decoupled from HamClock as a dependency.
+
+**OpenHamClock** (https://github.com/accius/openhamclock) is the community
+replacement — MIT license, React/Node.js, Docker-friendly, port 3000.
+
+## What Was Done
+
+### Architecture Change: NOAA Primary, HamClock Optional
+
+**Before:** HamClock was the primary data source, NOAA was the "fallback"
+**After:** NOAA SWPC is the primary source (always works), HamClock/OpenHamClock are optional enhancements
+
+### New File: `src/commands/propagation.py`
+
+MeshForge-owned propagation command module. This is the new recommended
+interface for all space weather and propagation data.
+
+Features:
+- `get_space_weather()` — NOAA SWPC primary, always works
+- `get_band_conditions()` — Derived from NOAA SFI/Kp/A-index
+- `get_propagation_summary()` — One-line summary
+- `get_alerts()` — NOAA space weather alerts
+- `get_enhanced_data()` — NOAA + optional HamClock/OpenHamClock
+- `configure_source()` — Configure optional data sources
+- `check_source()` — Test connectivity to any source
+- `DataSource` enum: NOAA, OPENHAMCLOCK, HAMCLOCK
+
+### Modified Files
+
+1. **`src/commands/hamclock.py`**
+   - Updated docstring: marked as optional data source plugin
+   - Added OpenHamClock reference and sunset warning
+   - Inverted auto-fallback: NOAA primary, HamClock enhances
+   - All functions still work for backward compatibility
+
+2. **`src/commands/__init__.py`**
+   - Added `propagation` to imports and `__all__`
+   - Updated usage docstring
+
+3. **`src/launcher_tui/settings_menu_mixin.py`**
+   - "HamClock Settings" → "Propagation Data Sources"
+   - New submenu: NOAA (test), OpenHamClock (configure), HamClock Legacy
+   - "Test All Sources" option
+   - Sunset warning for legacy HamClock
+
+4. **`src/launcher_tui/service_discovery_mixin.py`**
+   - HamClock only shown in discovery if running
+   - Labeled as "(optional)" in discovery and status
+   - Core vs optional service separation in status overview
+
+5. **`tests/test_propagation.py`** (new)
+   - 31 tests covering all new functionality
+   - Backward compatibility tests for hamclock module
+
+### Not Changed (Already Independent)
+
+- `src/utils/space_weather.py` — Already standalone NOAA client
+- `src/launcher_tui/status_bar.py` — Already uses space_weather.py directly
+- `src/utils/ports.py` — HAMCLOCK_PORT kept for service detection
+- `src/utils/service_check.py` — hamclock still in KNOWN_SERVICES for optional detection
+
+## Test Results
+
+**3311 passed, 19 skipped, 0 failures**
+
+## What Remains (Future Sessions)
+
+### P1 — Should Do
+- [ ] Persist propagation source configuration to disk (SettingsManager)
+- [ ] Update CLAUDE.md architecture section and usage examples
+- [ ] Update `.claude/research/hamclock_complete.md` with OpenHamClock info
+
+### P2 — Nice to Have
+- [ ] Add OpenHamClock as Docker service option in service manager
+- [ ] Direct DX cluster telnet support (bypass HamClock for DX spots)
+- [ ] VOACAP online service integration (independent of HamClock)
+- [ ] Add ionosonde data from prop.kc2g.com (like OpenHamClock does)
+- [ ] PSKReporter integration via MQTT (like OpenHamClock)
+
+### P3 — Consider
+- [ ] Deprecation warnings for code calling hamclock module directly
+- [ ] Remove HamClock from KNOWN_SERVICES if sunset confirmed
+- [ ] CelesTrak TLE integration for standalone satellite tracking
+
+## Data Source Comparison
+
+| Feature | NOAA SWPC | OpenHamClock | HamClock (legacy) |
+|---------|-----------|--------------|-------------------|
+| SFI | Yes | Yes (proxied) | Yes |
+| Kp/A-index | Yes | Yes (proxied) | Yes |
+| X-ray flux | Yes | Yes (proxied) | Yes |
+| Band conditions | Derived | Display only | Yes |
+| VOACAP | No | ITU-R P.533 | Yes |
+| DX spots | No | Yes (DX Spider) | Yes |
+| Satellite | No | Yes (CelesTrak) | Yes |
+| PSKReporter | No | Yes (MQTT) | No |
+| POTA/SOTA | No | Yes | No |
+| Availability | Always | Self-hosted | Sunsets June 2026 |
+| MeshForge status | PRIMARY | Optional plugin | Optional/legacy |

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -5,7 +5,7 @@ Unified command interface for GTK and CLI.
 All UI-independent operations go here.
 
 Usage:
-    from commands import meshtastic, service, hardware, gateway, diagnostics, hamclock, rns, messaging
+    from commands import meshtastic, service, hardware, gateway, diagnostics, propagation, rns, messaging
 
     # Meshtastic operations
     result = meshtastic.get_node_info()
@@ -28,11 +28,17 @@ Usage:
     result = diagnostics.get_system_health()
     result = diagnostics.run_gateway_diagnostics()
 
-    # HamClock - Space Weather & Propagation
+    # Propagation - Space Weather & HF Propagation (NOAA primary, standalone)
+    result = propagation.get_space_weather()       # Always works (NOAA)
+    result = propagation.get_band_conditions()     # Derived from NOAA data
+    result = propagation.get_propagation_summary() # One-line summary
+    result = propagation.get_enhanced_data()       # + optional HamClock/OpenHamClock
+
+    # HamClock - Optional data source plugin (legacy)
+    # For standalone propagation data, use `propagation` module instead.
     hamclock.configure("localhost", api_port=8082)
-    result = hamclock.get_space_weather()
-    result = hamclock.get_voacap()
-    result = hamclock.get_noaa_solar_data()  # NOAA fallback
+    result = hamclock.get_voacap()                 # HamClock-specific
+    result = hamclock.get_dx_spots()               # HamClock-specific
 
     # RNS - Reticulum Network Stack
     result = rns.get_status()
@@ -61,6 +67,7 @@ from . import service
 from . import hardware
 from . import gateway
 from . import diagnostics
+from . import propagation
 from . import hamclock
 from . import rns
 from . import messaging
@@ -74,6 +81,7 @@ __all__ = [
     'hardware',
     'gateway',
     'diagnostics',
+    'propagation',
     'hamclock',
     'rns',
     'messaging',

--- a/src/commands/hamclock.py
+++ b/src/commands/hamclock.py
@@ -1,17 +1,23 @@
 """
-HamClock Commands
+HamClock Commands — Optional Data Source Plugin
 
-Provides unified interface for HamClock API operations.
-Used by both GTK and CLI interfaces.
+Provides REST API client for HamClock (legacy) and OpenHamClock.
+This module is an OPTIONAL enhancement — MeshForge works without it.
 
-HamClock provides:
-- Space weather data (SFI, Kp, A index, X-ray flux)
-- Band conditions (HF propagation status)
-- VOACAP propagation predictions
+For standalone space weather and propagation data, use:
+    from commands import propagation  # NOAA-based, always works
+
+HamClock/OpenHamClock provide supplementary data:
+- VOACAP propagation predictions (requires HamClock)
 - DX cluster spots
 - Satellite tracking
+- Space weather (also available from NOAA directly)
 
-Reference: https://www.clearskyinstitute.com/ham/HamClock/
+Original HamClock: https://www.clearskyinstitute.com/ham/HamClock/
+    NOTE: Original HamClock backend sunsets June 2026.
+
+OpenHamClock: https://github.com/accius/openhamclock
+    Modern open-source replacement (MIT license, self-hostable).
 """
 
 import urllib.request
@@ -880,48 +886,62 @@ def get_native_space_weather() -> CommandResult:
     )
 
 
-# ==================== Unified API (Auto-Fallback) ====================
+# ==================== Unified API (NOAA Primary) ====================
+#
+# NOTE: For new code, prefer using `commands.propagation` instead.
+# These functions are kept for backward compatibility.
 
 def get_space_weather_auto() -> CommandResult:
     """
-    Get space weather with automatic fallback.
+    Get space weather — NOAA primary, HamClock as optional enhancement.
 
-    Tries HamClock first, falls back to NOAA if unavailable.
-    This is the recommended function to use.
+    Uses NOAA SWPC as the primary data source. If HamClock is configured
+    and available, merges additional data (VOACAP, DX spots).
+
+    For new code, prefer: commands.propagation.get_space_weather()
     """
-    # Try HamClock first
-    if is_available():
-        result = get_space_weather()
-        if result.success:
-            result.data['source'] = 'HamClock'
-            result.data['hamclock_available'] = True
-            return result
+    # NOAA is primary (always works, no external service needed)
+    result = get_native_space_weather()
 
-    # Fall back to native NOAA
-    logger.info("HamClock not available, using native NOAA API")
-    return get_native_space_weather()
+    # Enhance with HamClock data if available
+    if is_available():
+        hc_result = get_space_weather()
+        if hc_result.success and result.success:
+            result.data['hamclock_available'] = True
+            result.data['source'] = 'NOAA SWPC + HamClock'
+            # Merge any HamClock-specific fields not in NOAA
+            for key in ('proton', 'aurora'):
+                if key in hc_result.data:
+                    result.data[key] = hc_result.data[key]
+    else:
+        if result.success:
+            result.data['hamclock_available'] = False
+
+    return result
 
 
 def get_band_conditions_auto() -> CommandResult:
     """
-    Get band conditions with automatic fallback.
+    Get band conditions — NOAA primary, HamClock as optional enhancement.
 
-    Tries HamClock first, derives from NOAA SFI if unavailable.
+    For new code, prefer: commands.propagation.get_band_conditions()
     """
-    # Try HamClock first
-    if is_available():
-        result = get_band_conditions()
-        if result.success:
-            return result
-
-    # Fall back to NOAA-based estimate
+    # NOAA-based estimate is primary
     result = get_noaa_solar_data()
     if result.success:
         data = result.data
-        data['source'] = 'NOAA estimate'
-        data['note'] = 'Band conditions estimated from Solar Flux Index'
+        data['source'] = 'NOAA SWPC'
+        data['note'] = 'Band conditions derived from NOAA Solar Flux Index'
+
+        # If HamClock available, use its band conditions instead
+        if is_available():
+            hc_result = get_band_conditions()
+            if hc_result.success:
+                data['source'] = 'NOAA SWPC + HamClock'
+                data['hamclock_bands'] = hc_result.data.get('bands', {})
+
         return CommandResult.ok(
-            f"Band conditions: {data.get('conditions', 'Unknown')} (SFI-based estimate)",
+            f"Band conditions: {data.get('conditions', 'Unknown')}",
             data=data
         )
     return result
@@ -931,7 +951,9 @@ def get_propagation_summary() -> CommandResult:
     """
     Get a summary of current propagation conditions.
 
-    Works with or without HamClock installed.
+    Uses NOAA SWPC as primary source. Works without HamClock.
+
+    For new code, prefer: commands.propagation.get_propagation_summary()
     """
     summary = {
         'timestamp': '',
@@ -941,7 +963,7 @@ def get_propagation_summary() -> CommandResult:
         'source': 'NOAA SWPC'
     }
 
-    # Get space weather
+    # Get space weather (NOAA primary)
     result = get_space_weather_auto()
     if result.success:
         data = result.data

--- a/src/commands/propagation.py
+++ b/src/commands/propagation.py
@@ -1,0 +1,620 @@
+"""
+MeshForge Propagation Commands — Standalone Space Weather & HF Propagation
+
+MeshForge-owned module for space weather and HF propagation data.
+Uses NOAA SWPC as the PRIMARY data source (no external dependencies).
+Optionally enhances with HamClock or OpenHamClock when available.
+
+Data Sources (priority order):
+    1. NOAA SWPC (primary, always available)
+    2. OpenHamClock (optional, REST API on port 3000)
+    3. HamClock (optional/legacy, REST API on port 8080/8082)
+
+Usage:
+    from commands import propagation
+
+    # Get space weather (always works - uses NOAA)
+    result = propagation.get_space_weather()
+
+    # Get band conditions (derived from NOAA data)
+    result = propagation.get_band_conditions()
+
+    # Get propagation summary
+    result = propagation.get_propagation_summary()
+
+    # Configure optional enhanced sources
+    propagation.configure_source(DataSource.OPENHAMCLOCK, host="localhost", port=3000)
+"""
+
+import logging
+from enum import Enum
+from typing import Optional, Dict, Any, List
+from dataclasses import dataclass, field
+
+from .base import CommandResult
+
+logger = logging.getLogger(__name__)
+
+
+class DataSource(Enum):
+    """Available propagation data sources."""
+    NOAA = "noaa"                  # NOAA SWPC (primary, always available)
+    OPENHAMCLOCK = "openhamclock"  # OpenHamClock (optional REST API)
+    HAMCLOCK = "hamclock"          # Original HamClock (legacy, optional)
+
+
+@dataclass
+class SourceConfig:
+    """Configuration for a data source."""
+    source: DataSource
+    host: str = "localhost"
+    port: int = 0
+    enabled: bool = False
+    timeout: int = 10
+
+    @property
+    def base_url(self) -> str:
+        if self.source == DataSource.OPENHAMCLOCK:
+            return f"http://{self.host}:{self.port}"
+        elif self.source == DataSource.HAMCLOCK:
+            return f"http://{self.host}:{self.port}"
+        return ""
+
+
+# Module-level source configuration
+_sources: Dict[DataSource, SourceConfig] = {
+    DataSource.NOAA: SourceConfig(
+        source=DataSource.NOAA, enabled=True
+    ),
+    DataSource.OPENHAMCLOCK: SourceConfig(
+        source=DataSource.OPENHAMCLOCK, port=3000, enabled=False
+    ),
+    DataSource.HAMCLOCK: SourceConfig(
+        source=DataSource.HAMCLOCK, port=8080, enabled=False
+    ),
+}
+
+
+def configure_source(
+    source: DataSource,
+    host: str = "localhost",
+    port: int = 0,
+    enabled: bool = True,
+    timeout: int = 10,
+) -> CommandResult:
+    """Configure an optional data source.
+
+    NOAA is always enabled. This configures HamClock/OpenHamClock as
+    supplementary sources.
+
+    Args:
+        source: Which data source to configure
+        host: Hostname or IP
+        port: Port number (0 = use default)
+        enabled: Whether to use this source
+        timeout: Request timeout in seconds
+    """
+    if source == DataSource.NOAA:
+        return CommandResult.ok("NOAA is always enabled as primary source")
+
+    if not host:
+        return CommandResult.fail("Host cannot be empty")
+
+    default_ports = {
+        DataSource.OPENHAMCLOCK: 3000,
+        DataSource.HAMCLOCK: 8080,
+    }
+    actual_port = port or default_ports.get(source, 8080)
+
+    if not (1 <= actual_port <= 65535):
+        return CommandResult.fail(f"Invalid port: {actual_port}")
+
+    _sources[source] = SourceConfig(
+        source=source,
+        host=host.strip(),
+        port=actual_port,
+        enabled=enabled,
+        timeout=timeout,
+    )
+
+    return CommandResult.ok(
+        f"{source.value} configured: {host}:{actual_port} (enabled={enabled})",
+        data={
+            'source': source.value,
+            'host': host,
+            'port': actual_port,
+            'enabled': enabled,
+        }
+    )
+
+
+def get_sources() -> CommandResult:
+    """Get status of all configured data sources."""
+    sources_info = {}
+    for src, cfg in _sources.items():
+        sources_info[src.value] = {
+            'enabled': cfg.enabled,
+            'host': cfg.host,
+            'port': cfg.port,
+        }
+
+    return CommandResult.ok(
+        "Data source configuration",
+        data={'sources': sources_info}
+    )
+
+
+# ==================== Space Weather (NOAA Primary) ====================
+
+def get_space_weather() -> CommandResult:
+    """Get current space weather conditions.
+
+    Uses NOAA SWPC as primary source. This always works without
+    any external service dependencies.
+
+    Returns:
+        CommandResult with:
+        - solar_flux: Solar Flux Index (SFU)
+        - k_index: Kp index (0-9)
+        - a_index: A index (daily average)
+        - xray_flux: X-ray flux class (A/B/C/M/X)
+        - geomag_storm: Geomagnetic storm level
+        - band_conditions: Per-band HF condition assessment
+        - source: Data source used
+    """
+    try:
+        from utils.space_weather import SpaceWeatherAPI
+    except ImportError:
+        return CommandResult.fail(
+            "Space weather module not available",
+            error="utils.space_weather not found"
+        )
+
+    api = SpaceWeatherAPI(timeout=10)
+    data = api.get_current_conditions()
+
+    result_data = {
+        'solar_flux': data.solar_flux,
+        'sunspot_number': data.sunspot_number,
+        'k_index': data.k_index,
+        'a_index': data.a_index,
+        'xray_flux': data.xray_flux,
+        'xray_class': data.xray_class,
+        'geomag_storm': data.geomag_storm.value,
+        'band_conditions': {k: v.value for k, v in data.band_conditions.items()},
+        'source': 'NOAA SWPC',
+        'updated': data.updated.isoformat() if data.updated else None,
+    }
+
+    # Build summary
+    parts = []
+    if data.solar_flux:
+        parts.append(f"SFI={int(data.solar_flux)}")
+    if data.k_index is not None:
+        parts.append(f"Kp={data.k_index}")
+    if data.a_index is not None:
+        parts.append(f"A={data.a_index}")
+
+    summary = ", ".join(parts) if parts else "No data"
+
+    return CommandResult.ok(
+        f"Space weather: {summary} ({data.geomag_storm.value})",
+        data=result_data
+    )
+
+
+def get_band_conditions() -> CommandResult:
+    """Get HF band propagation conditions.
+
+    Derived from NOAA SWPC data (SFI, Kp, A-index). No external
+    service required.
+
+    Returns:
+        CommandResult with per-band condition assessments
+    """
+    try:
+        from utils.space_weather import SpaceWeatherAPI
+    except ImportError:
+        return CommandResult.fail(
+            "Space weather module not available",
+            error="utils.space_weather not found"
+        )
+
+    api = SpaceWeatherAPI(timeout=10)
+    data = api.get_current_conditions()
+
+    bands = {k: v.value for k, v in data.band_conditions.items()}
+
+    # Determine overall condition
+    if data.k_index is not None and data.k_index >= 5:
+        overall = "Disturbed"
+    elif data.solar_flux and data.solar_flux >= 120:
+        overall = "Good"
+    elif data.solar_flux and data.solar_flux >= 90:
+        overall = "Fair"
+    elif data.solar_flux:
+        overall = "Poor"
+    else:
+        overall = "Unknown"
+
+    return CommandResult.ok(
+        f"Band conditions: {overall} ({len(bands)} bands assessed)",
+        data={
+            'bands': bands,
+            'overall': overall,
+            'solar_flux': data.solar_flux,
+            'k_index': data.k_index,
+            'a_index': data.a_index,
+            'source': 'NOAA SWPC',
+        }
+    )
+
+
+def get_alerts() -> CommandResult:
+    """Get active space weather alerts from NOAA.
+
+    Returns:
+        CommandResult with list of active alerts
+    """
+    import urllib.request
+    import json
+
+    url = "https://services.swpc.noaa.gov/products/alerts.json"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=10) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        alerts = []
+        for alert in data[:10]:
+            alerts.append({
+                'message': alert.get('message', ''),
+                'issue_datetime': alert.get('issue_datetime', ''),
+            })
+
+        return CommandResult.ok(
+            f"{len(alerts)} space weather alerts",
+            data={'alerts': alerts, 'count': len(alerts), 'source': 'NOAA SWPC'}
+        )
+    except Exception as e:
+        return CommandResult.fail(f"Alerts fetch failed: {e}")
+
+
+def get_propagation_summary() -> CommandResult:
+    """Get a one-line propagation summary.
+
+    Works entirely from NOAA data - no external dependencies.
+
+    Returns:
+        CommandResult with summary string and overall assessment
+    """
+    try:
+        from utils.space_weather import SpaceWeatherAPI
+    except ImportError:
+        return CommandResult.fail("Space weather module not available")
+
+    api = SpaceWeatherAPI(timeout=10)
+    summary_str = api.get_quick_summary()
+    data = api.get_current_conditions()
+
+    # Overall assessment
+    overall = "Unknown"
+    try:
+        sfi = data.solar_flux or 0
+        kp = data.k_index or 0
+
+        if kp >= 5:
+            overall = "Disturbed"
+        elif sfi >= 120 and kp < 3:
+            overall = "Excellent"
+        elif sfi >= 90:
+            overall = "Good"
+        elif sfi >= 70:
+            overall = "Fair"
+        else:
+            overall = "Poor"
+    except (ValueError, TypeError):
+        pass
+
+    return CommandResult.ok(
+        summary_str,
+        data={
+            'summary': summary_str,
+            'overall': overall,
+            'solar_flux': data.solar_flux,
+            'k_index': data.k_index,
+            'a_index': data.a_index,
+            'geomag_storm': data.geomag_storm.value,
+            'source': 'NOAA SWPC',
+        }
+    )
+
+
+# ==================== Enhanced Data (Optional Sources) ====================
+
+def get_enhanced_data() -> CommandResult:
+    """Get enhanced propagation data from optional sources.
+
+    Tries OpenHamClock first, then HamClock, then returns NOAA-only.
+    Optional sources provide:
+    - VOACAP propagation predictions
+    - DX cluster spots
+    - Satellite tracking
+
+    Returns:
+        CommandResult with enhanced data (or NOAA-only if no sources configured)
+    """
+    # Start with NOAA base data
+    weather_result = get_space_weather()
+    base_data = weather_result.data if weather_result.success else {}
+
+    enhanced = {
+        'space_weather': base_data,
+        'voacap': None,
+        'dx_spots': None,
+        'source': base_data.get('source', 'NOAA SWPC'),
+        'enhanced_source': None,
+    }
+
+    # Try OpenHamClock
+    ohc_cfg = _sources.get(DataSource.OPENHAMCLOCK)
+    if ohc_cfg and ohc_cfg.enabled:
+        result = _fetch_openhamclock_data(ohc_cfg)
+        if result:
+            enhanced.update(result)
+            enhanced['enhanced_source'] = 'OpenHamClock'
+            return CommandResult.ok(
+                f"Enhanced data from OpenHamClock + NOAA",
+                data=enhanced
+            )
+
+    # Try HamClock (legacy)
+    hc_cfg = _sources.get(DataSource.HAMCLOCK)
+    if hc_cfg and hc_cfg.enabled:
+        result = _fetch_hamclock_enhanced(hc_cfg)
+        if result:
+            enhanced.update(result)
+            enhanced['enhanced_source'] = 'HamClock'
+            return CommandResult.ok(
+                f"Enhanced data from HamClock + NOAA",
+                data=enhanced
+            )
+
+    return CommandResult.ok(
+        "Space weather from NOAA (no enhanced sources configured)",
+        data=enhanced
+    )
+
+
+def check_source(source: DataSource) -> CommandResult:
+    """Test connectivity to an optional data source.
+
+    Args:
+        source: Which source to test
+
+    Returns:
+        CommandResult indicating connectivity status
+    """
+    if source == DataSource.NOAA:
+        return _test_noaa()
+    elif source == DataSource.OPENHAMCLOCK:
+        return _test_openhamclock()
+    elif source == DataSource.HAMCLOCK:
+        return _test_hamclock()
+    else:
+        return CommandResult.fail(f"Unknown source: {source}")
+
+
+# ==================== Internal: NOAA ====================
+
+def _test_noaa() -> CommandResult:
+    """Test NOAA SWPC connectivity."""
+    import urllib.request
+
+    url = "https://services.swpc.noaa.gov/json/planetary_k_index_1m.json"
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+        with urllib.request.urlopen(req, timeout=10) as response:
+            if response.status == 200:
+                return CommandResult.ok(
+                    "NOAA SWPC is reachable",
+                    data={'status': 'connected', 'source': 'NOAA SWPC'}
+                )
+    except Exception as e:
+        return CommandResult.fail(
+            f"NOAA SWPC unreachable: {e}",
+            error=str(e),
+            data={'hint': 'Check internet connectivity'}
+        )
+    return CommandResult.fail("NOAA SWPC returned unexpected response")
+
+
+# ==================== Internal: OpenHamClock ====================
+
+def _test_openhamclock() -> CommandResult:
+    """Test OpenHamClock connectivity."""
+    import urllib.request
+
+    cfg = _sources.get(DataSource.OPENHAMCLOCK)
+    if not cfg or not cfg.enabled:
+        return CommandResult.fail(
+            "OpenHamClock not configured",
+            data={'hint': 'Configure with: propagation.configure_source(DataSource.OPENHAMCLOCK, host="...", port=3000)'}
+        )
+
+    url = f"{cfg.base_url}/api/dxcluster/spots"
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as response:
+            if response.status == 200:
+                return CommandResult.ok(
+                    f"OpenHamClock connected at {cfg.host}:{cfg.port}",
+                    data={'status': 'connected', 'source': 'OpenHamClock',
+                          'host': cfg.host, 'port': cfg.port}
+                )
+    except Exception as e:
+        return CommandResult.fail(
+            f"Cannot reach OpenHamClock at {cfg.host}:{cfg.port}: {e}",
+            error=str(e),
+            data={'hint': 'Ensure OpenHamClock is running (docker compose up)'}
+        )
+    return CommandResult.fail("OpenHamClock returned unexpected response")
+
+
+def _fetch_openhamclock_data(cfg: SourceConfig) -> Optional[Dict[str, Any]]:
+    """Fetch enhanced data from OpenHamClock.
+
+    OpenHamClock provides JSON REST API on port 3000:
+    - /api/dxcluster/spots - DX cluster spots
+    - Space weather proxied from NOAA
+
+    Args:
+        cfg: OpenHamClock source configuration
+
+    Returns:
+        Dict with enhanced data or None on failure
+    """
+    import urllib.request
+    import json
+
+    enhanced = {}
+
+    # Fetch DX spots
+    try:
+        url = f"{cfg.base_url}/api/dxcluster/spots"
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+        req.add_header('Accept', 'application/json')
+
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if isinstance(data, list):
+            enhanced['dx_spots'] = {
+                'spots': data[:20],
+                'count': len(data),
+                'source': 'OpenHamClock',
+            }
+    except Exception as e:
+        logger.debug(f"OpenHamClock DX spots fetch failed: {e}")
+
+    return enhanced if enhanced else None
+
+
+# ==================== Internal: HamClock (Legacy) ====================
+
+def _test_hamclock() -> CommandResult:
+    """Test HamClock connectivity."""
+    import urllib.request
+
+    cfg = _sources.get(DataSource.HAMCLOCK)
+    if not cfg or not cfg.enabled:
+        return CommandResult.fail(
+            "HamClock not configured",
+            data={'hint': 'Configure with: propagation.configure_source(DataSource.HAMCLOCK, host="...", port=8080)'}
+        )
+
+    url = f"{cfg.base_url}/get_sys.txt"
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as response:
+            data = response.read().decode('utf-8')
+            if data:
+                return CommandResult.ok(
+                    f"HamClock connected at {cfg.host}:{cfg.port}",
+                    data={'status': 'connected', 'source': 'HamClock',
+                          'host': cfg.host, 'port': cfg.port, 'info': data[:200]}
+                )
+    except Exception as e:
+        return CommandResult.fail(
+            f"Cannot reach HamClock at {cfg.host}:{cfg.port}: {e}",
+            error=str(e),
+            data={'hint': 'Ensure HamClock is running'}
+        )
+    return CommandResult.fail("HamClock returned unexpected response")
+
+
+def _fetch_hamclock_enhanced(cfg: SourceConfig) -> Optional[Dict[str, Any]]:
+    """Fetch enhanced data from HamClock (legacy).
+
+    HamClock REST API returns key=value text format.
+
+    Args:
+        cfg: HamClock source configuration
+
+    Returns:
+        Dict with enhanced data or None on failure
+    """
+    import urllib.request
+
+    enhanced = {}
+
+    def fetch_endpoint(endpoint: str) -> Optional[str]:
+        try:
+            url = f"{cfg.base_url}/{endpoint}"
+            req = urllib.request.Request(url)
+            req.add_header('User-Agent', 'MeshForge/1.0')
+            with urllib.request.urlopen(req, timeout=cfg.timeout) as response:
+                return response.read().decode('utf-8')
+        except Exception as e:
+            logger.debug(f"HamClock {endpoint} fetch failed: {e}")
+            return None
+
+    def parse_kv(data: str) -> Dict[str, str]:
+        result = {}
+        for line in data.strip().split('\n'):
+            if '=' in line:
+                key, value = line.split('=', 1)
+                result[key.strip()] = value.strip()
+        return result
+
+    # VOACAP propagation predictions
+    raw = fetch_endpoint('get_voacap.txt')
+    if raw:
+        voacap = {'path': '', 'utc': '', 'bands': {}}
+        for line in raw.strip().split('\n'):
+            if '=' not in line:
+                continue
+            key, value = line.split('=', 1)
+            key = key.strip().lower()
+            value = value.strip()
+            if key == 'path':
+                voacap['path'] = value
+            elif key == 'utc':
+                voacap['utc'] = value
+            elif 'm' in key:
+                try:
+                    if ',' in value:
+                        rel, snr = value.split(',', 1)
+                        reliability = int(rel.strip())
+                    else:
+                        reliability = int(value)
+                        snr = "0"
+                    voacap['bands'][key] = {
+                        'reliability': reliability,
+                        'snr': int(snr.strip()) if ',' in value else 0,
+                    }
+                except ValueError:
+                    pass
+
+        if voacap['bands']:
+            enhanced['voacap'] = voacap
+
+    # DX spots
+    raw = fetch_endpoint('get_dxspots.txt')
+    if raw:
+        lines = [l.strip() for l in raw.strip().split('\n') if l.strip()]
+        if lines:
+            enhanced['dx_spots'] = {
+                'spots': lines,
+                'count': len(lines),
+                'source': 'HamClock',
+            }
+
+    return enhanced if enhanced else None

--- a/src/launcher_tui/service_discovery_mixin.py
+++ b/src/launcher_tui/service_discovery_mixin.py
@@ -99,15 +99,16 @@ class ServiceDiscoveryMixin:
             details=rns_status.message or ""
         ))
 
-        # Check HamClock
+        # Check HamClock (optional enhanced data source)
         hc_status = check_service('hamclock')
-        services.append(DiscoveredService(
-            name="HamClock",
-            status="running" if hc_status.available else "stopped",
-            address="localhost:8080",
-            service_type="hamclock",
-            details=hc_status.message or ""
-        ))
+        if hc_status.available:
+            services.append(DiscoveredService(
+                name="HamClock (optional)",
+                status="running",
+                address="localhost:8080",
+                service_type="hamclock",
+                details="Enhanced propagation data source"
+            ))
 
         # Check for AREDN (10.x.x.x network)
         aredn_found = self._check_aredn_network()
@@ -266,16 +267,24 @@ class ServiceDiscoveryMixin:
         self.dialog.infobox("Checking", "Checking service status...")
 
         # Check all known services
+        # Core services required for mesh operations
         services = [
             ('meshtasticd', 'Meshtastic Daemon'),
             ('rnsd', 'Reticulum Network Stack'),
-            ('hamclock', 'HamClock Space Weather'),
+        ]
+
+        # Optional services (enhanced data sources)
+        optional_services = [
+            ('hamclock', 'HamClock (optional)'),
         ]
 
         lines = ["MeshForge Service Status\n"]
         lines.append("=" * 40)
 
         warnings = []
+
+        # Core services
+        lines.append("\nCore Services:")
         for svc_id, svc_name in services:
             status = check_service(svc_id)
             icon = "✓" if status.available else "✗"
@@ -298,6 +307,14 @@ class ServiceDiscoveryMixin:
 
             if status.message:
                 lines.append(f"  Info: {status.message}")
+
+        # Optional services (only show if running)
+        lines.append("\n\nOptional Data Sources:")
+        lines.append("  Space weather: NOAA SWPC (always active)")
+        for svc_id, svc_name in optional_services:
+            status = check_service(svc_id)
+            if status.available:
+                lines.append(f"  ✓ {svc_name}: running")
 
         if warnings:
             lines.append("\n" + "-" * 40)

--- a/src/launcher_tui/settings_menu_mixin.py
+++ b/src/launcher_tui/settings_menu_mixin.py
@@ -12,7 +12,7 @@ class SettingsMenuMixin:
         """Settings menu."""
         choices = [
             ("connection", "Meshtastic Connection"),
-            ("hamclock", "HamClock Settings"),
+            ("propagation", "Propagation Data Sources"),
             ("back", "Back"),
         ]
 
@@ -28,8 +28,8 @@ class SettingsMenuMixin:
 
             if choice == "connection":
                 self._configure_connection()
-            elif choice == "hamclock":
-                self._configure_hamclock()
+            elif choice == "propagation":
+                self._configure_propagation_sources()
 
     def _configure_connection(self):
         """Configure Meshtastic connection."""
@@ -81,35 +81,230 @@ class SettingsMenuMixin:
         except ImportError:
             pass  # MapDataCollector not available
 
-    def _configure_hamclock(self):
-        """Configure HamClock settings - test API connection."""
+    def _configure_propagation_sources(self):
+        """Configure propagation data sources.
+
+        NOAA SWPC is always active (primary). Users can optionally
+        enable HamClock or OpenHamClock for enhanced data.
+        """
+        while True:
+            choices = [
+                ("noaa", "NOAA SWPC (Primary - always active)"),
+                ("openhamclock", "OpenHamClock (Optional)"),
+                ("hamclock", "HamClock Legacy (Optional)"),
+                ("test", "Test All Sources"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Propagation Data Sources",
+                "NOAA is always active as primary source.\n"
+                "Optionally configure HamClock/OpenHamClock for\n"
+                "enhanced data (VOACAP, DX spots).",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "noaa":
+                self._test_noaa_source()
+            elif choice == "openhamclock":
+                self._configure_openhamclock()
+            elif choice == "hamclock":
+                self._configure_hamclock_legacy()
+            elif choice == "test":
+                self._test_all_sources()
+
+    def _test_noaa_source(self):
+        """Test NOAA SWPC connectivity and show current data."""
+        try:
+            from commands import propagation
+            result = propagation.check_source(propagation.DataSource.NOAA)
+            if result.success:
+                # Also get current conditions
+                wx = propagation.get_space_weather()
+                if wx.success:
+                    d = wx.data
+                    lines = [
+                        "NOAA SWPC - Connected",
+                        "",
+                        f"Solar Flux (SFI): {d.get('solar_flux', 'N/A')}",
+                        f"Kp Index: {d.get('k_index', 'N/A')}",
+                        f"A Index: {d.get('a_index', 'N/A')}",
+                        f"X-ray: {d.get('xray_flux', 'N/A')}",
+                        f"Geomagnetic: {d.get('geomag_storm', 'N/A')}",
+                        "",
+                        "Band Conditions:",
+                    ]
+                    for band, cond in d.get('band_conditions', {}).items():
+                        lines.append(f"  {band}: {cond}")
+                    self.dialog.msgbox("NOAA Space Weather", "\n".join(lines))
+                else:
+                    self.dialog.msgbox("NOAA SWPC", "Connected but no data available.")
+            else:
+                self.dialog.msgbox("Error", f"Cannot reach NOAA SWPC:\n{result.message}")
+        except ImportError:
+            self.dialog.msgbox("Error", "Propagation module not available.")
+
+    def _configure_openhamclock(self):
+        """Configure OpenHamClock as optional data source."""
         host = self.dialog.inputbox(
-            "HamClock Host",
-            "Enter HamClock hostname or IP:",
+            "OpenHamClock Host",
+            "Enter OpenHamClock hostname or IP:\n"
+            "(Docker: localhost, Remote: IP address)",
             "localhost"
         )
 
-        if host:
-            if not self._validate_hostname(host):
-                self.dialog.msgbox("Error", "Invalid hostname or IP address.")
-                return
+        if not host:
+            return
 
-            port = self.dialog.inputbox(
-                "HamClock API Port",
-                "Enter API port (default 8082):",
-                "8082"
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
+        port = self.dialog.inputbox(
+            "OpenHamClock Port",
+            "Enter port (default 3000):",
+            "3000"
+        )
+
+        if not port:
+            return
+
+        if not self._validate_port(port):
+            self.dialog.msgbox("Error", "Invalid port number (1-65535).")
+            return
+
+        try:
+            from commands import propagation
+            result = propagation.configure_source(
+                propagation.DataSource.OPENHAMCLOCK,
+                host=host,
+                port=int(port),
             )
+            if result.success:
+                # Test connectivity
+                test = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
+                if test.success:
+                    self.dialog.msgbox(
+                        "OpenHamClock Connected",
+                        f"API: {host}:{port}\n\nOpenHamClock is now active as\n"
+                        "an enhanced data source."
+                    )
+                else:
+                    self.dialog.msgbox(
+                        "OpenHamClock Configured",
+                        f"Saved: {host}:{port}\n\n"
+                        f"Connection test failed:\n{test.message}\n\n"
+                        "Make sure OpenHamClock is running\n"
+                        "(docker compose up)"
+                    )
+            else:
+                self.dialog.msgbox("Error", result.message)
+        except ImportError:
+            self.dialog.msgbox("Error", "Propagation module not available.")
 
-            if port:
-                if not self._validate_port(port):
-                    self.dialog.msgbox("Error", "Invalid port number (1-65535).")
-                    return
+    def _configure_hamclock_legacy(self):
+        """Configure legacy HamClock as optional data source."""
+        host = self.dialog.inputbox(
+            "HamClock Host",
+            "Enter HamClock hostname or IP:\n"
+            "(NOTE: Original HamClock sunsets June 2026)",
+            "localhost"
+        )
 
-                try:
-                    import urllib.request
-                    url = f"http://{host}:{port}/get_de.txt"
-                    req = urllib.request.urlopen(url, timeout=5)
-                    data = req.read().decode()
-                    self.dialog.msgbox("HamClock Connected", f"API: {host}:{port}\n\nDE Station:\n{data}")
-                except Exception as e:
-                    self.dialog.msgbox("Error", f"Cannot reach HamClock at {host}:{port}\n\n{e}\n\nMake sure HamClock is running.")
+        if not host:
+            return
+
+        if not self._validate_hostname(host):
+            self.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
+        port = self.dialog.inputbox(
+            "HamClock API Port",
+            "Enter API port (default 8080):",
+            "8080"
+        )
+
+        if not port:
+            return
+
+        if not self._validate_port(port):
+            self.dialog.msgbox("Error", "Invalid port number (1-65535).")
+            return
+
+        try:
+            from commands import propagation
+            result = propagation.configure_source(
+                propagation.DataSource.HAMCLOCK,
+                host=host,
+                port=int(port),
+            )
+            if result.success:
+                test = propagation.check_source(propagation.DataSource.HAMCLOCK)
+                if test.success:
+                    self.dialog.msgbox(
+                        "HamClock Connected",
+                        f"API: {host}:{port}\n\nHamClock is now active as\n"
+                        "an enhanced data source.\n\n"
+                        "NOTE: Consider migrating to OpenHamClock\n"
+                        "(original HamClock sunsets June 2026)"
+                    )
+                else:
+                    self.dialog.msgbox(
+                        "HamClock Configured",
+                        f"Saved: {host}:{port}\n\n"
+                        f"Connection test failed:\n{test.message}\n\n"
+                        "Make sure HamClock is running."
+                    )
+            else:
+                self.dialog.msgbox("Error", result.message)
+        except ImportError:
+            self.dialog.msgbox("Error", "Propagation module not available.")
+
+    def _test_all_sources(self):
+        """Test all configured propagation data sources."""
+        lines = ["Propagation Source Status", "=" * 35, ""]
+
+        try:
+            from commands import propagation
+
+            # NOAA (always)
+            noaa = propagation.check_source(propagation.DataSource.NOAA)
+            status = "Connected" if noaa.success else "Unreachable"
+            lines.append(f"NOAA SWPC (primary): {status}")
+
+            # OpenHamClock
+            ohc = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
+            if ohc.success:
+                lines.append(f"OpenHamClock: Connected")
+            else:
+                lines.append(f"OpenHamClock: Not configured")
+
+            # HamClock
+            hc = propagation.check_source(propagation.DataSource.HAMCLOCK)
+            if hc.success:
+                lines.append(f"HamClock (legacy): Connected")
+            else:
+                lines.append(f"HamClock (legacy): Not configured")
+
+            # Current data
+            wx = propagation.get_space_weather()
+            if wx.success:
+                d = wx.data
+                lines.append("")
+                lines.append("-" * 35)
+                lines.append("Current Conditions:")
+                sfi = d.get('solar_flux')
+                kp = d.get('k_index')
+                if sfi:
+                    lines.append(f"  SFI: {int(sfi)}")
+                if kp is not None:
+                    lines.append(f"  Kp: {kp}")
+                lines.append(f"  {d.get('geomag_storm', '')}")
+
+        except ImportError:
+            lines.append("Propagation module not available.")
+
+        self.dialog.msgbox("Source Status", "\n".join(lines))

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,0 +1,275 @@
+"""
+Tests for MeshForge Propagation Commands (standalone space weather).
+
+Tests the NOAA-primary propagation module that works without
+any external services (HamClock/OpenHamClock are optional).
+"""
+
+import pytest
+import sys
+import os
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from commands.propagation import (
+    DataSource, SourceConfig,
+    configure_source, get_sources,
+    get_space_weather, get_band_conditions,
+    get_alerts, get_propagation_summary,
+    get_enhanced_data, check_source,
+)
+from commands.base import CommandResult
+
+
+class TestDataSource:
+    """Test DataSource enum."""
+
+    def test_data_source_values(self):
+        assert DataSource.NOAA.value == "noaa"
+        assert DataSource.OPENHAMCLOCK.value == "openhamclock"
+        assert DataSource.HAMCLOCK.value == "hamclock"
+
+    def test_all_sources_defined(self):
+        assert len(DataSource) == 3
+
+
+class TestSourceConfig:
+    """Test SourceConfig dataclass."""
+
+    def test_default_config(self):
+        cfg = SourceConfig(source=DataSource.NOAA)
+        assert cfg.host == "localhost"
+        assert cfg.port == 0
+        assert cfg.enabled is False
+        assert cfg.timeout == 10
+
+    def test_openhamclock_base_url(self):
+        cfg = SourceConfig(
+            source=DataSource.OPENHAMCLOCK,
+            host="192.168.1.100",
+            port=3000,
+        )
+        assert cfg.base_url == "http://192.168.1.100:3000"
+
+    def test_hamclock_base_url(self):
+        cfg = SourceConfig(
+            source=DataSource.HAMCLOCK,
+            host="hamclock.local",
+            port=8080,
+        )
+        assert cfg.base_url == "http://hamclock.local:8080"
+
+    def test_noaa_base_url_empty(self):
+        cfg = SourceConfig(source=DataSource.NOAA)
+        assert cfg.base_url == ""
+
+
+class TestConfigureSource:
+    """Test source configuration."""
+
+    def test_configure_noaa_always_enabled(self):
+        result = configure_source(DataSource.NOAA)
+        assert result.success is True
+        assert "always enabled" in result.message.lower()
+
+    def test_configure_openhamclock(self):
+        result = configure_source(
+            DataSource.OPENHAMCLOCK,
+            host="myhost",
+            port=3000,
+        )
+        assert result.success is True
+        assert result.data['source'] == 'openhamclock'
+        assert result.data['host'] == 'myhost'
+        assert result.data['port'] == 3000
+        assert result.data['enabled'] is True
+
+    def test_configure_hamclock(self):
+        result = configure_source(
+            DataSource.HAMCLOCK,
+            host="192.168.1.50",
+            port=8082,
+        )
+        assert result.success is True
+        assert result.data['port'] == 8082
+
+    def test_configure_default_port_openhamclock(self):
+        result = configure_source(DataSource.OPENHAMCLOCK, host="localhost")
+        assert result.success is True
+        assert result.data['port'] == 3000
+
+    def test_configure_default_port_hamclock(self):
+        result = configure_source(DataSource.HAMCLOCK, host="localhost")
+        assert result.success is True
+        assert result.data['port'] == 8080
+
+    def test_configure_empty_host_rejected(self):
+        result = configure_source(DataSource.OPENHAMCLOCK, host="")
+        assert result.success is False
+
+    def test_configure_invalid_port_rejected(self):
+        result = configure_source(
+            DataSource.OPENHAMCLOCK,
+            host="localhost",
+            port=99999,
+        )
+        assert result.success is False
+
+    def test_get_sources(self):
+        result = get_sources()
+        assert result.success is True
+        sources = result.data['sources']
+        assert 'noaa' in sources
+        assert 'openhamclock' in sources
+        assert 'hamclock' in sources
+        assert sources['noaa']['enabled'] is True
+
+
+class TestGetSpaceWeather:
+    """Test space weather retrieval from NOAA."""
+
+    @patch('commands.propagation.SpaceWeatherAPI', create=True)
+    def test_space_weather_success(self, _):
+        """Space weather returns CommandResult."""
+        result = get_space_weather()
+        assert isinstance(result, CommandResult)
+
+    def test_space_weather_returns_source(self):
+        """Result includes source information."""
+        result = get_space_weather()
+        assert isinstance(result, CommandResult)
+        if result.success:
+            assert result.data.get('source') == 'NOAA SWPC'
+
+
+class TestGetBandConditions:
+    """Test band condition assessment."""
+
+    def test_band_conditions_returns_result(self):
+        result = get_band_conditions()
+        assert isinstance(result, CommandResult)
+        if result.success:
+            assert 'bands' in result.data
+            assert 'overall' in result.data
+            assert result.data.get('source') == 'NOAA SWPC'
+
+
+class TestGetAlerts:
+    """Test NOAA alerts retrieval."""
+
+    def test_alerts_returns_result(self):
+        result = get_alerts()
+        assert isinstance(result, CommandResult)
+        if result.success:
+            assert 'alerts' in result.data
+            assert 'count' in result.data
+
+
+class TestGetPropagationSummary:
+    """Test propagation summary."""
+
+    def test_summary_returns_result(self):
+        result = get_propagation_summary()
+        assert isinstance(result, CommandResult)
+        if result.success:
+            assert 'summary' in result.data
+            assert 'overall' in result.data
+            assert 'source' in result.data
+
+
+class TestGetEnhancedData:
+    """Test enhanced data with optional sources."""
+
+    def test_enhanced_without_sources_returns_noaa(self):
+        """Without optional sources, returns NOAA-only data."""
+        # Disable optional sources
+        configure_source(DataSource.OPENHAMCLOCK, host="localhost", enabled=False)
+        configure_source(DataSource.HAMCLOCK, host="localhost", enabled=False)
+
+        result = get_enhanced_data()
+        assert isinstance(result, CommandResult)
+        if result.success:
+            assert result.data.get('enhanced_source') is None
+            assert 'space_weather' in result.data
+
+
+class TestCheckSource:
+    """Test source connectivity testing."""
+
+    def test_test_noaa(self):
+        """NOAA test returns a result."""
+        result = check_source(DataSource.NOAA)
+        assert isinstance(result, CommandResult)
+
+    def test_test_unconfigured_openhamclock(self):
+        """Unconfigured OpenHamClock returns failure."""
+        configure_source(DataSource.OPENHAMCLOCK, host="localhost", enabled=False)
+        result = check_source(DataSource.OPENHAMCLOCK)
+        assert isinstance(result, CommandResult)
+        assert result.success is False
+
+    def test_test_unconfigured_hamclock(self):
+        """Unconfigured HamClock returns failure."""
+        configure_source(DataSource.HAMCLOCK, host="localhost", enabled=False)
+        result = check_source(DataSource.HAMCLOCK)
+        assert isinstance(result, CommandResult)
+        assert result.success is False
+
+
+class TestModuleExports:
+    """Test that propagation module is properly exported."""
+
+    def test_propagation_importable(self):
+        from commands import propagation
+        assert propagation is not None
+
+    def test_propagation_has_key_functions(self):
+        from commands import propagation
+        assert hasattr(propagation, 'get_space_weather')
+        assert hasattr(propagation, 'get_band_conditions')
+        assert hasattr(propagation, 'get_propagation_summary')
+        assert hasattr(propagation, 'get_enhanced_data')
+        assert hasattr(propagation, 'configure_source')
+        assert hasattr(propagation, 'check_source')
+        assert hasattr(propagation, 'DataSource')
+
+    def test_propagation_in_commands_all(self):
+        import commands
+        assert 'propagation' in commands.__all__
+
+    def test_hamclock_still_importable(self):
+        """HamClock module still works for backward compatibility."""
+        from commands import hamclock
+        assert hasattr(hamclock, 'configure')
+        assert hasattr(hamclock, 'get_space_weather')
+        assert hasattr(hamclock, 'get_voacap')
+
+
+class TestBackwardCompatibility:
+    """Ensure existing hamclock tests still pass."""
+
+    def test_hamclock_configure(self):
+        from commands import hamclock
+        result = hamclock.configure("localhost", api_port=8082)
+        assert result.success is True
+
+    def test_hamclock_get_config(self):
+        from commands import hamclock
+        hamclock.configure("testhost", api_port=8082)
+        config = hamclock.get_config()
+        assert config.host == 'testhost'
+
+    def test_hamclock_reliability_mapping(self):
+        from commands import hamclock
+        assert hamclock._reliability_to_status(90) == 'excellent'
+        assert hamclock._reliability_to_status(0) == 'closed'
+
+    def test_hamclock_auto_functions_exist(self):
+        """Auto functions still exist for backward compat."""
+        from commands import hamclock
+        assert hasattr(hamclock, 'get_space_weather_auto')
+        assert hasattr(hamclock, 'get_band_conditions_auto')
+        assert hasattr(hamclock, 'get_propagation_summary')


### PR DESCRIPTION
MeshForge now owns its space weather and propagation data pipeline independently of HamClock. NOAA SWPC is the primary data source (always works, no external services needed). HamClock and OpenHamClock are optional enhancement plugins for VOACAP and DX spots.

Changes:
- New `commands/propagation.py`: MeshForge-owned propagation module with DataSource enum (NOAA/OPENHAMCLOCK/HAMCLOCK), source config, and standalone space weather/band conditions/alerts
- Refactored `commands/hamclock.py`: marked as optional plugin, inverted auto-fallback priority (NOAA primary), added sunset warning
- Settings menu: "HamClock Settings" → "Propagation Data Sources" with NOAA test, OpenHamClock config, HamClock legacy config
- Service discovery: HamClock shown only when running, labeled optional
- 31 new tests in test_propagation.py, all 3311 tests pass

Context: Original HamClock developer is SK, backend sunsets June 2026. OpenHamClock (github.com/accius/openhamclock) is community replacement.

https://claude.ai/code/session_012kZ87cmEwGpprnyRD8S7YB