### PR TITLE
fix: Correct rnsd test mock to match systemctl-only architecture

### DIFF
--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -1,19 +1,48 @@
 # MeshForge Session Notes
 
 **Last Updated**: 2026-02-09
-**Current Branch**: `claude/configure-meshforge-broker-h1VTf`
+**Current Branch**: `claude/session-management-tasks-ZV5yT`
 **Version**: v0.5.2-beta
-**Tests**: 3926 passed, 1 failed (pre-existing rnsd sandbox), 19 skipped
+**Tests**: 3927 passed, 0 failed, 19 skipped
 **Linter**: 0 issues (clean)
 
-## Session Focus: MOC1 Broker Configuration (2026-02-09)
+## Session Focus: Reliability Audit & Test Fix (2026-02-09)
+
+Systematic review of all remaining work items from prior sessions. Found that
+8 of 8 priority items were already completed in previous sessions. Fixed the
+one pre-existing test failure.
+
+### Changes This Session
+- **FIXED** `tests/test_status_consistency.py` — `test_rnsd_running_consistent` now
+  correctly mocks `subprocess.run` instead of helper functions. rnsd is a systemd
+  service (`is_systemd=True`), so `check_service()` calls subprocess.run directly,
+  bypassing the mocked helpers. Same pattern as the meshtasticd tests.
+
+### Audit Results — All Priority Items Complete
+
+| Priority Item | Issue | Status |
+|--------------|-------|--------|
+| Service detection simplification | #20 Phase 1 | Done — systemctl-only for systemd services |
+| MQTT service check (mosquitto) | #20 Phase 1 | Done — `is_systemd: True` in KNOWN_SERVICES |
+| Gateway bridge mode fix | #16 | Done — defaults to `message_bridge`, auto-corrects |
+| Status display separation | #20 Phase 2 | Done — `detection_method` field in ServiceStatus |
+| RX message event bus | #20 Phase 3 | Done — `event_bus.py` (306 lines), rns_bridge emits |
+| Post-install verification | #23 | Done — `verify_post_install.sh`, `--verify-install` flag |
+| Python environment mismatch | #24 | Done — `gateway_diagnostic.py` checks root importability |
+| Test coverage (4 gateway modules) | — | Done — 321+ tests across rns_bridge/node_tracker/message_queue/reconnect |
+
+### Test Results
+- Full suite: **3927 passed, 0 failed, 19 skipped** (was 3926+1 failed)
+- Linter: 0 issues
+
+## Previous Session: MOC1 Broker Configuration (2026-02-09)
 
 Configured MeshForge broker templates for MOC1 (Pi5 + Meshtoad + LongFast) with
 MQTT-bridged topology to MOC2 (Pi HAT + ShortTurbo + RNS/NomadNet).
 
 See: `.claude/session_notes_moc_broker.md` for full details.
 
-### Changes This Session
+### Changes That Session
 - **NEW** `templates/meshtoad.yaml` — Meshtoad CH341 SPI hardware template
 - **NEW** `templates/meshforge-presets/moc1-broker.yaml` — MOC1 full preset
 - **NEW** `templates/gateway-pair/moc-mqtt-bridge.md` — MQTT-bridged deployment guide
@@ -81,27 +110,21 @@ New test file added this session:
 
 ### Remaining Work (Next Session Priorities)
 
-#### Reliability Improvements (from persistent_issues.md)
-1. **Gateway bridge mode fix** — `mesh_bridge` → `message_bridge` for single-radio setups (Issue #16)
-2. **Grafana metrics** — needs gateway running for metrics server on port 9090
-3. **MQTT service check** — verify `mosquitto` service status detection works (Issue #20 Phase 1)
-4. **Service detection simplification** — trust systemctl only for systemd services (Issue #20 Phase 1, LOW effort / HIGH impact)
-5. **Status display separation** — separate "service running" from "preset detected" in UI (Issue #20 Phase 2)
-6. **RX message event bus** — messages received by gateway not displayed in UI (Issue #20 Phase 3)
-7. **Post-install verification** — ensure `verify_post_install.sh` runs automatically (Issue #23)
-8. **Python environment mismatch** — rnsd can't find meshtastic module when installed via pipx (Issue #24)
+#### All Software Items RESOLVED (as of 2026-02-09)
+Issues #16, #20 (all phases), #23, #24 — all implemented and tested.
+Test coverage for all 4 gateway modules — all have comprehensive suites.
 
-#### Additional Test Coverage Targets
-- `rns_bridge.py` (1,614 lines) — core gateway bridge logic
-- `node_tracker.py` (930 lines) — unified node tracking
-- `message_queue.py` — persistent SQLite queue
-- `reconnect.py` — reconnection strategy with backoff
+#### Still Open
+1. **Grafana metrics** — needs gateway running for metrics server on port 9090
+2. **MOC1 hardware install** — flash meshtasticd, plug Meshtoad, run broker setup (see session_notes_moc_broker.md)
 
-#### Hardware Testing
+#### Hardware Testing (requires physical deployment)
 - Maps on actual Pi with radio connected
 - Coverage map with real GPS nodes
 - AREDN integration with actual AREDN hardware
 - Headless/SSH browser detection path
+- Cross-mesh message test: LongFast → MQTT → ShortTurbo
+- RNS bridge test: ShortTurbo → Gateway → RNS/NomadNet
 
 ### File Sizes (All Under 1,500 lines)
 - launcher_tui/main.py: ~1,433 lines

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -136,33 +136,41 @@ class TestServiceCheckContract:
 
 
 class TestRnsdStatusAcrossUIs:
-    """Integration test: rnsd status should be consistent across all UIs."""
+    """Integration test: rnsd status should be consistent across all UIs.
 
-    @patch('src.utils.service_check.check_udp_port')
-    @patch('src.utils.service_check.check_process_running')
-    @patch('src.utils.service_check.check_systemd_service')
-    def test_rnsd_running_consistent(self, mock_systemd, mock_proc, mock_udp):
+    Note: rnsd is a systemd service (is_systemd=True), so check_service()
+    calls subprocess.run(['systemctl', ...]) directly — NOT the helper
+    functions check_systemd_service/check_udp_port/check_process_running.
+    We must mock subprocess.run to control behavior (same pattern as
+    TestMeshtasticdStatusConsistency).
+    """
+
+    @patch('subprocess.run')
+    def test_rnsd_running_consistent(self, mock_run):
         """When rnsd is running, all UIs should report it as running."""
-        # Simulate rnsd running (UDP port in use)
-        mock_udp.return_value = True  # Port check succeeds (in use)
-        mock_proc.return_value = True  # Process found
-        mock_systemd.return_value = (True, True)  # (active, enabled)
+        # First call: systemctl is-active → "active"
+        # Second call: systemctl show --property=SubState → "SubState=running"
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout='active\n'),
+            MagicMock(returncode=0, stdout='SubState=running\n'),
+        ]
 
         from src.utils.service_check import check_service
 
         result = check_service('rnsd')
         assert result.available is True, \
-            "rnsd should be reported as available when UDP port is in use"
+            "rnsd should be reported as available when systemctl says active"
+        assert result.detection_method == "systemctl", \
+            "rnsd status should be via systemctl"
 
-    @patch('src.utils.service_check.check_udp_port')
-    @patch('src.utils.service_check.check_process_running')
-    @patch('src.utils.service_check.check_systemd_service')
-    def test_rnsd_stopped_consistent(self, mock_systemd, mock_proc, mock_udp):
+    @patch('subprocess.run')
+    def test_rnsd_stopped_consistent(self, mock_run):
         """When rnsd is stopped, all UIs should report it as stopped."""
-        # Simulate rnsd stopped
-        mock_udp.return_value = False  # Port not in use
-        mock_proc.return_value = False  # No process
-        mock_systemd.return_value = (False, False)  # (inactive, disabled)
+        # systemctl is-active rnsd returns "inactive"
+        mock_run.return_value = MagicMock(
+            returncode=3,
+            stdout='inactive\n'
+        )
 
         from src.utils.service_check import check_service
 


### PR DESCRIPTION
test_rnsd_running_consistent was failing because it mocked helper functions (check_udp_port, check_process_running, check_systemd_service) that are NOT called for systemd services. Since rnsd has is_systemd=True, check_service() calls subprocess.run(['systemctl', ...]) directly. Now mocks subprocess.run matching the meshtasticd test pattern. 3927 pass, 0 fail.

https://claude.ai/code/session_0154XoKoKAiFfwH7rMbdLdyG