### PR TITLE
feat: Persist propagation config, add standalone data sources, Docker…

### DIFF
--- a/.claude/research/hamclock_complete.md
+++ b/.claude/research/hamclock_complete.md
@@ -1,7 +1,20 @@
 # HamClock Integration - Complete Reference
 
 > Consolidated documentation for MeshForge HamClock integration
-> Updated: 2026-01-08
+> Updated: 2026-02-08
+
+## Status Update (2026-02-08)
+
+**Original HamClock backend sunsets June 2026** (author Elwood Downey WB0OEW is SK).
+
+MeshForge now uses **NOAA SWPC as the primary data source** via `commands.propagation`.
+HamClock and OpenHamClock are optional enhancements — see `src/commands/propagation.py`.
+
+**OpenHamClock** (https://github.com/accius/openhamclock) is the community replacement:
+- MIT license, React/Node.js, Docker-friendly
+- REST API on port 3000
+- Adds: PSKReporter MQTT, POTA/SOTA, ionosonde data from prop.kc2g.com
+- CelesTrak TLE for satellite tracking
 
 ## Overview
 
@@ -223,11 +236,73 @@ SFI (Solar Flux Index) above 100 generally indicates good HF conditions.
 
 ---
 
+## OpenHamClock (Community Replacement)
+
+### Overview
+
+OpenHamClock (https://github.com/accius/openhamclock) is the community fork/replacement
+for HamClock, designed to survive the June 2026 backend sunset.
+
+- **License**: MIT
+- **Stack**: React + Node.js
+- **Port**: 3000 (default)
+- **Deployment**: Docker recommended
+
+### Docker Installation
+
+```bash
+# Clone and run
+git clone https://github.com/accius/openhamclock.git
+cd openhamclock
+docker compose up -d
+```
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/dxcluster/spots` | DX cluster spots (JSON) |
+| `/api/spaceweather` | Space weather (proxied from NOAA) |
+| `/api/satellites` | Satellite tracking (CelesTrak TLE) |
+| `/api/propagation` | ITU-R P.533 predictions |
+
+### MeshForge Integration
+
+```python
+from commands import propagation
+from commands.propagation import DataSource
+
+# Configure (persists to ~/.config/meshforge/propagation.json)
+propagation.configure_source(DataSource.OPENHAMCLOCK, host="localhost", port=3000)
+
+# Check connectivity
+result = propagation.check_source(DataSource.OPENHAMCLOCK)
+
+# Get enhanced data (NOAA + OpenHamClock)
+result = propagation.get_enhanced_data()
+```
+
+### Feature Comparison vs HamClock
+
+| Feature | OpenHamClock | HamClock (legacy) |
+|---------|--------------|-------------------|
+| DX Spots | Yes (DX Spider) | Yes |
+| VOACAP | ITU-R P.533 | Yes |
+| Satellites | CelesTrak TLE | Yes |
+| PSKReporter | Yes (MQTT) | No |
+| POTA/SOTA | Yes | No |
+| Ionosonde | Yes (prop.kc2g.com) | No |
+| Self-hosted | Docker | Build from source |
+| License | MIT | Proprietary |
+
 ## References
 
-- [HamClock Official](https://www.clearskyinstitute.com/ham/HamClock/)
+- [HamClock Official](https://www.clearskyinstitute.com/ham/HamClock/) *(sunsets June 2026)*
 - [HamClock User Guide (PDF)](https://www.clearskyinstitute.com/ham/HamClock/HamClockKey.pdf)
 - [pa28/hamclock-systemd](https://github.com/pa28/hamclock-systemd)
+- [OpenHamClock](https://github.com/accius/openhamclock) *(community replacement)*
+- [NOAA SWPC](https://services.swpc.noaa.gov/) *(primary data source)*
 
 ---
 *Consolidated from hamclock.md, hamclock_api.md, hamclock_integration.md*
+*Updated 2026-02-08: Added OpenHamClock, NOAA primary architecture*

--- a/.claude/research/hamclock_decoupling.md
+++ b/.claude/research/hamclock_decoupling.md
@@ -71,24 +71,32 @@ Features:
 
 **3311 passed, 19 skipped, 0 failures**
 
-## What Remains (Future Sessions)
+## Completed (Session 2026-02-08b — branch: claude/persist-config-docs-Kpb7l)
 
-### P1 — Should Do
-- [ ] Persist propagation source configuration to disk (SettingsManager)
-- [ ] Update CLAUDE.md architecture section and usage examples
-- [ ] Update `.claude/research/hamclock_complete.md` with OpenHamClock info
+### P1 — Done ✅
+- [x] Persist propagation source config to disk via SettingsManager
+  - `propagation.json` in `~/.config/meshforge/`
+  - Auto-loads on module import, auto-saves on `configure_source()`
+  - Graceful degradation if SettingsManager unavailable
+- [x] Update CLAUDE.md: Added `commands/` to architecture, propagation docs section
+- [x] Update `hamclock_complete.md`: Added OpenHamClock section, sunset warning, feature comparison
 
-### P2 — Nice to Have
-- [ ] Add OpenHamClock as Docker service option in service manager
-- [ ] Direct DX cluster telnet support (bypass HamClock for DX spots)
-- [ ] VOACAP online service integration (independent of HamClock)
-- [ ] Add ionosonde data from prop.kc2g.com (like OpenHamClock does)
-- [ ] PSKReporter integration via MQTT (like OpenHamClock)
+### P2 — Done ✅
+- [x] Docker OpenHamClock management in service menu (start/stop/status/logs)
+  - Auto-configures MeshForge propagation source on first Docker start
+- [x] Direct DX cluster telnet: `get_dx_spots_telnet()` — connects to DX Spider nodes
+- [x] VOACAP online: `get_voacap_online()` — public VOACAP P2P predictions
+- [x] Ionosonde data: `get_ionosonde_data()` — real foF2/MUF from prop.kc2g.com
+- [ ] PSKReporter integration via MQTT (like OpenHamClock) — future
 
-### P3 — Consider
-- [ ] Deprecation warnings for code calling hamclock module directly
-- [ ] Remove HamClock from KNOWN_SERVICES if sunset confirmed
-- [ ] CelesTrak TLE integration for standalone satellite tracking
+### P3 — Done ✅
+- [x] Deprecation warnings on `hamclock.get_space_weather_auto()`, `get_band_conditions_auto()`, `get_propagation_summary()`
+- [x] CelesTrak TLE: `get_satellite_tle()` — standalone satellite tracking
+- [ ] Remove HamClock from KNOWN_SERVICES if sunset confirmed — future
+
+### Tests
+- 46 tests in `test_propagation.py` (was 31) — all passing
+- 155 tests across affected test files — all passing
 
 ## Data Source Comparison
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,10 @@ python3 -c "from src.__version__ import __version__; print(__version__)"
 src/
 ├── launcher_tui/      # Terminal UI — PRIMARY INTERFACE
 │   └── main.py        # NOC dispatcher (whiptail/dialog)
+├── commands/          # Command modules
+│   ├── propagation.py # Space weather & HF propagation (NOAA primary)
+│   ├── hamclock.py    # HamClock client (optional/legacy)
+│   └── base.py        # CommandResult base class
 ├── gateway/           # RNS-Meshtastic bridge
 │   ├── rns_bridge.py  # Main gateway bridge
 │   └── message_queue.py # Persistent message queue (SQLite)
@@ -285,6 +289,33 @@ gen = CoverageMapGenerator()
 gen.add_nodes_from_geojson(geojson_data)
 gen.generate("coverage_map.html")
 ```
+
+## Propagation Data Sources
+
+**Architecture**: NOAA SWPC is the PRIMARY data source (always works). HamClock and OpenHamClock are optional enhancements.
+
+```python
+from commands import propagation
+from commands.propagation import DataSource
+
+# Get space weather (always works - uses NOAA)
+result = propagation.get_space_weather()
+
+# Configure optional sources (persists to ~/.config/meshforge/propagation.json)
+propagation.configure_source(DataSource.OPENHAMCLOCK, host="localhost", port=3000)
+
+# Get enhanced data (NOAA + optional sources)
+result = propagation.get_enhanced_data()
+```
+
+**Data source priority:**
+1. NOAA SWPC — Primary, always available, no dependencies
+2. OpenHamClock — Optional, self-hosted Docker (port 3000)
+3. HamClock (legacy) — Optional, sunsets June 2026
+
+**Config persistence**: Source configuration auto-saves to `~/.config/meshforge/propagation.json` via `SettingsManager`. Settings survive restarts.
+
+**For legacy code**: `commands.hamclock` still works for backward compatibility but new code should use `commands.propagation`.
 
 ## Contact
 

--- a/src/commands/hamclock.py
+++ b/src/commands/hamclock.py
@@ -24,6 +24,7 @@ import urllib.request
 import urllib.error
 import json
 import logging
+import warnings
 from typing import Optional, Dict, Any
 from dataclasses import dataclass
 
@@ -895,11 +896,15 @@ def get_space_weather_auto() -> CommandResult:
     """
     Get space weather — NOAA primary, HamClock as optional enhancement.
 
-    Uses NOAA SWPC as the primary data source. If HamClock is configured
-    and available, merges additional data (VOACAP, DX spots).
-
-    For new code, prefer: commands.propagation.get_space_weather()
+    .. deprecated::
+        Use ``commands.propagation.get_space_weather()`` instead.
     """
+    warnings.warn(
+        "hamclock.get_space_weather_auto() is deprecated. "
+        "Use commands.propagation.get_space_weather() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # NOAA is primary (always works, no external service needed)
     result = get_native_space_weather()
 
@@ -924,8 +929,15 @@ def get_band_conditions_auto() -> CommandResult:
     """
     Get band conditions — NOAA primary, HamClock as optional enhancement.
 
-    For new code, prefer: commands.propagation.get_band_conditions()
+    .. deprecated::
+        Use ``commands.propagation.get_band_conditions()`` instead.
     """
+    warnings.warn(
+        "hamclock.get_band_conditions_auto() is deprecated. "
+        "Use commands.propagation.get_band_conditions() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # NOAA-based estimate is primary
     result = get_noaa_solar_data()
     if result.success:
@@ -951,10 +963,15 @@ def get_propagation_summary() -> CommandResult:
     """
     Get a summary of current propagation conditions.
 
-    Uses NOAA SWPC as primary source. Works without HamClock.
-
-    For new code, prefer: commands.propagation.get_propagation_summary()
+    .. deprecated::
+        Use ``commands.propagation.get_propagation_summary()`` instead.
     """
+    warnings.warn(
+        "hamclock.get_propagation_summary() is deprecated. "
+        "Use commands.propagation.get_propagation_summary() instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     summary = {
         'timestamp': '',
         'overall': 'Unknown',

--- a/src/commands/propagation.py
+++ b/src/commands/propagation.py
@@ -35,6 +35,20 @@ from .base import CommandResult
 
 logger = logging.getLogger(__name__)
 
+# Settings persistence for source configuration
+try:
+    from utils.common import SettingsManager
+    _settings = SettingsManager("propagation", defaults={
+        "sources": {
+            "openhamclock": {"host": "localhost", "port": 3000, "enabled": False, "timeout": 10},
+            "hamclock": {"host": "localhost", "port": 8080, "enabled": False, "timeout": 10},
+        }
+    })
+    _HAS_SETTINGS = True
+except ImportError:
+    _settings = None
+    _HAS_SETTINGS = False
+
 
 class DataSource(Enum):
     """Available propagation data sources."""
@@ -61,7 +75,7 @@ class SourceConfig:
         return ""
 
 
-# Module-level source configuration
+# Module-level source configuration (defaults)
 _sources: Dict[DataSource, SourceConfig] = {
     DataSource.NOAA: SourceConfig(
         source=DataSource.NOAA, enabled=True
@@ -73,6 +87,47 @@ _sources: Dict[DataSource, SourceConfig] = {
         source=DataSource.HAMCLOCK, port=8080, enabled=False
     ),
 }
+
+
+def _load_sources() -> None:
+    """Load source configuration from disk (if available)."""
+    if not _HAS_SETTINGS or _settings is None:
+        return
+    saved = _settings.get("sources", {})
+    for key, src_enum in [("openhamclock", DataSource.OPENHAMCLOCK),
+                          ("hamclock", DataSource.HAMCLOCK)]:
+        cfg = saved.get(key)
+        if cfg and isinstance(cfg, dict):
+            _sources[src_enum] = SourceConfig(
+                source=src_enum,
+                host=cfg.get("host", "localhost"),
+                port=cfg.get("port", _sources[src_enum].port),
+                enabled=cfg.get("enabled", False),
+                timeout=cfg.get("timeout", 10),
+            )
+
+
+def _save_sources() -> bool:
+    """Persist source configuration to disk."""
+    if not _HAS_SETTINGS or _settings is None:
+        return False
+    data = {}
+    for key, src_enum in [("openhamclock", DataSource.OPENHAMCLOCK),
+                          ("hamclock", DataSource.HAMCLOCK)]:
+        cfg = _sources.get(src_enum)
+        if cfg:
+            data[key] = {
+                "host": cfg.host,
+                "port": cfg.port,
+                "enabled": cfg.enabled,
+                "timeout": cfg.timeout,
+            }
+    _settings.set("sources", data)
+    return _settings.save()
+
+
+# Load persisted config on module import
+_load_sources()
 
 
 def configure_source(
@@ -117,6 +172,9 @@ def configure_source(
         timeout=timeout,
     )
 
+    # Persist to disk
+    saved = _save_sources()
+
     return CommandResult.ok(
         f"{source.value} configured: {host}:{actual_port} (enabled={enabled})",
         data={
@@ -124,6 +182,7 @@ def configure_source(
             'host': host,
             'port': actual_port,
             'enabled': enabled,
+            'persisted': saved,
         }
     )
 
@@ -505,6 +564,346 @@ def _fetch_openhamclock_data(cfg: SourceConfig) -> Optional[Dict[str, Any]]:
 
     return enhanced if enhanced else None
 
+
+# ==================== Standalone: DX Cluster (Telnet) ====================
+
+def get_dx_spots_telnet(
+    server: str = "dxc.nc7j.com",
+    port: int = 7373,
+    callsign: str = "N0CALL",
+    max_spots: int = 20,
+    timeout: int = 15,
+) -> CommandResult:
+    """Get DX cluster spots via direct telnet connection.
+
+    Bypasses HamClock — connects directly to a DX Spider cluster node.
+    Common public DX clusters:
+        dxc.nc7j.com:7373, telnet.reversebeacon.net:7000
+
+    Args:
+        server: DX cluster hostname
+        port: DX cluster port
+        callsign: Login callsign (some clusters require a valid call)
+        max_spots: Maximum spots to collect
+        timeout: Connection timeout in seconds
+
+    Returns:
+        CommandResult with DX spots list
+    """
+    import socket
+
+    spots = []
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(timeout)
+        sock.connect((server, port))
+
+        # Read login prompt and send callsign
+        data = sock.recv(4096).decode('utf-8', errors='replace')
+        sock.sendall(f"{callsign}\n".encode('utf-8'))
+
+        # Collect spot data
+        buffer = ""
+        import time
+        deadline = time.monotonic() + timeout
+        while len(spots) < max_spots and time.monotonic() < deadline:
+            try:
+                chunk = sock.recv(4096).decode('utf-8', errors='replace')
+                if not chunk:
+                    break
+                buffer += chunk
+                lines = buffer.split('\n')
+                buffer = lines[-1]  # Keep incomplete line
+                for line in lines[:-1]:
+                    line = line.strip()
+                    if line.startswith('DX de ') or 'DX de' in line[:10]:
+                        spots.append(_parse_dx_spot(line))
+            except socket.timeout:
+                break
+
+        sock.sendall(b"bye\n")
+        sock.close()
+
+    except socket.timeout:
+        if not spots:
+            return CommandResult.fail(
+                f"Connection to {server}:{port} timed out",
+                data={'hint': f'Check connectivity to {server}'}
+            )
+    except socket.gaierror:
+        return CommandResult.fail(
+            f"Cannot resolve {server}",
+            data={'hint': 'Check DNS or use IP address'}
+        )
+    except ConnectionRefusedError:
+        return CommandResult.fail(
+            f"Connection refused by {server}:{port}",
+            data={'hint': 'Server may be down or port incorrect'}
+        )
+    except Exception as e:
+        if not spots:
+            return CommandResult.fail(f"DX cluster error: {e}")
+
+    if not spots:
+        return CommandResult.fail("No DX spots received")
+
+    return CommandResult.ok(
+        f"{len(spots)} DX spots from {server}",
+        data={
+            'spots': spots,
+            'count': len(spots),
+            'server': server,
+            'source': 'DX Cluster (telnet)',
+        }
+    )
+
+
+def _parse_dx_spot(line: str) -> Dict[str, Any]:
+    """Parse a DX cluster spot line.
+
+    Format: DX de <spotter>: <freq> <dx_call> <comment> <time>Z
+    """
+    spot: Dict[str, Any] = {'raw': line}
+    try:
+        parts = line.split()
+        if len(parts) >= 5:
+            spot['spotter'] = parts[2].rstrip(':')
+            spot['frequency'] = parts[3]
+            spot['dx_call'] = parts[4]
+            # Comment is everything between dx_call and time
+            if len(parts) > 5:
+                # Last token might be time (e.g., "1234Z")
+                if parts[-1].endswith('Z') and parts[-1][:-1].isdigit():
+                    spot['time'] = parts[-1]
+                    spot['comment'] = ' '.join(parts[5:-1])
+                else:
+                    spot['comment'] = ' '.join(parts[5:])
+    except (IndexError, ValueError):
+        pass
+    return spot
+
+
+# ==================== Standalone: VOACAP Online ====================
+
+def get_voacap_online(
+    tx_lat: float = 0.0,
+    tx_lon: float = 0.0,
+    rx_lat: float = 0.0,
+    rx_lon: float = 0.0,
+    timeout: int = 15,
+) -> CommandResult:
+    """Get VOACAP propagation prediction from VOACAP online service.
+
+    Uses the public VOACAP point-to-point prediction service.
+    Independent of HamClock — works standalone.
+
+    Args:
+        tx_lat: Transmitter latitude
+        tx_lon: Transmitter longitude
+        rx_lat: Receiver latitude
+        rx_lon: Receiver longitude
+        timeout: Request timeout
+
+    Returns:
+        CommandResult with band reliability predictions
+    """
+    import urllib.request
+    import json
+
+    if tx_lat == 0 and tx_lon == 0 and rx_lat == 0 and rx_lon == 0:
+        return CommandResult.fail(
+            "Coordinates required for VOACAP prediction",
+            data={'hint': 'Provide TX and RX lat/lon coordinates'}
+        )
+
+    # VOACAP online API (public, no auth required)
+    url = (
+        f"https://www.voacap.com/prediction.json"
+        f"?tx_lat={tx_lat}&tx_lon={tx_lon}"
+        f"&rx_lat={rx_lat}&rx_lon={rx_lon}"
+        f"&mode=SSB&power=100"
+    )
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        bands = {}
+        if isinstance(data, dict):
+            for key, value in data.items():
+                if 'm' in key.lower() or key.isdigit():
+                    bands[key] = value
+
+        return CommandResult.ok(
+            f"VOACAP prediction: {len(bands)} bands",
+            data={
+                'bands': bands,
+                'tx': {'lat': tx_lat, 'lon': tx_lon},
+                'rx': {'lat': rx_lat, 'lon': rx_lon},
+                'source': 'VOACAP Online',
+                'raw': data,
+            }
+        )
+    except Exception as e:
+        return CommandResult.fail(
+            f"VOACAP online error: {e}",
+            data={'hint': 'Check internet connectivity'}
+        )
+
+
+# ==================== Standalone: Ionosonde Data (prop.kc2g.com) ====================
+
+def get_ionosonde_data(timeout: int = 15) -> CommandResult:
+    """Get real-time ionosonde data from prop.kc2g.com.
+
+    Provides critical frequency (foF2) and Maximum Usable Frequency (MUF)
+    data from ionosonde stations. This is real measured ionospheric data,
+    not modeled predictions.
+
+    Args:
+        timeout: Request timeout
+
+    Returns:
+        CommandResult with ionosonde measurements
+    """
+    import urllib.request
+    import json
+
+    url = "https://prop.kc2g.com/api/stations.json"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if not data:
+            return CommandResult.fail("No ionosonde data available")
+
+        stations = []
+        for station in data[:30]:  # Limit to 30 stations
+            entry: Dict[str, Any] = {
+                'name': station.get('name', ''),
+                'lat': station.get('lat'),
+                'lon': station.get('lon'),
+            }
+            if 'fof2' in station:
+                entry['fof2'] = station['fof2']
+            if 'muf' in station:
+                entry['muf'] = station['muf']
+            if 'hmf2' in station:
+                entry['hmf2'] = station['hmf2']
+            stations.append(entry)
+
+        # Calculate averages for summary
+        fof2_values = [s['fof2'] for s in stations if s.get('fof2')]
+        muf_values = [s['muf'] for s in stations if s.get('muf')]
+        avg_fof2 = sum(fof2_values) / len(fof2_values) if fof2_values else None
+        avg_muf = sum(muf_values) / len(muf_values) if muf_values else None
+
+        summary_parts = []
+        if avg_fof2:
+            summary_parts.append(f"foF2={avg_fof2:.1f}MHz")
+        if avg_muf:
+            summary_parts.append(f"MUF={avg_muf:.1f}MHz")
+
+        return CommandResult.ok(
+            f"Ionosonde: {len(stations)} stations ({', '.join(summary_parts)})",
+            data={
+                'stations': stations,
+                'count': len(stations),
+                'avg_fof2': avg_fof2,
+                'avg_muf': avg_muf,
+                'source': 'prop.kc2g.com',
+            }
+        )
+    except Exception as e:
+        return CommandResult.fail(
+            f"Ionosonde data error: {e}",
+            data={'hint': 'Check internet connectivity'}
+        )
+
+
+# ==================== Standalone: CelesTrak TLE (Satellites) ====================
+
+def get_satellite_tle(
+    satellite: str = "ISS",
+    timeout: int = 15,
+) -> CommandResult:
+    """Get satellite TLE data from CelesTrak.
+
+    Provides Two-Line Element sets for satellite tracking.
+    Independent of HamClock — uses CelesTrak public API directly.
+
+    Args:
+        satellite: Satellite name or NORAD catalog number
+        timeout: Request timeout
+
+    Returns:
+        CommandResult with TLE data
+    """
+    import urllib.request
+    import json
+
+    # Common satellite name mappings
+    name_map = {
+        'ISS': '25544',
+        'NOAA-19': '33591',
+        'NOAA-18': '28654',
+        'ISS (ZARYA)': '25544',
+        'SO-50': '27607',
+        'AO-91': '43017',
+    }
+
+    # Determine query: by name or NORAD ID
+    norad_id = name_map.get(satellite.upper(), '')
+    if norad_id:
+        url = f"https://celestrak.org/NORAD/elements/gp.php?CATNR={norad_id}&FORMAT=JSON"
+    elif satellite.isdigit():
+        url = f"https://celestrak.org/NORAD/elements/gp.php?CATNR={satellite}&FORMAT=JSON"
+    else:
+        url = f"https://celestrak.org/NORAD/elements/gp.php?NAME={satellite}&FORMAT=JSON"
+
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', 'MeshForge/1.0')
+
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            data = json.loads(response.read().decode('utf-8'))
+
+        if not data:
+            return CommandResult.fail(
+                f"No TLE data for '{satellite}'",
+                data={'hint': 'Check satellite name or NORAD ID'}
+            )
+
+        # CelesTrak returns JSON GP format
+        sat_data = data[0] if isinstance(data, list) else data
+        result = {
+            'name': sat_data.get('OBJECT_NAME', satellite),
+            'norad_id': sat_data.get('NORAD_CAT_ID', ''),
+            'epoch': sat_data.get('EPOCH', ''),
+            'inclination': sat_data.get('INCLINATION', ''),
+            'eccentricity': sat_data.get('ECCENTRICITY', ''),
+            'period_min': sat_data.get('PERIOD', ''),
+            'tle_line1': sat_data.get('TLE_LINE1', ''),
+            'tle_line2': sat_data.get('TLE_LINE2', ''),
+            'source': 'CelesTrak',
+        }
+
+        return CommandResult.ok(
+            f"TLE: {result['name']} (NORAD {result['norad_id']})",
+            data=result
+        )
+    except Exception as e:
+        return CommandResult.fail(
+            f"CelesTrak error: {e}",
+            data={'hint': 'Check internet connectivity'}
+        )
 
 # ==================== Internal: HamClock (Legacy) ====================
 

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -269,6 +269,7 @@ class ServiceMenuMixin:
                 ("restart-rns", "Restart rnsd"),
                 ("install", "Install meshtasticd"),
                 ("mqtt-setup", "MQTT Setup           Install & configure broker"),
+                ("openhamclock", "OpenHamClock Docker  Start/stop/status"),
                 ("back", "Back"),
             ]
 
@@ -409,6 +410,8 @@ class ServiceMenuMixin:
                 self._install_native_meshtasticd()
             elif choice == "mqtt-setup":
                 self._mqtt_setup_wizard()
+            elif choice == "openhamclock":
+                self._manage_openhamclock_docker()
             else:
                 self._manage_service(choice)
 
@@ -890,6 +893,192 @@ WantedBy=multi-user.target
                     timeout=15
                 )
             self._wait_for_enter()
+
+    # =========================================================================
+    # OpenHamClock Docker Management
+    # =========================================================================
+
+    def _manage_openhamclock_docker(self):
+        """Manage OpenHamClock as a Docker container."""
+        docker_bin = shutil.which('docker')
+        if not docker_bin:
+            self.dialog.msgbox(
+                "Docker Not Found",
+                "Docker is required for OpenHamClock.\n\n"
+                "Install Docker:\n"
+                "  curl -fsSL https://get.docker.com | sh\n"
+                "  sudo usermod -aG docker $USER"
+            )
+            return
+
+        while True:
+            # Check current container status
+            running = self._is_openhamclock_running()
+            status_str = "Running" if running else "Stopped"
+
+            choices = [
+                ("status", f"Status: {status_str}"),
+                ("start", "Start OpenHamClock"),
+                ("stop", "Stop OpenHamClock"),
+                ("logs", "View Logs"),
+                ("configure", "Configure in MeshForge"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "OpenHamClock (Docker)",
+                "Manage OpenHamClock container.\n"
+                "Community replacement for HamClock.\n"
+                "https://github.com/accius/openhamclock",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "status":
+                self._openhamclock_docker_status()
+            elif choice == "start":
+                self._start_openhamclock_docker()
+            elif choice == "stop":
+                self._stop_openhamclock_docker()
+            elif choice == "logs":
+                self._openhamclock_docker_logs()
+            elif choice == "configure":
+                # Delegate to settings menu mixin
+                try:
+                    self._configure_openhamclock()
+                except AttributeError:
+                    self.dialog.msgbox("Error", "Settings menu not available.")
+
+    def _is_openhamclock_running(self) -> bool:
+        """Check if OpenHamClock Docker container is running."""
+        try:
+            result = subprocess.run(
+                ['docker', 'ps', '--filter', 'name=openhamclock',
+                 '--filter', 'status=running', '--format', '{{.Names}}'],
+                capture_output=True, text=True, timeout=10
+            )
+            return 'openhamclock' in result.stdout.lower()
+        except (subprocess.SubprocessError, OSError):
+            return False
+
+    def _openhamclock_docker_status(self):
+        """Show OpenHamClock Docker container status."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== OpenHamClock Docker Status ===\n")
+
+        try:
+            result = subprocess.run(
+                ['docker', 'ps', '-a', '--filter', 'name=openhamclock',
+                 '--format', 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.stdout.strip():
+                print(result.stdout)
+            else:
+                print("No OpenHamClock container found.\n")
+                print("Start with: docker run -d --name openhamclock -p 3000:3000 openhamclock")
+        except (subprocess.SubprocessError, OSError) as e:
+            print(f"Error checking status: {e}")
+
+        self._wait_for_enter()
+
+    def _start_openhamclock_docker(self):
+        """Start OpenHamClock Docker container."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Starting OpenHamClock ===\n")
+
+        # Check if container already exists
+        try:
+            result = subprocess.run(
+                ['docker', 'ps', '-a', '--filter', 'name=openhamclock',
+                 '--format', '{{.Names}}'],
+                capture_output=True, text=True, timeout=10
+            )
+
+            if 'openhamclock' in result.stdout.lower():
+                # Container exists, just start it
+                print("Starting existing container...")
+                result = subprocess.run(
+                    ['docker', 'start', 'openhamclock'],
+                    capture_output=True, text=True, timeout=30
+                )
+                if result.returncode == 0:
+                    print("\033[0;32m✓\033[0m OpenHamClock started on port 3000")
+                else:
+                    print(f"\033[0;31mError:\033[0m {result.stderr}")
+            else:
+                # Need to create the container
+                print("Pulling and starting OpenHamClock...")
+                print("(This may take a moment on first run)\n")
+                result = subprocess.run(
+                    ['docker', 'run', '-d',
+                     '--name', 'openhamclock',
+                     '-p', '3000:3000',
+                     '--restart', 'unless-stopped',
+                     'ghcr.io/accius/openhamclock:latest'],
+                    capture_output=True, text=True, timeout=120
+                )
+                if result.returncode == 0:
+                    print("\033[0;32m✓\033[0m OpenHamClock started on port 3000")
+                    print("\nAuto-configuring MeshForge...")
+                    try:
+                        from commands import propagation
+                        propagation.configure_source(
+                            propagation.DataSource.OPENHAMCLOCK,
+                            host="localhost", port=3000
+                        )
+                        print("\033[0;32m✓\033[0m MeshForge configured for OpenHamClock")
+                    except ImportError:
+                        pass
+                else:
+                    print(f"\033[0;31mError:\033[0m {result.stderr}")
+
+        except subprocess.TimeoutExpired:
+            print("\033[0;31mError:\033[0m Docker operation timed out.")
+        except (subprocess.SubprocessError, OSError) as e:
+            print(f"\033[0;31mError:\033[0m {e}")
+
+        self._wait_for_enter()
+
+    def _stop_openhamclock_docker(self):
+        """Stop OpenHamClock Docker container."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== Stopping OpenHamClock ===\n")
+
+        try:
+            result = subprocess.run(
+                ['docker', 'stop', 'openhamclock'],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                print("\033[0;32m✓\033[0m OpenHamClock stopped.")
+            else:
+                print(f"\033[0;31mError:\033[0m {result.stderr}")
+        except subprocess.TimeoutExpired:
+            print("\033[0;31mError:\033[0m Stop operation timed out.")
+        except (subprocess.SubprocessError, OSError) as e:
+            print(f"\033[0;31mError:\033[0m {e}")
+
+        self._wait_for_enter()
+
+    def _openhamclock_docker_logs(self):
+        """Show OpenHamClock Docker container logs."""
+        subprocess.run(['clear'], check=False, timeout=5)
+        print("=== OpenHamClock Logs (last 30) ===\n")
+
+        try:
+            subprocess.run(
+                ['docker', 'logs', '--tail', '30', 'openhamclock'],
+                timeout=15
+            )
+        except subprocess.TimeoutExpired:
+            print("Log retrieval timed out.")
+        except (subprocess.SubprocessError, OSError) as e:
+            print(f"Error: {e}")
+
+        self._wait_for_enter()
 
     # =========================================================================
     # MQTT Setup Wizard - Local broker for multi-consumer architecture

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -248,6 +248,170 @@ class TestModuleExports:
         assert hasattr(hamclock, 'get_voacap')
 
 
+class TestConfigPersistence:
+    """Test that source config persists to disk via SettingsManager."""
+
+    def test_configure_source_returns_persisted_flag(self):
+        """configure_source result includes persisted status."""
+        result = configure_source(
+            DataSource.OPENHAMCLOCK, host="persist-test", port=3000
+        )
+        assert result.success is True
+        assert 'persisted' in result.data
+
+    def test_save_and_load_round_trip(self, tmp_path):
+        """Config survives save/load cycle."""
+        import commands.propagation as prop
+
+        # Patch SettingsManager to use temp directory
+        from utils.common import SettingsManager
+        test_settings = SettingsManager(
+            "propagation_test", config_dir=tmp_path,
+            defaults={"sources": {
+                "openhamclock": {"host": "localhost", "port": 3000, "enabled": False, "timeout": 10},
+                "hamclock": {"host": "localhost", "port": 8080, "enabled": False, "timeout": 10},
+            }}
+        )
+
+        # Swap in test settings
+        orig_settings = prop._settings
+        orig_has = prop._HAS_SETTINGS
+        prop._settings = test_settings
+        prop._HAS_SETTINGS = True
+
+        try:
+            # Configure a source (triggers save)
+            result = configure_source(
+                DataSource.OPENHAMCLOCK, host="10.0.0.5", port=3001
+            )
+            assert result.success is True
+            assert result.data['persisted'] is True
+
+            # Reset in-memory to defaults
+            prop._sources[DataSource.OPENHAMCLOCK] = SourceConfig(
+                source=DataSource.OPENHAMCLOCK, port=3000, enabled=False
+            )
+            assert prop._sources[DataSource.OPENHAMCLOCK].host == "localhost"
+
+            # Reload from disk
+            prop._load_sources()
+            cfg = prop._sources[DataSource.OPENHAMCLOCK]
+            assert cfg.host == "10.0.0.5"
+            assert cfg.port == 3001
+            assert cfg.enabled is True
+        finally:
+            prop._settings = orig_settings
+            prop._HAS_SETTINGS = orig_has
+
+    def test_noaa_config_not_persisted(self):
+        """NOAA config is not persisted (always enabled)."""
+        result = configure_source(DataSource.NOAA)
+        assert result.success is True
+        assert 'persisted' not in result.data
+
+    def test_persistence_graceful_without_settings(self):
+        """Module works even if SettingsManager unavailable."""
+        import commands.propagation as prop
+
+        orig_has = prop._HAS_SETTINGS
+        prop._HAS_SETTINGS = False
+        try:
+            result = configure_source(
+                DataSource.HAMCLOCK, host="fallback-test", port=8080
+            )
+            assert result.success is True
+            assert result.data['persisted'] is False
+        finally:
+            prop._HAS_SETTINGS = orig_has
+
+    def test_settings_file_created(self, tmp_path):
+        """Settings file is actually written to disk."""
+        import commands.propagation as prop
+        from utils.common import SettingsManager
+
+        test_settings = SettingsManager(
+            "propagation_file_test", config_dir=tmp_path,
+            defaults={"sources": {}}
+        )
+
+        orig_settings = prop._settings
+        orig_has = prop._HAS_SETTINGS
+        prop._settings = test_settings
+        prop._HAS_SETTINGS = True
+
+        try:
+            configure_source(DataSource.HAMCLOCK, host="filetest", port=8082)
+            assert (tmp_path / "propagation_file_test.json").exists()
+        finally:
+            prop._settings = orig_settings
+            prop._HAS_SETTINGS = orig_has
+
+
+class TestStandaloneFunctions:
+    """Test standalone data source functions."""
+
+    def test_dx_spots_telnet_importable(self):
+        from commands.propagation import get_dx_spots_telnet
+        assert callable(get_dx_spots_telnet)
+
+    def test_voacap_online_requires_coordinates(self):
+        from commands.propagation import get_voacap_online
+        result = get_voacap_online()
+        assert result.success is False
+        assert "coordinates" in result.message.lower()
+
+    def test_voacap_online_importable(self):
+        from commands.propagation import get_voacap_online
+        assert callable(get_voacap_online)
+
+    def test_ionosonde_importable(self):
+        from commands.propagation import get_ionosonde_data
+        assert callable(get_ionosonde_data)
+
+    def test_satellite_tle_importable(self):
+        from commands.propagation import get_satellite_tle
+        assert callable(get_satellite_tle)
+
+    def test_parse_dx_spot(self):
+        from commands.propagation import _parse_dx_spot
+        spot = _parse_dx_spot("DX de W1AW:     14074.0  JA1ABC       FT8 -12 dB 1234Z")
+        assert spot.get('spotter') == 'W1AW'
+        assert spot.get('dx_call') == 'JA1ABC'
+
+    def test_parse_dx_spot_minimal(self):
+        from commands.propagation import _parse_dx_spot
+        spot = _parse_dx_spot("DX de W1AW: 14074.0 JA1ABC comment 1234Z")
+        assert 'raw' in spot
+
+
+class TestDeprecationWarnings:
+    """Test that deprecated hamclock functions emit warnings."""
+
+    def test_get_space_weather_auto_warns(self):
+        import warnings
+        from commands import hamclock
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            hamclock.get_space_weather_auto()
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
+
+    def test_get_band_conditions_auto_warns(self):
+        import warnings
+        from commands import hamclock
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            hamclock.get_band_conditions_auto()
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
+
+    def test_get_propagation_summary_warns(self):
+        import warnings
+        from commands import hamclock
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            hamclock.get_propagation_summary()
+            assert any("deprecated" in str(warning.message).lower() for warning in w)
+
+
 class TestBackwardCompatibility:
     """Ensure existing hamclock tests still pass."""
 


### PR DESCRIPTION
… OpenHamClock

P1 - Config Persistence:
- Propagation source config now persists to ~/.config/meshforge/propagation.json via SettingsManager with auto-load on import and auto-save on configure_source()
- Updated CLAUDE.md with commands/ architecture and propagation usage docs
- Updated hamclock_complete.md with OpenHamClock section and sunset warning

P2 - Standalone Data Sources (no HamClock dependency):
- get_dx_spots_telnet(): Direct DX cluster telnet to DX Spider nodes
- get_voacap_online(): Public VOACAP point-to-point predictions
- get_ionosonde_data(): Real foF2/MUF measurements from prop.kc2g.com
- get_satellite_tle(): CelesTrak TLE for satellite tracking
- Docker OpenHamClock management in service menu (start/stop/status/logs)

P3 - Deprecation:
- Added DeprecationWarning to hamclock.get_space_weather_auto(), get_band_conditions_auto(), get_propagation_summary()

Tests: 46 passed (was 31), 155 across affected files, 0 failures.

https://claude.ai/code/session_013rJQ3XS51KdVw3fDuoCQ8s