### PR TITLE
feat: Add gateway test coverage and TUI entries for heatmap, tiles, a…

### DIFF
--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -953,3 +953,380 @@ class AIToolsMixin:
                     pass
 
         threading.Thread(target=do_open, daemon=True).start()
+
+    # =========================================================================
+    # Heatmap Generation
+    # =========================================================================
+
+    def _generate_heatmap(self):
+        """Generate a node density heatmap and open in browser."""
+        self.dialog.infobox("Generating", "Creating node density heatmap...")
+
+        try:
+            from utils.coverage_map import CoverageMapGenerator
+            from utils.paths import get_real_user_home
+
+            generator = CoverageMapGenerator()
+
+            # Collect nodes from all sources
+            try:
+                from utils.map_data_service import MapDataCollector
+                collector = MapDataCollector()
+                geojson = collector.collect()
+                features = geojson.get('features', [])
+                if features:
+                    generator.add_nodes_from_geojson(geojson)
+                else:
+                    self.dialog.msgbox(
+                        "No Nodes",
+                        "No nodes found from any source.\n\n"
+                        "Check meshtasticd, MQTT, or node cache."
+                    )
+                    return
+            except ImportError as e:
+                self.dialog.msgbox("Error", f"MapDataCollector not available: {e}")
+                return
+
+            # Generate heatmap
+            output_dir = get_real_user_home() / ".local" / "share" / "meshforge"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_file = str(output_dir / "coverage_heatmap.html")
+
+            result_path = generator.generate_heatmap(output_path=output_file)
+
+            if not result_path:
+                self.dialog.msgbox(
+                    "Error",
+                    "Heatmap generation failed.\n\n"
+                    "Folium with HeatMap plugin is required:\n"
+                    "pip3 install folium"
+                )
+                return
+
+            self.dialog.msgbox(
+                "Heatmap Generated",
+                f"Node density heatmap saved to:\n{result_path}\n\n"
+                "Opening in browser..."
+            )
+            self._open_in_browser(result_path)
+
+        except ImportError as e:
+            self.dialog.msgbox(
+                "Error",
+                f"Coverage map generator not available: {e}\n\n"
+                "You may need to install folium:\n"
+                "pip3 install folium"
+            )
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Heatmap generation failed: {e}")
+
+    # =========================================================================
+    # Tile Cache Manager
+    # =========================================================================
+
+    def _tile_cache_menu(self):
+        """Manage offline tile cache for maps."""
+        while True:
+            choices = [
+                ("stats", "Cache Stats         View tile cache status"),
+                ("download", "Download Region     Cache tiles for area"),
+                ("estimate", "Estimate Size       Preview download size"),
+                ("clear", "Clear Expired       Remove old tiles"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Offline Tile Cache",
+                "Manage cached map tiles for offline use:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "stats": ("Cache Stats", self._tile_cache_stats),
+                "download": ("Download Region", self._tile_cache_download),
+                "estimate": ("Estimate Size", self._tile_cache_estimate),
+                "clear": ("Clear Expired", self._tile_cache_clear),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self._safe_call(*entry)
+
+    def _tile_cache_stats(self):
+        """Display tile cache statistics."""
+        try:
+            from utils.tile_cache import TileCache
+            cache = TileCache()
+            stats = cache.get_stats()
+
+            info = [
+                f"Cached Tiles: {stats['tile_count']}",
+                f"Cache Size:   {stats['size_mb']:.1f} MB",
+            ]
+            if stats.get('oldest'):
+                info.append(f"Oldest Tile:  {stats['oldest']}")
+            if stats.get('newest'):
+                info.append(f"Newest Tile:  {stats['newest']}")
+            if stats['tile_count'] == 0:
+                info.append("")
+                info.append("No tiles cached yet. Use 'Download Region'")
+                info.append("to cache tiles for offline map viewing.")
+
+            self.dialog.msgbox("Tile Cache Stats", "\n".join(info))
+        except ImportError:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Failed to get cache stats: {e}")
+
+    def _tile_cache_download(self):
+        """Download tiles for a geographic region."""
+        try:
+            from utils.tile_cache import TileCache, HAWAII_BOUNDS
+
+            # Get bounds from user
+            region_choices = [
+                ("hawaii", "Hawaii              (18.5-22.5N, 160.5-154.5W)"),
+                ("custom", "Custom Region       Enter coordinates"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Download Region",
+                "Select region to cache tiles for:",
+                region_choices
+            )
+
+            if choice is None or choice == "back":
+                return
+
+            if choice == "hawaii":
+                bounds = HAWAII_BOUNDS
+            elif choice == "custom":
+                coords = self.dialog.inputbox(
+                    "Custom Region",
+                    "Enter bounds as: south,west,north,east\n"
+                    "Example: 21.0,-158.5,21.7,-157.5"
+                )
+                if not coords:
+                    return
+                try:
+                    parts = [float(x.strip()) for x in coords.split(',')]
+                    if len(parts) != 4:
+                        self.dialog.msgbox("Error", "Enter exactly 4 coordinates.")
+                        return
+                    bounds = tuple(parts)
+                except ValueError:
+                    self.dialog.msgbox("Error", "Invalid coordinates.")
+                    return
+            else:
+                return
+
+            # Estimate first
+            estimate = TileCache.estimate_download_size(bounds)
+            if 'error' in estimate:
+                self.dialog.msgbox("Error", estimate['error'])
+                return
+
+            confirm = self.dialog.yesno(
+                "Confirm Download",
+                f"Tiles to download: {estimate['total_tiles']}\n"
+                f"Estimated size: {estimate['estimated_mb']:.1f} MB\n\n"
+                "Proceed with download?"
+            )
+
+            if not confirm:
+                return
+
+            self.dialog.infobox("Downloading", "Caching tiles... This may take a while.")
+
+            cache = TileCache()
+            result = cache.download_region(bounds)
+
+            if 'error' in result:
+                self.dialog.msgbox("Error", result['error'])
+            else:
+                self.dialog.msgbox(
+                    "Download Complete",
+                    f"Downloaded: {result['downloaded']} tiles\n"
+                    f"Skipped (cached): {result['skipped']}\n"
+                    f"Failed: {result['failed']}"
+                )
+
+        except ImportError:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Tile download failed: {e}")
+
+    def _tile_cache_estimate(self):
+        """Estimate download size for a region."""
+        try:
+            from utils.tile_cache import TileCache, HAWAII_BOUNDS
+
+            coords = self.dialog.inputbox(
+                "Estimate Size",
+                "Enter bounds as: south,west,north,east\n"
+                "Example: 21.0,-158.5,21.7,-157.5\n"
+                "(Leave empty for Hawaii)"
+            )
+
+            if coords:
+                try:
+                    parts = [float(x.strip()) for x in coords.split(',')]
+                    if len(parts) != 4:
+                        self.dialog.msgbox("Error", "Enter exactly 4 coordinates.")
+                        return
+                    bounds = tuple(parts)
+                except ValueError:
+                    self.dialog.msgbox("Error", "Invalid coordinates.")
+                    return
+            else:
+                bounds = HAWAII_BOUNDS
+
+            estimate = TileCache.estimate_download_size(bounds)
+
+            if 'error' in estimate:
+                self.dialog.msgbox("Error", estimate['error'])
+            else:
+                self.dialog.msgbox(
+                    "Download Estimate",
+                    f"Region: ({bounds[0]:.1f}, {bounds[1]:.1f}) to "
+                    f"({bounds[2]:.1f}, {bounds[3]:.1f})\n"
+                    f"Tile count: {estimate['total_tiles']}\n"
+                    f"Estimated size: {estimate['estimated_mb']:.1f} MB\n"
+                    f"Within limit: {'Yes' if estimate['within_limit'] else 'No'}"
+                )
+
+        except ImportError:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Estimation failed: {e}")
+
+    def _tile_cache_clear(self):
+        """Clear expired tiles from cache."""
+        try:
+            from utils.tile_cache import TileCache
+
+            confirm = self.dialog.yesno(
+                "Clear Expired Tiles",
+                "Remove tiles older than 30 days?\n\n"
+                "This frees disk space but requires re-download\n"
+                "for offline use."
+            )
+
+            if not confirm:
+                return
+
+            cache = TileCache()
+            result = cache.clear_expired()
+
+            freed_mb = result['bytes_freed'] / (1024 * 1024)
+            self.dialog.msgbox(
+                "Cache Cleared",
+                f"Removed: {result['removed']} expired tiles\n"
+                f"Space freed: {freed_mb:.1f} MB"
+            )
+
+        except ImportError:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Cache clear failed: {e}")
+
+    # =========================================================================
+    # Auto-Review System
+    # =========================================================================
+
+    def _auto_review_menu(self):
+        """Code review system - run automated code analysis."""
+        while True:
+            choices = [
+                ("full", "Full Review         Run all review agents"),
+                ("security", "Security Review     Command injection, creds"),
+                ("redundancy", "Redundancy Review   Duplicate code, imports"),
+                ("performance", "Performance Review  Timeouts, loops, memory"),
+                ("reliability", "Reliability Review  Error handling, TODOs"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Code Review",
+                "Automated code analysis agents:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "full": ("Full Review", lambda: self._run_auto_review("ALL")),
+                "security": ("Security Review", lambda: self._run_auto_review("SECURITY")),
+                "redundancy": ("Redundancy Review", lambda: self._run_auto_review("REDUNDANCY")),
+                "performance": ("Performance Review", lambda: self._run_auto_review("PERFORMANCE")),
+                "reliability": ("Reliability Review", lambda: self._run_auto_review("RELIABILITY")),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self._safe_call(*entry)
+
+    def _run_auto_review(self, scope_name: str):
+        """Execute an auto-review with the specified scope."""
+        self.dialog.infobox("Reviewing", f"Running {scope_name.lower()} review...")
+
+        try:
+            from utils.auto_review import ReviewOrchestrator, ReviewScope
+
+            scope_map = {
+                "ALL": ReviewScope.ALL,
+                "SECURITY": ReviewScope.SECURITY,
+                "REDUNDANCY": ReviewScope.REDUNDANCY,
+                "PERFORMANCE": ReviewScope.PERFORMANCE,
+                "RELIABILITY": ReviewScope.RELIABILITY,
+            }
+            scope = scope_map.get(scope_name, ReviewScope.ALL)
+
+            orchestrator = ReviewOrchestrator()
+            report = orchestrator.run_full_review(scope=scope)
+
+            # Build summary
+            lines = [
+                f"Scope: {scope_name}",
+                f"Files Scanned: {report.total_files_scanned}",
+                f"Total Issues: {report.total_issues}",
+                f"Fixes Applied: {report.total_fixes_applied}",
+                "",
+            ]
+
+            for category, result in report.agent_results.items():
+                lines.append(
+                    f"  {category.value.upper()}: "
+                    f"{result.total_issues} issues "
+                    f"({result.critical_count} critical, "
+                    f"{result.high_count} high)"
+                )
+
+            # Show top findings
+            findings = report.get_all_findings()
+            if findings:
+                lines.append("")
+                lines.append("Top findings:")
+                for finding in findings[:10]:
+                    lines.append(
+                        f"  [{finding.severity.value.upper()}] "
+                        f"{finding.file_path}:{finding.line_number or '?'}"
+                    )
+                    lines.append(f"    {finding.issue}")
+
+                if len(findings) > 10:
+                    lines.append(f"  ... and {len(findings) - 10} more")
+
+            self.dialog.msgbox("Review Results", "\n".join(lines))
+
+        except ImportError:
+            self.dialog.msgbox(
+                "Error",
+                "Auto-review module not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Review failed: {e}")

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -877,6 +877,8 @@ class MeshForgeLauncher(
             choices = [
                 ("livemap", "Live NOC Map        Real-time browser view"),
                 ("coverage", "Coverage Map        Generate coverage map"),
+                ("heatmap", "Heatmap             Node density heatmap"),
+                ("tiles", "Offline Tiles       Cache map tiles"),
                 ("topology", "Network Topology    D3.js graph view"),
                 ("traffic", "Traffic Inspector   Packet capture & analysis"),
                 ("quality", "Link Quality        Quality analysis"),
@@ -897,6 +899,8 @@ class MeshForgeLauncher(
             dispatch = {
                 "livemap": ("Live NOC Map", self._open_live_map),
                 "coverage": ("Coverage Map", self._generate_coverage_map),
+                "heatmap": ("Heatmap", self._generate_heatmap),
+                "tiles": ("Offline Tile Cache", self._tile_cache_menu),
                 "topology": ("Network Topology", self._topology_menu),
                 "traffic": ("Traffic Inspector", self.menu_traffic_inspector),
                 "quality": ("Link Quality", self._link_quality_menu),
@@ -1041,6 +1045,7 @@ class MeshForgeLauncher(
                 ("logs", "Logs                View/follow logs"),
                 ("network", "Network Tools       Ping, ports, interfaces"),
                 ("diagnose", "Diagnostics         System health check"),
+                ("review", "Code Review         Auto-review codebase"),
                 ("status", "Quick Status        One-shot status display"),
                 ("shell", "Linux Shell         Drop to bash"),
                 ("reboot", "Reboot/Shutdown     Safe system control"),
@@ -1061,6 +1066,7 @@ class MeshForgeLauncher(
                 "logs": ("Log Viewer", self._logs_menu),
                 "network": ("Network Tools", self._network_menu),
                 "diagnose": ("Diagnostics", self._run_diagnostics),
+                "review": ("Code Review", self._auto_review_menu),
                 "status": ("Quick Status", self._run_terminal_status),
                 "shell": ("Linux Shell", self._drop_to_shell),
                 "reboot": ("Reboot/Shutdown", self._reboot_menu),

--- a/tests/test_meshtastic_handler.py
+++ b/tests/test_meshtastic_handler.py
@@ -1,0 +1,928 @@
+"""
+Tests for MeshtasticHandler - Meshtastic connection and message processing.
+
+Tests the handler's connection logic, message receiving, node tracking,
+send operations, relay discovery, and CLI fallback.
+
+All dependencies are mocked — no live device or network needed.
+
+Run: python3 -m pytest tests/test_meshtastic_handler.py -v
+"""
+
+import sys
+import threading
+import time
+from pathlib import Path
+from queue import Queue, Full
+from unittest.mock import MagicMock, patch, PropertyMock, call
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from gateway.meshtastic_handler import MeshtasticHandler
+from gateway.config import GatewayConfig, MeshtasticConfig
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def gateway_config():
+    """Create a GatewayConfig with test defaults."""
+    config = GatewayConfig()
+    config.meshtastic = MeshtasticConfig(host="127.0.0.1", port=4403)
+    return config
+
+
+@pytest.fixture
+def mock_node_tracker():
+    """Mock UnifiedNodeTracker."""
+    tracker = MagicMock()
+    tracker.get_meshtastic_nodes.return_value = []
+    tracker.add_node = MagicMock()
+    return tracker
+
+
+@pytest.fixture
+def mock_health():
+    """Mock BridgeHealthMonitor."""
+    health = MagicMock()
+    health.record_connection_event = MagicMock()
+    health.record_error = MagicMock(return_value="transient")
+    health.record_message_received = MagicMock()
+    return health
+
+
+@pytest.fixture
+def stop_event():
+    """Threading stop event."""
+    return threading.Event()
+
+
+@pytest.fixture
+def message_queue():
+    """Queue for mesh→RNS messages."""
+    return Queue(maxsize=100)
+
+
+@pytest.fixture
+def handler(gateway_config, mock_node_tracker, mock_health, stop_event, message_queue):
+    """Create a MeshtasticHandler with all mocked dependencies."""
+    stats = {'errors': 0, 'messages_received': 0, 'messages_sent': 0}
+    stats_lock = threading.Lock()
+
+    h = MeshtasticHandler(
+        config=gateway_config,
+        node_tracker=mock_node_tracker,
+        health=mock_health,
+        stop_event=stop_event,
+        stats=stats,
+        stats_lock=stats_lock,
+        message_queue=message_queue,
+    )
+    yield h
+    # Ensure disconnected after test
+    h.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Initialization tests
+# ---------------------------------------------------------------------------
+
+class TestHandlerInit:
+    """Tests for MeshtasticHandler initialization."""
+
+    def test_initial_state(self, handler):
+        """Handler starts disconnected with no interface."""
+        assert handler.is_connected is False
+        assert handler.interface is None
+
+    def test_config_stored(self, handler, gateway_config):
+        """Handler stores config reference."""
+        assert handler.config is gateway_config
+        assert handler.config.meshtastic.host == "127.0.0.1"
+        assert handler.config.meshtastic.port == 4403
+
+    def test_set_network_topology(self, handler):
+        """Setting network topology stores reference."""
+        mock_topo = MagicMock()
+        handler.set_network_topology(mock_topo)
+        assert handler._network_topology is mock_topo
+
+
+# ---------------------------------------------------------------------------
+# Connection tests
+# ---------------------------------------------------------------------------
+
+class TestConnect:
+    """Tests for connection establishment."""
+
+    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
+    @patch('gateway.meshtastic_handler.pub', create=True)
+    def test_connect_success(self, mock_pub, mock_get_cm, handler):
+        """Successful TCP connection via connection manager."""
+        # Mock connection manager
+        mock_cm = MagicMock()
+        mock_cm.acquire_persistent.return_value = True
+        mock_iface = MagicMock()
+        mock_iface.nodes = {}
+        mock_iface.getMyNodeInfo.return_value = {'num': 0xAABB0001}
+        mock_cm.get_interface.return_value = mock_iface
+        mock_get_cm.return_value = mock_cm
+
+        # Patch the imports inside connect()
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': mock_pub,
+            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
+        }):
+            result = handler.connect()
+
+        assert result is True
+        assert handler.is_connected is True
+
+    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
+    def test_connect_acquire_fails(self, mock_get_cm, handler):
+        """Connection fails when persistent acquire returns False."""
+        mock_cm = MagicMock()
+        mock_cm.acquire_persistent.return_value = False
+        mock_get_cm.return_value = mock_cm
+
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': MagicMock(),
+            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
+        }):
+            result = handler.connect()
+
+        assert result is False
+        assert handler.is_connected is False
+
+    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
+    def test_connect_interface_none(self, mock_get_cm, handler):
+        """Connection fails when interface is None."""
+        mock_cm = MagicMock()
+        mock_cm.acquire_persistent.return_value = True
+        mock_cm.get_interface.return_value = None
+        mock_get_cm.return_value = mock_cm
+
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': MagicMock(),
+            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
+        }):
+            result = handler.connect()
+
+        assert result is False
+        assert handler.is_connected is False
+
+    def test_connect_import_error_cli_fallback(self, handler):
+        """Falls back to CLI when meshtastic library not available."""
+        with patch.object(handler, '_test_cli', return_value=True):
+            # Force ImportError on the first import
+            with patch.dict('sys.modules', {'pubsub': None}):
+                with patch('builtins.__import__', side_effect=ImportError("No pubsub")):
+                    result = handler.connect()
+
+        # Should fall back to CLI
+        assert handler.is_connected is True
+
+    def test_connect_general_exception(self, handler):
+        """General exception during connect returns False."""
+        with patch.dict('sys.modules', {'pubsub': None}):
+            with patch('builtins.__import__', side_effect=RuntimeError("boom")):
+                result = handler.connect()
+
+        assert result is False
+        assert handler.is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# Disconnect tests
+# ---------------------------------------------------------------------------
+
+class TestDisconnect:
+    """Tests for disconnection."""
+
+    def test_disconnect_clears_state(self, handler):
+        """Disconnect clears connection state."""
+        handler._connected = True
+        handler._interface = MagicMock()
+        handler._conn_manager = MagicMock()
+
+        handler.disconnect()
+
+        assert handler.is_connected is False
+        assert handler.interface is None
+
+    def test_disconnect_releases_persistent(self, handler):
+        """Disconnect releases persistent connection."""
+        mock_cm = MagicMock()
+        handler._conn_manager = mock_cm
+        handler._connected = True
+
+        handler.disconnect()
+
+        mock_cm.release_persistent.assert_called_once()
+
+    def test_disconnect_unsubscribes_pubsub(self, handler):
+        """Disconnect unsubscribes from pubsub."""
+        mock_handler = MagicMock()
+        handler._pubsub_handler = mock_handler
+        handler._connected = True
+
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': MagicMock(),
+        }):
+            handler.disconnect()
+
+        assert handler._pubsub_handler is None
+
+    def test_disconnect_handles_errors_gracefully(self, handler):
+        """Disconnect doesn't crash on errors."""
+        mock_cm = MagicMock()
+        mock_cm.release_persistent.side_effect = RuntimeError("already closed")
+        handler._conn_manager = mock_cm
+        handler._connected = True
+
+        # Should not raise
+        handler.disconnect()
+        assert handler.is_connected is False
+
+
+# ---------------------------------------------------------------------------
+# Send tests
+# ---------------------------------------------------------------------------
+
+class TestSendText:
+    """Tests for text message sending."""
+
+    def test_send_text_success(self, handler):
+        """Successful send via interface."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        handler._interface = mock_iface
+
+        result = handler.send_text("Hello mesh!", destination="!aabb0001", channel=0)
+
+        assert result is True
+        mock_iface.sendText.assert_called_once_with(
+            "Hello mesh!",
+            destinationId="!aabb0001",
+            channelIndex=0
+        )
+
+    def test_send_text_broadcast(self, handler):
+        """Broadcast when no destination specified."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        handler._interface = mock_iface
+
+        result = handler.send_text("Hello everyone!")
+
+        assert result is True
+        mock_iface.sendText.assert_called_once_with(
+            "Hello everyone!",
+            destinationId="^all",
+            channelIndex=0
+        )
+
+    def test_send_text_not_connected(self, handler):
+        """Send returns False when not connected."""
+        result = handler.send_text("Hello!")
+        assert result is False
+
+    def test_send_text_exception(self, handler):
+        """Send returns False on exception and increments error count."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        mock_iface.sendText.side_effect = RuntimeError("send failed")
+        handler._interface = mock_iface
+
+        result = handler.send_text("Hello!")
+
+        assert result is False
+        assert handler.stats['errors'] == 1
+
+    def test_send_text_cli_fallback(self, handler):
+        """Falls back to CLI when no interface."""
+        handler._connected = True
+        handler._interface = None
+
+        with patch.object(handler, '_send_via_cli', return_value=True) as mock_cli:
+            result = handler.send_text("Hello!", destination="!aabb")
+            assert result is True
+            mock_cli.assert_called_once_with("Hello!", "!aabb", 0)
+
+
+# ---------------------------------------------------------------------------
+# Queue send tests
+# ---------------------------------------------------------------------------
+
+class TestQueueSend:
+    """Tests for persistent queue send handler."""
+
+    def test_queue_send_success(self, handler):
+        """Queue send dispatches message correctly."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        handler._interface = mock_iface
+
+        payload = {'message': 'Test msg', 'destination': '!aabb', 'channel': 1}
+        result = handler.queue_send(payload)
+
+        assert result is True
+        mock_iface.sendText.assert_called_once_with(
+            "Test msg", destinationId="!aabb", channelIndex=1
+        )
+
+    def test_queue_send_broadcast(self, handler):
+        """Queue send broadcasts when no destination."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        handler._interface = mock_iface
+
+        payload = {'message': 'Broadcast'}
+        result = handler.queue_send(payload)
+
+        assert result is True
+        mock_iface.sendText.assert_called_once_with(
+            "Broadcast", destinationId="^all", channelIndex=0
+        )
+
+    def test_queue_send_not_connected(self, handler):
+        """Queue send returns False when disconnected."""
+        result = handler.queue_send({'message': 'test'})
+        assert result is False
+
+    def test_queue_send_no_interface(self, handler):
+        """Queue send returns False with no interface."""
+        handler._connected = True
+        handler._interface = None
+
+        result = handler.queue_send({'message': 'test'})
+        assert result is False
+
+    def test_queue_send_exception(self, handler):
+        """Queue send returns False on exception."""
+        handler._connected = True
+        mock_iface = MagicMock()
+        mock_iface.sendText.side_effect = RuntimeError("boom")
+        handler._interface = mock_iface
+
+        result = handler.queue_send({'message': 'test'})
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Test connection tests
+# ---------------------------------------------------------------------------
+
+class TestTestConnection:
+    """Tests for TCP connection test."""
+
+    @patch('socket.socket')
+    def test_connection_test_success(self, mock_socket_cls, handler):
+        """Successful TCP connection test."""
+        mock_sock = MagicMock()
+        mock_sock.connect_ex.return_value = 0
+        mock_socket_cls.return_value = mock_sock
+
+        result = handler.test_connection()
+
+        assert result is True
+        mock_sock.close.assert_called_once()
+
+    @patch('socket.socket')
+    def test_connection_test_refused(self, mock_socket_cls, handler):
+        """Failed TCP connection test (refused)."""
+        mock_sock = MagicMock()
+        mock_sock.connect_ex.return_value = 111  # ECONNREFUSED
+        mock_socket_cls.return_value = mock_sock
+
+        result = handler.test_connection()
+
+        assert result is False
+
+    @patch('socket.socket')
+    def test_connection_test_exception(self, mock_socket_cls, handler):
+        """TCP connection test handles exceptions."""
+        mock_socket_cls.side_effect = OSError("No network")
+
+        result = handler.test_connection()
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Message receiving tests
+# ---------------------------------------------------------------------------
+
+class TestOnReceive:
+    """Tests for incoming message handling."""
+
+    def test_on_receive_text_message(self, handler, mock_node_tracker, message_queue):
+        """Text messages are queued for bridging."""
+        handler._connected = True
+
+        packet = {
+            'fromId': '!aabb0001',
+            'toId': '!ffffffff',
+            'decoded': {
+                'portnum': 'TEXT_MESSAGE_APP',
+                'payload': b'Hello from mesh!',
+            },
+            'rxSnr': 8.5,
+            'rxRssi': -80,
+            'channel': 0,
+            'hopStart': 3,
+            'hopLimit': 2,
+        }
+
+        with patch.dict('sys.modules', {
+            'commands': MagicMock(),
+            'commands.messaging': MagicMock(),
+        }):
+            handler._on_receive(packet)
+
+        # Node should be added to tracker
+        mock_node_tracker.add_node.assert_called()
+
+        # Message should be in the queue
+        assert not message_queue.empty()
+        msg = message_queue.get_nowait()
+        assert msg.content == "Hello from mesh!"
+        assert msg.source_id == '!aabb0001'
+        assert msg.is_broadcast is True
+
+    def test_on_receive_non_text_portnum(self, handler, mock_node_tracker, message_queue):
+        """Non-text messages don't get queued for bridging."""
+        packet = {
+            'fromId': '!aabb0001',
+            'decoded': {
+                'portnum': 'POSITION_APP',
+            },
+            'hopStart': 3,
+            'hopLimit': 3,
+        }
+
+        handler._on_receive(packet)
+
+        # Node should still be tracked
+        mock_node_tracker.add_node.assert_called()
+        # But no message in queue
+        assert message_queue.empty()
+
+    def test_on_receive_with_relay_node(self, handler, mock_node_tracker):
+        """Relay node discovery via Meshtastic 2.6+ field."""
+        handler._connected = True
+        mock_topo = MagicMock()
+        handler.set_network_topology(mock_topo)
+
+        packet = {
+            'fromId': '!aabb0001',
+            'decoded': {'portnum': 'POSITION_APP'},
+            'relayNode': 0x42,
+            'rxSnr': 5.0,
+            'rxRssi': -90,
+            'hopStart': 3,
+            'hopLimit': 2,
+        }
+
+        handler._on_receive(packet)
+
+        # Relay node should be discovered and added
+        assert mock_node_tracker.add_node.call_count >= 1
+
+    def test_on_receive_exception_handled(self, handler):
+        """Exceptions during receive don't crash."""
+        # Malformed packet
+        packet = {}
+        handler._on_receive(packet)  # Should not raise
+
+    def test_on_receive_routing_filter(self, handler, message_queue):
+        """Messages blocked by routing rules are not queued."""
+        handler._connected = True
+        handler._should_bridge = MagicMock(return_value=False)
+
+        packet = {
+            'fromId': '!aabb0001',
+            'toId': '!ffffffff',
+            'decoded': {
+                'portnum': 'TEXT_MESSAGE_APP',
+                'payload': b'Blocked message',
+            },
+            'hopStart': 3,
+            'hopLimit': 3,
+        }
+
+        with patch.dict('sys.modules', {
+            'commands': MagicMock(),
+            'commands.messaging': MagicMock(),
+        }):
+            handler._on_receive(packet)
+
+        # Message should NOT be in the queue
+        assert message_queue.empty()
+
+    def test_on_receive_queue_full(self, handler, mock_node_tracker):
+        """Full queue drops message gracefully."""
+        small_queue = Queue(maxsize=1)
+        small_queue.put("filler")  # Fill the queue
+        handler._mesh_to_rns_queue = small_queue
+        handler._connected = True
+
+        packet = {
+            'fromId': '!aabb0001',
+            'toId': '!ffffffff',
+            'decoded': {
+                'portnum': 'TEXT_MESSAGE_APP',
+                'payload': b'Overflow message',
+            },
+            'hopStart': 3,
+            'hopLimit': 3,
+        }
+
+        with patch.dict('sys.modules', {
+            'commands': MagicMock(),
+            'commands.messaging': MagicMock(),
+        }):
+            handler._on_receive(packet)  # Should not raise
+
+        assert handler.stats['errors'] == 1
+
+    def test_on_receive_message_callback(self, handler, message_queue):
+        """Message callback is invoked for text messages."""
+        handler._connected = True
+        callback = MagicMock()
+        handler._message_callback = callback
+
+        packet = {
+            'fromId': '!aabb0001',
+            'toId': '!ccdd0002',
+            'decoded': {
+                'portnum': 'TEXT_MESSAGE_APP',
+                'payload': b'Direct message',
+            },
+            'hopStart': 3,
+            'hopLimit': 3,
+        }
+
+        with patch.dict('sys.modules', {
+            'commands': MagicMock(),
+            'commands.messaging': MagicMock(),
+        }):
+            handler._on_receive(packet)
+
+        callback.assert_called_once()
+        msg = callback.call_args[0][0]
+        assert msg.content == "Direct message"
+        assert msg.is_broadcast is False
+
+    def test_on_receive_string_payload(self, handler, message_queue):
+        """String payload (non-bytes) is handled correctly."""
+        handler._connected = True
+
+        packet = {
+            'fromId': '!aabb0001',
+            'toId': '!ffffffff',
+            'decoded': {
+                'portnum': 'TEXT_MESSAGE_APP',
+                'payload': 'Already a string',
+            },
+            'hopStart': 3,
+            'hopLimit': 3,
+        }
+
+        with patch.dict('sys.modules', {
+            'commands': MagicMock(),
+            'commands.messaging': MagicMock(),
+        }):
+            handler._on_receive(packet)
+
+        msg = message_queue.get_nowait()
+        assert msg.content == "Already a string"
+
+
+# ---------------------------------------------------------------------------
+# Relay node discovery tests
+# ---------------------------------------------------------------------------
+
+class TestDiscoverRelayNode:
+    """Tests for relay node discovery (Meshtastic 2.6+)."""
+
+    def test_discover_known_relay(self, handler, mock_node_tracker):
+        """Matches relay byte to known node and updates topology."""
+        mock_topo = MagicMock()
+        handler.set_network_topology(mock_topo)
+
+        # Create a known node whose last byte is 0x42
+        from gateway.node_tracker import UnifiedNode
+        mock_node = MagicMock()
+        mock_node.meshtastic_id = "!aabb0042"
+        mock_node.id = "node-0042"
+        mock_node_tracker.get_meshtastic_nodes.return_value = [mock_node]
+
+        packet = {'rxSnr': 8.0, 'rxRssi': -75}
+        handler._discover_relay_node(0x42, "!ccdd0001", packet)
+
+        mock_topo.add_edge.assert_called_once()
+
+    def test_discover_unknown_relay(self, handler, mock_node_tracker):
+        """Unknown relay byte creates placeholder node."""
+        mock_node_tracker.get_meshtastic_nodes.return_value = []
+
+        handler._discover_relay_node(0xFF, "!ccdd0001", {})
+
+        # A partial node should be added
+        calls = mock_node_tracker.add_node.call_args_list
+        assert len(calls) >= 1
+        added_node = calls[-1][0][0]
+        assert added_node.id == "!????ff"
+
+    def test_discover_relay_invalid_byte(self, handler, mock_node_tracker):
+        """Invalid relay byte (0 or >255) is ignored."""
+        handler._discover_relay_node(0, "!ccdd0001", {})
+        handler._discover_relay_node(256, "!ccdd0001", {})
+        # No nodes should be added for relay discovery (only from _on_receive)
+        # The add_node calls should be 0 since we're calling _discover_relay_node directly
+        mock_node_tracker.add_node.assert_not_called()
+
+    def test_discover_relay_exception_handled(self, handler, mock_node_tracker):
+        """Exceptions during relay discovery don't crash."""
+        mock_node_tracker.get_meshtastic_nodes.side_effect = RuntimeError("boom")
+        handler._discover_relay_node(0x42, "!ccdd0001", {})  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Poll and connection health tests
+# ---------------------------------------------------------------------------
+
+class TestPoll:
+    """Tests for health polling."""
+
+    def test_poll_interface_connected(self, handler):
+        """Polling passes when interface is connected."""
+        mock_iface = MagicMock()
+        mock_iface.isConnected = True
+        mock_iface.nodes = {}
+        handler._interface = mock_iface
+        handler._connected = True
+
+        handler._poll()  # Should not change state
+        assert handler._connected is True
+
+    def test_poll_interface_disconnected(self, handler):
+        """Polling detects disconnected interface."""
+        mock_iface = MagicMock()
+        mock_iface.isConnected = False
+        handler._interface = mock_iface
+        handler._connected = True
+
+        with patch.object(handler, '_handle_connection_lost'):
+            handler._poll()
+            handler._handle_connection_lost.assert_called_once()
+
+    def test_poll_broken_pipe(self, handler):
+        """Polling handles broken pipe exceptions."""
+        mock_iface = MagicMock()
+        type(mock_iface).nodes = PropertyMock(side_effect=BrokenPipeError)
+        mock_iface.isConnected = True
+        handler._interface = mock_iface
+        handler._connected = True
+
+        with patch.object(handler, '_handle_connection_lost'):
+            handler._poll()
+            handler._handle_connection_lost.assert_called_once()
+
+    def test_poll_no_interface(self, handler):
+        """Polling does nothing when no interface."""
+        handler._interface = None
+        handler._poll()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Connection lost handling tests
+# ---------------------------------------------------------------------------
+
+class TestHandleConnectionLost:
+    """Tests for connection loss handling."""
+
+    def test_handle_connection_lost_clears_state(self, handler):
+        """Connection loss resets handler state."""
+        handler._connected = True
+        handler._interface = MagicMock()
+        mock_cm = MagicMock()
+        handler._conn_manager = mock_cm
+
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': MagicMock(),
+            'utils.meshtastic_connection': MagicMock(),
+        }):
+            handler._handle_connection_lost()
+
+        assert handler._connected is False
+        assert handler._interface is None
+        mock_cm.release_persistent.assert_called_once()
+
+    def test_handle_connection_lost_notifies_status(self, handler):
+        """Connection loss triggers status callback."""
+        handler._connected = True
+        callback = MagicMock()
+        handler._status_callback = callback
+
+        with patch.dict('sys.modules', {
+            'pubsub': MagicMock(),
+            'pubsub.pub': MagicMock(),
+            'utils.meshtastic_connection': MagicMock(),
+        }):
+            handler._handle_connection_lost()
+
+        callback.assert_called_with("meshtastic_disconnected")
+
+
+# ---------------------------------------------------------------------------
+# CLI fallback tests
+# ---------------------------------------------------------------------------
+
+class TestCLIFallback:
+    """Tests for Meshtastic CLI fallback."""
+
+    @patch('subprocess.run')
+    def test_send_via_cli_success(self, mock_run, handler):
+        """CLI send with destination."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch.dict('sys.modules', {
+            'utils.cli': MagicMock(find_meshtastic_cli=MagicMock(return_value='/usr/bin/meshtastic')),
+        }):
+            result = handler._send_via_cli("Hello!", "!aabb", 1)
+
+        assert result is True
+        cmd = mock_run.call_args[0][0]
+        assert '--sendtext' in cmd
+        assert 'Hello!' in cmd
+        assert '--dest' in cmd
+        assert '--ch-index' in cmd
+
+    @patch('subprocess.run')
+    def test_send_via_cli_failure(self, mock_run, handler):
+        """CLI send returns False on failure."""
+        mock_run.return_value = MagicMock(returncode=1)
+
+        with patch.dict('sys.modules', {
+            'utils.cli': MagicMock(find_meshtastic_cli=MagicMock(return_value='meshtastic')),
+        }):
+            result = handler._send_via_cli("Hello!")
+
+        assert result is False
+
+    @patch('subprocess.run')
+    def test_send_via_cli_exception(self, mock_run, handler):
+        """CLI send handles exceptions."""
+        mock_run.side_effect = FileNotFoundError("no such file")
+
+        with patch.dict('sys.modules', {
+            'utils.cli': MagicMock(find_meshtastic_cli=MagicMock(return_value='meshtastic')),
+        }):
+            result = handler._send_via_cli("Hello!")
+
+        assert result is False
+
+    @patch('subprocess.run')
+    def test_test_cli_success(self, mock_run, handler):
+        """CLI availability test success."""
+        mock_run.return_value = MagicMock(returncode=0)
+
+        with patch.dict('sys.modules', {
+            'utils.cli': MagicMock(find_meshtastic_cli=MagicMock(return_value='/usr/bin/meshtastic')),
+        }):
+            result = handler._test_cli()
+
+        assert result is True
+
+    def test_test_cli_not_found(self, handler):
+        """CLI test returns False when CLI not found."""
+        with patch.dict('sys.modules', {
+            'utils.cli': MagicMock(find_meshtastic_cli=MagicMock(return_value=None)),
+        }):
+            result = handler._test_cli()
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Node update tests
+# ---------------------------------------------------------------------------
+
+class TestUpdateNodes:
+    """Tests for node tracker updates."""
+
+    def test_update_nodes_from_interface(self, handler, mock_node_tracker):
+        """Nodes from interface are added to tracker."""
+        mock_iface = MagicMock()
+        mock_iface.getMyNodeInfo.return_value = {'num': 0xAABB0001}
+        mock_iface.nodes = {
+            '!aabb0001': {'num': 0xAABB0001, 'user': {'longName': 'Local'}},
+            '!ccdd0002': {'num': 0xCCDD0002, 'user': {'longName': 'Remote'}},
+        }
+        handler._interface = mock_iface
+
+        handler._update_nodes()
+
+        assert mock_node_tracker.add_node.call_count == 2
+
+    def test_update_nodes_no_interface(self, handler, mock_node_tracker):
+        """Update does nothing without interface."""
+        handler._interface = None
+        handler._update_nodes()
+        mock_node_tracker.add_node.assert_not_called()
+
+    def test_update_nodes_exception(self, handler, mock_node_tracker):
+        """Update handles exceptions gracefully."""
+        mock_iface = MagicMock()
+        mock_iface.getMyNodeInfo.side_effect = RuntimeError("boom")
+        handler._interface = mock_iface
+
+        handler._update_nodes()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Status notification tests
+# ---------------------------------------------------------------------------
+
+class TestNotifyStatus:
+    """Tests for status callback notification."""
+
+    def test_notify_status_calls_callback(self, handler):
+        """Status callback is invoked."""
+        callback = MagicMock()
+        handler._status_callback = callback
+
+        handler._notify_status("meshtastic_connected")
+
+        callback.assert_called_once_with("meshtastic_connected")
+
+    def test_notify_status_no_callback(self, handler):
+        """No error when callback is None."""
+        handler._status_callback = None
+        handler._notify_status("meshtastic_connected")  # Should not raise
+
+    def test_notify_status_callback_error(self, handler):
+        """Callback errors don't crash handler."""
+        callback = MagicMock(side_effect=RuntimeError("boom"))
+        handler._status_callback = callback
+
+        handler._notify_status("meshtastic_connected")  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Run loop tests
+# ---------------------------------------------------------------------------
+
+class TestRunLoop:
+    """Tests for the main connection loop."""
+
+    def test_run_loop_stops_on_event(self, handler, stop_event):
+        """Run loop exits when stop event is set."""
+        stop_event.set()
+        handler.run_loop()  # Should return immediately
+
+    def test_run_loop_connects_and_polls(self, handler, stop_event, mock_health):
+        """Run loop attempts connection then polls."""
+        call_count = [0]
+
+        def mock_connect():
+            handler._connected = True
+            return True
+
+        def mock_poll():
+            call_count[0] += 1
+            if call_count[0] >= 2:
+                stop_event.set()
+
+        with patch.object(handler, 'connect', side_effect=mock_connect):
+            with patch.object(handler, '_poll', side_effect=mock_poll):
+                handler.run_loop()
+
+        assert call_count[0] >= 1
+        mock_health.record_connection_event.assert_any_call("meshtastic", "connected")
+
+    def test_run_loop_handles_connection_error(self, handler, stop_event, mock_health):
+        """Run loop handles connection errors with backoff."""
+        attempt = [0]
+
+        def mock_connect():
+            attempt[0] += 1
+            if attempt[0] >= 2:
+                stop_event.set()
+            raise ConnectionResetError("connection reset")
+
+        with patch.object(handler, 'connect', side_effect=mock_connect):
+            handler.run_loop()
+
+        mock_health.record_error.assert_called()

--- a/tests/test_packet_dissectors.py
+++ b/tests/test_packet_dissectors.py
@@ -1,0 +1,1028 @@
+"""
+Tests for Packet Dissectors - Protocol parsers for mesh network packets.
+
+Tests MeshtasticDissector, RNSDissector, and DisplayFilter.
+Validates packet parsing, protocol tree construction, and filter matching.
+
+Run: python3 -m pytest tests/test_packet_dissectors.py -v
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# Add src to path
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from monitoring.traffic_models import (
+    FieldType,
+    HopState,
+    MeshPacket,
+    MESHTASTIC_PORTS,
+    PacketDirection,
+    PacketField,
+    PacketProtocol,
+    PacketTree,
+)
+from monitoring.packet_dissectors import (
+    MeshtasticDissector,
+    RNSDissector,
+    DisplayFilter,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def meshtastic_dissector():
+    """Create a MeshtasticDissector instance."""
+    return MeshtasticDissector()
+
+
+@pytest.fixture
+def rns_dissector():
+    """Create an RNSDissector instance."""
+    return RNSDissector()
+
+
+@pytest.fixture
+def basic_meshtastic_metadata():
+    """Basic Meshtastic packet metadata."""
+    return {
+        "protocol": "meshtastic",
+        "from": "!aabb0001",
+        "to": "!ffffffff",
+        "channel": 0,
+        "hopLimit": 2,
+        "hopStart": 3,
+        "viaMqtt": False,
+        "wantAck": False,
+        "portnum": 1,
+        "snr": 8.5,
+        "rssi": -80,
+    }
+
+
+@pytest.fixture
+def text_message_metadata():
+    """Meshtastic text message metadata with decoded payload."""
+    return {
+        "protocol": "meshtastic",
+        "from": "!aabb0001",
+        "to": "!ccdd0002",
+        "channel": 0,
+        "hopLimit": 3,
+        "hopStart": 3,
+        "portnum": 1,
+        "snr": 12.0,
+        "rssi": -65,
+        "decoded": {
+            "portnum": 1,
+            "text": "Hello mesh!",
+            "payload": b"Hello mesh!",
+        },
+    }
+
+
+@pytest.fixture
+def position_metadata():
+    """Meshtastic position packet metadata."""
+    return {
+        "protocol": "meshtastic",
+        "from": "!aabb0001",
+        "to": "!ffffffff",
+        "channel": 0,
+        "hopLimit": 3,
+        "hopStart": 3,
+        "portnum": 4,
+        "decoded": {
+            "portnum": 4,
+            "position": {
+                "latitude": 21.3069,
+                "longitude": -157.8583,
+                "altitude": 45,
+            }
+        },
+    }
+
+
+@pytest.fixture
+def nodeinfo_metadata():
+    """Meshtastic node info packet metadata."""
+    return {
+        "protocol": "meshtastic",
+        "from": "!aabb0001",
+        "to": "!ffffffff",
+        "portnum": 5,
+        "hopLimit": 3,
+        "hopStart": 3,
+        "decoded": {
+            "portnum": 5,
+            "user": {
+                "longName": "Maui Gateway",
+                "shortName": "MG01",
+                "hwModel": "HELTEC_V3",
+            }
+        },
+    }
+
+
+@pytest.fixture
+def telemetry_metadata():
+    """Meshtastic telemetry packet metadata."""
+    return {
+        "protocol": "meshtastic",
+        "from": "!aabb0001",
+        "to": "!ffffffff",
+        "portnum": 67,
+        "hopLimit": 3,
+        "hopStart": 3,
+        "decoded": {
+            "portnum": 67,
+            "telemetry": {
+                "deviceMetrics": {
+                    "batteryLevel": 85,
+                    "voltage": 3.7,
+                    "channelUtilization": 12.5,
+                }
+            }
+        },
+    }
+
+
+@pytest.fixture
+def rns_metadata():
+    """Basic RNS packet metadata."""
+    return {
+        "protocol": "rns",
+        "dest_hash": "abcdef0123456789abcdef0123456789",
+        "source_hash": "1234567890abcdef1234567890abcdef",
+        "packet_type": "DATA",
+        "hops": 2,
+        "interface": "TCPInterface",
+        "service_type": "lxmf.delivery",
+    }
+
+
+@pytest.fixture
+def rns_announce_metadata():
+    """RNS announce packet metadata."""
+    return {
+        "protocol": "rns",
+        "dest_hash": "abcdef0123456789abcdef0123456789",
+        "source_hash": "1234567890abcdef1234567890abcdef",
+        "packet_type": "ANNOUNCE",
+        "hops": 0,
+        "interface": "AutoInterface",
+        "aspect": "lxmf.delivery",
+        "announce_app_data": b"Maui Node",
+        "identity_hash": "aabbccdd11223344",
+    }
+
+
+# ---------------------------------------------------------------------------
+# MeshtasticDissector - can_dissect tests
+# ---------------------------------------------------------------------------
+
+class TestMeshtasticCanDissect:
+    """Tests for MeshtasticDissector.can_dissect()."""
+
+    def test_can_dissect_by_protocol(self, meshtastic_dissector):
+        """Detects Meshtastic by protocol field."""
+        assert meshtastic_dissector.can_dissect(b"", {"protocol": "meshtastic"}) is True
+
+    def test_can_dissect_by_from_to(self, meshtastic_dissector):
+        """Detects Meshtastic by from/to fields."""
+        assert meshtastic_dissector.can_dissect(b"", {"from": "!abc", "to": "!fff"}) is True
+
+    def test_cannot_dissect_rns(self, meshtastic_dissector):
+        """Does not match RNS protocol."""
+        assert meshtastic_dissector.can_dissect(b"", {"protocol": "rns"}) is False
+
+    def test_cannot_dissect_empty(self, meshtastic_dissector):
+        """Does not match empty metadata."""
+        assert meshtastic_dissector.can_dissect(b"", {}) is False
+
+
+# ---------------------------------------------------------------------------
+# MeshtasticDissector - dissect tests
+# ---------------------------------------------------------------------------
+
+class TestMeshtasticDissect:
+    """Tests for MeshtasticDissector.dissect()."""
+
+    def test_basic_packet_fields(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Basic packet fields are extracted correctly."""
+        packet = meshtastic_dissector.dissect(b"test_data", basic_meshtastic_metadata)
+
+        assert packet.protocol == PacketProtocol.MESHTASTIC
+        assert packet.source == "!aabb0001"
+        assert packet.destination == "!ffffffff"
+        assert packet.channel == 0
+        assert packet.hop_limit == 2
+        assert packet.hop_start == 3
+        assert packet.hops_taken == 1
+        assert packet.via_mqtt is False
+        assert packet.want_ack is False
+        assert packet.portnum == 1
+        assert packet.port_name == "TEXT_MESSAGE"
+        assert packet.snr == 8.5
+        assert packet.rssi == -80
+        assert packet.size == 9  # len(b"test_data")
+
+    def test_direction_inbound(self, meshtastic_dissector):
+        """Default direction is inbound."""
+        metadata = {"from": "!abc", "to": "!fff", "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.direction == PacketDirection.INBOUND
+
+    def test_direction_outbound(self, meshtastic_dissector):
+        """Outbound direction from metadata."""
+        metadata = {"from": "!abc", "to": "!fff", "direction": "outbound",
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.direction == PacketDirection.OUTBOUND
+
+    def test_direction_relayed(self, meshtastic_dissector):
+        """Relayed direction when relay node present."""
+        metadata = {"from": "!abc", "to": "!fff", "relayNode": 42,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.direction == PacketDirection.RELAYED
+
+    def test_via_mqtt(self, meshtastic_dissector):
+        """Via MQTT flag is captured."""
+        metadata = {"from": "!abc", "to": "!fff", "viaMqtt": True,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.via_mqtt is True
+
+    def test_channel_utilization(self, meshtastic_dissector):
+        """Channel utilization metric captured."""
+        metadata = {"from": "!abc", "to": "!fff", "channelUtilization": 25.5,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.channel_utilization == 25.5
+
+    def test_air_util_tx(self, meshtastic_dissector):
+        """TX air utilization metric captured."""
+        metadata = {"from": "!abc", "to": "!fff", "airUtilTx": 3.2,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.air_util_tx == 3.2
+
+    def test_relay_node_captured(self, meshtastic_dissector):
+        """Relay node from 2.6+ captured."""
+        metadata = {"from": "!abc", "to": "!fff", "relayNode": 0x42,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.relay_node == 0x42
+
+    def test_next_hop_captured(self, meshtastic_dissector):
+        """Next hop from 2.6+ captured."""
+        metadata = {"from": "!abc", "to": "!fff", "nextHop": 0x55,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.next_hop == 0x55
+
+    def test_relay_node_zero_ignored(self, meshtastic_dissector):
+        """Relay node 0 is treated as not set."""
+        metadata = {"from": "!abc", "to": "!fff", "relayNode": 0,
+                     "hopLimit": 3, "hopStart": 3}
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.relay_node is None
+
+    def test_decoded_text_payload(self, meshtastic_dissector, text_message_metadata):
+        """Text message payload extracted."""
+        packet = meshtastic_dissector.dissect(b"test", text_message_metadata)
+        assert packet.decoded_payload is not None
+        assert packet.payload == b"Hello mesh!"
+
+    def test_decoded_string_payload(self, meshtastic_dissector):
+        """String payload (non-bytes) is encoded."""
+        metadata = {
+            "from": "!abc", "to": "!fff", "portnum": 1,
+            "hopLimit": 3, "hopStart": 3,
+            "decoded": {"payload": "string_payload"},
+        }
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.payload == b"string_payload"
+
+    def test_alternative_field_names(self, meshtastic_dissector):
+        """Alternative field names (fromId, toId, rxSnr, rxRssi) work."""
+        metadata = {
+            "fromId": "!aabb0001",
+            "toId": "!ccdd0002",
+            "rxSnr": 5.0,
+            "rxRssi": -90,
+            "hopLimit": 3,
+            "hopStart": 3,
+        }
+        packet = meshtastic_dissector.dissect(b"", metadata)
+        assert packet.source == "!aabb0001"
+        assert packet.destination == "!ccdd0002"
+        assert packet.snr == 5.0
+        assert packet.rssi == -90
+
+
+# ---------------------------------------------------------------------------
+# MeshtasticDissector - protocol tree tests
+# ---------------------------------------------------------------------------
+
+class TestMeshtasticProtocolTree:
+    """Tests for protocol tree construction."""
+
+    def test_tree_has_frame_layer(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Protocol tree includes Frame layer."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+        assert packet.tree is not None
+
+        frame = packet.tree.get_field("frame.time")
+        assert frame is not None
+        assert frame.field_type == FieldType.TIMESTAMP
+
+    def test_tree_has_mesh_layer(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Protocol tree includes Meshtastic layer fields."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+
+        source = packet.tree.get_field("mesh.from")
+        assert source is not None
+        assert source.value == "!aabb0001"
+
+        dest = packet.tree.get_field("mesh.to")
+        assert dest is not None
+        assert dest.value == "!ffffffff"
+
+    def test_tree_has_routing(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Protocol tree includes routing fields."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+
+        hop_limit = packet.tree.get_field("mesh.hop_limit")
+        assert hop_limit is not None
+        assert hop_limit.value == 2
+
+        hops = packet.tree.get_field("mesh.hops")
+        assert hops is not None
+        assert hops.value == 1
+
+    def test_tree_has_metrics(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Protocol tree includes radio metrics."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+
+        snr = packet.tree.get_field("mesh.snr")
+        assert snr is not None
+        assert snr.value == 8.5
+
+        rssi = packet.tree.get_field("mesh.rssi")
+        assert rssi is not None
+        assert rssi.value == -80
+
+    def test_tree_has_payload_info(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Protocol tree includes payload info."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+
+        portnum = packet.tree.get_field("mesh.portnum")
+        assert portnum is not None
+        assert portnum.value == 1
+
+        port_name = packet.tree.get_field("mesh.port")
+        assert port_name is not None
+        assert port_name.value == "TEXT_MESSAGE"
+
+    def test_tree_relay_tracking(self, meshtastic_dissector):
+        """Protocol tree includes relay/next_hop fields."""
+        metadata = {
+            "from": "!abc", "to": "!fff",
+            "relayNode": 0x42, "nextHop": 0x55,
+            "hopLimit": 2, "hopStart": 3,
+        }
+        packet = meshtastic_dissector.dissect(b"", metadata)
+
+        relay = packet.tree.get_field("mesh.relay")
+        assert relay is not None
+        assert "42" in relay.value
+
+        next_hop = packet.tree.get_field("mesh.next_hop")
+        assert next_hop is not None
+        assert "55" in next_hop.value
+
+    def test_tree_text_message_decoded(self, meshtastic_dissector, text_message_metadata):
+        """Text message content appears in tree."""
+        packet = meshtastic_dissector.dissect(b"", text_message_metadata)
+
+        text = packet.tree.get_field("mesh.text")
+        assert text is not None
+        assert text.value == "Hello mesh!"
+
+    def test_tree_position_decoded(self, meshtastic_dissector, position_metadata):
+        """Position data appears in tree."""
+        packet = meshtastic_dissector.dissect(b"", position_metadata)
+
+        lat = packet.tree.get_field("mesh.pos.lat")
+        assert lat is not None
+        assert abs(lat.value - 21.3069) < 0.001
+
+        lon = packet.tree.get_field("mesh.pos.lon")
+        assert lon is not None
+        assert abs(lon.value - (-157.8583)) < 0.001
+
+    def test_tree_nodeinfo_decoded(self, meshtastic_dissector, nodeinfo_metadata):
+        """Node info data appears in tree."""
+        packet = meshtastic_dissector.dissect(b"", nodeinfo_metadata)
+
+        long_name = packet.tree.get_field("mesh.user.long")
+        assert long_name is not None
+        assert long_name.value == "Maui Gateway"
+
+        short_name = packet.tree.get_field("mesh.user.short")
+        assert short_name is not None
+        assert short_name.value == "MG01"
+
+    def test_tree_telemetry_decoded(self, meshtastic_dissector, telemetry_metadata):
+        """Telemetry data appears in tree."""
+        packet = meshtastic_dissector.dissect(b"", telemetry_metadata)
+
+        battery = packet.tree.get_field("mesh.telem.battery")
+        assert battery is not None
+        assert battery.value == 85
+
+        voltage = packet.tree.get_field("mesh.telem.voltage")
+        assert voltage is not None
+        assert abs(voltage.value - 3.7) < 0.01
+
+    def test_tree_ascii_output(self, meshtastic_dissector, basic_meshtastic_metadata):
+        """Tree generates readable ASCII output."""
+        packet = meshtastic_dissector.dissect(b"data", basic_meshtastic_metadata)
+        ascii_output = packet.tree.format_ascii()
+
+        assert "Frame" in ascii_output
+        assert "Meshtastic" in ascii_output
+        assert "Source" in ascii_output
+
+
+# ---------------------------------------------------------------------------
+# RNSDissector - can_dissect tests
+# ---------------------------------------------------------------------------
+
+class TestRNSCanDissect:
+    """Tests for RNSDissector.can_dissect()."""
+
+    def test_can_dissect_by_protocol(self, rns_dissector):
+        """Detects RNS by protocol field."""
+        assert rns_dissector.can_dissect(b"", {"protocol": "rns"}) is True
+
+    def test_can_dissect_by_dest_hash(self, rns_dissector):
+        """Detects RNS by dest_hash field."""
+        assert rns_dissector.can_dissect(b"", {"dest_hash": "abcdef"}) is True
+
+    def test_can_dissect_by_destination_hash(self, rns_dissector):
+        """Detects RNS by destination_hash field."""
+        assert rns_dissector.can_dissect(b"", {"destination_hash": "abcdef"}) is True
+
+    def test_can_dissect_by_packet_type(self, rns_dissector):
+        """Detects RNS by packet_type field."""
+        assert rns_dissector.can_dissect(b"", {"packet_type": "ANNOUNCE"}) is True
+
+    def test_cannot_dissect_meshtastic(self, rns_dissector):
+        """Does not match Meshtastic protocol."""
+        assert rns_dissector.can_dissect(b"", {"protocol": "meshtastic"}) is False
+
+    def test_cannot_dissect_empty(self, rns_dissector):
+        """Does not match empty metadata."""
+        assert rns_dissector.can_dissect(b"", {}) is False
+
+
+# ---------------------------------------------------------------------------
+# RNSDissector - dissect tests
+# ---------------------------------------------------------------------------
+
+class TestRNSDissect:
+    """Tests for RNSDissector.dissect()."""
+
+    def test_basic_rns_packet(self, rns_dissector, rns_metadata):
+        """Basic RNS packet fields are extracted."""
+        raw_data = bytes(20)  # Enough for header parsing
+        packet = rns_dissector.dissect(raw_data, rns_metadata)
+
+        assert packet.protocol == PacketProtocol.RNS
+        assert packet.rns_dest_hash == bytes.fromhex("abcdef0123456789abcdef0123456789")
+        assert packet.source == "1234567890abcdef1234567890abcdef"
+        assert packet.hops_taken == 2
+        assert packet.rns_service == "lxmf.delivery"
+        assert packet.rns_interface == "TCPInterface"
+
+    def test_rns_destination_from_hash(self, rns_dissector, rns_metadata):
+        """Destination is derived from dest_hash (first 16 hex chars)."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+        assert packet.destination == "abcdef0123456789"  # First 16 hex chars
+
+    def test_rns_hop_calculation(self, rns_dissector, rns_metadata):
+        """RNS hop limit is 128 - hops_taken."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+        assert packet.hop_start == 128
+        assert packet.hop_limit == 126  # 128 - 2
+
+    def test_rns_direction_inbound(self, rns_dissector):
+        """Default direction is inbound."""
+        metadata = {"protocol": "rns", "dest_hash": "aa" * 16}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.direction == PacketDirection.INBOUND
+
+    def test_rns_direction_outbound(self, rns_dissector):
+        """Outbound direction from metadata."""
+        metadata = {"protocol": "rns", "dest_hash": "aa" * 16, "direction": "outbound"}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.direction == PacketDirection.OUTBOUND
+
+    def test_rns_direction_internal(self, rns_dissector):
+        """Internal direction from metadata."""
+        metadata = {"protocol": "rns", "dest_hash": "aa" * 16, "direction": "internal"}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.direction == PacketDirection.INTERNAL
+
+    def test_rns_dest_hash_bytes(self, rns_dissector):
+        """dest_hash as bytes instead of string."""
+        dest = bytes.fromhex("abcdef0123456789abcdef0123456789")
+        metadata = {"protocol": "rns", "dest_hash": dest}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.rns_dest_hash == dest
+
+    def test_rns_dest_hash_invalid(self, rns_dissector):
+        """Invalid dest_hash string is handled."""
+        metadata = {"protocol": "rns", "dest_hash": "not_hex"}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.rns_dest_hash is None
+
+    def test_rns_source_from_bytes(self, rns_dissector):
+        """Source hash from bytes is converted to hex string."""
+        source = bytes.fromhex("aabbccdd11223344")
+        metadata = {"protocol": "rns", "source_hash": source}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.source == "aabbccdd11223344"
+
+    def test_rns_source_fallback(self, rns_dissector):
+        """Source falls back to 'local' when not available."""
+        metadata = {"protocol": "rns"}
+        packet = rns_dissector.dissect(bytes(20), metadata)
+        assert packet.source == "local"
+
+    def test_rns_empty_data(self, rns_dissector):
+        """Empty raw data doesn't crash."""
+        metadata = {"protocol": "rns"}
+        packet = rns_dissector.dissect(b"", metadata)
+        assert packet.size == 0
+
+
+# ---------------------------------------------------------------------------
+# RNSDissector - protocol tree tests
+# ---------------------------------------------------------------------------
+
+class TestRNSProtocolTree:
+    """Tests for RNS protocol tree construction."""
+
+    def test_tree_has_frame_layer(self, rns_dissector, rns_metadata):
+        """Tree includes Frame layer."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+        assert packet.tree is not None
+
+        frame_time = packet.tree.get_field("frame.time")
+        assert frame_time is not None
+
+    def test_tree_has_rns_layer(self, rns_dissector, rns_metadata):
+        """Tree includes Reticulum layer."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+
+        packet_type = packet.tree.get_field("rns.type")
+        assert packet_type is not None
+        assert packet_type.value == "DATA"
+
+    def test_tree_has_dest_hash(self, rns_dissector, rns_metadata):
+        """Tree includes destination hash."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+
+        dest = packet.tree.get_field("rns.dest_hash")
+        assert dest is not None
+        assert dest.value == "abcdef0123456789abcdef0123456789"
+
+    def test_tree_has_routing(self, rns_dissector, rns_metadata):
+        """Tree includes routing fields."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+
+        hops = packet.tree.get_field("rns.hops")
+        assert hops is not None
+        assert hops.value == 2
+
+        ttl = packet.tree.get_field("rns.ttl")
+        assert ttl is not None
+        assert ttl.value == 126
+
+    def test_tree_has_interface(self, rns_dissector, rns_metadata):
+        """Tree includes interface info."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+
+        iface = packet.tree.get_field("rns.interface")
+        assert iface is not None
+        assert iface.value == "TCPInterface"
+
+    def test_tree_has_service(self, rns_dissector, rns_metadata):
+        """Tree includes service/aspect."""
+        packet = rns_dissector.dissect(bytes(20), rns_metadata)
+
+        service = packet.tree.get_field("rns.service")
+        assert service is not None
+        assert service.value == "lxmf.delivery"
+
+    def test_tree_header_parsing(self, rns_dissector, rns_metadata):
+        """Tree parses raw header bytes when available."""
+        # Construct raw data with known header bytes
+        raw = bytes([0x32, 0x10]) + bytes(18)  # flags=3, hops=2, type=1
+        packet = rns_dissector.dissect(raw, rns_metadata)
+
+        flags = packet.tree.get_field("rns.header.flags")
+        assert flags is not None
+        assert flags.value == 3
+
+        header_hops = packet.tree.get_field("rns.header.hops")
+        assert header_hops is not None
+        assert header_hops.value == 2
+
+    def test_tree_announce_fields(self, rns_dissector, rns_announce_metadata):
+        """Announce packet has announce-specific fields."""
+        raw = bytes(20)
+        packet = rns_dissector.dissect(raw, rns_announce_metadata)
+
+        aspect = packet.tree.get_field("rns.announce.aspect")
+        assert aspect is not None
+        assert aspect.value == "lxmf.delivery"
+
+        name = packet.tree.get_field("rns.announce.name")
+        assert name is not None
+        assert name.value == "Maui Node"
+
+    def test_tree_announce_identity(self, rns_dissector, rns_announce_metadata):
+        """Announce packet includes identity hash."""
+        raw = bytes(20)
+        packet = rns_dissector.dissect(raw, rns_announce_metadata)
+
+        identity = packet.tree.get_field("rns.announce.identity")
+        assert identity is not None
+        assert identity.value == "aabbccdd11223344"
+
+    def test_tree_link_fields(self, rns_dissector):
+        """Link packets include link-specific fields."""
+        metadata = {
+            "protocol": "rns",
+            "packet_type": "LINK_REQUEST",
+            "link_id": "deadbeef12345678",
+            "link_state": "pending",
+            "rtt_ms": 150.5,
+        }
+        packet = rns_dissector.dissect(bytes(20), metadata)
+
+        link_id = packet.tree.get_field("rns.link.id")
+        assert link_id is not None
+        assert link_id.value == "deadbeef12345678"
+
+        state = packet.tree.get_field("rns.link.state")
+        assert state is not None
+        assert state.value == "pending"
+
+        rtt = packet.tree.get_field("rns.link.rtt")
+        assert rtt is not None
+        assert abs(rtt.value - 150.5) < 0.1
+
+    def test_tree_lxmf_fields(self, rns_dissector):
+        """LXMF service includes message fields."""
+        metadata = {
+            "protocol": "rns",
+            "service_type": "lxmf.delivery",
+            "lxmf_title": "Test Message",
+            "lxmf_content": "Hello from RNS!",
+        }
+        packet = rns_dissector.dissect(bytes(20), metadata)
+
+        title = packet.tree.get_field("rns.lxmf.title")
+        assert title is not None
+        assert title.value == "Test Message"
+
+        content = packet.tree.get_field("rns.lxmf.content")
+        assert content is not None
+        assert content.value == "Hello from RNS!"
+
+    def test_tree_lxmf_long_content_truncated(self, rns_dissector):
+        """Long LXMF content is truncated in tree."""
+        long_content = "A" * 200
+        metadata = {
+            "protocol": "rns",
+            "service_type": "lxmf.delivery",
+            "lxmf_content": long_content,
+        }
+        packet = rns_dissector.dissect(bytes(20), metadata)
+
+        content = packet.tree.get_field("rns.lxmf.content")
+        assert content is not None
+        assert len(content.value) < 200
+        assert content.value.endswith("...")
+
+    def test_tree_interface_type(self, rns_dissector):
+        """Interface type field appears when provided."""
+        metadata = {
+            "protocol": "rns",
+            "interface_type": "LoRa",
+        }
+        packet = rns_dissector.dissect(bytes(20), metadata)
+
+        iface_type = packet.tree.get_field("rns.iface_type")
+        assert iface_type is not None
+        assert iface_type.value == "LoRa"
+
+
+# ---------------------------------------------------------------------------
+# DisplayFilter tests
+# ---------------------------------------------------------------------------
+
+class TestDisplayFilter:
+    """Tests for Wireshark-style display filter."""
+
+    def _make_meshtastic_packet(self, **overrides):
+        """Helper to create a Meshtastic packet with tree."""
+        dissector = MeshtasticDissector()
+        metadata = {
+            "from": "!aabb0001",
+            "to": "!ffffffff",
+            "channel": 0,
+            "hopLimit": 2,
+            "hopStart": 3,
+            "portnum": 1,
+            "snr": 8.5,
+            "rssi": -80,
+        }
+        metadata.update(overrides)
+        return dissector.dissect(b"data", metadata)
+
+    def test_empty_filter_matches_all(self):
+        """Empty filter matches everything."""
+        f = DisplayFilter("")
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_equality_filter(self):
+        """Equality filter on string field."""
+        f = DisplayFilter('mesh.from == "!aabb0001"')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_equality_filter_no_match(self):
+        """Equality filter doesn't match wrong value."""
+        f = DisplayFilter('mesh.from == "!ccdd0002"')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is False
+
+    def test_inequality_filter(self):
+        """Inequality filter."""
+        f = DisplayFilter('mesh.from != "!ccdd0002"')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_numeric_greater_than(self):
+        """Numeric greater than filter."""
+        f = DisplayFilter('mesh.hops > 0')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_numeric_less_than(self):
+        """Numeric less than filter."""
+        f = DisplayFilter('mesh.hop_limit < 5')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_numeric_greater_equal(self):
+        """Numeric greater-or-equal filter."""
+        f = DisplayFilter('mesh.hop_limit >= 2')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_numeric_less_equal(self):
+        """Numeric less-or-equal filter."""
+        f = DisplayFilter('mesh.hops <= 1')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_float_filter(self):
+        """Float comparison filter."""
+        f = DisplayFilter('mesh.snr >= -5')
+        packet = self._make_meshtastic_packet(snr=8.5)
+        assert f.matches(packet) is True
+
+    def test_float_filter_negative(self):
+        """Float comparison with negative target."""
+        f = DisplayFilter('mesh.snr > 10')
+        packet = self._make_meshtastic_packet(snr=8.5)
+        assert f.matches(packet) is False
+
+    def test_boolean_filter_true(self):
+        """Boolean filter matches true."""
+        f = DisplayFilter('mesh.mqtt == true')
+        packet = self._make_meshtastic_packet(viaMqtt=True)
+        assert f.matches(packet) is True
+
+    def test_boolean_filter_false(self):
+        """Boolean filter matches false."""
+        f = DisplayFilter('mesh.mqtt == false')
+        packet = self._make_meshtastic_packet(viaMqtt=False)
+        assert f.matches(packet) is True
+
+    def test_missing_field_no_match(self):
+        """Filter on non-existent field returns False."""
+        f = DisplayFilter('mesh.nonexistent == "value"')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is False
+
+    def test_no_tree_no_match(self):
+        """Packet without tree returns False."""
+        f = DisplayFilter('mesh.from == "!abc"')
+        packet = MeshPacket()
+        assert f.matches(packet) is False
+
+    def test_compile_empty(self):
+        """Compiling empty expression succeeds."""
+        f = DisplayFilter("")
+        assert f.compile() is True
+
+    def test_compile_valid(self):
+        """Compiling valid expression succeeds."""
+        f = DisplayFilter('mesh.from == "!abc"')
+        assert f.compile() is True
+
+    def test_and_filter(self):
+        """AND filter combines multiple conditions."""
+        f = DisplayFilter('mesh.channel == 0 and mesh.hops > 0')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is True
+
+    def test_and_filter_fails(self):
+        """AND filter fails when one condition doesn't match."""
+        f = DisplayFilter('mesh.channel == 0 and mesh.hops > 5')
+        packet = self._make_meshtastic_packet()
+        assert f.matches(packet) is False
+
+    def test_portnum_filter(self):
+        """Portnum filter for protocol selection."""
+        f = DisplayFilter('mesh.portnum == 1')
+        packet = self._make_meshtastic_packet(portnum=1)
+        assert f.matches(packet) is True
+
+    def test_available_fields(self):
+        """get_available_fields returns expected fields."""
+        fields = DisplayFilter.get_available_fields()
+        assert "mesh.from" in fields
+        assert "mesh.snr" in fields
+        assert "rns.type" in fields
+        assert "frame.protocol" in fields
+        # Check descriptions are non-empty
+        assert len(fields["mesh.from"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Traffic models tests
+# ---------------------------------------------------------------------------
+
+class TestTrafficModels:
+    """Tests for traffic_models data classes."""
+
+    def test_packet_field_to_dict(self):
+        """PacketField serializes to dict."""
+        f = PacketField(name="Test", abbrev="test.field", value="hello",
+                        field_type=FieldType.STRING, description="A test field")
+        d = f.to_dict()
+        assert d["name"] == "Test"
+        assert d["value"] == "hello"
+        assert d["type"] == "string"
+
+    def test_packet_field_with_children(self):
+        """PacketField serializes children."""
+        parent = PacketField(name="Parent", abbrev="p", value=None,
+                             field_type=FieldType.NESTED)
+        child = PacketField(name="Child", abbrev="p.c", value=42,
+                            field_type=FieldType.INTEGER)
+        parent.children.append(child)
+        d = parent.to_dict()
+        assert "children" in d
+        assert len(d["children"]) == 1
+
+    def test_packet_field_display_value(self):
+        """PacketField display value formatting."""
+        # None
+        f = PacketField(name="T", abbrev="t", value=None)
+        assert f.get_display_value() == "<none>"
+
+        # Bool
+        f = PacketField(name="T", abbrev="t", value=True, field_type=FieldType.BOOLEAN)
+        assert f.get_display_value() == "True"
+
+        # Float
+        f = PacketField(name="T", abbrev="t", value=3.14159, field_type=FieldType.FLOAT)
+        assert "3.1416" in f.get_display_value()
+
+        # Bytes (short)
+        f = PacketField(name="T", abbrev="t", value=b"\xab\xcd")
+        assert f.get_display_value() == "abcd"
+
+        # Bytes (long)
+        f = PacketField(name="T", abbrev="t", value=b"\x00" * 20)
+        assert "bytes" in f.get_display_value()
+
+    def test_packet_field_matches_filter_contains(self):
+        """PacketField contains operator."""
+        f = PacketField(name="T", abbrev="t", value="Hello World",
+                        field_type=FieldType.STRING)
+        assert f.matches_filter("contains", "world") is True
+        assert f.matches_filter("contains", "xyz") is False
+
+    def test_packet_field_matches_filter_matches(self):
+        """PacketField regex matches operator."""
+        f = PacketField(name="T", abbrev="t", value="!aabb0001",
+                        field_type=FieldType.STRING)
+        assert f.matches_filter("matches", r"!aabb\d+") is True
+        assert f.matches_filter("matches", r"^!ccdd") is False
+
+    def test_packet_tree_operations(self):
+        """PacketTree add/get operations."""
+        tree = PacketTree()
+        layer = tree.add_layer("Test", "test")
+        tree.add_field(layer, "Value", "test.val", 42, FieldType.INTEGER)
+
+        assert tree.get_field("test.val") is not None
+        assert tree.get_field("test.val").value == 42
+        assert tree.get_field("nonexistent") is None
+
+    def test_packet_tree_to_dict(self):
+        """PacketTree serializes to dict list."""
+        tree = PacketTree()
+        layer = tree.add_layer("Layer", "l")
+        tree.add_field(layer, "F", "l.f", "v")
+
+        d = tree.to_dict()
+        assert isinstance(d, list)
+        assert len(d) == 1
+
+    def test_mesh_packet_summary(self):
+        """MeshPacket summary string."""
+        pkt = MeshPacket(
+            protocol=PacketProtocol.MESHTASTIC,
+            source="!aabb0001",
+            destination="!ffffffff",
+            port_name="TEXT_MESSAGE",
+            snr=8.5,
+            rssi=-80,
+        )
+        summary = pkt.get_summary()
+        assert "!aabb0001" in summary
+        assert "TEXT_MESSAGE" in summary
+
+    def test_mesh_packet_to_dict(self):
+        """MeshPacket serializes to dict."""
+        pkt = MeshPacket(
+            protocol=PacketProtocol.MESHTASTIC,
+            source="!abc",
+        )
+        d = pkt.to_dict()
+        assert d["protocol"] == "meshtastic"
+        assert d["source"] == "!abc"
+
+    def test_mesh_packet_from_dict(self):
+        """MeshPacket deserializes from dict."""
+        data = {
+            "id": "test_pkt",
+            "timestamp": datetime.now().isoformat(),
+            "protocol": "meshtastic",
+            "source": "!abc",
+            "destination": "broadcast",
+            "channel": 1,
+            "portnum": 1,
+        }
+        pkt = MeshPacket.from_dict(data)
+        assert pkt.source == "!abc"
+        assert pkt.channel == 1
+
+    def test_meshtastic_ports_mapping(self):
+        """MESHTASTIC_PORTS has expected entries."""
+        assert MESHTASTIC_PORTS[1] == "TEXT_MESSAGE"
+        assert MESHTASTIC_PORTS[4] == "POSITION"
+        assert MESHTASTIC_PORTS[5] == "NODEINFO"
+        assert MESHTASTIC_PORTS[67] == "TELEMETRY"
+        assert MESHTASTIC_PORTS[70] == "TRACEROUTE"
+        assert MESHTASTIC_PORTS[71] == "NEIGHBORINFO"
+
+    def test_hop_info_to_dict(self):
+        """HopInfo serializes correctly."""
+        from monitoring.traffic_models import HopInfo
+        hop = HopInfo(hop_number=1, node_id="!abc", snr=5.0, rssi=-75)
+        d = hop.to_dict()
+        assert d["hop"] == 1
+        assert d["node_id"] == "!abc"
+        assert d["snr"] == 5.0


### PR DESCRIPTION
…uto-review

Test coverage (147 new tests):
- test_meshtastic_handler.py (57 tests): connection, send, receive, relay discovery, polling, CLI fallback, run loop
- test_packet_dissectors.py (90 tests): MeshtasticDissector, RNSDissector, DisplayFilter, protocol tree construction, traffic_models data classes

TUI feature entries:
- Heatmap: Maps & Viz > Heatmap (node density via Folium HeatMap)
- Tile Cache: Maps & Viz > Offline Tiles (download, stats, estimate, clear)
- Auto-Review: System > Code Review (security, redundancy, performance, reliability)

https://claude.ai/code/session_01DdC4gqM8yBS7riRLgasU6f