### PR TITLE
fix: Resolve rnsd PermissionError on /etc/reticulum/storage/ratchets

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -980,11 +980,14 @@ if $INSTALL_RNS; then
     # RNS stores data in a 'storage' subdirectory of its config directory.
     # When using system-wide config (/etc/reticulum/config), rnsd needs
     # the storage directory to exist with proper permissions.
+    # The 'ratchets' subdirectory is required by RNS Identity.persist_job()
+    # for key ratcheting (added in newer RNS versions).
     echo "  Creating /etc/reticulum/ structure..."
-    mkdir -p /etc/reticulum/storage
+    mkdir -p /etc/reticulum/storage/ratchets
     mkdir -p /etc/reticulum/interfaces
     chmod 755 /etc/reticulum
     chmod 755 /etc/reticulum/storage
+    chmod 755 /etc/reticulum/storage/ratchets
     chmod 755 /etc/reticulum/interfaces
 
     # Create systemd service if not exists

--- a/src/core/diagnostics/checks/__init__.py
+++ b/src/core/diagnostics/checks/__init__.py
@@ -31,6 +31,7 @@ from .rns import (
     check_rns_installed,
     check_rns_config,
     check_rns_port,
+    check_rns_storage_permissions,
     check_meshtastic_interface_file,
 )
 
@@ -84,6 +85,7 @@ __all__ = [
     'check_rns_installed',
     'check_rns_config',
     'check_rns_port',
+    'check_rns_storage_permissions',
     'check_meshtastic_interface_file',
     # Meshtastic
     'check_meshtastic_installed',

--- a/src/core/diagnostics/checks/rns.py
+++ b/src/core/diagnostics/checks/rns.py
@@ -4,6 +4,7 @@ RNS (Reticulum Network Stack) diagnostic checks.
 Checks for RNS installation, configuration, and Meshtastic interface.
 """
 
+import os
 import socket
 import time
 import logging
@@ -145,6 +146,63 @@ def check_rns_port() -> CheckResult:
             message=str(e),
             duration_ms=(time.time() - start) * 1000
         )
+
+
+def check_rns_storage_permissions() -> CheckResult:
+    """Check that RNS storage directories exist with correct permissions.
+
+    RNS Identity.persist_job() requires the 'ratchets' subdirectory under
+    the storage directory. If missing or not writable, rnsd crashes with
+    PermissionError in a background thread.
+    """
+    start = time.time()
+
+    # Only relevant for system-wide config
+    etc_storage = Path('/etc/reticulum/storage')
+    if not etc_storage.parent.exists():
+        return CheckResult(
+            name="RNS storage permissions",
+            category=CheckCategory.RNS,
+            status=CheckStatus.PASS,
+            message="System-wide config not used (OK)",
+            duration_ms=(time.time() - start) * 1000
+        )
+
+    ratchets_dir = etc_storage / 'ratchets'
+    issues = []
+
+    if not etc_storage.exists():
+        issues.append("storage/ directory missing")
+    elif not os.access(str(etc_storage), os.W_OK):
+        issues.append("storage/ not writable")
+
+    if not ratchets_dir.exists():
+        issues.append("storage/ratchets/ directory missing")
+    elif not os.access(str(ratchets_dir), os.W_OK):
+        issues.append("storage/ratchets/ not writable")
+
+    duration = (time.time() - start) * 1000
+
+    if issues:
+        return CheckResult(
+            name="RNS storage permissions",
+            category=CheckCategory.RNS,
+            status=CheckStatus.FAIL,
+            message="; ".join(issues),
+            fix_hint=(
+                "sudo mkdir -p /etc/reticulum/storage/ratchets && "
+                "sudo chmod 755 /etc/reticulum/storage /etc/reticulum/storage/ratchets"
+            ),
+            duration_ms=duration
+        )
+
+    return CheckResult(
+        name="RNS storage permissions",
+        category=CheckCategory.RNS,
+        status=CheckStatus.PASS,
+        message="storage/ and ratchets/ directories OK",
+        duration_ms=duration
+    )
 
 
 def check_meshtastic_interface_file() -> CheckResult:

--- a/src/core/diagnostics/engine.py
+++ b/src/core/diagnostics/engine.py
@@ -49,6 +49,7 @@ from .checks import (
     check_rns_installed,
     check_rns_config,
     check_rns_port,
+    check_rns_storage_permissions,
     check_meshtastic_interface_file,
     # Meshtastic
     check_meshtastic_installed,
@@ -300,6 +301,7 @@ class DiagnosticEngine:
         results.append(check_rns_config())
         results.append(check_process('rnsd', 'RNS daemon'))
         results.append(check_rns_port())
+        results.append(check_rns_storage_permissions())
         results.append(check_meshtastic_interface_file())
         self._update_subsystem_health('rns', results)
         return results

--- a/src/utils/knowledge_content.py
+++ b/src/utils/knowledge_content.py
@@ -1013,6 +1013,33 @@ Common Issues:
     ))
 
     kb._add_guide(TroubleshootingGuide(
+        problem="rnsd_ratchets_permission",
+        description="rnsd crashes with PermissionError on /etc/reticulum/storage/ratchets",
+        prerequisites=["rnsd installed", "Using system-wide config at /etc/reticulum/"],
+        steps=[
+            TroubleshootingStep(
+                instruction="Check if ratchets directory exists",
+                command="ls -la /etc/reticulum/storage/ratchets",
+                expected_result="Directory exists with write permissions",
+                if_fail="Directory missing — RNS Identity.persist_job() needs it for key ratcheting",
+            ),
+            TroubleshootingStep(
+                instruction="Create the ratchets directory with correct permissions",
+                command="sudo mkdir -p /etc/reticulum/storage/ratchets && sudo chmod 755 /etc/reticulum/storage/ratchets",
+                expected_result="Directory created successfully",
+                if_fail="Check filesystem is not mounted read-only",
+            ),
+            TroubleshootingStep(
+                instruction="Restart rnsd to verify the fix",
+                command="sudo systemctl restart rnsd",
+                expected_result="Active: active (running)",
+                if_fail="Check journalctl -u rnsd for other errors",
+            ),
+        ],
+        related_problems=["rnsd_not_starting"],
+    ))
+
+    kb._add_guide(TroubleshootingGuide(
         problem="rns_path_failure",
         description="Cannot reach RNS destination — path not found",
         prerequisites=["rnsd running", "At least one interface active"],

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -109,6 +109,7 @@ class ReticulumPaths:
     # System-wide paths
     ETC_BASE = Path('/etc/reticulum')
     ETC_STORAGE = ETC_BASE / 'storage'
+    ETC_RATCHETS = ETC_STORAGE / 'ratchets'
     ETC_INTERFACES = ETC_BASE / 'interfaces'
 
     @classmethod
@@ -119,6 +120,10 @@ class ReticulumPaths:
         When using /etc/reticulum/config, this means /etc/reticulum/storage
         must exist with proper permissions before rnsd can start.
 
+        The 'ratchets' subdirectory is required by RNS Identity.persist_job()
+        for key ratcheting support (added in newer RNS versions). Without it,
+        rnsd crashes with PermissionError in a background thread.
+
         Returns:
             True if directories exist or were created, False on permission error.
 
@@ -128,6 +133,7 @@ class ReticulumPaths:
         try:
             cls.ETC_BASE.mkdir(mode=0o755, parents=True, exist_ok=True)
             cls.ETC_STORAGE.mkdir(mode=0o755, parents=True, exist_ok=True)
+            cls.ETC_RATCHETS.mkdir(mode=0o755, parents=True, exist_ok=True)
             cls.ETC_INTERFACES.mkdir(mode=0o755, parents=True, exist_ok=True)
             return True
         except PermissionError:

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -97,9 +97,9 @@ KNOWN_SERVICES = {
         'port': RNS_SHARED_INSTANCE_PORT,
         'port_type': 'udp',
         'systemd_name': 'rnsd',
-        'is_systemd': False,  # rnsd is a user-space daemon, NOT a systemd service
+        'is_systemd': True,  # rnsd runs as systemd service (install_noc.sh creates unit)
         'description': 'Reticulum Network Stack daemon',
-        'fix_hint': 'Start with: rnsd (run as user, not root)',
+        'fix_hint': 'Start with: sudo systemctl start rnsd',
     },
     'mosquitto': {
         'port': MQTT_PORT,


### PR DESCRIPTION
RNS Identity.persist_job() requires a 'ratchets' subdirectory under storage for key ratcheting (added in newer RNS versions). Without it, rnsd crashes with PermissionError in a background thread.

- install_noc.sh: Pre-create storage/ratchets/ with 755 permissions
- paths.py: Add ETC_RATCHETS to ReticulumPaths.ensure_system_dirs()
- service_check.py: Update rnsd to is_systemd=True (matches install script)
- diagnostics: Add check_rns_storage_permissions() check
- knowledge_base: Add rnsd_ratchets_permission troubleshooting guide

https://claude.ai/code/session_01GbP7hznrMKcGLcg7z6FSzV