### PR TITLE
feat: Add config drift detection with active fix for rnsd path diverg…

### DIFF
--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -603,6 +603,17 @@ class GatewayConfig:
                 ))
             seen.add(name)
 
+        # Config drift detection: check if gateway's RNS config path
+        # matches what rnsd is actually using
+        try:
+            from utils.config_drift import validate_gateway_rns_config
+            drift_errors = validate_gateway_rns_config(self)
+            errors.extend(drift_errors)
+        except ImportError:
+            pass  # config_drift module not available
+        except Exception as e:
+            logger.debug("Config drift check failed: %s", e)
+
         # Determine if valid (only errors count, not warnings/info)
         is_valid = not any(e.severity == "error" for e in errors)
 

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -828,15 +828,37 @@ class RNSMeshtasticBridge:
         from utils.gateway_diagnostic import find_rns_processes
         rns_pids = find_rns_processes()
 
-        # Determine config directory: explicit config > RNS default resolution
+        # Determine config directory: explicit config > rnsd's actual path > default
         config_dir = self.config.rns.config_dir or None
         if config_dir:
             logger.info(f"Using explicit RNS config dir: {config_dir}")
         else:
-            # Let RNS resolve its own config path (matches rnsd's resolution)
-            rns_config = ReticulumPaths.get_config_file()
-            logger.info(f"RNS config path: {rns_config} "
-                       f"(exists: {rns_config.exists()})")
+            # Active drift fix: prefer rnsd's actual config path over default
+            # resolution. This prevents the gateway from reading a different
+            # config than the running daemon (e.g. ~/.reticulum vs /etc/reticulum)
+            try:
+                from utils.config_drift import (
+                    detect_rnsd_config_drift, get_rnsd_effective_config_dir
+                )
+                drift = detect_rnsd_config_drift()
+                if drift.drifted:
+                    logger.warning(drift.message)
+                    if drift.fix_hint:
+                        logger.info("Drift fix: %s", drift.fix_hint)
+                    # Use rnsd's actual path as the active fix
+                    config_dir = str(drift.rnsd_config_dir)
+                    logger.info("Active fix: using rnsd's config dir %s "
+                               "instead of gateway's resolved %s",
+                               drift.rnsd_config_dir, drift.gateway_config_dir)
+                else:
+                    rns_config = ReticulumPaths.get_config_file()
+                    logger.info(f"RNS config path: {rns_config} "
+                               f"(exists: {rns_config.exists()}) "
+                               f"[{drift.detection_method}]")
+            except ImportError:
+                rns_config = ReticulumPaths.get_config_file()
+                logger.info(f"RNS config path: {rns_config} "
+                           f"(exists: {rns_config.exists()})")
 
         try:
             if rns_pids:
@@ -895,6 +917,15 @@ class RNSMeshtasticBridge:
                 from utils.gateway_diagnostic import find_rns_processes
                 rns_pids = find_rns_processes()
                 config_dir = self.config.rns.config_dir or None
+
+                # Active drift fix: prefer rnsd's actual config path
+                if not config_dir:
+                    try:
+                        from utils.config_drift import get_rnsd_effective_config_dir
+                        effective = get_rnsd_effective_config_dir()
+                        config_dir = str(effective)
+                    except ImportError:
+                        pass
 
                 if rns_pids:
                     logger.info(f"rnsd detected (PID: {rns_pids[0]}), "

--- a/src/utils/config_drift.py
+++ b/src/utils/config_drift.py
@@ -1,0 +1,388 @@
+"""
+Config Drift Detection for MeshForge
+
+Detects when the gateway's resolved RNS config path diverges from what rnsd
+is actually using. This prevents silent misconfigurations where the bridge
+reads one config while rnsd operates on another.
+
+Active fix: When rnsd is a systemd service using /etc/reticulum/config,
+the gateway should prefer that path for system deploys.
+
+Usage:
+    from utils.config_drift import detect_rnsd_config_drift, DriftResult
+
+    result = detect_rnsd_config_drift()
+    if result.drifted:
+        logger.warning(result.message)
+        if result.fix_hint:
+            logger.info(result.fix_hint)
+
+    # Active fix: get the correct config dir for gateway to use
+    config_dir = get_rnsd_effective_config_dir()
+"""
+
+import logging
+import os
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Import centralized path utility
+from utils.paths import ReticulumPaths, get_real_user_home
+
+
+@dataclass
+class DriftResult:
+    """Result of a config drift check."""
+    drifted: bool
+    gateway_config_dir: Optional[Path]   # What the gateway resolved
+    rnsd_config_dir: Optional[Path]      # What rnsd is actually using
+    rnsd_pid: Optional[int] = None
+    detection_method: str = ""           # How we determined rnsd's path
+    message: str = ""
+    fix_hint: str = ""
+    severity: str = "info"               # "info", "warning", "error"
+
+
+def _get_rnsd_pid() -> Optional[int]:
+    """Get the PID of the running rnsd process.
+
+    Returns:
+        PID as int, or None if rnsd is not running.
+    """
+    try:
+        result = subprocess.run(
+            ['pgrep', '-x', 'rnsd'],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return int(result.stdout.strip().split('\n')[0])
+    except (subprocess.SubprocessError, FileNotFoundError, ValueError):
+        pass
+
+    # Fallback: check for python-based rnsd
+    try:
+        result = subprocess.run(
+            ['pgrep', '-f', 'python.*rnsd'],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            pids = result.stdout.strip().split('\n')
+            for pid_str in pids:
+                try:
+                    return int(pid_str)
+                except ValueError:
+                    continue
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def _get_rnsd_config_from_proc(pid: int) -> Optional[Path]:
+    """Extract rnsd's config directory from /proc/<pid>/cmdline.
+
+    rnsd accepts --config <path> as a command-line argument.
+    If not specified, it uses RNS's default resolution.
+
+    Args:
+        pid: Process ID of rnsd.
+
+    Returns:
+        Config directory path, or None if not determinable from cmdline.
+    """
+    cmdline_path = Path(f'/proc/{pid}/cmdline')
+    if not cmdline_path.exists():
+        return None
+
+    try:
+        # /proc/pid/cmdline uses null bytes as separators
+        raw = cmdline_path.read_bytes()
+        args = raw.decode('utf-8', errors='replace').split('\0')
+        args = [a for a in args if a]  # Remove empty strings
+
+        # Look for --config or -c followed by a path
+        for i, arg in enumerate(args):
+            if arg in ('--config', '-c') and i + 1 < len(args):
+                config_path = Path(args[i + 1])
+                # If it's a file, return its parent directory
+                if config_path.is_file():
+                    return config_path.parent
+                # If it's a directory, return it directly
+                if config_path.is_dir():
+                    return config_path
+                # Path doesn't exist yet but was specified
+                return config_path
+            # Handle --config=<path> format
+            if arg.startswith('--config='):
+                config_path = Path(arg.split('=', 1)[1])
+                if config_path.is_file():
+                    return config_path.parent
+                if config_path.is_dir():
+                    return config_path
+                return config_path
+
+    except (OSError, UnicodeDecodeError) as e:
+        logger.debug("Could not read /proc/%d/cmdline: %s", pid, e)
+
+    return None
+
+
+def _get_rnsd_config_from_systemd() -> Optional[Path]:
+    """Extract rnsd's config directory from its systemd unit file.
+
+    Parses the ExecStart line for --config arguments.
+
+    Returns:
+        Config directory path from systemd unit, or None.
+    """
+    try:
+        result = subprocess.run(
+            ['systemctl', 'show', 'rnsd', '--property=ExecStart', '--no-pager'],
+            capture_output=True, text=True, timeout=10
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        exec_line = result.stdout.strip()
+        # ExecStart line format varies; look for --config
+        parts = exec_line.split()
+        for i, part in enumerate(parts):
+            if part in ('--config', '-c') and i + 1 < len(parts):
+                config_val = parts[i + 1].rstrip(';')
+                config_path = Path(config_val)
+                if config_path.is_file():
+                    return config_path.parent
+                if config_path.is_dir():
+                    return config_path
+                return config_path
+            if part.startswith('--config='):
+                config_val = part.split('=', 1)[1].rstrip(';')
+                config_path = Path(config_val)
+                if config_path.is_file():
+                    return config_path.parent
+                if config_path.is_dir():
+                    return config_path
+                return config_path
+
+    except (subprocess.SubprocessError, FileNotFoundError):
+        pass
+
+    return None
+
+
+def _get_rnsd_effective_config() -> tuple:
+    """Determine what config directory rnsd is actually using.
+
+    Resolution order:
+    1. From /proc/<pid>/cmdline (most accurate, running process)
+    2. From systemd unit file (if rnsd is a systemd service)
+    3. From RNS's default resolution (same as ReticulumPaths)
+
+    Returns:
+        Tuple of (config_dir: Optional[Path], pid: Optional[int],
+                  detection_method: str)
+    """
+    pid = _get_rnsd_pid()
+
+    # Method 1: Check running process cmdline
+    if pid is not None:
+        config_dir = _get_rnsd_config_from_proc(pid)
+        if config_dir is not None:
+            return config_dir, pid, "proc_cmdline"
+
+    # Method 2: Check systemd unit file
+    systemd_config = _get_rnsd_config_from_systemd()
+    if systemd_config is not None:
+        return systemd_config, pid, "systemd_unit"
+
+    # Method 3: rnsd uses RNS default resolution (no explicit --config)
+    # This means rnsd will find config the same way we do,
+    # BUT if rnsd runs as root its ~ differs from the sudo user's ~
+    if pid is not None:
+        # rnsd is running without --config flag
+        # Check if rnsd runs as root (systemd services typically do)
+        try:
+            stat = os.stat(f'/proc/{pid}')
+            if stat.st_uid == 0:
+                # rnsd runs as root - its default resolution starts at /etc/reticulum
+                # then falls to /root/.config/reticulum, then /root/.reticulum
+                if Path('/etc/reticulum/config').is_file():
+                    return Path('/etc/reticulum'), pid, "rnsd_root_default"
+                elif Path('/root/.config/reticulum/config').is_file():
+                    return Path('/root/.config/reticulum'), pid, "rnsd_root_default"
+                elif Path('/root/.reticulum/config').is_file():
+                    return Path('/root/.reticulum'), pid, "rnsd_root_default"
+        except OSError:
+            pass
+
+        # rnsd runs as non-root (unusual but possible)
+        return None, pid, "rnsd_default_unknown"
+
+    # rnsd is not running
+    return None, None, "rnsd_not_running"
+
+
+def detect_rnsd_config_drift() -> DriftResult:
+    """Detect if the gateway's RNS config path diverges from rnsd's actual path.
+
+    Compares what ReticulumPaths.get_config_dir() resolves (the gateway's view)
+    against what rnsd is actually using (from /proc, systemd, or root defaults).
+
+    Returns:
+        DriftResult with drift status, paths, and remediation hints.
+    """
+    gateway_dir = ReticulumPaths.get_config_dir()
+    rnsd_dir, rnsd_pid, method = _get_rnsd_effective_config()
+
+    # rnsd not running - no drift to detect
+    if rnsd_pid is None:
+        return DriftResult(
+            drifted=False,
+            gateway_config_dir=gateway_dir,
+            rnsd_config_dir=None,
+            rnsd_pid=None,
+            detection_method="rnsd_not_running",
+            message="rnsd is not running; config drift check skipped",
+            severity="info",
+        )
+
+    # rnsd running but couldn't determine its config
+    if rnsd_dir is None:
+        return DriftResult(
+            drifted=False,
+            gateway_config_dir=gateway_dir,
+            rnsd_config_dir=None,
+            rnsd_pid=rnsd_pid,
+            detection_method=method,
+            message=(f"rnsd running (PID {rnsd_pid}) but config dir not "
+                     "determinable; assuming default resolution matches"),
+            severity="info",
+        )
+
+    # Compare resolved paths
+    try:
+        gw_resolved = gateway_dir.resolve()
+        rnsd_resolved = rnsd_dir.resolve()
+    except OSError:
+        gw_resolved = gateway_dir
+        rnsd_resolved = rnsd_dir
+
+    if gw_resolved == rnsd_resolved:
+        return DriftResult(
+            drifted=False,
+            gateway_config_dir=gateway_dir,
+            rnsd_config_dir=rnsd_dir,
+            rnsd_pid=rnsd_pid,
+            detection_method=method,
+            message=(f"Config aligned: gateway and rnsd both use "
+                     f"{gateway_dir}"),
+            severity="info",
+        )
+
+    # DRIFT DETECTED
+    return DriftResult(
+        drifted=True,
+        gateway_config_dir=gateway_dir,
+        rnsd_config_dir=rnsd_dir,
+        rnsd_pid=rnsd_pid,
+        detection_method=method,
+        message=(
+            f"CONFIG DRIFT: Gateway resolves to {gateway_dir} but rnsd "
+            f"(PID {rnsd_pid}) uses {rnsd_dir} "
+            f"(detected via {method})"
+        ),
+        fix_hint=(
+            f"Set rns.config_dir in gateway.json to '{rnsd_dir}', "
+            f"or move your RNS config to {rnsd_dir}/config"
+        ),
+        severity="warning",
+    )
+
+
+def get_rnsd_effective_config_dir() -> Path:
+    """Get the config directory the gateway should use, preferring rnsd's actual path.
+
+    Active fix: If rnsd is running and using a different config than what
+    ReticulumPaths would resolve, return rnsd's path instead. This ensures
+    the gateway reads the same config as the running daemon.
+
+    For system deploys (rnsd as systemd service), this prefers /etc/reticulum/.
+
+    Returns:
+        Path to the config directory the gateway should use.
+    """
+    rnsd_dir, rnsd_pid, method = _get_rnsd_effective_config()
+
+    if rnsd_dir is not None:
+        logger.debug("Using rnsd's config dir: %s (detected via %s)", rnsd_dir, method)
+        return rnsd_dir
+
+    # rnsd not running or config not determinable - prefer system path
+    # for system deploys, fall back to ReticulumPaths default resolution
+    if os.geteuid() == 0 and Path('/etc/reticulum/config').is_file():
+        logger.debug("Running as root, preferring /etc/reticulum")
+        return Path('/etc/reticulum')
+
+    return ReticulumPaths.get_config_dir()
+
+
+def validate_gateway_rns_config(config) -> list:
+    """Validate gateway config against rnsd's actual state.
+
+    Runs drift detection and returns ConfigValidationError-compatible warnings
+    that integrate with GatewayConfig.validate().
+
+    Args:
+        config: GatewayConfig instance to validate.
+
+    Returns:
+        List of ConfigValidationError instances (imported from gateway.config).
+    """
+    from gateway.config import ConfigValidationError
+
+    errors = []
+
+    # Check for config drift
+    drift = detect_rnsd_config_drift()
+
+    if drift.drifted:
+        errors.append(ConfigValidationError(
+            field="rns.config_dir",
+            message=drift.message,
+            severity="warning",
+        ))
+        if drift.fix_hint:
+            errors.append(ConfigValidationError(
+                field="rns.config_dir",
+                message=f"Fix: {drift.fix_hint}",
+                severity="info",
+            ))
+
+    # Check if explicit config_dir in gateway.json matches rnsd
+    if config.rns.config_dir:
+        explicit_dir = Path(config.rns.config_dir)
+        if drift.rnsd_config_dir and explicit_dir.resolve() != drift.rnsd_config_dir.resolve():
+            errors.append(ConfigValidationError(
+                field="rns.config_dir",
+                message=(
+                    f"gateway.json sets config_dir='{config.rns.config_dir}' "
+                    f"but rnsd uses '{drift.rnsd_config_dir}'"
+                ),
+                severity="warning",
+            ))
+
+    # Check if config file actually exists at the resolved path
+    gateway_dir = ReticulumPaths.get_config_dir()
+    config_file = gateway_dir / 'config'
+    if not config_file.is_file():
+        errors.append(ConfigValidationError(
+            field="rns.config_dir",
+            message=f"RNS config file not found at {config_file}",
+            severity="error",
+        ))
+
+    return errors

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -264,7 +264,7 @@ class GatewayDiagnostic:
             )
 
     def check_rns_config(self) -> CheckResult:
-        """Check RNS configuration file."""
+        """Check RNS configuration file and detect config drift."""
         from utils.paths import ReticulumPaths
         config_path = ReticulumPaths.get_config_file()
 
@@ -290,15 +290,27 @@ class GatewayDiagnostic:
             # Check for Meshtastic interface
             has_meshtastic = 'meshtastic' in content.lower()
 
+            # Check for config drift between gateway and rnsd
+            try:
+                from utils.config_drift import detect_rnsd_config_drift
+                drift = detect_rnsd_config_drift()
+                if drift.drifted:
+                    issues.append(
+                        f"Config drift: gateway uses {drift.gateway_config_dir} "
+                        f"but rnsd uses {drift.rnsd_config_dir}"
+                    )
+            except ImportError:
+                pass
+
             if issues:
                 return CheckResult(
                     name="RNS Config",
                     status=CheckStatus.WARN,
                     message=f"Config exists but: {'; '.join(issues)}",
-                    fix_hint="Edit ~/.reticulum/config to add interfaces"
+                    fix_hint=f"Config at: {config_path.parent}"
                 )
 
-            msg = "Config valid"
+            msg = f"Config valid ({config_path.parent})"
             if has_meshtastic:
                 msg += " (Meshtastic interface configured)"
 
@@ -312,7 +324,7 @@ class GatewayDiagnostic:
                 name="RNS Config",
                 status=CheckStatus.FAIL,
                 message=f"Error reading config: {e}",
-                fix_hint="Check file permissions on ~/.reticulum/config"
+                fix_hint=f"Check file permissions on {config_path}"
             )
 
     def check_rnsd_running(self) -> CheckResult:

--- a/tests/test_config_drift.py
+++ b/tests/test_config_drift.py
@@ -1,0 +1,378 @@
+"""
+Tests for config drift detection between gateway and rnsd.
+
+Run: python3 -m pytest tests/test_config_drift.py -v
+"""
+
+import os
+import pytest
+import tempfile
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+from src.utils.config_drift import (
+    DriftResult,
+    detect_rnsd_config_drift,
+    get_rnsd_effective_config_dir,
+    validate_gateway_rns_config,
+    _get_rnsd_pid,
+    _get_rnsd_config_from_proc,
+    _get_rnsd_config_from_systemd,
+    _get_rnsd_effective_config,
+)
+
+
+class TestGetRnsdPid:
+    """Tests for _get_rnsd_pid."""
+
+    @patch('subprocess.run')
+    def test_rnsd_running_exact_match(self, mock_run):
+        """Test finding rnsd via exact process name."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="1234\n"
+        )
+        assert _get_rnsd_pid() == 1234
+
+    @patch('subprocess.run')
+    def test_rnsd_not_running(self, mock_run):
+        """Test when rnsd is not running."""
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout=""
+        )
+        assert _get_rnsd_pid() is None
+
+    @patch('subprocess.run')
+    def test_pgrep_not_found(self, mock_run):
+        """Test when pgrep is not available."""
+        mock_run.side_effect = FileNotFoundError("pgrep not found")
+        assert _get_rnsd_pid() is None
+
+    @patch('subprocess.run')
+    def test_multiple_pids_returns_first(self, mock_run):
+        """Test multiple rnsd PIDs returns first."""
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="1234\n5678\n"
+        )
+        assert _get_rnsd_pid() == 1234
+
+
+class TestGetRnsdConfigFromProc:
+    """Tests for _get_rnsd_config_from_proc."""
+
+    def test_cmdline_with_config_flag(self, tmp_path):
+        """Test extracting config from --config flag in cmdline."""
+        config_dir = tmp_path / "reticulum"
+        config_dir.mkdir()
+        config_file = config_dir / "config"
+        config_file.write_text("[reticulum]\n")
+
+        # Simulate /proc/<pid>/cmdline with null separators
+        cmdline = f"rnsd\0--config\0{config_file}\0".encode()
+
+        with patch.object(Path, 'exists', return_value=True):
+            with patch.object(Path, 'read_bytes', return_value=cmdline):
+                result = _get_rnsd_config_from_proc(1234)
+                assert result == config_dir
+
+    def test_cmdline_with_config_equals(self, tmp_path):
+        """Test extracting config from --config=<path> format."""
+        config_dir = tmp_path / "reticulum"
+        config_dir.mkdir()
+        config_file = config_dir / "config"
+        config_file.write_text("[reticulum]\n")
+
+        cmdline = f"rnsd\0--config={config_file}\0".encode()
+
+        with patch.object(Path, 'exists', return_value=True):
+            with patch.object(Path, 'read_bytes', return_value=cmdline):
+                result = _get_rnsd_config_from_proc(1234)
+                assert result == config_dir
+
+    def test_cmdline_without_config_flag(self):
+        """Test cmdline with no --config flag returns None."""
+        cmdline = b"rnsd\0--verbose\0"
+
+        with patch.object(Path, 'exists', return_value=True):
+            with patch.object(Path, 'read_bytes', return_value=cmdline):
+                result = _get_rnsd_config_from_proc(1234)
+                assert result is None
+
+    def test_proc_not_readable(self):
+        """Test when /proc/<pid>/cmdline doesn't exist."""
+        with patch.object(Path, 'exists', return_value=False):
+            result = _get_rnsd_config_from_proc(1234)
+            assert result is None
+
+    def test_cmdline_config_dir_flag(self, tmp_path):
+        """Test --config pointing to a directory."""
+        config_dir = tmp_path / "reticulum"
+        config_dir.mkdir()
+
+        cmdline = f"rnsd\0--config\0{config_dir}\0".encode()
+
+        with patch.object(Path, 'exists', return_value=True):
+            with patch.object(Path, 'read_bytes', return_value=cmdline):
+                result = _get_rnsd_config_from_proc(1234)
+                assert result == config_dir
+
+
+class TestGetRnsdConfigFromSystemd:
+    """Tests for _get_rnsd_config_from_systemd."""
+
+    @patch('subprocess.run')
+    def test_systemd_unit_with_config(self, mock_run):
+        """Test parsing --config from systemd ExecStart."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ExecStart=/usr/bin/rnsd --config /etc/reticulum\n"
+        )
+        result = _get_rnsd_config_from_systemd()
+        assert result == Path('/etc/reticulum')
+
+    @patch('subprocess.run')
+    def test_systemd_unit_without_config(self, mock_run):
+        """Test ExecStart with no --config flag."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="ExecStart=/usr/bin/rnsd\n"
+        )
+        result = _get_rnsd_config_from_systemd()
+        assert result is None
+
+    @patch('subprocess.run')
+    def test_systemd_not_available(self, mock_run):
+        """Test when systemctl is not available."""
+        mock_run.side_effect = FileNotFoundError("systemctl not found")
+        result = _get_rnsd_config_from_systemd()
+        assert result is None
+
+    @patch('subprocess.run')
+    def test_systemd_unit_not_found(self, mock_run):
+        """Test when rnsd unit doesn't exist."""
+        mock_run.return_value = MagicMock(
+            returncode=4, stdout=""
+        )
+        result = _get_rnsd_config_from_systemd()
+        assert result is None
+
+
+class TestDetectRnsdConfigDrift:
+    """Tests for detect_rnsd_config_drift."""
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    def test_no_drift_when_rnsd_not_running(self, mock_effective):
+        """Test no drift reported when rnsd is not running."""
+        mock_effective.return_value = (None, None, "rnsd_not_running")
+        result = detect_rnsd_config_drift()
+
+        assert not result.drifted
+        assert result.rnsd_pid is None
+        assert "not running" in result.message
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('src.utils.config_drift.ReticulumPaths.get_config_dir')
+    def test_no_drift_same_path(self, mock_gw_dir, mock_effective):
+        """Test no drift when paths match."""
+        mock_gw_dir.return_value = Path('/etc/reticulum')
+        mock_effective.return_value = (
+            Path('/etc/reticulum'), 1234, "proc_cmdline"
+        )
+        result = detect_rnsd_config_drift()
+
+        assert not result.drifted
+        assert result.rnsd_pid == 1234
+        assert "aligned" in result.message
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('src.utils.config_drift.ReticulumPaths.get_config_dir')
+    def test_drift_detected(self, mock_gw_dir, mock_effective):
+        """Test drift detected when paths differ."""
+        mock_gw_dir.return_value = Path('/home/user/.reticulum')
+        mock_effective.return_value = (
+            Path('/etc/reticulum'), 1234, "proc_cmdline"
+        )
+        result = detect_rnsd_config_drift()
+
+        assert result.drifted
+        assert result.gateway_config_dir == Path('/home/user/.reticulum')
+        assert result.rnsd_config_dir == Path('/etc/reticulum')
+        assert "DRIFT" in result.message
+        assert result.fix_hint
+        assert result.severity == "warning"
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('src.utils.config_drift.ReticulumPaths.get_config_dir')
+    def test_drift_etc_vs_home(self, mock_gw_dir, mock_effective):
+        """Test common drift: gateway uses ~/.reticulum but rnsd uses /etc."""
+        mock_gw_dir.return_value = Path('/home/meshforge/.reticulum')
+        mock_effective.return_value = (
+            Path('/etc/reticulum'), 5678, "rnsd_root_default"
+        )
+        result = detect_rnsd_config_drift()
+
+        assert result.drifted
+        assert "/etc/reticulum" in result.fix_hint
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('src.utils.config_drift.ReticulumPaths.get_config_dir')
+    def test_no_drift_unknown_rnsd_config(self, mock_gw_dir, mock_effective):
+        """Test no drift reported when rnsd config is undeterminable."""
+        mock_gw_dir.return_value = Path('/etc/reticulum')
+        mock_effective.return_value = (
+            None, 1234, "rnsd_default_unknown"
+        )
+        result = detect_rnsd_config_drift()
+
+        assert not result.drifted
+        assert "not determinable" in result.message
+
+
+class TestGetRnsdEffectiveConfigDir:
+    """Tests for get_rnsd_effective_config_dir."""
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    def test_returns_rnsd_path_when_available(self, mock_effective):
+        """Test returns rnsd's actual path when determinable."""
+        mock_effective.return_value = (
+            Path('/etc/reticulum'), 1234, "proc_cmdline"
+        )
+        result = get_rnsd_effective_config_dir()
+        assert result == Path('/etc/reticulum')
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('src.utils.config_drift.ReticulumPaths.get_config_dir')
+    @patch('os.geteuid', return_value=1000)
+    def test_falls_back_to_default_for_non_root(self, mock_euid,
+                                                  mock_gw_dir, mock_effective):
+        """Test fallback to ReticulumPaths when rnsd config unknown."""
+        mock_effective.return_value = (None, None, "rnsd_not_running")
+        mock_gw_dir.return_value = Path('/home/user/.reticulum')
+        result = get_rnsd_effective_config_dir()
+        assert result == Path('/home/user/.reticulum')
+
+    @patch('src.utils.config_drift._get_rnsd_effective_config')
+    @patch('os.geteuid', return_value=0)
+    def test_prefers_etc_for_root(self, mock_euid, mock_effective):
+        """Test root prefers /etc/reticulum when config exists."""
+        mock_effective.return_value = (None, None, "rnsd_not_running")
+
+        with patch.object(Path, 'is_file', return_value=True):
+            result = get_rnsd_effective_config_dir()
+            assert result == Path('/etc/reticulum')
+
+
+class TestValidateGatewayRnsConfig:
+    """Tests for validate_gateway_rns_config."""
+
+    @patch('src.utils.config_drift.detect_rnsd_config_drift')
+    def test_no_errors_when_aligned(self, mock_drift):
+        """Test no validation errors when configs are aligned."""
+        mock_drift.return_value = DriftResult(
+            drifted=False,
+            gateway_config_dir=Path('/etc/reticulum'),
+            rnsd_config_dir=Path('/etc/reticulum'),
+            detection_method="proc_cmdline",
+            message="aligned",
+        )
+
+        from src.gateway.config import GatewayConfig
+        config = GatewayConfig()
+
+        with patch.object(Path, 'is_file', return_value=True):
+            errors = validate_gateway_rns_config(config)
+            # Should only have config file existence check (if any)
+            warning_errors = [e for e in errors if e.severity == "warning"]
+            assert len(warning_errors) == 0
+
+    @patch('src.utils.config_drift.detect_rnsd_config_drift')
+    def test_warning_when_drifted(self, mock_drift):
+        """Test validation warning when config drift detected."""
+        mock_drift.return_value = DriftResult(
+            drifted=True,
+            gateway_config_dir=Path('/home/user/.reticulum'),
+            rnsd_config_dir=Path('/etc/reticulum'),
+            rnsd_pid=1234,
+            detection_method="proc_cmdline",
+            message="CONFIG DRIFT: gateway uses /home/user/.reticulum but rnsd uses /etc/reticulum",
+            fix_hint="Set rns.config_dir to /etc/reticulum",
+        )
+
+        from src.gateway.config import GatewayConfig
+        config = GatewayConfig()
+
+        with patch.object(Path, 'is_file', return_value=True):
+            errors = validate_gateway_rns_config(config)
+            warning_msgs = [e.message for e in errors if e.severity == "warning"]
+            assert any("DRIFT" in m for m in warning_msgs)
+
+    @patch('src.utils.config_drift.detect_rnsd_config_drift')
+    def test_warning_explicit_config_dir_mismatch(self, mock_drift):
+        """Test warning when explicit config_dir doesn't match rnsd."""
+        mock_drift.return_value = DriftResult(
+            drifted=False,
+            gateway_config_dir=Path('/home/user/.reticulum'),
+            rnsd_config_dir=Path('/etc/reticulum'),
+            rnsd_pid=1234,
+            detection_method="proc_cmdline",
+            message="aligned",
+        )
+
+        from src.gateway.config import GatewayConfig, RNSConfig
+        config = GatewayConfig(rns=RNSConfig(config_dir="/home/user/.reticulum"))
+
+        with patch.object(Path, 'is_file', return_value=True):
+            errors = validate_gateway_rns_config(config)
+            warning_msgs = [e.message for e in errors if e.severity == "warning"]
+            assert any("gateway.json" in m for m in warning_msgs)
+
+    @patch('src.utils.config_drift.detect_rnsd_config_drift')
+    def test_error_config_file_missing(self, mock_drift):
+        """Test error when config file doesn't exist."""
+        mock_drift.return_value = DriftResult(
+            drifted=False,
+            gateway_config_dir=Path('/etc/reticulum'),
+            rnsd_config_dir=None,
+            detection_method="rnsd_not_running",
+            message="rnsd not running",
+        )
+
+        from src.gateway.config import GatewayConfig
+        config = GatewayConfig()
+
+        with patch.object(Path, 'is_file', return_value=False):
+            errors = validate_gateway_rns_config(config)
+            error_msgs = [e for e in errors if e.severity == "error"]
+            assert len(error_msgs) >= 1
+            assert "not found" in error_msgs[0].message
+
+
+class TestDriftResult:
+    """Tests for DriftResult dataclass."""
+
+    def test_defaults(self):
+        """Test default values."""
+        result = DriftResult(
+            drifted=False,
+            gateway_config_dir=Path('/etc/reticulum'),
+            rnsd_config_dir=None,
+        )
+        assert result.severity == "info"
+        assert result.message == ""
+        assert result.fix_hint == ""
+        assert result.rnsd_pid is None
+        assert result.detection_method == ""
+
+    def test_drift_result_with_all_fields(self):
+        """Test full DriftResult construction."""
+        result = DriftResult(
+            drifted=True,
+            gateway_config_dir=Path('/home/user/.reticulum'),
+            rnsd_config_dir=Path('/etc/reticulum'),
+            rnsd_pid=1234,
+            detection_method="proc_cmdline",
+            message="drift detected",
+            fix_hint="update config",
+            severity="warning",
+        )
+        assert result.drifted is True
+        assert result.rnsd_pid == 1234


### PR DESCRIPTION
…ence

Detects when the gateway's resolved RNS config path diverges from what rnsd is actually using. Common scenario: rnsd (systemd, runs as root) uses /etc/reticulum/config while the gateway resolves to ~/.reticulum.

Detection methods (priority order):
1. /proc/<pid>/cmdline — rnsd's actual --config flag
2. systemd unit ExecStart — rnsd's configured path
3. Root default resolution — /etc/reticulum for root-owned rnsd

Active fix: bridge startup now prefers rnsd's actual config path over default resolution, preventing silent config divergence.

Integration points:
- GatewayConfig.validate() — warns on drift during config validation
- rns_bridge._init_rns_main_thread() — applies active fix at startup
- rns_bridge._connect_rns() — applies active fix in fallback path
- gateway_diagnostic.check_rns_config() — reports drift in diagnostics

New files:
- src/utils/config_drift.py — DriftResult, detect/fix/validate functions
- tests/test_config_drift.py — 27 tests covering all detection methods

https://claude.ai/code/session_01CEw5A3txH1o4oZVMAfpLZa