### PR TITLE
feat: Add private MQTT broker support with profile templates

### DIFF
--- a/examples/configs/broker-private-acl.conf
+++ b/examples/configs/broker-private-acl.conf
@@ -1,0 +1,57 @@
+# MeshForge MQTT Broker ACL (Access Control List)
+# ================================================
+#
+# Install to: /etc/mosquitto/meshforge_acl
+#
+# Controls which users can read/write which MQTT topics.
+# Topic pattern: msh/{region}/2/e/{channel}/!{node_id}
+
+# =============================================================================
+# MeshForge admin user - full access to all mesh topics
+# =============================================================================
+user meshforge
+topic readwrite msh/#
+topic readwrite meshforge/#
+topic read $SYS/#
+
+# =============================================================================
+# Gateway nodes - access to their channel topics
+# =============================================================================
+# Each Meshtastic gateway radio connects with its own credentials.
+# Restrict to specific channels/regions as needed.
+#
+# Example: gateway on US/LongFast channel
+# user gateway1
+# topic readwrite msh/US/2/e/LongFast/#
+# topic readwrite msh/US/2/json/LongFast/#
+#
+# Example: gateway on US/ShortTurbo channel
+# user gateway2
+# topic readwrite msh/US/2/e/ShortTurbo/#
+# topic readwrite msh/US/2/json/ShortTurbo/#
+#
+# Example: gateway with access to all US topics
+# user gateway_us
+# topic readwrite msh/US/#
+
+# =============================================================================
+# Read-only monitoring users
+# =============================================================================
+# For dashboards, logging, or external monitoring tools
+#
+# user monitor
+# topic read msh/#
+# topic read $SYS/#
+#
+# user homeassistant
+# topic read msh/#
+# topic readwrite homeassistant/#
+
+# =============================================================================
+# RNS Bridge user - access for the gateway bridge
+# =============================================================================
+# If running the RNS gateway bridge as a separate process
+#
+# user rns_bridge
+# topic readwrite msh/#
+# topic readwrite meshforge/bridge/#

--- a/examples/configs/broker-private-template.json
+++ b/examples/configs/broker-private-template.json
@@ -1,0 +1,57 @@
+{
+  "_name": "MeshForge Private Broker Template",
+  "_description": "Run your own MQTT broker for Meshtastic <-> RNS bridging. Full control, no zero-hop restriction.",
+  "_usage": "Use 'MQTT Broker Manager > Setup Private Broker' in the TUI, or configure manually below.",
+  "_docs": "https://meshtastic.org/docs/software/integrations/mqtt/mosquitto/",
+
+  "broker": "localhost",
+  "port": 1883,
+  "topic": "msh/US/2/json/LongFast/#",
+  "username": "meshforge",
+  "password": "CHANGE_THIS_PASSWORD",
+  "use_tls": false,
+
+  "_mosquitto_setup": {
+    "install": "sudo apt install mosquitto mosquitto-clients",
+    "create_password": "sudo mosquitto_passwd -c /etc/mosquitto/meshforge_passwd meshforge",
+    "config_file": "Copy examples/configs/broker-private.conf to /etc/mosquitto/conf.d/meshforge.conf",
+    "acl_file": "Copy examples/configs/broker-private-acl.conf to /etc/mosquitto/meshforge_acl",
+    "restart": "sudo systemctl restart mosquitto",
+    "enable_boot": "sudo systemctl enable mosquitto"
+  },
+
+  "_radio_setup": {
+    "description": "Configure each Meshtastic gateway radio to connect to this broker",
+    "note": "Replace YOUR_SERVER_IP with the LAN IP of the machine running mosquitto",
+    "commands": [
+      "meshtastic --host localhost --set mqtt.enabled true",
+      "meshtastic --host localhost --set mqtt.address YOUR_SERVER_IP",
+      "meshtastic --host localhost --set mqtt.username meshforge",
+      "meshtastic --host localhost --set mqtt.password CHANGE_THIS_PASSWORD",
+      "meshtastic --host localhost --set mqtt.encryption_enabled true",
+      "meshtastic --host localhost --set mqtt.json_enabled true",
+      "meshtastic --host localhost --set mqtt.tls_enabled false",
+      "meshtastic --host localhost --ch-set uplink_enabled true --ch-index 0",
+      "meshtastic --host localhost --ch-set downlink_enabled true --ch-index 0"
+    ]
+  },
+
+  "_architecture": {
+    "description": "MeshForge as central MQTT hub for mesh bridging",
+    "flow": [
+      "Meshtastic LongFast Radio -> WiFi -> mosquitto (this broker)",
+      "mosquitto -> MeshForge MQTT Subscriber (monitoring)",
+      "mosquitto -> RNS Gateway Bridge (Meshtastic <-> RNS)",
+      "mosquitto -> Other consumers (Home Assistant, logging, etc.)",
+      "",
+      "Enables: Meshtastic LF <-> Private Broker <-> RNS Gateway <-> Meshtastic ST"
+    ]
+  },
+
+  "_notes": {
+    "security": "NEVER use the default PSK (AQ==) as your only security on a private broker. Always use authentication + custom channel PSK.",
+    "no_zero_hop": "Unlike the public broker, private brokers do NOT enforce zero-hop. Downlinked messages WILL propagate into the mesh.",
+    "json_topic": "Using json topic (msh/2/json/) for local broker gives parsed messages. Use e/ for encrypted protobuf.",
+    "multi_consumer": "Multiple apps can subscribe to the same broker simultaneously (MeshForge, Home Assistant, Node-RED, etc.)"
+  }
+}

--- a/examples/configs/broker-private.conf
+++ b/examples/configs/broker-private.conf
@@ -1,0 +1,83 @@
+# MeshForge Private MQTT Broker Configuration
+# =============================================
+#
+# This is a mosquitto.conf for running MeshForge as its own MQTT broker.
+# Install to: /etc/mosquitto/conf.d/meshforge.conf
+#
+# Architecture:
+#   Meshtastic Radio (WiFi) -> mosquitto (this broker) -> MeshForge NOC
+#                                                      -> RNS Gateway
+#                                                      -> Other consumers
+#
+# Meshtastic MQTT topic convention:
+#   msh/{region}/2/e/{channel}/!{node_id}     (encrypted protobuf)
+#   msh/{region}/2/json/{channel}/!{node_id}  (JSON)
+#
+# See: https://meshtastic.org/docs/software/integrations/mqtt/
+
+# =============================================================================
+# Listeners
+# =============================================================================
+
+# Plain TCP listener for local Meshtastic devices and MeshForge
+listener 1883
+
+# Bind to all interfaces so gateway radios on LAN can connect
+# Change to 127.0.0.1 if you only need local access
+bind_address 0.0.0.0
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+# IMPORTANT: Do NOT use allow_anonymous on private brokers.
+# Private brokers don't enforce zero-hop, so unauthenticated access
+# can flood your mesh with traffic.
+allow_anonymous false
+
+# Password file - create with:
+#   sudo mosquitto_passwd -c /etc/mosquitto/meshforge_passwd meshforge
+#   (enter password when prompted)
+#
+# Add more users:
+#   sudo mosquitto_passwd /etc/mosquitto/meshforge_passwd gateway1
+password_file /etc/mosquitto/meshforge_passwd
+
+# =============================================================================
+# Access Control (ACL)
+# =============================================================================
+
+# ACL file controls which users can read/write which topics
+acl_file /etc/mosquitto/meshforge_acl
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+log_dest syslog
+log_type warning
+log_type error
+log_type notice
+
+# =============================================================================
+# Connection Limits
+# =============================================================================
+
+# Max simultaneous connections
+max_connections 100
+
+# Keepalive timeout (seconds)
+max_keepalive 120
+
+# Max queued messages per client
+max_queued_messages 1000
+
+# Max message size (Meshtastic ServiceEnvelope is typically < 256 bytes)
+message_size_limit 4096

--- a/examples/configs/broker-public-template.json
+++ b/examples/configs/broker-public-template.json
@@ -1,0 +1,21 @@
+{
+  "_name": "Meshtastic Public Broker Template",
+  "_description": "Connect to mqtt.meshtastic.org for nodeless mesh monitoring. Read-only, no local radio needed.",
+  "_usage": "Use 'MQTT Broker Manager > Use Public Broker' in the TUI, or copy this to ~/.config/meshforge/mqtt_nodeless.json",
+  "_docs": "https://meshtastic.org/docs/software/integrations/mqtt/",
+
+  "broker": "mqtt.meshtastic.org",
+  "port": 8883,
+  "topic": "msh/US/2/e/LongFast/#",
+  "username": "meshdev",
+  "password": "large4cats",
+  "use_tls": true,
+
+  "_notes": {
+    "zero_hop": "Public broker enforces zero-hop: downlinked messages don't propagate further into mesh",
+    "encryption": "Messages are encrypted with the channel PSK (default AQ== for LongFast)",
+    "region": "Change US to your region: EU_868, ANZ, etc.",
+    "channel": "Change LongFast to your channel name",
+    "supported_ports": "NodeinfoApp, TextMessageApp, PositionApp, TelemetryApp"
+  }
+}

--- a/src/launcher_tui/broker_mixin.py
+++ b/src/launcher_tui/broker_mixin.py
@@ -1,0 +1,819 @@
+"""
+Broker Management Mixin - Private MQTT broker setup and management for MeshForge TUI.
+
+Provides:
+- Broker profile selection (Private / Public / Custom)
+- Mosquitto installation and configuration
+- Meshtastic radio MQTT setup commands
+- Broker service management (start/stop/status)
+
+Architecture:
+    Meshtastic Radio -> mosquitto (private broker) -> MeshForge MQTT subscriber
+                                                   -> RNS Gateway bridge
+                                                   -> Other MQTT consumers
+
+This enables MeshForge to be its own private broker, solving the
+Meshtastic <-> RNS communication gap via MQTT as the common transport.
+"""
+
+import logging
+import os
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Import broker profiles
+try:
+    from utils.broker_profiles import (
+        BrokerProfile,
+        BrokerType,
+        create_private_profile,
+        create_public_profile,
+        create_custom_profile,
+        load_profiles,
+        save_profiles,
+        set_active_profile,
+        get_active_profile,
+        ensure_default_profiles,
+        generate_mosquitto_conf,
+        generate_mosquitto_acl,
+        install_mosquitto_config,
+        check_mosquitto_installed,
+        check_mosquitto_running,
+        restart_mosquitto,
+        enable_mosquitto_at_boot,
+        get_meshtastic_mqtt_setup_commands,
+    )
+    _HAS_BROKER_PROFILES = True
+except ImportError:
+    _HAS_BROKER_PROFILES = False
+
+
+class BrokerMixin:
+    """Mixin providing MQTT broker management for the MeshForge TUI."""
+
+    def _broker_menu(self):
+        """MQTT Broker management menu."""
+        if not _HAS_BROKER_PROFILES:
+            self.dialog.msgbox(
+                "Module Unavailable",
+                "Broker profiles module not found.\n\n"
+                "Ensure utils/broker_profiles.py exists."
+            )
+            return
+
+        while True:
+            # Get current state
+            profiles = ensure_default_profiles()
+            active = get_active_profile(profiles)
+            active_name = active.display_name if active else "None"
+
+            # Check mosquitto status
+            installed, _ = check_mosquitto_installed()
+            running, _ = check_mosquitto_running()
+
+            mosquitto_status = "Not installed"
+            if installed and running:
+                mosquitto_status = "Running"
+            elif installed:
+                mosquitto_status = "Installed (stopped)"
+
+            choices = [
+                ("profiles", f"Broker Profiles     Active: {active_name[:20]}"),
+                ("private", "Setup Private Broker  MeshForge mosquitto"),
+                ("public", "Use Public Broker     mqtt.meshtastic.org"),
+                ("custom", "Add Custom Broker     Your own server"),
+                ("mosquitto", f"Mosquitto Service    {mosquitto_status}"),
+                ("radio", "Radio MQTT Setup      Configure device uplink"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "MQTT Broker Manager",
+                "Manage MQTT broker for Meshtastic <-> RNS bridging.\n\n"
+                "A private broker enables MeshForge as the central\n"
+                "message hub between mesh networks.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "profiles": ("Broker Profiles", self._broker_profiles_menu),
+                "private": ("Private Broker Setup", self._setup_private_broker),
+                "public": ("Public Broker Setup", self._setup_public_broker),
+                "custom": ("Custom Broker Setup", self._setup_custom_broker),
+                "mosquitto": ("Mosquitto Service", self._mosquitto_service_menu),
+                "radio": ("Radio MQTT Setup", self._radio_mqtt_setup),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self._safe_call(*entry)
+
+    def _broker_profiles_menu(self):
+        """View and manage broker profiles."""
+        profiles = ensure_default_profiles()
+
+        while True:
+            choices = []
+            for name, profile in profiles.items():
+                active_marker = " [ACTIVE]" if profile.is_active else ""
+                ptype = profile.broker_type.upper()[:4]
+                choices.append(
+                    (name, f"[{ptype}] {profile.host}:{profile.port}{active_marker}")
+                )
+            choices.append(("back", "Back"))
+
+            choice = self.dialog.menu(
+                f"Broker Profiles ({len(profiles)})",
+                "Select a profile to view/activate:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice in profiles:
+                self._profile_detail_menu(choice, profiles)
+                # Reload in case changes were made
+                profiles = load_profiles()
+
+    def _profile_detail_menu(self, name: str, profiles: dict):
+        """Show profile details and management options."""
+        profile = profiles[name]
+
+        while True:
+            lines = [
+                f"Profile: {name}",
+                f"Type: {profile.broker_type}",
+                f"Host: {profile.host}:{profile.port}",
+                f"Username: {profile.username or '(anonymous)'}",
+                f"TLS: {'Yes' if profile.use_tls else 'No'}",
+                f"Channel: {profile.channel}",
+                f"Region: {profile.region}",
+                f"Topic: {profile.topic_filter}",
+                f"Active: {'Yes' if profile.is_active else 'No'}",
+                "",
+                profile.description,
+            ]
+
+            choices = [
+                ("activate", "Set as Active Profile"),
+                ("apply", "Apply to MQTT Subscriber"),
+                ("radio", "Show Radio Setup Commands"),
+            ]
+
+            if profile.broker_type == BrokerType.PRIVATE.value:
+                choices.append(("install", "Install Mosquitto Config"))
+                choices.append(("conf", "View mosquitto.conf"))
+
+            choices.extend([
+                ("delete", "Delete Profile"),
+                ("back", "Back"),
+            ])
+
+            choice = self.dialog.menu(
+                f"Profile: {name}",
+                "\n".join(lines),
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "activate":
+                set_active_profile(name, profiles)
+                profile.is_active = True
+                self.dialog.msgbox("Activated", f"Profile '{name}' is now active.")
+
+            elif choice == "apply":
+                self._apply_profile_to_mqtt(profile)
+
+            elif choice == "radio":
+                cmds = get_meshtastic_mqtt_setup_commands(profile)
+                self.dialog.msgbox(
+                    "Radio MQTT Setup",
+                    f"Run these commands to configure your radio:\n\n{cmds}",
+                    width=70
+                )
+
+            elif choice == "install":
+                self._install_broker_config(profile)
+
+            elif choice == "conf":
+                conf = generate_mosquitto_conf(profile)
+                self.dialog.msgbox(
+                    "mosquitto.conf Preview",
+                    conf,
+                    width=70
+                )
+
+            elif choice == "delete":
+                if profile.is_active:
+                    self.dialog.msgbox(
+                        "Cannot Delete",
+                        "Cannot delete the active profile.\n"
+                        "Activate a different profile first."
+                    )
+                elif self.dialog.yesno("Confirm Delete", f"Delete profile '{name}'?"):
+                    del profiles[name]
+                    save_profiles(profiles)
+                    self.dialog.msgbox("Deleted", f"Profile '{name}' deleted.")
+                    break
+
+    def _setup_private_broker(self):
+        """Guided setup for MeshForge private broker."""
+        # Check if mosquitto is installed
+        installed, msg = check_mosquitto_installed()
+
+        if not installed:
+            self.dialog.msgbox(
+                "Mosquitto Required",
+                f"{msg}\n\n"
+                "After installing, re-run this setup."
+            )
+            if self.dialog.yesno(
+                "Install Now?",
+                "Attempt to install mosquitto?\n\n"
+                "This requires an internet connection."
+            ):
+                self._install_mosquitto()
+            return
+
+        # Gather configuration
+        channel = self.dialog.inputbox(
+            "Channel Name",
+            "Meshtastic channel for this broker:\n\n"
+            "  LongFast    (default Meshtastic)\n"
+            "  ShortTurbo  (short range, high speed)\n"
+            "  YourChannel (custom name)\n\n"
+            "Must match your radio's primary channel.",
+            init="LongFast"
+        )
+        if not channel:
+            return
+
+        region = self.dialog.inputbox(
+            "Region",
+            "Meshtastic region code:\n\n"
+            "  US      (902-928 MHz)\n"
+            "  EU_868  (863-870 MHz)\n"
+            "  ANZ     (915-928 MHz)\n"
+            "  Other supported regions as configured",
+            init="US"
+        )
+        if not region:
+            return
+
+        username = self.dialog.inputbox(
+            "MQTT Username",
+            "Username for broker authentication:\n\n"
+            "This is used by MeshForge and your gateway\n"
+            "nodes to connect to the private broker.",
+            init="meshforge"
+        )
+        if not username:
+            return
+
+        # Generate a password
+        from utils.broker_profiles import generate_password
+        default_pw = generate_password(12)
+
+        password = self.dialog.inputbox(
+            "MQTT Password",
+            "Password for broker authentication:\n\n"
+            "A random password has been generated.\n"
+            "You can use it or enter your own.",
+            init=default_pw
+        )
+        if not password:
+            return
+
+        # Create profile
+        profile = create_private_profile(
+            name="meshforge_private",
+            channel=channel,
+            region=region,
+            username=username,
+            password=password,
+        )
+
+        # Save profile
+        profiles = load_profiles()
+        # Deactivate others
+        for p in profiles.values():
+            p.is_active = False
+        profile.is_active = True
+        profiles["meshforge_private"] = profile
+        save_profiles(profiles)
+
+        # Offer to install mosquitto config
+        if os.geteuid() == 0:
+            if self.dialog.yesno(
+                "Install Config",
+                "Install mosquitto configuration now?\n\n"
+                "This will create:\n"
+                "  /etc/mosquitto/conf.d/meshforge.conf\n"
+                "  /etc/mosquitto/meshforge_passwd\n"
+                "  /etc/mosquitto/meshforge_acl\n\n"
+                "And restart mosquitto."
+            ):
+                self._install_broker_config(profile)
+        else:
+            self.dialog.msgbox(
+                "Manual Install Required",
+                "Run MeshForge with sudo to install broker config,\n"
+                "or manually create the mosquitto configuration.\n\n"
+                "Use 'View mosquitto.conf' to see the template."
+            )
+
+        # Show radio setup commands
+        cmds = get_meshtastic_mqtt_setup_commands(profile)
+        self.dialog.msgbox(
+            "Setup Complete",
+            f"Private broker profile created and activated!\n\n"
+            f"Broker: localhost:{profile.port}\n"
+            f"User: {username}\n"
+            f"Channel: {channel}\n"
+            f"Region: {region}\n\n"
+            f"Configure your Meshtastic radio:\n\n{cmds}",
+            width=70
+        )
+
+        # Apply to MQTT subscriber config
+        self._apply_profile_to_mqtt(profile)
+
+    def _setup_public_broker(self):
+        """Quick setup for Meshtastic public broker."""
+        region = self.dialog.inputbox(
+            "Region",
+            "Meshtastic region:\n\n"
+            "  US, EU_868, ANZ, etc.",
+            init="US"
+        )
+        if not region:
+            return
+
+        channel = self.dialog.inputbox(
+            "Channel",
+            "Channel to monitor:\n\n"
+            "  LongFast (default, highest traffic)",
+            init="LongFast"
+        )
+        if not channel:
+            return
+
+        profile = create_public_profile(region=region, channel=channel)
+
+        profiles = load_profiles()
+        for p in profiles.values():
+            p.is_active = False
+        profile.is_active = True
+        profiles["meshtastic_public"] = profile
+        save_profiles(profiles)
+
+        self.dialog.msgbox(
+            "Public Broker Set",
+            f"Configured for Meshtastic public broker.\n\n"
+            f"Broker: mqtt.meshtastic.org:8883 (TLS)\n"
+            f"Channel: {channel}\n"
+            f"Region: {region}\n\n"
+            "This is read-only nodeless monitoring.\n"
+            "No local radio needed.\n\n"
+            "Public broker enforces zero-hop policy\n"
+            "(downlinked messages don't re-enter mesh)."
+        )
+
+        self._apply_profile_to_mqtt(profile)
+
+    def _setup_custom_broker(self):
+        """Guided setup for a custom MQTT broker."""
+        name = self.dialog.inputbox(
+            "Profile Name",
+            "Name for this broker profile:",
+            init="my_broker"
+        )
+        if not name:
+            return
+
+        host = self.dialog.inputbox(
+            "Broker Host",
+            "MQTT broker hostname or IP:\n\n"
+            "Examples:\n"
+            "  mqtt.example.com\n"
+            "  192.168.1.100\n"
+            "  gt.wildc.net",
+        )
+        if not host:
+            return
+
+        port = self.dialog.inputbox(
+            "Port",
+            "MQTT port:\n\n"
+            "  1883 = Plain TCP\n"
+            "  8883 = TLS encrypted",
+            init="1883"
+        )
+        if not port or not port.isdigit():
+            return
+
+        username = self.dialog.inputbox(
+            "Username",
+            "MQTT username (blank for anonymous):",
+        )
+
+        password = ""
+        if username:
+            password = self.dialog.inputbox(
+                "Password",
+                "MQTT password:",
+            ) or ""
+
+        region = self.dialog.inputbox(
+            "Region",
+            "Meshtastic region code:",
+            init="US"
+        ) or "US"
+
+        channel = self.dialog.inputbox(
+            "Channel",
+            "Meshtastic channel name:",
+            init="LongFast"
+        ) or "LongFast"
+
+        root_topic = self.dialog.inputbox(
+            "Root Topic",
+            "MQTT root topic:\n\n"
+            "  msh/{region}/2/e  (standard)\n"
+            "  msh              (all regions)",
+            init=f"msh/{region}/2/e"
+        ) or f"msh/{region}/2/e"
+
+        profile = create_custom_profile(
+            name=name,
+            host=host,
+            port=int(port),
+            username=username or "",
+            password=password,
+            use_tls=(int(port) == 8883),
+            root_topic=root_topic,
+            channel=channel,
+            region=region,
+        )
+
+        profiles = load_profiles()
+        for p in profiles.values():
+            p.is_active = False
+        profile.is_active = True
+        profiles[name] = profile
+        save_profiles(profiles)
+
+        self.dialog.msgbox(
+            "Custom Broker Saved",
+            f"Profile '{name}' created and activated.\n\n"
+            f"Broker: {host}:{port}\n"
+            f"Channel: {channel}\n"
+            f"Topic: {profile.topic_filter}"
+        )
+
+        self._apply_profile_to_mqtt(profile)
+
+    def _mosquitto_service_menu(self):
+        """Manage the local mosquitto service."""
+        while True:
+            installed, inst_msg = check_mosquitto_installed()
+            running, run_msg = check_mosquitto_running()
+
+            if not installed:
+                choices = [
+                    ("install", "Install Mosquitto"),
+                    ("back", "Back"),
+                ]
+                subtitle = f"Status: {inst_msg}"
+            else:
+                status = "Running" if running else "Stopped"
+                choices = [
+                    ("status", f"Status: {status}"),
+                    ("start", "Start Mosquitto"),
+                    ("stop", "Stop Mosquitto"),
+                    ("restart", "Restart Mosquitto"),
+                    ("enable", "Enable at Boot"),
+                    ("logs", "View Logs"),
+                    ("test", "Test Connection"),
+                    ("back", "Back"),
+                ]
+                subtitle = f"Mosquitto: {status}"
+
+            choice = self.dialog.menu(
+                "Mosquitto Service",
+                subtitle,
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "install":
+                self._install_mosquitto()
+
+            elif choice == "status":
+                self._show_mosquitto_status()
+
+            elif choice == "start":
+                self._mosquitto_action("start")
+
+            elif choice == "stop":
+                self._mosquitto_action("stop")
+
+            elif choice == "restart":
+                success, msg = restart_mosquitto()
+                self.dialog.msgbox(
+                    "Restart" if success else "Error",
+                    msg
+                )
+
+            elif choice == "enable":
+                success, msg = enable_mosquitto_at_boot()
+                self.dialog.msgbox(
+                    "Enabled" if success else "Error",
+                    msg
+                )
+
+            elif choice == "logs":
+                self._show_mosquitto_logs()
+
+            elif choice == "test":
+                self._test_mosquitto_connection()
+
+    def _install_mosquitto(self):
+        """Install mosquitto via apt."""
+        if os.geteuid() != 0:
+            self.dialog.msgbox(
+                "Root Required",
+                "Run MeshForge with sudo to install packages.\n\n"
+                "Or install manually:\n"
+                "  sudo apt install mosquitto mosquitto-clients"
+            )
+            return
+
+        if not self.dialog.yesno(
+            "Install Mosquitto",
+            "Install mosquitto MQTT broker?\n\n"
+            "This will run:\n"
+            "  apt install -y mosquitto mosquitto-clients"
+        ):
+            return
+
+        self.dialog.infobox("Installing", "Installing mosquitto...")
+
+        import subprocess
+        try:
+            result = subprocess.run(
+                ["apt", "install", "-y", "mosquitto", "mosquitto-clients"],
+                capture_output=True, text=True, timeout=120
+            )
+            if result.returncode == 0:
+                self.dialog.msgbox(
+                    "Installed",
+                    "Mosquitto installed successfully.\n\n"
+                    "Use 'Setup Private Broker' to configure it."
+                )
+            else:
+                self.dialog.msgbox(
+                    "Install Failed",
+                    f"apt install failed:\n{result.stderr[:500]}"
+                )
+        except subprocess.TimeoutExpired:
+            self.dialog.msgbox("Timeout", "Installation timed out.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Installation failed:\n{e}")
+
+    def _install_broker_config(self, profile: BrokerProfile):
+        """Install mosquitto config for a profile."""
+        success, msg = install_mosquitto_config(profile)
+
+        if success:
+            self.dialog.msgbox("Config Installed", msg)
+
+            # Offer to restart mosquitto
+            if self.dialog.yesno(
+                "Restart Mosquitto",
+                "Restart mosquitto to apply the new configuration?"
+            ):
+                rsuccess, rmsg = restart_mosquitto()
+                self.dialog.msgbox(
+                    "Restarted" if rsuccess else "Error",
+                    rmsg
+                )
+        else:
+            self.dialog.msgbox("Error", msg)
+
+    def _show_mosquitto_status(self):
+        """Show detailed mosquitto status."""
+        import subprocess
+
+        lines = ["MOSQUITTO STATUS", "=" * 40, ""]
+
+        # Check installed
+        installed, inst_msg = check_mosquitto_installed()
+        lines.append(f"Installed: {'Yes' if installed else 'No'}")
+
+        if installed:
+            # Check running
+            running, run_msg = check_mosquitto_running()
+            lines.append(f"Running: {'Yes' if running else 'No'}")
+
+            # Get systemd status
+            try:
+                result = subprocess.run(
+                    ["systemctl", "status", "mosquitto", "--no-pager", "-l"],
+                    capture_output=True, text=True, timeout=10
+                )
+                # Show first few lines of status
+                status_lines = result.stdout.strip().split('\n')[:8]
+                lines.append("")
+                lines.append("SYSTEMD STATUS:")
+                lines.extend(f"  {l}" for l in status_lines)
+            except (subprocess.TimeoutExpired, FileNotFoundError):
+                pass
+
+            # Check if MeshForge config is installed
+            from pathlib import Path
+            mf_conf = Path("/etc/mosquitto/conf.d/meshforge.conf")
+            lines.append("")
+            lines.append(f"MeshForge config: {'Installed' if mf_conf.exists() else 'Not installed'}")
+
+        self.dialog.msgbox("Mosquitto Status", "\n".join(lines), width=60)
+
+    def _mosquitto_action(self, action: str):
+        """Start/stop mosquitto service."""
+        if os.geteuid() != 0:
+            self.dialog.msgbox(
+                "Root Required",
+                f"Run MeshForge with sudo to {action} services."
+            )
+            return
+
+        import subprocess
+        try:
+            result = subprocess.run(
+                ["systemctl", action, "mosquitto"],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                self.dialog.msgbox(
+                    action.title(),
+                    f"Mosquitto {action}ed successfully."
+                )
+            else:
+                self.dialog.msgbox(
+                    "Error",
+                    f"Failed to {action} mosquitto:\n{result.stderr.strip()}"
+                )
+        except subprocess.TimeoutExpired:
+            self.dialog.msgbox("Timeout", f"Command timed out.")
+        except FileNotFoundError:
+            self.dialog.msgbox("Error", "systemctl not found.")
+
+    def _show_mosquitto_logs(self):
+        """Show recent mosquitto logs."""
+        import subprocess
+        try:
+            result = subprocess.run(
+                ["journalctl", "-u", "mosquitto", "-n", "30", "--no-pager"],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.stdout:
+                self.dialog.msgbox(
+                    "Mosquitto Logs (last 30 lines)",
+                    result.stdout,
+                    width=76
+                )
+            else:
+                self.dialog.msgbox("No Logs", "No mosquitto log entries found.")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            self.dialog.msgbox("Error", "Could not retrieve logs.")
+
+    def _test_mosquitto_connection(self):
+        """Test MQTT connection to the active broker."""
+        profiles = load_profiles()
+        active = get_active_profile(profiles)
+
+        if not active:
+            self.dialog.msgbox(
+                "No Active Profile",
+                "No broker profile is active.\n"
+                "Set up a broker profile first."
+            )
+            return
+
+        self.dialog.infobox("Testing", f"Connecting to {active.host}:{active.port}...")
+
+        import subprocess
+        try:
+            # Use mosquitto_pub to test connection
+            cmd = [
+                "mosquitto_pub",
+                "-h", active.host,
+                "-p", str(active.port),
+                "-t", "meshforge/test",
+                "-m", "MeshForge connection test",
+            ]
+
+            if active.username:
+                cmd.extend(["-u", active.username])
+            if active.password:
+                cmd.extend(["-P", active.password])
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True, text=True, timeout=10
+            )
+
+            if result.returncode == 0:
+                self.dialog.msgbox(
+                    "Connection OK",
+                    f"Successfully connected to {active.host}:{active.port}\n\n"
+                    f"Published test message to meshforge/test topic."
+                )
+            else:
+                self.dialog.msgbox(
+                    "Connection Failed",
+                    f"Could not connect to {active.host}:{active.port}\n\n"
+                    f"Error: {result.stderr.strip()}\n\n"
+                    "Check:\n"
+                    "  1. Mosquitto is running\n"
+                    "  2. Credentials are correct\n"
+                    "  3. Firewall allows port " + str(active.port)
+                )
+        except FileNotFoundError:
+            self.dialog.msgbox(
+                "Tool Missing",
+                "mosquitto_pub not found.\n\n"
+                "Install: sudo apt install mosquitto-clients"
+            )
+        except subprocess.TimeoutExpired:
+            self.dialog.msgbox(
+                "Connection Timeout",
+                f"Connection to {active.host}:{active.port} timed out."
+            )
+
+    def _radio_mqtt_setup(self):
+        """Show Meshtastic radio MQTT configuration commands."""
+        profiles = load_profiles()
+        active = get_active_profile(profiles)
+
+        if not active:
+            self.dialog.msgbox(
+                "No Active Profile",
+                "No broker profile is active.\n"
+                "Set up a broker profile first."
+            )
+            return
+
+        cmds = get_meshtastic_mqtt_setup_commands(active)
+
+        lines = [
+            "MESHTASTIC RADIO MQTT SETUP",
+            "=" * 50,
+            "",
+            f"Active Profile: {active.display_name}",
+            f"Broker: {active.host}:{active.port}",
+            "",
+            "Run these commands on each gateway node to connect",
+            "the radio to your MQTT broker:",
+            "",
+            cmds,
+            "",
+            "IMPORTANT NOTES:",
+            "- The radio connects to the broker directly via WiFi",
+            "- Set mqtt.address to the broker's LAN IP (not localhost)",
+            "- Enable uplink on channels you want to bridge",
+            "- Enable downlink to receive MQTT messages on mesh",
+            "",
+            "For private brokers: do NOT use the default AQ== key",
+            "on your mesh channel. Use a custom PSK for security.",
+        ]
+
+        self.dialog.msgbox(
+            "Radio MQTT Setup",
+            "\n".join(lines),
+            width=70
+        )
+
+    def _apply_profile_to_mqtt(self, profile: BrokerProfile):
+        """Apply a broker profile to the MQTT subscriber configuration.
+
+        This updates the mqtt_nodeless.json config that the MQTT
+        subscriber and TUI uses for connecting.
+        """
+        tui_config = profile.to_tui_config()
+
+        # Preserve existing auto-start settings
+        existing_config = self._load_mqtt_config()
+        tui_config['auto_start'] = existing_config.get('auto_start', False)
+        tui_config['auto_start_telemetry'] = existing_config.get('auto_start_telemetry', True)
+
+        self._save_mqtt_config(tui_config)
+        logger.info("Applied broker profile '%s' to MQTT subscriber config", profile.name)

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -130,6 +130,7 @@ from device_backup_mixin import DeviceBackupMixin
 from traffic_inspector_mixin import TrafficInspectorMixin
 from updates_mixin import UpdatesMixin
 from mqtt_mixin import MQTTMixin
+from broker_mixin import BrokerMixin
 from gateway_config_mixin import GatewayConfigMixin
 from favorites_mixin import FavoritesMixin
 from network_tools_mixin import NetworkToolsMixin
@@ -167,6 +168,7 @@ class MeshForgeLauncher(
     TrafficInspectorMixin,
     UpdatesMixin,
     MQTTMixin,
+    BrokerMixin,
     GatewayConfigMixin,
     FavoritesMixin,
     NetworkToolsMixin,

--- a/src/launcher_tui/mqtt_mixin.py
+++ b/src/launcher_tui/mqtt_mixin.py
@@ -166,7 +166,14 @@ class MQTTMixin:
                 logger.debug("MQTT config load failed: %s", e)
                 config = {}
             broker = config.get('broker', 'mqtt.meshtastic.org')
-            mode = "Local" if broker == "localhost" else "Public"
+
+            # Determine mode from broker profile or config
+            if broker in ("localhost", "127.0.0.1"):
+                mode = "Private"
+            elif broker == "mqtt.meshtastic.org":
+                mode = "Public"
+            else:
+                mode = "Custom"
 
             # Check WebSocket bridge status
             try:
@@ -179,7 +186,8 @@ class MQTTMixin:
                 ("status", f"Status              {status}"),
                 ("start", "Start Subscriber    Connect to MQTT broker"),
                 ("stop", "Stop Subscriber     Disconnect from broker"),
-                ("config", f"Configure           Mode: {mode}"),
+                ("broker", f"Broker Manager      Mode: {mode}"),
+                ("config", "Configure           Advanced settings"),
                 ("nodes", "View Nodes          Show discovered nodes"),
                 ("stats", "Statistics          Node counts, activity"),
                 ("telemetry", "Request Telemetry   Poll silent 2.7+ nodes"),
@@ -192,11 +200,13 @@ class MQTTMixin:
 
             choices.append(("back", "Back"))
 
-            subtitle = f"MQTT Mode: {mode} ({broker})\n"
-            if mode == "Local":
-                subtitle += "Multi-consumer: shares messages with other apps"
-            else:
+            subtitle = f"MQTT Broker: {mode} ({broker})\n"
+            if mode == "Private":
+                subtitle += "MeshForge private broker (multi-consumer)"
+            elif mode == "Public":
                 subtitle += "Nodeless monitoring without local radio"
+            else:
+                subtitle += f"Custom broker: {broker}"
 
             choice = self.dialog.menu(
                 "MQTT Monitoring",
@@ -211,6 +221,7 @@ class MQTTMixin:
                 "status": ("MQTT Status", self._show_mqtt_status),
                 "start": ("Start MQTT Subscriber", self._start_mqtt_subscriber),
                 "stop": ("Stop MQTT Subscriber", self._stop_mqtt_subscriber),
+                "broker": ("Broker Manager", self._broker_menu),
                 "config": ("MQTT Configuration", self._configure_mqtt),
                 "nodes": ("MQTT Nodes", self._show_mqtt_nodes),
                 "stats": ("MQTT Statistics", self._show_mqtt_stats),

--- a/src/utils/broker_profiles.py
+++ b/src/utils/broker_profiles.py
@@ -1,0 +1,805 @@
+"""
+MeshForge MQTT Broker Profiles
+
+Provides broker configuration templates following Meshtastic MQTT conventions:
+- MeshForge Private Broker (localhost mosquitto, custom PSK)
+- Meshtastic Public Broker (mqtt.meshtastic.org)
+- Custom Broker (user-defined)
+
+Also generates mosquitto.conf files for the private broker mode, enabling
+MeshForge to act as its own MQTT broker for bridging:
+
+    Meshtastic LF -> Private Broker -> RNS Gateway -> Meshtastic ST
+
+Topic structure follows Meshtastic conventions:
+    msh/{region}/2/e/{channel}/!{node_id}   (encrypted protobuf)
+    msh/{region}/2/json/{channel}/!{node_id} (JSON, if enabled)
+
+See: https://meshtastic.org/docs/software/integrations/mqtt/
+"""
+
+import json
+import logging
+import os
+import secrets
+import string
+import subprocess
+from dataclasses import dataclass, field, asdict
+from enum import Enum
+from pathlib import Path
+from typing import Optional, Dict, Any, Tuple, List
+
+logger = logging.getLogger(__name__)
+
+# Import centralized path utility - see persistent_issues.md Issue #1
+try:
+    from utils.paths import get_real_user_home
+except ImportError:
+    def get_real_user_home() -> Path:
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f'/home/{sudo_user}')
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f'/home/{logname}')
+        return Path('/root')
+
+
+class BrokerType(Enum):
+    """Broker profile types."""
+    PRIVATE = "private"    # MeshForge-managed mosquitto
+    PUBLIC = "public"      # mqtt.meshtastic.org
+    CUSTOM = "custom"      # User-defined broker
+
+
+@dataclass
+class BrokerProfile:
+    """MQTT broker configuration profile.
+
+    Follows Meshtastic MQTT conventions for topic structure,
+    authentication, and encryption settings.
+    """
+    name: str
+    broker_type: str  # BrokerType value as string for JSON serialization
+    host: str
+    port: int
+    username: str = ""
+    password: str = ""
+    use_tls: bool = False
+    root_topic: str = "msh/US/2/e"
+    channel: str = "LongFast"
+    encryption_key: str = "AQ=="  # Default Meshtastic key (NOT recommended for private)
+    region: str = "US"
+    json_enabled: bool = True
+    uplink_enabled: bool = True
+    downlink_enabled: bool = True
+    # Private broker specific
+    allow_anonymous: bool = False
+    acl_enabled: bool = True
+    # Metadata
+    description: str = ""
+    is_active: bool = False
+
+    @property
+    def topic_filter(self) -> str:
+        """Build MQTT topic filter string for subscription."""
+        return f"{self.root_topic}/{self.channel}/#"
+
+    @property
+    def json_topic_filter(self) -> str:
+        """Build JSON topic filter (parallel to encrypted topic)."""
+        json_root = self.root_topic.replace("/e", "/json")
+        return f"{json_root}/{self.channel}/#"
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable display name."""
+        if self.broker_type == BrokerType.PRIVATE.value:
+            return f"Private: {self.name}"
+        elif self.broker_type == BrokerType.PUBLIC.value:
+            return f"Public: {self.host}"
+        return f"Custom: {self.name} ({self.host})"
+
+    def to_mqtt_config(self) -> Dict[str, Any]:
+        """Convert to MQTTNodelessSubscriber config format."""
+        return {
+            "broker": self.host,
+            "port": self.port,
+            "username": self.username,
+            "password": self.password,
+            "root_topic": self.root_topic,
+            "channel": self.channel,
+            "key": self.encryption_key,
+            "use_tls": self.use_tls,
+            "auto_reconnect": True,
+            "reconnect_delay": 2 if self.host in ("localhost", "127.0.0.1") else 5,
+            "max_reconnect_delay": 30 if self.host in ("localhost", "127.0.0.1") else 60,
+        }
+
+    def to_tui_config(self) -> Dict[str, Any]:
+        """Convert to TUI mqtt_nodeless.json format."""
+        topic = self.topic_filter
+        if self.json_enabled and self.host in ("localhost", "127.0.0.1"):
+            topic = self.json_topic_filter
+        return {
+            "broker": self.host,
+            "port": self.port,
+            "topic": topic,
+            "username": self.username or None,
+            "password": self.password or None,
+            "use_tls": self.use_tls,
+        }
+
+    def to_meshtastic_cli_args(self) -> List[str]:
+        """Generate meshtastic CLI args to configure the radio's MQTT module.
+
+        Returns list of --set arguments for the meshtastic CLI.
+        """
+        args = [
+            "--set", "mqtt.enabled", "true",
+            "--set", "mqtt.address", self.host,
+        ]
+        if self.username:
+            args.extend(["--set", "mqtt.username", self.username])
+        if self.password:
+            args.extend(["--set", "mqtt.password", self.password])
+        if self.root_topic != "msh":
+            args.extend(["--set", "mqtt.root", self.root_topic.split("/")[0]])
+        args.extend([
+            "--set", "mqtt.encryption_enabled", "true",
+            "--set", "mqtt.json_enabled", str(self.json_enabled).lower(),
+            "--set", "mqtt.tls_enabled", str(self.use_tls).lower(),
+        ])
+        return args
+
+
+def generate_password(length: int = 16) -> str:
+    """Generate a secure random password for MQTT authentication."""
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for _ in range(length))
+
+
+# =============================================================================
+# Profile Factory Functions
+# =============================================================================
+
+def create_private_profile(
+    name: str = "meshforge",
+    channel: str = "LongFast",
+    region: str = "US",
+    username: str = "meshforge",
+    password: str = "",
+) -> BrokerProfile:
+    """Create a MeshForge private broker profile.
+
+    This is the recommended setup for bridging Meshtastic <-> RNS.
+    Runs mosquitto locally with authentication and proper ACLs.
+
+    IMPORTANT: Do NOT use the default Meshtastic key (AQ==) on private brokers.
+    This generates a random password if none is provided.
+
+    Args:
+        name: Profile name
+        channel: Meshtastic channel name
+        region: Region code (US, EU_868, etc.)
+        username: MQTT username
+        password: MQTT password (generated if empty)
+    """
+    if not password:
+        password = generate_password()
+
+    return BrokerProfile(
+        name=name,
+        broker_type=BrokerType.PRIVATE.value,
+        host="localhost",
+        port=1883,
+        username=username,
+        password=password,
+        use_tls=False,  # Localhost doesn't need TLS
+        root_topic=f"msh/{region}/2/e",
+        channel=channel,
+        encryption_key="AQ==",  # Meshtastic default - radio handles encryption
+        region=region,
+        json_enabled=True,
+        uplink_enabled=True,
+        downlink_enabled=True,
+        allow_anonymous=False,
+        acl_enabled=True,
+        description=(
+            "MeshForge private broker (localhost mosquitto). "
+            "Authenticated access, ACL-controlled topics. "
+            "Ideal for Meshtastic <-> RNS gateway bridging."
+        ),
+    )
+
+
+def create_public_profile(
+    region: str = "US",
+    channel: str = "LongFast",
+) -> BrokerProfile:
+    """Create a Meshtastic public broker profile.
+
+    Connects to mqtt.meshtastic.org for nodeless monitoring.
+    Uses default Meshtastic credentials and encryption key.
+
+    Note: Public broker enforces zero-hop policy (messages don't
+    propagate further into the mesh from MQTT downlink).
+    """
+    return BrokerProfile(
+        name="Meshtastic Public",
+        broker_type=BrokerType.PUBLIC.value,
+        host="mqtt.meshtastic.org",
+        port=8883,
+        username="meshdev",
+        password="large4cats",
+        use_tls=True,
+        root_topic=f"msh/{region}/2/e",
+        channel=channel,
+        encryption_key="AQ==",
+        region=region,
+        json_enabled=False,  # Public broker mainly uses encrypted protobuf
+        uplink_enabled=False,  # Read-only monitoring
+        downlink_enabled=False,
+        allow_anonymous=False,
+        acl_enabled=False,
+        description=(
+            "Meshtastic public broker (mqtt.meshtastic.org). "
+            "Nodeless monitoring - observe the mesh without local radio. "
+            "Read-only, zero-hop policy enforced."
+        ),
+    )
+
+
+def create_custom_profile(
+    name: str,
+    host: str,
+    port: int = 1883,
+    username: str = "",
+    password: str = "",
+    use_tls: bool = False,
+    root_topic: str = "msh/US/2/e",
+    channel: str = "LongFast",
+    region: str = "US",
+) -> BrokerProfile:
+    """Create a custom broker profile.
+
+    For users running their own MQTT infrastructure or connecting
+    to community/regional brokers.
+    """
+    return BrokerProfile(
+        name=name,
+        broker_type=BrokerType.CUSTOM.value,
+        host=host,
+        port=port,
+        username=username,
+        password=password,
+        use_tls=use_tls,
+        root_topic=root_topic,
+        channel=channel,
+        encryption_key="AQ==",
+        region=region,
+        json_enabled=True,
+        uplink_enabled=True,
+        downlink_enabled=True,
+        allow_anonymous=not username,
+        acl_enabled=False,
+        description=f"Custom broker at {host}:{port}",
+    )
+
+
+# =============================================================================
+# Mosquitto Configuration Generator
+# =============================================================================
+
+MOSQUITTO_CONF_TEMPLATE = """\
+# MeshForge Private MQTT Broker Configuration
+# Generated by MeshForge broker profile manager
+#
+# Meshtastic MQTT topic convention:
+#   msh/{{region}}/2/e/{{channel}}/!{{node_id}}   (encrypted protobuf)
+#   msh/{{region}}/2/json/{{channel}}/!{{node_id}} (JSON)
+#
+# See: https://meshtastic.org/docs/software/integrations/mqtt/
+
+# =============================================================================
+# Listeners
+# =============================================================================
+
+# Plain TCP listener for local Meshtastic devices and MeshForge
+listener {port}
+protocol mqtt
+
+# Bind to all interfaces (change to 127.0.0.1 for local-only)
+# For LAN gateway nodes, use 0.0.0.0
+bind_address {bind_address}
+
+# =============================================================================
+# Authentication
+# =============================================================================
+
+# Require username/password (recommended for private brokers)
+allow_anonymous {allow_anonymous}
+
+# Password file (generated with mosquitto_passwd)
+{password_file_line}
+
+# =============================================================================
+# Access Control
+# =============================================================================
+
+# ACL file for topic-level permissions
+{acl_file_line}
+
+# =============================================================================
+# Persistence
+# =============================================================================
+
+persistence true
+persistence_location /var/lib/mosquitto/
+
+# =============================================================================
+# Logging
+# =============================================================================
+
+log_dest syslog
+log_type warning
+log_type error
+log_type notice
+
+# =============================================================================
+# Connection limits
+# =============================================================================
+
+# Max connections (adjust based on mesh size)
+max_connections 100
+
+# Keepalive timeout (seconds)
+max_keepalive 120
+
+# Max queued messages per client
+max_queued_messages 1000
+
+# Max message size (Meshtastic packets are small, 256 bytes typical)
+message_size_limit 4096
+"""
+
+MOSQUITTO_ACL_TEMPLATE = """\
+# MeshForge MQTT Broker ACL
+# Generated by MeshForge broker profile manager
+#
+# Controls which users can read/write which topics.
+# Topic pattern: msh/{{region}}/2/e/{{channel}}/!{{node_id}}
+
+# =============================================================================
+# MeshForge user - full access to mesh topics
+# =============================================================================
+user {username}
+topic readwrite msh/#
+topic readwrite meshforge/#
+topic read $SYS/#
+
+# =============================================================================
+# Meshtastic gateway nodes - access to their channel topics
+# =============================================================================
+# Add gateway node users here:
+# user gateway1
+# topic readwrite msh/{region}/2/e/{channel}/#
+# topic readwrite msh/{region}/2/json/{channel}/#
+
+# =============================================================================
+# Read-only monitoring users
+# =============================================================================
+# user monitor
+# topic read msh/#
+# topic read $SYS/#
+"""
+
+
+def generate_mosquitto_conf(profile: BrokerProfile) -> str:
+    """Generate mosquitto.conf content for a private broker profile.
+
+    Args:
+        profile: BrokerProfile with private broker settings
+
+    Returns:
+        String content for mosquitto.conf
+    """
+    allow_anon = "true" if profile.allow_anonymous else "false"
+
+    if profile.allow_anonymous:
+        password_file_line = "# password_file not needed (anonymous access)"
+        acl_file_line = "# acl_file not needed (anonymous access)"
+    else:
+        password_file_line = "password_file /etc/mosquitto/meshforge_passwd"
+        acl_file_line = "acl_file /etc/mosquitto/meshforge_acl"
+
+    # Local-only vs LAN-accessible
+    bind_address = "0.0.0.0"  # LAN-accessible by default for gateway nodes
+
+    return MOSQUITTO_CONF_TEMPLATE.format(
+        port=profile.port,
+        bind_address=bind_address,
+        allow_anonymous=allow_anon,
+        password_file_line=password_file_line,
+        acl_file_line=acl_file_line,
+    )
+
+
+def generate_mosquitto_acl(profile: BrokerProfile) -> str:
+    """Generate ACL file content for a private broker profile.
+
+    Args:
+        profile: BrokerProfile with private broker settings
+
+    Returns:
+        String content for mosquitto ACL file
+    """
+    return MOSQUITTO_ACL_TEMPLATE.format(
+        username=profile.username or "meshforge",
+        region=profile.region,
+        channel=profile.channel,
+    )
+
+
+# =============================================================================
+# Profile Storage
+# =============================================================================
+
+PROFILES_FILENAME = "broker_profiles.json"
+
+
+def _get_profiles_path() -> Path:
+    """Get path to broker profiles config file."""
+    return get_real_user_home() / ".config" / "meshforge" / PROFILES_FILENAME
+
+
+def load_profiles() -> Dict[str, BrokerProfile]:
+    """Load broker profiles from config file.
+
+    Returns:
+        Dict mapping profile name to BrokerProfile
+    """
+    profiles_path = _get_profiles_path()
+    profiles = {}
+
+    if profiles_path.exists():
+        try:
+            with open(profiles_path) as f:
+                data = json.load(f)
+            for name, pdata in data.get("profiles", {}).items():
+                try:
+                    profiles[name] = BrokerProfile(**pdata)
+                except TypeError as e:
+                    logger.warning("Skipping malformed profile '%s': %s", name, e)
+        except (json.JSONDecodeError, OSError) as e:
+            logger.error("Error loading broker profiles: %s", e)
+
+    return profiles
+
+
+def save_profiles(profiles: Dict[str, BrokerProfile]) -> bool:
+    """Save broker profiles to config file.
+
+    Args:
+        profiles: Dict mapping profile name to BrokerProfile
+
+    Returns:
+        True if saved successfully
+    """
+    profiles_path = _get_profiles_path()
+    try:
+        profiles_path.parent.mkdir(parents=True, exist_ok=True)
+
+        data = {
+            "profiles": {name: asdict(p) for name, p in profiles.items()},
+            "active_profile": next(
+                (name for name, p in profiles.items() if p.is_active), None
+            ),
+        }
+
+        # Atomic write via temp file
+        tmp_path = profiles_path.with_suffix('.tmp')
+        with open(tmp_path, 'w') as f:
+            json.dump(data, f, indent=2)
+        tmp_path.rename(profiles_path)
+
+        return True
+    except OSError as e:
+        logger.error("Error saving broker profiles: %s", e)
+        return False
+
+
+def get_active_profile(profiles: Optional[Dict[str, BrokerProfile]] = None) -> Optional[BrokerProfile]:
+    """Get the currently active broker profile.
+
+    Args:
+        profiles: Profiles dict (loaded if None)
+
+    Returns:
+        Active BrokerProfile or None
+    """
+    if profiles is None:
+        profiles = load_profiles()
+
+    for profile in profiles.values():
+        if profile.is_active:
+            return profile
+    return None
+
+
+def set_active_profile(name: str, profiles: Optional[Dict[str, BrokerProfile]] = None) -> bool:
+    """Set a profile as the active broker profile.
+
+    Args:
+        name: Profile name to activate
+        profiles: Profiles dict (loaded if None)
+
+    Returns:
+        True if activated successfully
+    """
+    if profiles is None:
+        profiles = load_profiles()
+
+    if name not in profiles:
+        logger.error("Profile '%s' not found", name)
+        return False
+
+    # Deactivate all, activate target
+    for pname, profile in profiles.items():
+        profile.is_active = (pname == name)
+
+    return save_profiles(profiles)
+
+
+# =============================================================================
+# Mosquitto Service Management
+# =============================================================================
+
+def install_mosquitto_config(profile: BrokerProfile) -> Tuple[bool, str]:
+    """Install mosquitto configuration files for a private broker.
+
+    Creates:
+    - /etc/mosquitto/conf.d/meshforge.conf
+    - /etc/mosquitto/meshforge_passwd (password file)
+    - /etc/mosquitto/meshforge_acl (ACL file)
+
+    Requires root privileges.
+
+    Args:
+        profile: Private broker profile
+
+    Returns:
+        (success, message) tuple
+    """
+    if os.geteuid() != 0:
+        return False, "Root privileges required. Run with sudo."
+
+    conf_dir = Path("/etc/mosquitto/conf.d")
+    if not conf_dir.parent.exists():
+        return False, (
+            "Mosquitto not installed.\n"
+            "Install with: sudo apt install mosquitto mosquitto-clients"
+        )
+
+    try:
+        # Ensure conf.d exists
+        conf_dir.mkdir(parents=True, exist_ok=True)
+
+        # Write mosquitto config
+        conf_path = conf_dir / "meshforge.conf"
+        conf_content = generate_mosquitto_conf(profile)
+        with open(conf_path, 'w') as f:
+            f.write(conf_content)
+
+        messages = [f"Config written to {conf_path}"]
+
+        # Create password file if authenticated
+        if not profile.allow_anonymous and profile.username and profile.password:
+            passwd_path = Path("/etc/mosquitto/meshforge_passwd")
+
+            # mosquitto_passwd creates/updates the password file
+            result = subprocess.run(
+                ["mosquitto_passwd", "-b", str(passwd_path),
+                 profile.username, profile.password],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                messages.append(f"Password file created: {passwd_path}")
+                # Set permissions
+                os.chmod(str(passwd_path), 0o640)
+            else:
+                messages.append(
+                    f"Warning: mosquitto_passwd failed: {result.stderr.strip()}"
+                )
+
+        # Write ACL file if enabled
+        if profile.acl_enabled and not profile.allow_anonymous:
+            acl_path = Path("/etc/mosquitto/meshforge_acl")
+            acl_content = generate_mosquitto_acl(profile)
+            with open(acl_path, 'w') as f:
+                f.write(acl_content)
+            messages.append(f"ACL file written to {acl_path}")
+
+        return True, "\n".join(messages)
+
+    except subprocess.TimeoutExpired:
+        return False, "mosquitto_passwd timed out"
+    except OSError as e:
+        return False, f"File operation failed: {e}"
+
+
+def check_mosquitto_installed() -> Tuple[bool, str]:
+    """Check if mosquitto is installed and available.
+
+    Returns:
+        (installed, message) tuple
+    """
+    import shutil
+
+    mosquitto_bin = shutil.which("mosquitto")
+    mosquitto_passwd = shutil.which("mosquitto_passwd")
+
+    if not mosquitto_bin:
+        return False, (
+            "Mosquitto broker not installed.\n\n"
+            "Install with:\n"
+            "  sudo apt install mosquitto mosquitto-clients"
+        )
+
+    if not mosquitto_passwd:
+        return False, (
+            "Mosquitto tools not fully installed.\n\n"
+            "Install mosquitto-clients:\n"
+            "  sudo apt install mosquitto-clients"
+        )
+
+    return True, "Mosquitto is installed"
+
+
+def check_mosquitto_running() -> Tuple[bool, str]:
+    """Check if mosquitto service is running.
+
+    Returns:
+        (running, message) tuple
+    """
+    try:
+        from utils.service_check import check_service
+        status = check_service('mosquitto')
+        return status.available, status.message
+    except ImportError:
+        pass
+
+    # Fallback: check via systemctl
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "mosquitto"],
+            capture_output=True, text=True, timeout=10
+        )
+        active = result.stdout.strip() == "active"
+        return active, "Running" if active else "Not running"
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False, "Cannot determine status"
+
+
+def restart_mosquitto() -> Tuple[bool, str]:
+    """Restart the mosquitto service after config changes.
+
+    Returns:
+        (success, message) tuple
+    """
+    if os.geteuid() != 0:
+        return False, "Root privileges required. Run with sudo."
+
+    try:
+        from utils.service_check import apply_config_and_restart
+        return apply_config_and_restart('mosquitto')
+    except ImportError:
+        pass
+
+    # Fallback
+    try:
+        result = subprocess.run(
+            ["systemctl", "restart", "mosquitto"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            return True, "Mosquitto restarted successfully"
+        return False, f"Restart failed: {result.stderr.strip()}"
+    except subprocess.TimeoutExpired:
+        return False, "Restart timed out"
+    except FileNotFoundError:
+        return False, "systemctl not found"
+
+
+def enable_mosquitto_at_boot() -> Tuple[bool, str]:
+    """Enable mosquitto to start at boot.
+
+    Returns:
+        (success, message) tuple
+    """
+    if os.geteuid() != 0:
+        return False, "Root privileges required. Run with sudo."
+
+    try:
+        from utils.service_check import enable_service
+        return enable_service('mosquitto', start=True)
+    except ImportError:
+        pass
+
+    # Fallback
+    try:
+        result = subprocess.run(
+            ["systemctl", "enable", "--now", "mosquitto"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode == 0:
+            return True, "Mosquitto enabled at boot and started"
+        return False, f"Enable failed: {result.stderr.strip()}"
+    except subprocess.TimeoutExpired:
+        return False, "Enable timed out"
+    except FileNotFoundError:
+        return False, "systemctl not found"
+
+
+def get_meshtastic_mqtt_setup_commands(profile: BrokerProfile) -> str:
+    """Generate meshtastic CLI commands to configure the radio for this broker.
+
+    Returns a multi-line string of commands the user can run.
+    """
+    lines = [
+        "# Configure Meshtastic radio MQTT module for this broker",
+        f"# Profile: {profile.name}",
+        "",
+    ]
+
+    host = profile.host
+    if host in ("localhost", "127.0.0.1"):
+        lines.append("# NOTE: Set broker to your device's LAN IP, not localhost")
+        lines.append("# The radio needs the IP of the machine running mosquitto")
+        host = "<YOUR_SERVER_IP>"
+
+    cmd_parts = ["meshtastic", "--host", "localhost"]
+    cmd_parts.extend(["--set", "mqtt.enabled", "true"])
+    cmd_parts.extend(["--set", "mqtt.address", host])
+
+    if profile.username:
+        cmd_parts.extend(["--set", "mqtt.username", profile.username])
+    if profile.password:
+        cmd_parts.extend(["--set", "mqtt.password", profile.password])
+
+    cmd_parts.extend(["--set", "mqtt.encryption_enabled", "true"])
+    cmd_parts.extend(["--set", "mqtt.json_enabled", str(profile.json_enabled).lower()])
+    cmd_parts.extend(["--set", "mqtt.tls_enabled", str(profile.use_tls).lower()])
+
+    lines.append(" \\\n  ".join(cmd_parts))
+    lines.append("")
+
+    # Channel uplink/downlink
+    lines.append("# Enable uplink (mesh -> MQTT) and downlink (MQTT -> mesh)")
+    lines.append("meshtastic --host localhost \\")
+    lines.append("  --ch-set uplink_enabled true --ch-index 0 \\")
+    lines.append("  --ch-set downlink_enabled true --ch-index 0")
+
+    return "\n".join(lines)
+
+
+# =============================================================================
+# Convenience: Initialize default profiles
+# =============================================================================
+
+def ensure_default_profiles() -> Dict[str, BrokerProfile]:
+    """Ensure default broker profiles exist. Creates them if missing.
+
+    Returns:
+        Dict of all profiles (existing + newly created defaults)
+    """
+    profiles = load_profiles()
+
+    # Create defaults if none exist
+    if not profiles:
+        profiles["meshforge_private"] = create_private_profile()
+        profiles["meshtastic_public"] = create_public_profile()
+        save_profiles(profiles)
+        logger.info("Created default broker profiles")
+
+    return profiles

--- a/tests/test_broker_profiles.py
+++ b/tests/test_broker_profiles.py
@@ -1,0 +1,509 @@
+"""
+Tests for MQTT broker profiles module.
+
+Run: python3 -m pytest tests/test_broker_profiles.py -v
+"""
+
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from src.utils.broker_profiles import (
+    BrokerProfile,
+    BrokerType,
+    create_private_profile,
+    create_public_profile,
+    create_custom_profile,
+    generate_mosquitto_conf,
+    generate_mosquitto_acl,
+    generate_password,
+    load_profiles,
+    save_profiles,
+    get_active_profile,
+    set_active_profile,
+    ensure_default_profiles,
+    check_mosquitto_installed,
+    get_meshtastic_mqtt_setup_commands,
+)
+
+
+class TestBrokerProfile:
+    """Tests for BrokerProfile dataclass."""
+
+    def test_topic_filter(self):
+        """Test topic filter generation follows Meshtastic convention."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="private",
+            host="localhost",
+            port=1883,
+            root_topic="msh/US/2/e",
+            channel="LongFast",
+        )
+        assert profile.topic_filter == "msh/US/2/e/LongFast/#"
+
+    def test_json_topic_filter(self):
+        """Test JSON topic filter replaces /e/ with /json/."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="private",
+            host="localhost",
+            port=1883,
+            root_topic="msh/US/2/e",
+            channel="LongFast",
+        )
+        assert profile.json_topic_filter == "msh/US/2/json/LongFast/#"
+
+    def test_display_name_private(self):
+        """Test display name for private broker."""
+        profile = BrokerProfile(
+            name="mybroker",
+            broker_type=BrokerType.PRIVATE.value,
+            host="localhost",
+            port=1883,
+        )
+        assert "Private" in profile.display_name
+        assert "mybroker" in profile.display_name
+
+    def test_display_name_public(self):
+        """Test display name for public broker."""
+        profile = BrokerProfile(
+            name="pub",
+            broker_type=BrokerType.PUBLIC.value,
+            host="mqtt.meshtastic.org",
+            port=8883,
+        )
+        assert "Public" in profile.display_name
+
+    def test_display_name_custom(self):
+        """Test display name for custom broker."""
+        profile = BrokerProfile(
+            name="myserver",
+            broker_type=BrokerType.CUSTOM.value,
+            host="mqtt.example.com",
+            port=1883,
+        )
+        assert "Custom" in profile.display_name
+        assert "myserver" in profile.display_name
+
+    def test_to_mqtt_config(self):
+        """Test conversion to MQTT subscriber config format."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="private",
+            host="localhost",
+            port=1883,
+            username="meshforge",
+            password="secret",
+            root_topic="msh/US/2/e",
+            channel="LongFast",
+            encryption_key="AQ==",
+            use_tls=False,
+        )
+        config = profile.to_mqtt_config()
+        assert config["broker"] == "localhost"
+        assert config["port"] == 1883
+        assert config["username"] == "meshforge"
+        assert config["password"] == "secret"
+        assert config["root_topic"] == "msh/US/2/e"
+        assert config["channel"] == "LongFast"
+        assert config["key"] == "AQ=="
+        assert config["use_tls"] is False
+        assert config["auto_reconnect"] is True
+        # Localhost gets faster reconnect
+        assert config["reconnect_delay"] == 2
+
+    def test_to_mqtt_config_remote(self):
+        """Test remote broker gets slower reconnect."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="public",
+            host="mqtt.meshtastic.org",
+            port=8883,
+        )
+        config = profile.to_mqtt_config()
+        assert config["reconnect_delay"] == 5
+
+    def test_to_tui_config(self):
+        """Test conversion to TUI config format."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="private",
+            host="localhost",
+            port=1883,
+            username="meshforge",
+            password="secret",
+            root_topic="msh/US/2/e",
+            channel="LongFast",
+            json_enabled=True,
+        )
+        config = profile.to_tui_config()
+        assert config["broker"] == "localhost"
+        assert config["port"] == 1883
+        # Local broker with json_enabled should use json topic
+        assert "json" in config["topic"]
+
+    def test_to_meshtastic_cli_args(self):
+        """Test generation of meshtastic CLI args."""
+        profile = BrokerProfile(
+            name="test",
+            broker_type="private",
+            host="192.168.1.100",
+            port=1883,
+            username="meshforge",
+            password="secret",
+            json_enabled=True,
+            use_tls=False,
+        )
+        args = profile.to_meshtastic_cli_args()
+        assert "--set" in args
+        assert "mqtt.enabled" in args
+        assert "true" in args
+        assert "mqtt.address" in args
+        assert "192.168.1.100" in args
+        assert "mqtt.username" in args
+        assert "meshforge" in args
+        assert "mqtt.password" in args
+        assert "secret" in args
+
+
+class TestProfileFactories:
+    """Tests for profile factory functions."""
+
+    def test_create_private_profile(self):
+        """Test private broker profile creation."""
+        profile = create_private_profile(
+            name="test_private",
+            channel="TestChannel",
+            region="EU_868",
+            username="testuser",
+            password="testpass",
+        )
+        assert profile.broker_type == BrokerType.PRIVATE.value
+        assert profile.host == "localhost"
+        assert profile.port == 1883
+        assert profile.username == "testuser"
+        assert profile.password == "testpass"
+        assert profile.channel == "TestChannel"
+        assert profile.region == "EU_868"
+        assert profile.root_topic == "msh/EU_868/2/e"
+        assert profile.use_tls is False
+        assert profile.allow_anonymous is False
+        assert profile.acl_enabled is True
+        assert profile.json_enabled is True
+
+    def test_create_private_profile_generates_password(self):
+        """Test that private profile generates password when not provided."""
+        profile = create_private_profile()
+        assert profile.password  # Should not be empty
+        assert len(profile.password) == 16  # Default length
+
+    def test_create_public_profile(self):
+        """Test public broker profile creation."""
+        profile = create_public_profile(region="US", channel="LongFast")
+        assert profile.broker_type == BrokerType.PUBLIC.value
+        assert profile.host == "mqtt.meshtastic.org"
+        assert profile.port == 8883
+        assert profile.username == "meshdev"
+        assert profile.password == "large4cats"
+        assert profile.use_tls is True
+        assert profile.encryption_key == "AQ=="
+        assert profile.uplink_enabled is False  # Read-only
+        assert profile.downlink_enabled is False
+
+    def test_create_custom_profile(self):
+        """Test custom broker profile creation."""
+        profile = create_custom_profile(
+            name="community",
+            host="mqtt.community.net",
+            port=8883,
+            username="node1",
+            password="secret",
+            use_tls=True,
+            channel="CommunityMesh",
+        )
+        assert profile.broker_type == BrokerType.CUSTOM.value
+        assert profile.host == "mqtt.community.net"
+        assert profile.port == 8883
+        assert profile.use_tls is True
+        assert profile.channel == "CommunityMesh"
+
+    def test_create_custom_profile_anonymous(self):
+        """Test custom profile with anonymous access."""
+        profile = create_custom_profile(name="anon", host="10.0.0.1")
+        assert profile.allow_anonymous is True
+
+
+class TestPasswordGeneration:
+    """Tests for password generation."""
+
+    def test_generate_password_default_length(self):
+        """Test default password length."""
+        pw = generate_password()
+        assert len(pw) == 16
+
+    def test_generate_password_custom_length(self):
+        """Test custom password length."""
+        pw = generate_password(32)
+        assert len(pw) == 32
+
+    def test_generate_password_is_alphanumeric(self):
+        """Test password only contains letters and digits."""
+        pw = generate_password(100)
+        assert pw.isalnum()
+
+    def test_generate_password_uniqueness(self):
+        """Test that generated passwords are different."""
+        passwords = {generate_password() for _ in range(10)}
+        assert len(passwords) == 10  # All unique
+
+
+class TestMosquittoConfGeneration:
+    """Tests for mosquitto.conf generation."""
+
+    def test_generate_private_conf(self):
+        """Test mosquitto.conf generation for private broker."""
+        profile = create_private_profile(username="meshforge", password="secret")
+        conf = generate_mosquitto_conf(profile)
+
+        assert "listener 1883" in conf
+        assert "allow_anonymous false" in conf
+        assert "password_file /etc/mosquitto/meshforge_passwd" in conf
+        assert "acl_file /etc/mosquitto/meshforge_acl" in conf
+        assert "persistence true" in conf
+        assert "message_size_limit 4096" in conf
+
+    def test_generate_anonymous_conf(self):
+        """Test mosquitto.conf generation for anonymous broker."""
+        profile = create_private_profile()
+        profile.allow_anonymous = True
+        conf = generate_mosquitto_conf(profile)
+
+        assert "allow_anonymous true" in conf
+        assert "password_file not needed" in conf
+
+    def test_generate_acl(self):
+        """Test ACL file generation."""
+        profile = create_private_profile(
+            username="meshforge",
+            channel="LongFast",
+            region="US",
+        )
+        acl = generate_mosquitto_acl(profile)
+
+        assert "user meshforge" in acl
+        assert "topic readwrite msh/#" in acl
+        assert "topic read $SYS/#" in acl
+
+
+class TestProfileStorage:
+    """Tests for profile persistence."""
+
+    def test_save_and_load_profiles(self, tmp_path):
+        """Test saving and loading profiles."""
+        profiles = {
+            "private": create_private_profile(password="test123"),
+            "public": create_public_profile(),
+        }
+        profiles["private"].is_active = True
+
+        config_dir = tmp_path / ".config" / "meshforge"
+
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=config_dir / "broker_profiles.json"):
+            assert save_profiles(profiles) is True
+            loaded = load_profiles()
+
+            assert "private" in loaded
+            assert "public" in loaded
+            assert loaded["private"].host == "localhost"
+            assert loaded["private"].is_active is True
+            assert loaded["public"].host == "mqtt.meshtastic.org"
+
+    def test_load_missing_file(self, tmp_path):
+        """Test loading when file doesn't exist returns empty dict."""
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=tmp_path / "nonexistent.json"):
+            profiles = load_profiles()
+            assert profiles == {}
+
+    def test_load_corrupted_file(self, tmp_path):
+        """Test loading corrupted JSON returns empty dict."""
+        bad_file = tmp_path / "broker_profiles.json"
+        bad_file.write_text("not valid json{{{")
+
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=bad_file):
+            profiles = load_profiles()
+            assert profiles == {}
+
+    def test_get_active_profile(self):
+        """Test getting active profile."""
+        profiles = {
+            "one": create_private_profile(password="p1"),
+            "two": create_public_profile(),
+        }
+        profiles["two"].is_active = True
+
+        active = get_active_profile(profiles)
+        assert active is not None
+        assert active.host == "mqtt.meshtastic.org"
+
+    def test_get_active_profile_none(self):
+        """Test getting active profile when none is active."""
+        profiles = {
+            "one": create_private_profile(password="p1"),
+        }
+        active = get_active_profile(profiles)
+        assert active is None
+
+    def test_set_active_profile(self, tmp_path):
+        """Test setting active profile."""
+        profiles = {
+            "one": create_private_profile(password="p1"),
+            "two": create_public_profile(),
+        }
+        profiles["one"].is_active = True
+
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=tmp_path / "broker_profiles.json"):
+            save_profiles(profiles)
+            assert set_active_profile("two", profiles) is True
+            assert profiles["one"].is_active is False
+            assert profiles["two"].is_active is True
+
+
+class TestEnsureDefaultProfiles:
+    """Tests for default profile initialization."""
+
+    def test_creates_defaults_when_empty(self, tmp_path):
+        """Test that default profiles are created when none exist."""
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=tmp_path / "broker_profiles.json"):
+            profiles = ensure_default_profiles()
+            assert "meshforge_private" in profiles
+            assert "meshtastic_public" in profiles
+            assert profiles["meshforge_private"].broker_type == BrokerType.PRIVATE.value
+            assert profiles["meshtastic_public"].broker_type == BrokerType.PUBLIC.value
+
+    def test_preserves_existing_profiles(self, tmp_path):
+        """Test that existing profiles are preserved."""
+        profiles_path = tmp_path / "broker_profiles.json"
+
+        existing = {"my_custom": create_custom_profile("custom", "example.com")}
+        with patch('src.utils.broker_profiles._get_profiles_path',
+                   return_value=profiles_path):
+            save_profiles(existing)
+            loaded = ensure_default_profiles()
+            assert "my_custom" in loaded
+
+
+class TestMosquittoChecks:
+    """Tests for mosquitto installation checks."""
+
+    @patch('shutil.which')
+    def test_mosquitto_installed(self, mock_which):
+        """Test detection of installed mosquitto."""
+        mock_which.side_effect = lambda x: f"/usr/sbin/{x}"
+        installed, msg = check_mosquitto_installed()
+        assert installed is True
+
+    @patch('shutil.which')
+    def test_mosquitto_not_installed(self, mock_which):
+        """Test detection of missing mosquitto."""
+        mock_which.return_value = None
+        installed, msg = check_mosquitto_installed()
+        assert installed is False
+        assert "not installed" in msg.lower()
+
+    @patch('shutil.which')
+    def test_mosquitto_partial_install(self, mock_which):
+        """Test detection of partial mosquitto installation."""
+        def side_effect(name):
+            if name == "mosquitto":
+                return "/usr/sbin/mosquitto"
+            return None
+        mock_which.side_effect = side_effect
+        installed, msg = check_mosquitto_installed()
+        assert installed is False
+        assert "mosquitto-clients" in msg
+
+
+class TestMeshtasticSetupCommands:
+    """Tests for radio MQTT setup command generation."""
+
+    def test_private_broker_commands(self):
+        """Test command generation for private broker."""
+        profile = create_private_profile(
+            username="meshforge",
+            password="secret123",
+        )
+        cmds = get_meshtastic_mqtt_setup_commands(profile)
+
+        # Should warn about localhost
+        assert "YOUR_SERVER_IP" in cmds
+        assert "mqtt.enabled" in cmds
+        assert "mqtt.username" in cmds
+        assert "meshforge" in cmds
+        assert "mqtt.password" in cmds
+        assert "secret123" in cmds
+        assert "uplink_enabled" in cmds
+        assert "downlink_enabled" in cmds
+
+    def test_remote_broker_commands(self):
+        """Test command generation for remote broker."""
+        profile = create_custom_profile(
+            name="remote",
+            host="mqtt.community.net",
+            port=8883,
+            username="node1",
+            password="pw",
+            use_tls=True,
+        )
+        cmds = get_meshtastic_mqtt_setup_commands(profile)
+
+        # Should use actual hostname, not placeholder
+        assert "mqtt.community.net" in cmds
+        assert "YOUR_SERVER_IP" not in cmds
+        assert "tls_enabled" in cmds
+        assert "true" in cmds
+
+    def test_public_broker_commands(self):
+        """Test command generation for public broker."""
+        profile = create_public_profile()
+        cmds = get_meshtastic_mqtt_setup_commands(profile)
+
+        assert "mqtt.meshtastic.org" in cmds
+
+
+class TestTopicConventions:
+    """Tests for Meshtastic MQTT topic convention compliance."""
+
+    def test_topic_format_us_longfast(self):
+        """Test standard US/LongFast topic format."""
+        profile = create_private_profile(channel="LongFast", region="US")
+        assert profile.topic_filter == "msh/US/2/e/LongFast/#"
+        assert profile.json_topic_filter == "msh/US/2/json/LongFast/#"
+
+    def test_topic_format_eu(self):
+        """Test EU region topic format."""
+        profile = create_private_profile(channel="LongFast", region="EU_868")
+        assert profile.topic_filter == "msh/EU_868/2/e/LongFast/#"
+
+    def test_topic_format_custom_channel(self):
+        """Test custom channel name in topic."""
+        profile = create_private_profile(channel="HawaiiNet", region="US")
+        assert profile.topic_filter == "msh/US/2/e/HawaiiNet/#"
+        assert profile.json_topic_filter == "msh/US/2/json/HawaiiNet/#"
+
+    def test_public_broker_uses_meshtastic_defaults(self):
+        """Test public broker uses standard Meshtastic settings."""
+        profile = create_public_profile()
+        assert profile.host == "mqtt.meshtastic.org"
+        assert profile.port == 8883
+        assert profile.username == "meshdev"
+        assert profile.password == "large4cats"
+        assert profile.encryption_key == "AQ=="
+        assert profile.use_tls is True


### PR DESCRIPTION
MeshForge can now act as its own private MQTT broker, enabling Meshtastic <-> RNS bridging through MQTT as a common transport:

  Meshtastic LF -> Private Broker -> RNS Gateway -> Meshtastic ST

Three broker profile templates:
- Private: localhost mosquitto with auth/ACL (recommended for bridging)
- Public: mqtt.meshtastic.org for nodeless monitoring
- Custom: user-defined broker configuration

New files:
- src/utils/broker_profiles.py: Profile management, mosquitto.conf generation, service management, radio CLI command generation
- src/launcher_tui/broker_mixin.py: TUI menu for broker setup, profile management, mosquitto service control
- examples/configs/broker-*.{conf,json}: Ready-to-use templates
- tests/test_broker_profiles.py: 39 tests covering all profiles

All configs follow Meshtastic MQTT topic conventions:
  msh/{region}/2/e/{channel}/!{node_id}

https://claude.ai/code/session_01MjbRxgmBGdaSudnB5MNWrX