### PR TITLE
feat: Add Meshtastic API proxy to fix message sync/ack on web client

### DIFF
--- a/.claude/research/web_serial_api_meshtastic_transport.md
+++ b/.claude/research/web_serial_api_meshtastic_transport.md
@@ -1,0 +1,756 @@
+# Web Serial API & Meshtastic Transport Architecture Deep Dive
+
+## Purpose
+
+Deep research into the Web Serial API, the Meshtastic web client's transport layer architecture,
+the `@meshtastic/js` library, and the feasibility of MeshForge serving as a WebSocket proxy
+between the web client and meshtasticd.
+
+---
+
+## Part 1: Web Serial API Fundamentals
+
+### What Is It?
+
+The Web Serial API allows web pages running in a browser to communicate directly with serial
+devices (USB, UART) connected to the user's computer. It provides `ReadableStream` and
+`WritableStream` interfaces for bidirectional binary data transfer, completely bypassing
+the need for any daemon or native application.
+
+- **Spec**: https://wicg.github.io/serial/
+- **Chrome Docs**: https://developer.chrome.com/docs/capabilities/serial
+- **MDN**: https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API
+
+### The `navigator.serial.requestPort()` Flow
+
+1. **User gesture required** -- a click/tap triggers the port selection dialog
+2. `navigator.serial.requestPort({ filters })` opens a browser-native chooser
+3. User selects a serial device (e.g., a Meshtastic radio on `/dev/ttyUSB0`)
+4. Returns a `SerialPort` object
+5. `await port.open({ baudRate: 115200 })` opens the connection
+6. `port.readable` gives a `ReadableStream<Uint8Array>` for incoming data
+7. `port.writable` gives a `WritableStream<Uint8Array>` for outgoing data
+
+Filters allow targeting specific USB vendor/product IDs:
+```javascript
+const port = await navigator.serial.requestPort({
+  filters: [{ usbVendorId: 0x10C4 }]  // Silicon Labs (common Meshtastic USB chip)
+});
+```
+
+### Reading Binary Data
+
+```javascript
+const reader = port.readable.getReader();
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  // value is Uint8Array -- raw binary protobuf-framed data
+  processIncomingBytes(value);
+}
+```
+
+### Writing Binary Data
+
+```javascript
+const writer = port.writable.getWriter();
+await writer.write(serializedProtobufWithFraming);
+writer.releaseLock();
+```
+
+### Error Handling and Disconnect
+
+Users can physically unplug the device at any time. Code must:
+- Catch read/write errors
+- Call `reader.cancel()` and `writer.releaseLock()` before `port.close()`
+- Update UI to reflect disconnection
+
+### Security Model
+
+- `requestPort()` **always** shows a user-controlled chooser -- no silent enumeration
+- Sites cannot access ports without explicit user consent
+- Only HTTPS contexts (or localhost) are allowed
+- One device per `requestPort()` call
+
+### Browser Compatibility
+
+| Browser       | Supported? | Versions         |
+|---------------|-----------|------------------|
+| **Chrome**    | YES       | 89+ (all current)|
+| **Edge**      | YES       | 89+ (Chromium)   |
+| **Opera**     | YES       | 76+              |
+| **Firefox**   | NO        | Not supported    |
+| **Safari**    | NO        | Not supported    |
+
+**Key implication**: Web Serial is Chromium-only. For Firefox/Safari users, a WebSocket
+bridge (like what MeshForge could provide) is the **only** way to get "browser-to-serial"
+functionality.
+
+### How It Bypasses the Daemon
+
+With Web Serial, the browser talks **directly** to the USB serial chip:
+
+```
+[Browser (Chrome)] --Web Serial API--> [USB serial chip] --> [Meshtastic radio]
+```
+
+No meshtasticd, no Python library, no daemon needed. The browser IS the client.
+However, this only works when the user has the device physically plugged into their computer.
+
+---
+
+## Part 2: Meshtastic Web Client Architecture
+
+### Repository & Build System
+
+- **Monorepo**: https://github.com/meshtastic/web
+- **Hosted**: https://client.meshtastic.org
+- **Build tool**: Vite + React + TypeScript
+- **Package manager**: Deno (formerly pnpm)
+- **State management**: Zustand (multiple specialized stores)
+- **Protobuf tooling**: Buf CLI for `packages/protobufs`
+
+### Monorepo Package Structure
+
+```
+packages/
+├── web/                         # The React web client UI
+├── core/                        # @meshtastic/core - MeshDevice, types, queue
+├── protobufs/                   # @meshtastic/protobufs - generated proto types
+├── transport-http/              # HTTP(S) transport (ESP32 / meshtasticd)
+├── transport-web-serial/        # Web Serial API transport
+├── transport-web-bluetooth/     # Web Bluetooth API transport
+├── transport-node/              # Node.js TCP transport (port 4403)
+├── transport-node-serial/       # Node.js serial transport
+└── transport-deno/              # Deno TCP transport
+```
+
+All packages are published to both JSR and npm.
+
+### Firmware v2.7.0 Change: Web UI Removed from Device
+
+As of firmware v2.7.0, the web UI is **no longer bundled on the ESP32**. Users must:
+1. Use the hosted version at `client.meshtastic.org`
+2. Self-host the web client (Docker, custom server, etc.)
+3. Bundle it on a Linux-native deployment (Raspberry Pi, OpenWRT)
+
+**This is a significant opportunity for MeshForge** -- users need somewhere to host the
+web client, and MeshForge already runs on Linux/Raspberry Pi.
+
+### Self-Hosting the Web Client
+
+**Docker (official image)**:
+```bash
+docker run -d -p 8080:8080 -p 8443:8443 \
+  --restart always --name Meshtastic-Web \
+  ghcr.io/meshtastic/web
+```
+This uses UBI9 Nginx 1.22 to serve the static files.
+
+**From source**:
+Build with Deno, output goes to `dist/` -- pure static HTML/JS/CSS that any
+web server can serve (Nginx, Python's http.server, Flask, etc.).
+
+---
+
+## Part 3: The Transport Interface (`@meshtastic/core`)
+
+### The Core Abstraction
+
+File: `packages/core/src/types.ts`
+
+```typescript
+export interface Transport {
+  toDevice: WritableStream<Uint8Array>;
+  fromDevice: ReadableStream<DeviceOutput>;
+  disconnect(): Promise<void>;
+}
+
+type DeviceOutput = Packet | DebugLog | StatusEvent;
+
+interface Packet {
+  type: "packet";
+  data: Uint8Array;
+}
+
+interface DebugLog {
+  type: "debug";
+  data: string;
+}
+
+interface StatusEvent {
+  type: "status";
+  data: { status: DeviceStatusEnum; reason?: string };
+}
+```
+
+**This is the critical interface.** Any object that provides `toDevice`, `fromDevice`,
+and `disconnect()` can be used as a transport. The web client does not care how the
+bytes get to/from the device.
+
+### MeshDevice Class
+
+File: `packages/core/src/meshDevice.ts`
+
+```typescript
+class MeshDevice {
+  public transport: Transport;
+
+  constructor(transport: Transport, configId?: number) {
+    this.transport = transport;
+    // Sets up logger, queue, events, xmodem
+    this.transport.fromDevice.pipeTo(decodePacket(this));
+  }
+
+  // Send raw protobuf bytes to device
+  public async sendRaw(toRadio: Uint8Array, id?: number): Promise<number> {
+    if (toRadio.length > 512) throw new Error("Message too long");
+    this.queue.push({ id, data: toRadio });
+    await this.queue.processQueue(this.transport.toDevice);
+    return this.queue.wait(id);
+  }
+}
+```
+
+Key architectural points:
+- `fromDevice` stream is piped through `decodePacket()` which handles protobuf parsing
+- `toDevice` is a `WritableStream` that the queue writes to
+- The queue system manages packet ordering and ACK tracking
+- All transports are interchangeable via this interface
+
+### Transport Factory Pattern
+
+Each transport package exports a static `create()` method:
+
+```typescript
+// Web Serial
+import { TransportWebSerial } from "@meshtastic/transport-web-serial";
+const transport = await TransportWebSerial.create();
+const device = new MeshDevice(transport);
+
+// HTTP
+import { TransportHTTP } from "@meshtastic/transport-http";
+const transport = await TransportHTTP.create("10.10.0.57");
+const device = new MeshDevice(transport);
+```
+
+### Connection Manager Pattern in the Web UI
+
+The web client uses Zustand stores and follows this flow for all connection types:
+1. **ID Generation**: `randId()` creates a unique device identifier
+2. **Device Registration**: `useDeviceStore.addDevice()` adds device to state
+3. **Connection Assignment**: `device.addConnection(transport)` binds transport
+4. **Event Subscription**: `subscribeAll()` registers for device events
+
+---
+
+## Part 4: The Meshtastic Framing Protocol
+
+### Serial/TCP Framing (4-Byte Header)
+
+All serial and TCP connections use a simple framing protocol:
+
+```
+[0x94][0xC3][LENGTH_MSB][LENGTH_LSB][PROTOBUF_PAYLOAD...]
+```
+
+| Byte | Value  | Description                          |
+|------|--------|--------------------------------------|
+| 0    | `0x94` | START1 magic byte                    |
+| 1    | `0xC3` | START2 magic byte                    |
+| 2    | MSB    | High byte of protobuf payload length |
+| 3    | LSB    | Low byte of protobuf payload length  |
+| 4+   | data   | Serialized protobuf (ToRadio or FromRadio) |
+
+- Maximum payload size: 512 bytes (lengths > 512 are treated as corruption)
+- The `0x94C3` magic bytes are chosen to not look like normal 7-bit ASCII
+- If the receiver doesn't see valid header bytes, it prints them as debug output
+- No CRC or error correction -- assumes the stream is reliable
+
+### HTTP Framing
+
+For HTTP connections, there is no 4-byte header. Protobuf payloads are sent as raw
+binary in the HTTP body:
+
+- **Send**: `PUT /api/v1/toradio` with binary protobuf body (one ToRadio per request)
+- **Receive**: `GET /api/v1/fromradio` returns binary protobuf body
+- Supports `chunked=true` for streaming
+- **Single client limitation**: only one client can poll `/api/v1/fromradio` at a time
+
+### BLE Framing
+
+BLE uses raw protobuf without headers, communicated via GATT characteristics:
+- **Service UUID**: `6ba1b218-15a8-461f-9fa8-5dcae273eafd`
+- **ToRadio**: `f75c76d2-129e-4dad-a1dd-7866124401e7`
+- **FromRadio**: `2c55e69e-4993-11ed-b878-0242ac120002`
+- **FromNum (notify)**: `ed9da18c-a800-4f66-a670-aa7547e34453`
+
+### Connection Initialization Flow (All Transports)
+
+1. Client sends `ToRadio { startConfig: configId }` to the device
+2. Device responds with a stream of `FromRadio` packets (entire NodeDB dump)
+3. Client reads until it gets an empty response (download complete)
+4. Client then subscribes for ongoing updates (BLE notify / HTTP poll / stream read)
+
+---
+
+## Part 5: ACK/Delivery Mechanism
+
+### How `want_ack` Works
+
+The `MeshPacket` protobuf has a `want_ack` boolean field:
+
+**Direct Messages**:
+```
+Packet 1: TEXT_MESSAGE_APP: A -> B  (id=101, want_ack=true)
+Packet 2: ROUTING_APP:      B -> A  (id=102, request_id=101, want_ack=false)
+```
+The ACK is a `ROUTING_APP` packet with `request_id` pointing back to the original.
+
+**Broadcast Messages**:
+- ACK flooding would overwhelm the channel
+- Instead: sender listens for rebroadcasts as "implicit ACK"
+- If no rebroadcast heard, retransmit (up to 3 times with exponential backoff)
+
+### ACK Handling in @meshtastic/core
+
+In `meshDevice.ts`, routing packets are processed:
+
+```typescript
+switch (routingPacket.variant.case) {
+  case "errorReason": {
+    if (routingPacket.variant.value === Routing_Error.NONE) {
+      // ACK received -- resolve the promise for this packet
+      this.queue.processAck(dataPacket.requestId);
+    } else {
+      // NACK or error -- reject the promise
+      this.queue.processError({
+        id: dataPacket.requestId,
+        error: routingPacket.variant.value,
+      });
+    }
+    break;
+  }
+}
+```
+
+The queue system uses promises: `sendRaw()` returns a promise that resolves when ACK
+is received, or rejects on error/timeout.
+
+### ACK in the Context of a Proxy
+
+If MeshForge sits between the web client and meshtasticd:
+- MeshForge must **faithfully forward** all ROUTING_APP packets (ACKs/NACKs)
+- The `request_id` field ties ACKs to original packets -- must be preserved
+- MeshForge can **observe** ACKs without consuming them
+- The queue system in `@meshtastic/core` handles ACK matching on the client side
+
+---
+
+## Part 6: Existing WebSocket Proxy Projects
+
+### 1. liamcottle/meshtastic-websocket-proxy
+
+- **GitHub**: https://github.com/liamcottle/meshtastic-websocket-proxy
+- **npm**: `@liamcottle/meshtastic-websocket-proxy`
+
+**Architecture**:
+```
+[WebSocket Client 1] ──┐
+[WebSocket Client 2] ──┼── WebSocket Server ──── HTTP API ──── [Meshtastic Device]
+[WebSocket Client N] ──┘     (port 8080)       (polling)         (ESP32/RPi)
+```
+
+**Key features**:
+- Solves the single-client limitation of the HTTP API
+- Broadcasts all `FromRadio` packets to all connected WebSocket clients
+- All clients can send `ToRadio` packets
+- JSON message format with base64-encoded protobuf:
+  ```json
+  {
+    "type": "from_radio",
+    "protobuf": "<base64 encoded protobuf>",
+    "json": { /* decoded packet for convenience */ }
+  }
+  ```
+- `--ignore-history` flag to skip packets received before proxy started
+
+**Usage**:
+```bash
+npx @liamcottle/meshtastic-websocket-proxy \
+  --meshtastic-host 127.0.0.1 \
+  --websocket-port 8080
+```
+
+**Limitation**: Uses JSON + base64 encoding, NOT the raw binary framing that
+the Meshtastic web client expects. Cannot be used directly as a transport for
+the official web client without modifications.
+
+### 2. WillerZ/ws-serial-gateway
+
+- **GitHub**: https://github.com/WillerZ/ws-serial-gateway
+- **Language**: Rust
+
+**Architecture**:
+```
+[Web Client] ── WebSocket ── [ws-serial-gateway] ── Serial ── [Meshtastic Device]
+```
+
+**Key features**:
+- Transparent binary tunnel -- WebSocket binary frames pass directly to/from serial
+- YAML config maps URL endpoints to serial ports + baud rates
+- Single client per serial port (hardware limitation)
+- No protocol awareness -- pure byte forwarding
+
+**This is closer to what MeshForge needs**: raw binary WebSocket frames that the
+Meshtastic transport layer can work with directly.
+
+### 3. Meshtastic Web PR #998 (WebSocket Transport)
+
+- **PR**: https://github.com/meshtastic/web/pull/998
+- **Status**: Open (not merged)
+- **Author**: WillerZ
+
+Adds a WebSocket transport module to the official web client that:
+- Creates a `Transport` object backed by a WebSocket connection
+- Implements `toDevice` / `fromDevice` using WebSocket binary frames
+- Works with `ws-serial-gateway` as the server
+- Successfully tested: connecting, viewing config, changing config, sending messages
+
+**Critical finding**: The transport code is described as "near-complete" and working.
+The UI changes need work, but the transport itself validates the approach.
+
+### 4. MeshTXT by Liam Cottle
+
+- **GitHub**: https://github.com/liamcottle/meshtxt
+- **Live**: https://meshtxt.liamcottle.net/
+
+A complete alternative web client with:
+- `--meshtastic-api-url` flag to proxy to a remote meshtasticd
+- Built-in server that proxies fromradio/toradio requests
+- CORS handling (or Caddy reverse proxy example)
+- Bluetooth, Serial, and HTTP connections
+
+---
+
+## Part 7: Can MeshForge Do This?
+
+### Question 1: Serve the Meshtastic web client from port 5000?
+
+**YES, absolutely.** The Meshtastic web client builds to static HTML/JS/CSS files.
+MeshForge already has a web server capability. Options:
+
+1. **Embed the pre-built web client**: Download the built assets from
+   `ghcr.io/meshtastic/web` Docker image or build from source, serve as static files
+2. **Reverse proxy**: Proxy requests to the Docker container
+3. **Build from source**: Include in MeshForge's build process
+
+The web client at `client.meshtastic.org` is just static files. Any HTTP server can
+serve them.
+
+### Question 2: Provide a WebSocket transport?
+
+**YES, and there's precedent.** The approach:
+
+1. MeshForge runs a WebSocket server (e.g., on `ws://localhost:5000/ws/serial`)
+2. MeshForge connects to meshtasticd via TCP (port 4403) using the 4-byte framed protocol
+3. The WebSocket carries the same 4-byte framed binary packets
+4. A custom transport module in the web client (or a fork) connects via WebSocket
+
+The `Transport` interface is simple:
+```typescript
+interface Transport {
+  toDevice: WritableStream<Uint8Array>;
+  fromDevice: ReadableStream<DeviceOutput>;
+  disconnect(): Promise<void>;
+}
+```
+
+MeshForge's Python WebSocket server would:
+- Accept WebSocket connections from the browser
+- Forward binary frames to meshtasticd TCP (port 4403)
+- Forward meshtasticd responses back as binary WebSocket frames
+- Handle the 4-byte framing (or pass it through transparently)
+
+### Question 3: Act as a man-in-the-middle?
+
+**YES, with caveats.** MeshForge can sit between the web client and meshtasticd:
+
+```
+[Meshtastic Web Client]          [MeshForge]              [meshtasticd]
+  (browser, port 5000)    <-->   WebSocket     <-->    TCP port 4403
+                                 Server                (4-byte framed)
+                                    |
+                                    v
+                            [MeshForge Logic]
+                            - ACK tracking
+                            - Message logging
+                            - Node tracking
+                            - Gateway bridge
+```
+
+**What MeshForge can do in the middle**:
+- **Log all packets** for monitoring/analytics
+- **Track nodes** by observing NodeInfo packets
+- **Monitor ACKs** by watching ROUTING_APP packets
+- **Inject packets** (e.g., MeshForge-originated messages)
+- **Multiplex clients** -- solve the single-client limitation
+
+**What MeshForge must NOT do**:
+- Modify packet IDs (breaks ACK matching)
+- Consume/swallow packets (breaks client state)
+- Add latency to ACK forwarding (causes timeouts)
+
+### Question 4: Intercept ACK packets and forward them properly?
+
+**YES.** ACKs are just `FromRadio` packets containing `ROUTING_APP` data with a
+`request_id` field. MeshForge can:
+
+1. Parse the `FromRadio` protobuf to identify ROUTING_APP packets
+2. Extract the `request_id` to correlate with original messages
+3. Log the ACK event for monitoring
+4. Forward the packet unchanged to the web client
+5. The web client's `queue.processAck()` handles the rest
+
+The Python `meshtastic` library already has protobuf definitions for all of this.
+
+---
+
+## Part 8: Proposed MeshForge Architecture
+
+### Option A: Transparent WebSocket Proxy (Simplest)
+
+```python
+# MeshForge WebSocket proxy -- transparent binary bridge
+import asyncio
+import websockets
+import socket
+
+async def proxy_handler(websocket, path):
+    """Bridge WebSocket client to meshtasticd TCP port 4403."""
+    # Connect to meshtasticd
+    tcp_reader, tcp_writer = await asyncio.open_connection('127.0.0.1', 4403)
+
+    async def ws_to_tcp():
+        async for message in websocket:
+            # Forward binary WebSocket frame to TCP (4-byte framing included)
+            tcp_writer.write(message)
+            await tcp_writer.drain()
+
+    async def tcp_to_ws():
+        while True:
+            data = await tcp_reader.read(4096)
+            if not data:
+                break
+            await websocket.send(data)
+
+    await asyncio.gather(ws_to_tcp(), tcp_to_ws())
+```
+
+**Pros**: Minimal code, no protobuf parsing needed, just byte forwarding.
+**Cons**: Cannot inspect/log packets without adding parsing.
+
+### Option B: Protocol-Aware Proxy (Recommended)
+
+```python
+# MeshForge protocol-aware proxy
+import asyncio
+import struct
+from meshtastic.protobuf import mesh_pb2
+
+START1 = 0x94
+START2 = 0xC3
+
+def parse_framed_packet(data: bytes) -> list[bytes]:
+    """Extract protobuf payloads from 4-byte framed stream."""
+    packets = []
+    i = 0
+    while i < len(data) - 3:
+        if data[i] == START1 and data[i+1] == START2:
+            length = struct.unpack('>H', data[i+2:i+4])[0]
+            if length <= 512 and i + 4 + length <= len(data):
+                packets.append(data[i+4:i+4+length])
+                i += 4 + length
+                continue
+        i += 1
+    return packets
+
+def inspect_from_radio(payload: bytes):
+    """Observe a FromRadio packet without modifying it."""
+    fr = mesh_pb2.FromRadio()
+    fr.ParseFromString(payload)
+    if fr.HasField('packet'):
+        mp = fr.packet
+        if mp.decoded.portnum == mesh_pb2.PortNum.ROUTING_APP:
+            # This is an ACK/NACK
+            routing = mesh_pb2.Routing()
+            routing.ParseFromString(mp.decoded.payload)
+            log_ack(mp.from_field, mp.to, mp.decoded.request_id, routing)
+        elif mp.decoded.portnum == mesh_pb2.PortNum.TEXT_MESSAGE_APP:
+            log_message(mp)
+        elif mp.decoded.portnum == mesh_pb2.PortNum.NODEINFO_APP:
+            update_node_tracker(mp)
+```
+
+**Pros**: Full visibility into mesh traffic, ACK tracking, node monitoring.
+**Cons**: More complex, must handle protobuf parsing errors gracefully.
+
+### Option C: Custom Transport Plugin for Web Client
+
+Create a `@meshforge/transport-websocket` package:
+
+```typescript
+import type { Transport, DeviceOutput } from "@meshtastic/core";
+
+export class TransportMeshForge {
+  static async create(url: string): Promise<Transport> {
+    const ws = new WebSocket(url);
+    ws.binaryType = "arraybuffer";
+
+    const fromDevice = new ReadableStream<DeviceOutput>({
+      start(controller) {
+        ws.onmessage = (event) => {
+          controller.enqueue({
+            type: "packet",
+            data: new Uint8Array(event.data),
+          });
+        };
+        ws.onclose = () => controller.close();
+      },
+    });
+
+    const toDevice = new WritableStream<Uint8Array>({
+      write(chunk) {
+        ws.send(chunk);
+      },
+    });
+
+    return {
+      fromDevice,
+      toDevice,
+      disconnect: async () => ws.close(),
+    };
+  }
+}
+```
+
+This would plug directly into the Meshtastic web client's `MeshDevice` constructor.
+
+---
+
+## Part 9: Key Technical Considerations
+
+### The Single-Client Problem
+
+meshtasticd's HTTP API (`/api/v1/fromradio`) only supports **one** client at a time.
+If the web client is polling fromradio, MeshForge's Python bridge cannot also read from it.
+
+**Solutions**:
+1. **Use TCP port 4403** instead of HTTP API -- TCP supports the same protocol
+2. **MeshForge becomes the sole TCP client** and multiplexes to WebSocket clients
+3. **Use serial connection** if meshtasticd is on the same machine
+
+### Framing Decision: Include or Strip?
+
+The 4-byte framing (`0x94 0xC3 + length`) is used on serial and TCP.
+For WebSocket, each message IS a frame, so you could:
+
+- **Option A**: Forward raw bytes including 4-byte headers (simple passthrough)
+- **Option B**: Strip headers on receive, add headers on send (cleaner but more work)
+
+The `ws-serial-gateway` project uses Option A (transparent passthrough).
+PR #998's WebSocket transport also appears to use raw binary frames.
+
+**Recommendation**: Use Option A (passthrough) for simplicity.
+
+### CORS Considerations
+
+If serving the web client from MeshForge (port 5000) and the WebSocket is also on
+port 5000 (e.g., `ws://localhost:5000/ws`), there are no CORS issues -- same origin.
+
+If they're on different ports, standard WebSocket connections are not subject to CORS
+(WebSocket is not same-origin restricted for the connection itself, though the
+initial HTTP upgrade is).
+
+### meshtasticd TCP Port 4403
+
+- Default Meshtastic TCP port: **4403**
+- Protocol: Same 4-byte framed protobuf as serial
+- MeshForge's Python library can connect:
+  ```python
+  import meshtastic.tcp_interface
+  iface = meshtastic.tcp_interface.TCPInterface(hostname="localhost", portNumber=4403)
+  ```
+- Or use raw sockets for more control (just 4-byte framing over TCP)
+
+---
+
+## Part 10: Summary & Recommendations
+
+### What's Proven to Work
+
+1. The Meshtastic `Transport` interface is simple and pluggable (3 members)
+2. WebSocket transport has been demonstrated (PR #998, ws-serial-gateway)
+3. The web client is just static files -- trivially self-hostable
+4. JSON + base64 WebSocket proxying works (liamcottle's proxy)
+5. Raw binary WebSocket proxying works (ws-serial-gateway)
+
+### Recommended MeshForge Approach
+
+1. **Phase 1**: Serve the Meshtastic web client's static files from MeshForge's
+   web server (port 5000). Download pre-built assets from the official Docker image.
+
+2. **Phase 2**: Implement a WebSocket proxy on MeshForge that bridges to meshtasticd
+   TCP port 4403. Use transparent binary forwarding (4-byte framing passthrough).
+
+3. **Phase 3**: Add protocol-aware inspection -- parse FromRadio packets to track
+   nodes, log messages, monitor ACKs, without modifying the packet stream.
+
+4. **Phase 4**: Create a lightweight `TransportMeshForge` TypeScript module that
+   the web client can use to connect via MeshForge's WebSocket endpoint instead
+   of direct HTTP/serial/BLE.
+
+### Why This Matters for MeshForge
+
+- **Single pane of glass**: Users access mesh monitoring AND device configuration
+  from one URL
+- **No daemon dependency for browsers**: Firefox/Safari users get access via WebSocket
+  (bypasses the Chromium-only Web Serial limitation)
+- **Multi-client support**: Multiple users can monitor the same radio simultaneously
+- **NOC integration**: MeshForge can observe ALL traffic for its monitoring dashboards
+  while the web client maintains full device control
+- **Firmware v2.7.0 gap**: Since the web UI was removed from firmware, users NEED
+  a self-hosted solution -- MeshForge can fill that gap
+
+---
+
+## Sources
+
+- [Web Serial API Spec (WICG)](https://wicg.github.io/serial/)
+- [MDN Web Serial API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Serial_API)
+- [Chrome Developers: Read and Write to Serial Ports](https://developer.chrome.com/docs/capabilities/serial)
+- [Can I Use: Web Serial](https://caniuse.com/web-serial)
+- [Meshtastic Web Monorepo (GitHub)](https://github.com/meshtastic/web)
+- [Meshtastic Web Client Overview](https://meshtastic.org/docs/software/web-client/)
+- [Meshtastic JS Development Docs](https://meshtastic.org/docs/development/js/)
+- [@meshtastic/core on JSR](https://jsr.io/@meshtastic/core)
+- [@meshtastic/transport-web-serial on npm](https://www.npmjs.com/package/@meshtastic/transport-web-serial)
+- [Meshtastic Client API (Serial/TCP/BLE)](https://meshtastic.org/docs/development/device/client-api/)
+- [Meshtastic HTTP API](https://meshtastic.org/docs/development/device/http-api/)
+- [Meshtastic Mesh Broadcast Algorithm (ACK)](https://meshtastic.org/docs/overview/mesh-algo/)
+- [liamcottle/meshtastic-websocket-proxy](https://github.com/liamcottle/meshtastic-websocket-proxy)
+- [WillerZ/ws-serial-gateway](https://github.com/WillerZ/ws-serial-gateway)
+- [PR #998: WebSocket Transport for Meshtastic Web](https://github.com/meshtastic/web/pull/998)
+- [liamcottle/meshtxt](https://github.com/liamcottle/meshtxt)
+- [fgadot/meshtastic-local-web-client (Docker)](https://github.com/fgadot/meshtastic-local-web-client)
+- [Meshtastic Protobufs (buf.build)](https://buf.build/meshtastic/protobufs)
+- [meshtastic/firmware StreamAPI.h](https://github.com/meshtastic/firmware/blob/master/src/mesh/StreamAPI.h)
+- [Meshtastic Python Library](https://python.meshtastic.org/)
+- [Bridging the Meshtastic Web Client to Serial Devices](https://blog.ipmotion.ca/bridging-the-meshtastic-web-client-to-serial-devices/)
+- [Feature Request: Reliable ACKs for DMs](https://github.com/meshtastic/firmware/issues/8164)
+- [Consider WebSockets (meshtastic.js Issue #12)](https://github.com/meshtastic/meshtastic.js/issues/12)
+- [Web Client Self-Hosting (Discourse)](https://meshtastic.discourse.group/t/web-client-self-hosting/7689)
+
+---
+*Last Updated: 2026-02-09*
+*Status: Research complete -- architecture validated, integration path clear*

--- a/.claude/session_notes/2026-02-09_api_proxy_message_sync_fix.md
+++ b/.claude/session_notes/2026-02-09_api_proxy_message_sync_fix.md
@@ -1,0 +1,97 @@
+# Session Notes: Meshtastic API Proxy - Message Sync/ACK Fix
+
+**Date**: 2026-02-09
+**Branch**: `claude/fix-message-sync-ack-kN2Xg`
+**Status**: Implemented - Ready for testing
+
+## Problem Statement
+
+The Meshtastic web client (port 9443) shows "waiting for delivery" and can't
+see messages from other nodes. This is a persistent issue across multiple
+apps, not just MeshForge.
+
+### Root Cause (Deep Research)
+
+The meshtasticd HTTP API (`/api/v1/fromradio`) has a **fundamental
+single-client limitation**: each GET request **consumes** the packet from the
+device buffer. When multiple clients (web browser, rnsd, MeshForge, etc.)
+poll fromradio, they "fight" for packets. The first to poll gets the packet;
+others never see it.
+
+This means:
+- ACK packets (ROUTING_APP) get consumed by rnsd or other clients
+- Web client never receives the ACK → shows "waiting for delivery"
+- Inbound messages get consumed by other pollers → web client can't see them
+
+### References
+- Meshtastic web client: https://github.com/meshtastic/web
+- Transport architecture: `@meshtastic/core` Transport interface
+- HTTP transport polls fromradio every 3 seconds
+- Web Serial API (Chrome): direct USB serial, bypasses daemon entirely
+- PR #998 on meshtastic/web: WebSocket transport (unmerged)
+- liamcottle/meshtastic-websocket-proxy: validates the multiplexer approach
+
+## Solution: MeshForge API Proxy
+
+MeshForge now **owns the meshtasticd HTTP API** via a proxy that:
+
+1. **Background poller**: MeshForge is the sole consumer of `/api/v1/fromradio`
+2. **Per-client multiplexer**: Each browser tab gets its own packet buffer
+3. **Transparent proxy**: Forwards `/api/v1/toradio`, `/json/*` to meshtasticd
+4. **Web client serving**: Proxies the meshtastic web client at `/mesh/`
+
+### Architecture
+
+```
+Browser(s)
+  ↕ (HTTP, per-client sessions)
+MeshForge :5000
+  /              → NOC Map (node_map.html)
+  /mesh/         → Meshtastic web client (proxied from meshtasticd)
+  /api/v1/fromradio → multiplexed per-client packets
+  /api/v1/toradio   → forwarded to meshtasticd
+  /json/*            → proxied from meshtasticd
+  ↕ (sole HTTP client)
+meshtasticd :9443
+```
+
+### Key Design Decisions
+- Per-client identification via session cookies + IP
+- Ring buffer per client (500 packets max) prevents memory leaks
+- Stale client pruning (5-minute timeout)
+- Auto-detect meshtasticd port (9443, 443, 80)
+- Fallback: direct HTTP client when proxy unavailable
+- Packet inspection callbacks for WebSocket/monitoring integration
+
+## Files Changed
+
+| File | Status | Description |
+|------|--------|-------------|
+| `src/gateway/meshtastic_api_proxy.py` | NEW | Per-client fromradio multiplexer |
+| `src/utils/map_http_handler.py` | Modified | Proxy endpoints for fromradio/toradio/json/mesh |
+| `src/utils/map_data_service.py` | Modified | Start API proxy alongside map server |
+
+## Testing
+
+1. Start MeshForge with API proxy:
+   ```bash
+   sudo python3 src/utils/map_data_service.py
+   ```
+2. Open browser to `http://localhost:5000/mesh/` → Meshtastic web client
+3. Open another tab to `http://localhost:5000/` → NOC Map
+4. Send message from another node → both UIs should see it
+5. Send message from web client → should show "delivered" (not "waiting")
+6. Open multiple tabs → all receive messages independently
+
+## Future Work
+
+1. **WebSocket transport**: Build a binary WebSocket proxy (0x94 0xC3 framing)
+   so the meshtastic web client can use WebSocket transport instead of HTTP
+   polling. This would give sub-second latency and true bidirectional comms.
+
+2. **Packet inspection**: Add protobuf parsing in packet callbacks to log
+   message types, track ACKs, and feed into bridge health monitoring.
+
+3. **meshtasticd web server config**: Consider disabling meshtasticd's built-in
+   web server and having MeshForge serve everything (Webserver.Enabled: false
+   in /etc/meshtasticd/config.yaml).

--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -1,0 +1,493 @@
+"""
+Meshtastic API Proxy - MeshForge owns the web client API.
+
+Solves the fundamental "single client" limitation of meshtasticd's HTTP API
+by making MeshForge the sole consumer of /api/v1/fromradio and multiplexing
+packets to all connected web clients via per-client buffers.
+
+Architecture:
+    Browser(s) <-> MeshForge Proxy (:5000) <-> meshtasticd (:9443)
+
+    1. MeshForge polls meshtasticd's /api/v1/fromradio in a background thread
+    2. Each received protobuf packet is copied to per-client ring buffers
+    3. Web clients poll MeshForge's /api/v1/fromradio (NOT meshtasticd directly)
+    4. Outbound /api/v1/toradio requests are forwarded to meshtasticd
+    5. /json/* endpoints are transparently proxied
+
+This means:
+    - ACK packets are properly delivered to EVERY web client
+    - Multiple browser tabs work simultaneously
+    - No more "waiting for delivery" caused by packet contention
+    - MeshForge can inspect packets for monitoring/logging
+
+Usage:
+    proxy = MeshtasticApiProxy(host='localhost', port=9443)
+    proxy.start()
+
+    # Per-client fromradio:
+    packet = proxy.get_next_packet(client_id='browser-1')
+
+    # Forward toradio:
+    proxy.send_toradio(protobuf_bytes)
+
+    proxy.stop()
+
+Reference:
+    - https://meshtastic.org/docs/development/device/http-api/
+    - Meshtastic web client: https://github.com/meshtastic/web
+"""
+
+import collections
+import logging
+import ssl
+import threading
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Deque, Dict, List, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+# Proxy defaults
+DEFAULT_MESHTASTICD_PORT = 9443
+POLL_INTERVAL = 0.3       # Seconds between fromradio polls (when idle)
+POLL_FAST = 0.05          # Seconds between polls when actively receiving
+MAX_EMPTY_FAST = 5        # Empty responses before switching back to slow poll
+CLIENT_BUFFER_SIZE = 500  # Max packets buffered per client
+CLIENT_TIMEOUT = 300      # Seconds before inactive client is pruned
+CONNECT_TIMEOUT = 5.0
+READ_TIMEOUT = 10.0
+
+
+@dataclass
+class ProxyStats:
+    """Statistics for the API proxy."""
+    packets_received: int = 0
+    packets_forwarded: int = 0
+    toradio_forwarded: int = 0
+    json_proxied: int = 0
+    active_clients: int = 0
+    errors: int = 0
+    started_at: Optional[datetime] = None
+    last_packet_time: Optional[datetime] = None
+
+
+@dataclass
+class ClientSession:
+    """Per-client state for fromradio multiplexing."""
+    client_id: str
+    buffer: Deque[bytes] = field(default_factory=lambda: collections.deque(maxlen=CLIENT_BUFFER_SIZE))
+    created_at: float = field(default_factory=time.time)
+    last_poll: float = field(default_factory=time.time)
+    packets_served: int = 0
+
+
+class MeshtasticApiProxy:
+    """
+    Proxy for meshtasticd's HTTP API with per-client packet multiplexing.
+
+    MeshForge becomes the sole consumer of meshtasticd's /api/v1/fromradio
+    and fans out packets to all registered web clients. This eliminates
+    the single-client limitation and ensures ACK packets reach every client.
+    """
+
+    def __init__(
+        self,
+        host: str = 'localhost',
+        port: int = DEFAULT_MESHTASTICD_PORT,
+        tls: bool = True,
+    ):
+        self.host = host
+        self.port = port
+        self.tls = tls
+
+        # Build base URL
+        scheme = "https" if tls else "http"
+        self._base_url = f"{scheme}://{host}:{port}"
+
+        # SSL context for meshtasticd's self-signed cert
+        self._ssl_ctx = ssl.create_default_context()
+        self._ssl_ctx.check_hostname = False
+        self._ssl_ctx.verify_mode = ssl.CERT_NONE
+
+        # Per-client packet buffers
+        self._clients: Dict[str, ClientSession] = {}
+        self._lock = threading.Lock()
+
+        # Polling state
+        self._polling = False
+        self._poll_thread: Optional[threading.Thread] = None
+        self._connected = False
+        self._config_complete = False
+
+        # Stats
+        self._stats = ProxyStats()
+
+        # Packet inspection callbacks (for WebSocket broadcast, logging, etc.)
+        self._packet_callbacks: List = []
+
+    @property
+    def stats(self) -> ProxyStats:
+        """Get proxy statistics."""
+        with self._lock:
+            self._stats.active_clients = len(self._clients)
+        return self._stats
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if proxy is connected to meshtasticd."""
+        return self._connected
+
+    def start(self) -> bool:
+        """Start the background fromradio poller.
+
+        Returns:
+            True if started, False if meshtasticd is unreachable.
+        """
+        if self._polling:
+            logger.warning("API proxy already running")
+            return True
+
+        # Probe meshtasticd before starting
+        if not self._probe():
+            logger.warning(
+                f"meshtasticd HTTP API not reachable at {self._base_url}. "
+                "Proxy will start anyway and retry."
+            )
+
+        self._polling = True
+        self._stats.started_at = datetime.now()
+        self._poll_thread = threading.Thread(
+            target=self._poll_loop,
+            daemon=True,
+            name="meshforge-api-proxy"
+        )
+        self._poll_thread.start()
+        logger.info(f"Meshtastic API proxy started → {self._base_url}")
+        return True
+
+    def stop(self):
+        """Stop the background poller."""
+        if not self._polling:
+            return
+
+        self._polling = False
+        if self._poll_thread and self._poll_thread.is_alive():
+            self._poll_thread.join(timeout=5)
+        self._poll_thread = None
+        self._connected = False
+        logger.info("Meshtastic API proxy stopped")
+
+    def add_packet_callback(self, callback):
+        """Register a callback for inspecting proxied packets.
+
+        Callback signature: callback(packet_bytes: bytes)
+        Called for each FromRadio packet received from meshtasticd.
+        """
+        self._packet_callbacks.append(callback)
+
+    # ─────────────────────────────────────────────────────────────────
+    # Client management
+    # ─────────────────────────────────────────────────────────────────
+
+    def register_client(self, client_id: str) -> None:
+        """Register a new web client to receive fromradio packets."""
+        with self._lock:
+            if client_id not in self._clients:
+                self._clients[client_id] = ClientSession(client_id=client_id)
+                logger.debug(f"API proxy: registered client {client_id}")
+
+    def unregister_client(self, client_id: str) -> None:
+        """Remove a web client."""
+        with self._lock:
+            self._clients.pop(client_id, None)
+
+    def get_next_packet(self, client_id: str) -> Optional[bytes]:
+        """Get the next fromradio packet for a specific client.
+
+        Returns:
+            Raw protobuf bytes, or None if no packets available.
+        """
+        with self._lock:
+            session = self._clients.get(client_id)
+            if not session:
+                # Auto-register on first poll
+                session = ClientSession(client_id=client_id)
+                self._clients[client_id] = session
+
+            session.last_poll = time.time()
+
+            try:
+                packet = session.buffer.popleft()
+                session.packets_served += 1
+                return packet
+            except IndexError:
+                return None
+
+    # ─────────────────────────────────────────────────────────────────
+    # Outbound: toradio forwarding
+    # ─────────────────────────────────────────────────────────────────
+
+    def send_toradio(self, data: bytes) -> bool:
+        """Forward a ToRadio protobuf to meshtasticd.
+
+        Args:
+            data: Raw protobuf bytes from the web client.
+
+        Returns:
+            True if forwarded successfully.
+        """
+        url = f"{self._base_url}/api/v1/toradio"
+        try:
+            req = urllib.request.Request(
+                url,
+                method='PUT',
+                data=data,
+                headers={
+                    'Content-Type': 'application/x-protobuf',
+                    'Content-Length': str(len(data)),
+                },
+            )
+            ctx = self._ssl_ctx if self.tls else None
+            with urllib.request.urlopen(req, timeout=CONNECT_TIMEOUT, context=ctx) as resp:
+                if resp.status in (200, 204):
+                    self._stats.toradio_forwarded += 1
+                    return True
+                logger.warning(f"toradio forward got HTTP {resp.status}")
+                return False
+        except Exception as e:
+            logger.debug(f"toradio forward failed: {e}")
+            self._stats.errors += 1
+            return False
+
+    # ─────────────────────────────────────────────────────────────────
+    # JSON endpoint proxying
+    # ─────────────────────────────────────────────────────────────────
+
+    def proxy_json(self, path: str) -> Optional[bytes]:
+        """Proxy a JSON endpoint from meshtasticd.
+
+        Args:
+            path: URL path (e.g., '/json/nodes', '/json/report')
+
+        Returns:
+            Raw response bytes, or None on error.
+        """
+        # Reject path traversal and authority injection
+        if '..' in path or not path.startswith('/'):
+            logger.warning(f"Rejected suspicious proxy path: {path}")
+            return None
+
+        url = f"{self._base_url}{path}"
+        try:
+            req = urllib.request.Request(
+                url,
+                method='GET',
+                headers={'Accept': 'application/json'},
+            )
+            ctx = self._ssl_ctx if self.tls else None
+            with urllib.request.urlopen(req, timeout=READ_TIMEOUT, context=ctx) as resp:
+                if resp.status == 200:
+                    self._stats.json_proxied += 1
+                    return resp.read()
+            return None
+        except Exception as e:
+            logger.debug(f"JSON proxy failed for {path}: {e}")
+            return None
+
+    def proxy_static(self, path: str) -> Optional[tuple]:
+        """Proxy a static file from meshtasticd's web server.
+
+        Returns:
+            Tuple of (content_bytes, content_type) or None on error.
+        """
+        # Reject path traversal and authority injection
+        if '..' in path or not path.startswith('/'):
+            logger.warning(f"Rejected suspicious proxy path: {path}")
+            return None
+
+        url = f"{self._base_url}{path}"
+        try:
+            req = urllib.request.Request(url, method='GET')
+            ctx = self._ssl_ctx if self.tls else None
+            with urllib.request.urlopen(req, timeout=READ_TIMEOUT, context=ctx) as resp:
+                if resp.status == 200:
+                    content_type = resp.headers.get('Content-Type', 'application/octet-stream')
+                    # Cap response size at 10MB to prevent memory exhaustion
+                    data = resp.read(10 * 1024 * 1024)
+                    return (data, content_type)
+            return None
+        except Exception as e:
+            logger.debug(f"Static proxy failed for {path}: {e}")
+            return None
+
+    # ─────────────────────────────────────────────────────────────────
+    # Background polling
+    # ─────────────────────────────────────────────────────────────────
+
+    def _poll_loop(self):
+        """Background loop: poll meshtasticd's fromradio and distribute."""
+        empty_count = 0
+
+        while self._polling:
+            try:
+                data = self._fetch_fromradio()
+
+                if data and len(data) > 0:
+                    self._connected = True
+                    empty_count = 0
+                    self._distribute_packet(data)
+                    self._stats.packets_received += 1
+                    self._stats.last_packet_time = datetime.now()
+
+                    # Notify callbacks (for WebSocket, monitoring, etc.)
+                    for cb in self._packet_callbacks:
+                        try:
+                            cb(data)
+                        except Exception as e:
+                            logger.debug(f"Packet callback error: {e}")
+
+                    # Fast poll when actively receiving
+                    time.sleep(POLL_FAST)
+                else:
+                    empty_count += 1
+                    if empty_count > MAX_EMPTY_FAST:
+                        time.sleep(POLL_INTERVAL)
+                    else:
+                        time.sleep(POLL_FAST)
+
+            except urllib.error.URLError as e:
+                if self._connected:
+                    logger.warning(f"Lost connection to meshtasticd: {e}")
+                    self._connected = False
+                time.sleep(2.0)  # Back off on connection errors
+            except Exception as e:
+                logger.debug(f"Poll error: {e}")
+                self._stats.errors += 1
+                time.sleep(1.0)
+
+            # Prune stale clients periodically
+            if empty_count > 0 and empty_count % 100 == 0:
+                self._prune_stale_clients()
+
+    def _fetch_fromradio(self) -> Optional[bytes]:
+        """GET one FromRadio protobuf packet from meshtasticd."""
+        url = f"{self._base_url}/api/v1/fromradio"
+        try:
+            req = urllib.request.Request(
+                url,
+                method='GET',
+                headers={'Accept': 'application/x-protobuf'},
+            )
+            ctx = self._ssl_ctx if self.tls else None
+            with urllib.request.urlopen(req, timeout=READ_TIMEOUT, context=ctx) as resp:
+                if resp.status == 200:
+                    data = resp.read()
+                    if data and len(data) > 0:
+                        return data
+            return None
+        except urllib.error.URLError:
+            raise  # Let poll_loop handle connection errors
+        except Exception as e:
+            logger.debug(f"fromradio fetch error: {e}")
+            return None
+
+    def _distribute_packet(self, data: bytes):
+        """Copy a FromRadio packet to all registered client buffers."""
+        with self._lock:
+            delivered = 0
+            for session in self._clients.values():
+                session.buffer.append(data)
+                delivered += 1
+            self._stats.packets_forwarded += delivered
+
+    def _prune_stale_clients(self):
+        """Remove clients that haven't polled recently."""
+        now = time.time()
+        with self._lock:
+            stale = [
+                cid for cid, session in self._clients.items()
+                if (now - session.last_poll) > CLIENT_TIMEOUT
+            ]
+            for cid in stale:
+                del self._clients[cid]
+                logger.debug(f"Pruned stale client: {cid}")
+
+    def _probe(self) -> bool:
+        """Check if meshtasticd HTTP API is reachable."""
+        try:
+            req = urllib.request.Request(
+                f"{self._base_url}/json/report",
+                method='GET',
+                headers={'Accept': 'application/json'},
+            )
+            ctx = self._ssl_ctx if self.tls else None
+            with urllib.request.urlopen(req, timeout=CONNECT_TIMEOUT, context=ctx) as resp:
+                return resp.status == 200
+        except Exception:
+            return False
+
+    def auto_detect_port(self) -> bool:
+        """Try common ports to find meshtasticd's web server.
+
+        Returns:
+            True if detected, updates self.port and self._base_url.
+        """
+        for port in [9443, 443, 80]:
+            for scheme in ['https', 'http']:
+                test_url = f"{scheme}://{self.host}:{port}"
+                try:
+                    req = urllib.request.Request(
+                        f"{test_url}/json/report",
+                        method='GET',
+                    )
+                    ctx = self._ssl_ctx if scheme == 'https' else None
+                    with urllib.request.urlopen(req, timeout=3, context=ctx) as resp:
+                        if resp.status == 200:
+                            self.port = port
+                            self.tls = (scheme == 'https')
+                            self._base_url = test_url
+                            logger.info(f"meshtasticd web server detected at {test_url}")
+                            return True
+                except Exception:
+                    continue
+        return False
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Singleton
+# ─────────────────────────────────────────────────────────────────────
+
+_api_proxy: Optional[MeshtasticApiProxy] = None
+_proxy_lock = threading.Lock()
+
+
+def get_api_proxy(
+    host: str = 'localhost',
+    port: int = DEFAULT_MESHTASTICD_PORT,
+    tls: bool = True,
+) -> MeshtasticApiProxy:
+    """Get or create the global API proxy instance."""
+    global _api_proxy
+    with _proxy_lock:
+        if _api_proxy is None:
+            _api_proxy = MeshtasticApiProxy(host=host, port=port, tls=tls)
+        return _api_proxy
+
+
+def start_api_proxy(
+    host: str = 'localhost',
+    port: int = DEFAULT_MESHTASTICD_PORT,
+    tls: bool = True,
+) -> bool:
+    """Start the global API proxy."""
+    proxy = get_api_proxy(host=host, port=port, tls=tls)
+    return proxy.start()
+
+
+def stop_api_proxy():
+    """Stop the global API proxy."""
+    if _api_proxy:
+        _api_proxy.stop()

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -112,6 +112,14 @@ class MapServer:
     - GET /api/status    -> server health check + history stats
     - GET /*             -> static files from web/
 
+    Meshtastic API Proxy (MeshForge-owned):
+    - GET  /api/v1/fromradio -> multiplexed protobuf from meshtasticd
+    - PUT  /api/v1/toradio   -> forwarded to meshtasticd
+    - GET  /json/nodes       -> proxied from meshtasticd
+    - GET  /json/report      -> proxied from meshtasticd
+    - GET  /mesh/*           -> meshtastic web client (proxied)
+    - GET  /api/proxy/status -> proxy health + stats
+
     Radio Control API (MeshForge-owned):
     - GET /api/radio/info     -> radio device information
     - GET /api/radio/nodes    -> nodes from connected radio
@@ -133,7 +141,11 @@ class MapServer:
                  cors_origins: Optional[List[str]] = None,
                  enable_message_listener: bool = True,
                  enable_websocket: bool = True,
-                 websocket_port: int = 5001):
+                 websocket_port: int = 5001,
+                 enable_api_proxy: bool = True,
+                 meshtasticd_host: str = 'localhost',
+                 meshtasticd_port: int = 9443,
+                 meshtasticd_tls: bool = True):
         """Initialize map server.
 
         Args:
@@ -149,6 +161,10 @@ class MapServer:
             enable_message_listener: Start MessageListener for inbound messages (default True)
             enable_websocket: Start WebSocket server for real-time message push (default True)
             websocket_port: WebSocket server port (default 5001)
+            enable_api_proxy: Start Meshtastic API proxy for web client (default True)
+            meshtasticd_host: meshtasticd host for API proxy (default 'localhost')
+            meshtasticd_port: meshtasticd web port for API proxy (default 9443)
+            meshtasticd_tls: Use TLS for API proxy (default True)
         """
         self.port = port
         self.host = host
@@ -156,11 +172,16 @@ class MapServer:
         self.enable_message_listener = enable_message_listener
         self.enable_websocket = enable_websocket
         self.websocket_port = websocket_port
+        self.enable_api_proxy = enable_api_proxy
+        self.meshtasticd_host = meshtasticd_host
+        self.meshtasticd_port = meshtasticd_port
+        self.meshtasticd_tls = meshtasticd_tls
         self.collector = MapDataCollector()
         self._server: Optional[HTTPServer] = None
         self._thread: Optional[threading.Thread] = None
         self._message_listener_started = False
         self._websocket_started = False
+        self._api_proxy_started = False
 
         # Find web directory
         src_dir = Path(__file__).parent.parent
@@ -208,6 +229,70 @@ class MapServer:
             logger.info("WebSocket server stopped")
         except Exception as e:
             logger.debug(f"Error stopping WebSocket server: {e}")
+
+    def _start_api_proxy(self):
+        """Start the Meshtastic API proxy for web client ownership.
+
+        MeshForge becomes the sole consumer of meshtasticd's HTTP API,
+        multiplexing packets to all connected web clients. This fixes
+        the 'waiting for delivery' bug and enables multi-client access.
+        """
+        if not self.enable_api_proxy:
+            return
+
+        try:
+            from gateway.meshtastic_api_proxy import MeshtasticApiProxy
+
+            proxy = MeshtasticApiProxy(
+                host=self.meshtasticd_host,
+                port=self.meshtasticd_port,
+                tls=self.meshtasticd_tls,
+            )
+
+            # Auto-detect port if default doesn't work
+            if not proxy._probe():
+                logger.info("API proxy: default port failed, auto-detecting...")
+                if proxy.auto_detect_port():
+                    logger.info(f"API proxy: found meshtasticd at {proxy._base_url}")
+                else:
+                    logger.warning(
+                        "API proxy: meshtasticd web server not found. "
+                        "Proxy will start anyway and retry on connection."
+                    )
+
+            if proxy.start():
+                self._api_proxy_started = True
+                MapRequestHandler.api_proxy = proxy
+                logger.info(
+                    f"Meshtastic API proxy started → "
+                    f"{proxy._base_url}"
+                )
+                print(f"  API Proxy: {proxy._base_url} (meshtastic web client at /mesh/)")
+            else:
+                logger.warning("Meshtastic API proxy failed to start")
+                print("  API Proxy: Failed to start")
+
+        except ImportError as e:
+            logger.debug(f"API proxy not available: {e}")
+            print("  API Proxy: Not available")
+        except Exception as e:
+            logger.warning(f"Error starting API proxy: {e}")
+            print(f"  API Proxy: Error - {e}")
+
+    def _stop_api_proxy(self):
+        """Stop the Meshtastic API proxy."""
+        if not self._api_proxy_started:
+            return
+
+        try:
+            # Stop the actual instance we started (not the singleton)
+            if MapRequestHandler.api_proxy:
+                MapRequestHandler.api_proxy.stop()
+            MapRequestHandler.api_proxy = None
+            self._api_proxy_started = False
+            logger.info("Meshtastic API proxy stopped")
+        except Exception as e:
+            logger.debug(f"Error stopping API proxy: {e}")
 
     def _start_message_listener(self):
         """Start the MessageListener for receiving inbound mesh messages."""
@@ -273,15 +358,19 @@ class MapServer:
             logger.debug(f"Error stopping MessageListener: {e}")
 
     def _stop_all_services(self):
-        """Stop all background services (MessageListener, WebSocket)."""
+        """Stop all background services (MessageListener, WebSocket, API Proxy)."""
         self._stop_message_listener()
         self._stop_websocket_server()
+        self._stop_api_proxy()
 
     def start(self):
         """Start server (blocking)."""
         MapRequestHandler.collector = self.collector
         MapRequestHandler.web_dir = self.web_dir
         MapRequestHandler.allowed_origins = self.cors_origins
+
+        # Start Meshtastic API proxy (owns the web client API)
+        self._start_api_proxy()
 
         # Start WebSocket server first (so callback can be registered)
         self._start_websocket_server()
@@ -291,17 +380,20 @@ class MapServer:
 
         self._server = HTTPServer((self.host, self.port), MapRequestHandler)
         logger.info(f"Map server starting on http://{self.host}:{self.port}")
-        print(f"MeshForge Map Server running on port {self.port}")
+        print(f"MeshForge NOC Server running on port {self.port}")
         if self.host == "0.0.0.0":
             # Show all available IPs when binding to all interfaces
             ips = get_all_ips()
             print("  Access via any of these URLs:")
             for ip in ips:
-                print(f"    http://{ip}:{self.port}/")
+                print(f"    NOC Map:    http://{ip}:{self.port}/")
+                print(f"    Mesh Client: http://{ip}:{self.port}/mesh/")
         elif self.host in ("127.0.0.1", "localhost"):
-            print(f"  URL: http://localhost:{self.port}/")
+            print(f"  NOC Map:     http://localhost:{self.port}/")
+            print(f"  Mesh Client: http://localhost:{self.port}/mesh/")
         else:
-            print(f"  URL: http://{self.host}:{self.port}/")
+            print(f"  NOC Map:     http://{self.host}:{self.port}/")
+            print(f"  Mesh Client: http://{self.host}:{self.port}/mesh/")
         print("  Press Ctrl+C to stop")
 
         try:
@@ -316,6 +408,9 @@ class MapServer:
         MapRequestHandler.collector = self.collector
         MapRequestHandler.web_dir = self.web_dir
         MapRequestHandler.allowed_origins = self.cors_origins
+
+        # Start Meshtastic API proxy (owns the web client API)
+        self._start_api_proxy()
 
         # Start WebSocket server first (so callback can be registered)
         self._start_websocket_server()

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -17,6 +17,13 @@ Endpoints:
 - GET /api/status    -> server health check + history stats
 - GET /*             -> static files from web/
 
+Meshtastic API Proxy (MeshForge-owned):
+- GET  /api/v1/fromradio -> multiplexed protobuf packets from meshtasticd
+- PUT  /api/v1/toradio   -> forwarded to meshtasticd
+- GET  /json/nodes       -> proxied from meshtasticd
+- GET  /json/report      -> proxied from meshtasticd
+- GET  /mesh/*           -> meshtastic web client (proxied from meshtasticd)
+
 Radio Control API (MeshForge-owned):
 - GET /api/radio/info     -> radio device information
 - GET /api/radio/nodes    -> nodes from connected radio
@@ -44,6 +51,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
     web_dir: Optional[str] = None
     # CORS: None = allow all, list = allow specific origins
     allowed_origins: Optional[List[str]] = None
+    # Meshtastic API proxy (set by MapServer when proxy is enabled)
+    api_proxy = None  # MeshtasticApiProxy instance
 
     def _send_cors_header(self):
         """Send appropriate CORS header based on configuration.
@@ -101,6 +110,21 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         elif self.path == '/api/network/topology' or self.path == '/api/network/topology/':
             self._serve_network_topology()
         # ─────────────────────────────────────────────────────────────
+        # Meshtastic API Proxy - MeshForge owns the web client API
+        # ─────────────────────────────────────────────────────────────
+        elif self.path.startswith('/api/v1/fromradio'):
+            self._proxy_fromradio()
+        elif self.path == '/json/nodes' or self.path == '/json/nodes/':
+            self._proxy_json('/json/nodes')
+        elif self.path == '/json/report' or self.path == '/json/report/':
+            self._proxy_json('/json/report')
+        elif self.path == '/json/blink' or self.path == '/json/blink/':
+            self._proxy_json('/json/blink')
+        elif self.path.startswith('/mesh/') or self.path == '/mesh':
+            self._proxy_mesh_client()
+        elif self.path == '/api/proxy/status' or self.path == '/api/proxy/status/':
+            self._serve_proxy_status()
+        # ─────────────────────────────────────────────────────────────
         # Radio Control API - MeshForge-owned radio access
         # ─────────────────────────────────────────────────────────────
         elif self.path == '/api/radio/info' or self.path == '/api/radio/info/':
@@ -122,12 +146,32 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
                 super().do_GET()
 
     def do_POST(self):
-        """Handle POST requests for radio control actions."""
+        """Handle POST requests for radio control and meshtastic API proxy."""
+        # ─────────────────────────────────────────────────────────────
+        # Meshtastic API Proxy - POST endpoints
+        # ─────────────────────────────────────────────────────────────
+        if self.path.startswith('/api/v1/toradio'):
+            self._proxy_toradio()
+        elif self.path == '/json/blink' or self.path == '/json/blink/':
+            self._proxy_toradio_json('/json/blink')
+        elif self.path == '/restart' or self.path == '/restart/':
+            # Restrict device restart to localhost only
+            if self.client_address[0] not in ('127.0.0.1', '::1'):
+                self.send_error(403, "Restart only allowed from localhost")
+            else:
+                self._proxy_toradio_json('/restart')
         # ─────────────────────────────────────────────────────────────
         # Radio Control API - POST endpoints
         # ─────────────────────────────────────────────────────────────
-        if self.path == '/api/radio/message' or self.path == '/api/radio/message/':
+        elif self.path == '/api/radio/message' or self.path == '/api/radio/message/':
             self._handle_send_message()
+        else:
+            self.send_error(404, "Not Found")
+
+    def do_PUT(self):
+        """Handle PUT requests (meshtastic web client uses PUT for toradio)."""
+        if self.path.startswith('/api/v1/toradio'):
+            self._proxy_toradio()
         else:
             self.send_error(404, "Not Found")
 
@@ -135,8 +179,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         """Handle CORS preflight requests."""
         self.send_response(200)
         self._send_cors_header()
-        self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-        self.send_header('Access-Control-Allow-Headers', 'Content-Type')
+        self.send_header('Access-Control-Allow-Methods', 'GET, POST, PUT, OPTIONS')
+        self.send_header('Access-Control-Allow-Headers', 'Content-Type, Accept')
         self.send_header('Content-Length', '0')
         self.end_headers()
 
@@ -851,6 +895,284 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
                 "gateway": len([n for n in nodes if n["is_gateway"]])
             },
             "timestamp": datetime.now().isoformat()
+        })
+
+    # ─────────────────────────────────────────────────────────────────
+    # Meshtastic API Proxy - MeshForge owns the web client
+    # ─────────────────────────────────────────────────────────────────
+
+    def _get_client_id(self) -> str:
+        """Generate a client ID from the request for per-client packet buffering.
+
+        Uses the client IP + a session cookie to distinguish browser tabs.
+        """
+        client_ip = self.client_address[0]
+
+        # Check for session cookie
+        cookie_header = self.headers.get('Cookie', '')
+        session_id = ''
+        for part in cookie_header.split(';'):
+            part = part.strip()
+            if part.startswith('meshforge_session='):
+                session_id = part.split('=', 1)[1]
+                break
+
+        if not session_id:
+            # Generate from User-Agent + remote port as fallback
+            ua = self.headers.get('User-Agent', '')
+            session_id = f"{hash(ua) & 0xFFFF:04x}"
+
+        return f"{client_ip}:{session_id}"
+
+    def _proxy_fromradio(self):
+        """Serve multiplexed FromRadio packets via the API proxy.
+
+        Each client gets its own stream of packets. The proxy ensures
+        ACK packets reach every connected browser.
+        """
+        if not self.api_proxy:
+            self.send_error(503, "Meshtastic API proxy not running")
+            return
+
+        client_id = self._get_client_id()
+        packet = self.api_proxy.get_next_packet(client_id)
+
+        # Check if we need to set a session cookie (for per-tab multiplexing)
+        cookie_header = self.headers.get('Cookie', '')
+        needs_cookie = 'meshforge_session=' not in cookie_header
+
+        if packet:
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/x-protobuf')
+            self.send_header('Content-Length', str(len(packet)))
+            self._send_cors_header()
+            self.send_header('Cache-Control', 'no-cache, no-store')
+            if needs_cookie:
+                import hashlib
+                session = hashlib.sha256(
+                    f"{self.client_address}{time.time()}".encode()
+                ).hexdigest()[:16]
+                self.send_header('Set-Cookie',
+                                 f'meshforge_session={session}; Path=/; SameSite=Lax')
+            self.end_headers()
+            self.wfile.write(packet)
+        else:
+            # No data - return empty 200 (meshtasticd convention)
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/x-protobuf')
+            self.send_header('Content-Length', '0')
+            self._send_cors_header()
+            self.send_header('Cache-Control', 'no-cache, no-store')
+            if needs_cookie:
+                import hashlib
+                session = hashlib.sha256(
+                    f"{self.client_address}{time.time()}".encode()
+                ).hexdigest()[:16]
+                self.send_header('Set-Cookie',
+                                 f'meshforge_session={session}; Path=/; SameSite=Lax')
+            self.end_headers()
+
+    def _proxy_toradio(self):
+        """Forward ToRadio protobuf to meshtasticd via the proxy."""
+        if not self.api_proxy:
+            self.send_error(503, "Meshtastic API proxy not running")
+            return
+
+        # Meshtastic protobuf packets are small (< 512 bytes)
+        max_size = 512
+
+        try:
+            content_length = int(self.headers.get('Content-Length', 0))
+            if content_length > max_size:
+                self.send_error(413, "Payload too large")
+                return
+            if content_length > 0:
+                data = self.rfile.read(content_length)
+            else:
+                # No Content-Length: read with a cap
+                data = self.rfile.read(max_size)
+
+            if not data:
+                self.send_response(400)
+                self._send_cors_header()
+                self.send_header('Content-Length', '0')
+                self.end_headers()
+                return
+
+            success = self.api_proxy.send_toradio(data)
+
+            if success:
+                self.send_response(200)
+                self._send_cors_header()
+                self.send_header('Content-Length', '0')
+                self.end_headers()
+            else:
+                self.send_error(502, "Failed to forward to meshtasticd")
+
+        except Exception as e:
+            logger.debug(f"toradio proxy error: {e}")
+            self.send_error(500, str(e))
+
+    def _proxy_json(self, path: str):
+        """Proxy a /json/* endpoint from meshtasticd."""
+        if not self.api_proxy:
+            # Fallback: try direct HTTP client
+            try:
+                from utils.meshtastic_http import get_http_client
+                client = get_http_client()
+                if path == '/json/nodes':
+                    data = client.get_nodes_as_dicts()
+                    self._serve_json(data)
+                    return
+                elif path == '/json/report':
+                    data = client.get_report_raw()
+                    if data:
+                        self._serve_json(data)
+                        return
+            except Exception:
+                pass
+            self.send_error(503, "Meshtastic API proxy not running")
+            return
+
+        data = self.api_proxy.proxy_json(path)
+        if data:
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(data)))
+            self._send_cors_header()
+            self.send_header('Cache-Control', 'no-cache')
+            self.end_headers()
+            self.wfile.write(data)
+        else:
+            self.send_error(502, f"Could not proxy {path} from meshtasticd")
+
+    def _proxy_toradio_json(self, path: str):
+        """Proxy a POST JSON endpoint to meshtasticd (blink, restart, etc.)."""
+        if not self.api_proxy:
+            self.send_error(503, "Meshtastic API proxy not running")
+            return
+
+        result = self.api_proxy.proxy_static(path)
+        if result:
+            content, content_type = result
+            self.send_response(200)
+            self.send_header('Content-Type', content_type)
+            self.send_header('Content-Length', str(len(content)))
+            self._send_cors_header()
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_error(502, f"Could not proxy {path}")
+
+    def _proxy_mesh_client(self):
+        """Serve the Meshtastic web client proxied from meshtasticd.
+
+        /mesh/         -> meshtasticd's index.html
+        /mesh/assets/* -> meshtasticd's static assets
+        """
+        if not self.api_proxy:
+            # Return a helpful page instead of an error
+            self._serve_mesh_client_fallback()
+            return
+
+        # Map /mesh/ to / on meshtasticd
+        path = self.path
+        if path == '/mesh' or path == '/mesh/':
+            path = '/'
+        elif path.startswith('/mesh/'):
+            path = path[5:]  # Strip /mesh prefix
+
+        result = self.api_proxy.proxy_static(path)
+        if result:
+            content, content_type = result
+
+            # For the index.html, inject base href so relative paths work
+            if path == '/' or path.endswith('.html'):
+                if isinstance(content, bytes):
+                    content_str = content.decode('utf-8', errors='replace')
+                    # Rewrite API URLs to go through MeshForge proxy
+                    content_str = content_str.replace(
+                        '</head>',
+                        '<base href="/mesh/">\n'
+                        '<script>\n'
+                        '// MeshForge API proxy: rewrite API calls to go through MeshForge\n'
+                        'window.__MESHFORGE_PROXY__ = true;\n'
+                        '</script>\n'
+                        '</head>'
+                    )
+                    content = content_str.encode('utf-8')
+                    content_type = 'text/html; charset=utf-8'
+
+            self.send_response(200)
+            self.send_header('Content-Type', content_type)
+            self.send_header('Content-Length', str(len(content)))
+            self._send_cors_header()
+            if content_type.startswith('text/html'):
+                self.send_header('Cache-Control', 'no-cache')
+            self.end_headers()
+            self.wfile.write(content)
+        else:
+            self.send_error(502, "Could not proxy from meshtasticd web server")
+
+    def _serve_mesh_client_fallback(self):
+        """Serve a fallback page when meshtasticd web server is unavailable."""
+        html = """<!DOCTYPE html>
+<html><head><title>MeshForge - Meshtastic Web Client</title>
+<style>
+body { font-family: sans-serif; background: #0a0e1a; color: #e0e0e0;
+       display: flex; justify-content: center; align-items: center;
+       min-height: 100vh; margin: 0; }
+.card { background: #141e2e; border-radius: 12px; padding: 2em;
+        max-width: 500px; text-align: center; }
+h1 { color: #4fc3f7; }
+a { color: #66bb6a; }
+code { background: #1a2a3a; padding: 2px 8px; border-radius: 4px; }
+</style></head><body>
+<div class="card">
+<h1>Meshtastic Web Client</h1>
+<p>The meshtasticd web server is not reachable.</p>
+<p>Make sure meshtasticd is running with its web server enabled:</p>
+<pre style="text-align:left;background:#1a2a3a;padding:1em;border-radius:8px;">
+# /etc/meshtasticd/config.yaml
+Webserver:
+  Port: 9443
+</pre>
+<p>Then restart: <code>sudo systemctl restart meshtasticd</code></p>
+<p style="margin-top:2em;">
+  <a href="/">MeshForge NOC Map</a> |
+  <a href="/api/proxy/status">Proxy Status</a>
+</p>
+</div></body></html>"""
+        data = html.encode('utf-8')
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html; charset=utf-8')
+        self.send_header('Content-Length', str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _serve_proxy_status(self):
+        """Serve API proxy status and statistics."""
+        if not self.api_proxy:
+            self._serve_json({
+                "enabled": False,
+                "error": "API proxy not started",
+            })
+            return
+
+        stats = self.api_proxy.stats
+        self._serve_json({
+            "enabled": True,
+            "connected": self.api_proxy.is_connected,
+            "target": f"{self.api_proxy.host}:{self.api_proxy.port}",
+            "tls": self.api_proxy.tls,
+            "packets_received": stats.packets_received,
+            "packets_forwarded": stats.packets_forwarded,
+            "toradio_forwarded": stats.toradio_forwarded,
+            "json_proxied": stats.json_proxied,
+            "active_clients": stats.active_clients,
+            "errors": stats.errors,
+            "started_at": stats.started_at.isoformat() if stats.started_at else None,
+            "last_packet": stats.last_packet_time.isoformat() if stats.last_packet_time else None,
         })
 
     # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
MeshForge now owns the meshtasticd HTTP API via a proxy that solves the fundamental "single client" limitation of /api/v1/fromradio. The native web client shows "waiting for delivery" because ACK packets get consumed by whichever client polls first (rnsd, MeshForge, another browser tab).

The MeshtasticApiProxy:
- Is the sole consumer of meshtasticd's /api/v1/fromradio
- Multiplexes packets to per-client ring buffers (via session cookies)
- Forwards /api/v1/toradio transparently to meshtasticd
- Proxies /json/* endpoints for the web client
- Serves the Meshtastic web client at /mesh/ (proxied from meshtasticd)
- Auto-detects meshtasticd port (9443, 443, 80)

Security hardening based on code review:
- Path traversal protection on proxy_json() and proxy_static()
- Payload size cap on toradio (512 bytes max)
- /restart restricted to localhost only
- 10MB response cap on proxied static files
- Session cookies set on all fromradio responses (not just data responses)

New endpoints on MeshForge :5000:
  GET  /api/v1/fromradio → multiplexed protobuf packets
  PUT  /api/v1/toradio   → forwarded to meshtasticd
  GET  /json/nodes       → proxied from meshtasticd
  GET  /json/report      → proxied from meshtasticd
  GET  /mesh/*           → meshtastic web client (proxied)
  GET  /api/proxy/status → proxy health and stats

https://claude.ai/code/session_01JNNpXA9Di8G1ChyZy5MqZB