### PR TITLE
fix: Add trusted SSL cert generation for meshtasticd localhost web UI

### DIFF
--- a/src/launcher_tui/web_client_mixin.py
+++ b/src/launcher_tui/web_client_mixin.py
@@ -81,7 +81,7 @@ class WebClientMixin:
             choices = [
                 ("open", "Open in Browser      Launch in default browser"),
                 ("url", "Show URLs            Copy to access from other devices"),
-                ("ssl", "SSL Certificate      First-time setup help"),
+                ("ssl", "SSL Certificate      Fix warnings / generate cert"),
                 ("back", "Back"),
             ]
 
@@ -165,12 +165,146 @@ class WebClientMixin:
         )
 
     def _show_ssl_certificate_help(self, local_ip: str):
-        """Show SSL certificate acceptance guidance."""
+        """Show SSL certificate menu with generation option."""
+        try:
+            from utils.ssl_cert import is_cert_installed
+            cert_installed = is_cert_installed()
+        except ImportError:
+            cert_installed = False
+
+        if cert_installed:
+            status_line = "Trusted certificate: INSTALLED"
+        else:
+            status_line = "Trusted certificate: NOT installed (using meshtasticd default)"
+
+        while True:
+            choices = [
+                ("generate", "Generate Trusted Cert   Eliminate browser warnings"),
+                ("manual", "Manual Accept Help     Browser-specific instructions"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "SSL Certificate",
+                f"{status_line}\n\n"
+                "meshtasticd uses HTTPS with a self-signed certificate.\n"
+                "This causes warnings in browsers and blocks lynx/curl.\n\n"
+                "Generate a trusted certificate to fix this permanently.",
+                choices,
+                height=18, width=65
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "generate":
+                self._generate_trusted_cert()
+                # Refresh status
+                try:
+                    cert_installed = is_cert_installed()
+                except Exception:
+                    pass
+            elif choice == "manual":
+                self._show_manual_ssl_help()
+
+    def _generate_trusted_cert(self):
+        """Generate and install a trusted localhost SSL certificate."""
+        try:
+            from utils.ssl_cert import generate_localhost_cert
+        except ImportError:
+            self.dialog.msgbox(
+                "Error",
+                "SSL certificate module not available.\n"
+                "Ensure src/utils/ssl_cert.py exists."
+            )
+            return
+
+        if os.geteuid() != 0:
+            self.dialog.msgbox(
+                "Root Required",
+                "Certificate generation requires root privileges.\n\n"
+                "MeshForge should already be running with sudo.\n"
+                "If not, restart with: sudo python3 src/launcher_tui/main.py"
+            )
+            return
+
+        self.dialog.infobox("SSL Certificate", "Generating trusted certificate...")
+
+        success, msg = generate_localhost_cert()
+
+        if success:
+            # Update meshtasticd config to use the new cert
+            config_updated = self._update_meshtasticd_ssl_config()
+
+            restart_msg = ""
+            if config_updated:
+                restart_msg = (
+                    "\nmeshtasticd config updated with new cert paths.\n"
+                    "Restart meshtasticd to apply:\n"
+                    "  sudo systemctl restart meshtasticd"
+                )
+
+            self.dialog.msgbox(
+                "Certificate Generated",
+                f"{msg}\n{restart_msg}"
+            )
+        else:
+            self.dialog.msgbox("Certificate Error", msg)
+
+    def _update_meshtasticd_ssl_config(self) -> bool:
+        """Add SSL cert/key paths to meshtasticd config.yaml."""
+        from pathlib import Path
+
+        config_path = Path("/etc/meshtasticd/config.yaml")
+        if not config_path.exists():
+            return False
+
+        try:
+            content = config_path.read_text()
+
+            # Check if SSLCert is already configured
+            if "SSLCert:" in content and "meshforge" in content.lower():
+                return True  # Already configured with our cert
+
+            import re
+
+            # Look for Webserver section and add/update SSL paths
+            if "SSLCert:" in content:
+                # Replace existing SSLCert/SSLKey lines
+                content = re.sub(
+                    r'(\s+)SSLCert:.*',
+                    r'\1SSLCert: /etc/meshtasticd/ssl/certificate.pem',
+                    content
+                )
+                content = re.sub(
+                    r'(\s+)SSLKey:.*',
+                    r'\1SSLKey: /etc/meshtasticd/ssl/private_key.pem',
+                    content
+                )
+            elif "Webserver:" in content:
+                # Add SSL paths after existing Webserver entries
+                content = re.sub(
+                    r'(Webserver:.*?\n(?:\s+\w+:.*\n)*)',
+                    r'\1  SSLCert: /etc/meshtasticd/ssl/certificate.pem\n'
+                    r'  SSLKey: /etc/meshtasticd/ssl/private_key.pem\n',
+                    content
+                )
+            else:
+                return False  # No Webserver section found
+
+            config_path.write_text(content)
+            logger.info("Updated meshtasticd config with SSL cert paths")
+            return True
+
+        except Exception as e:
+            logger.error("Failed to update meshtasticd SSL config: %s", e)
+            return False
+
+    def _show_manual_ssl_help(self):
+        """Show manual SSL certificate acceptance guidance."""
         self.dialog.msgbox(
-            "SSL Certificate Help",
-            "meshtasticd uses a self-signed SSL certificate.\n"
-            "Browsers show a warning - this is expected.\n\n"
-            "To accept the certificate:\n\n"
+            "Manual SSL Accept",
+            "If you prefer to manually accept the certificate:\n\n"
             "Chrome/Edge:\n"
             "  1. Click 'Advanced'\n"
             "  2. Click 'Proceed to localhost (unsafe)'\n\n"
@@ -180,6 +314,8 @@ class WebClientMixin:
             "Safari:\n"
             "  1. Click 'Show Details'\n"
             "  2. Click 'visit this website'\n\n"
-            "This only needs to be done ONCE per browser.\n"
-            "The certificate is local and safe to accept."
+            "lynx:\n"
+            "  Type 'y' at the certificate prompt\n\n"
+            "This must be done per-browser.\n"
+            "Generate a trusted cert to avoid this entirely."
         )

--- a/src/utils/ssl_cert.py
+++ b/src/utils/ssl_cert.py
@@ -1,0 +1,205 @@
+"""
+MeshForge SSL Certificate Generator.
+
+Generates a trusted self-signed CA and localhost server certificate
+for meshtasticd's HTTPS web UI (port 9443).
+
+The CA is added to the system trust store so all browsers and tools
+(including lynx, curl, etc.) trust the connection without warnings.
+
+Usage:
+    from utils.ssl_cert import generate_localhost_cert, is_cert_installed
+
+    if not is_cert_installed():
+        success, msg = generate_localhost_cert()
+"""
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+# Paths
+SSL_DIR = Path("/etc/meshtasticd/ssl")
+CA_KEY = SSL_DIR / "meshforge_ca.key"
+CA_CERT = SSL_DIR / "meshforge_ca.pem"
+SERVER_KEY = SSL_DIR / "private_key.pem"
+SERVER_CERT = SSL_DIR / "certificate.pem"
+SYSTEM_CA_DIR = Path("/usr/local/share/ca-certificates")
+SYSTEM_CA_LINK = SYSTEM_CA_DIR / "meshforge-localhost-ca.crt"
+
+# Certificate validity (days)
+CA_DAYS = 3650       # 10 years
+SERVER_DAYS = 3650   # 10 years
+
+
+def is_cert_installed() -> bool:
+    """Check if MeshForge localhost certificate is already installed and trusted."""
+    return (
+        SERVER_KEY.exists()
+        and SERVER_CERT.exists()
+        and CA_CERT.exists()
+        and SYSTEM_CA_LINK.exists()
+    )
+
+
+def generate_localhost_cert() -> Tuple[bool, str]:
+    """
+    Generate a trusted self-signed CA and localhost server certificate.
+
+    Creates:
+      - CA key + cert (signs the server cert)
+      - Server key + cert (used by meshtasticd, SANs: localhost + 127.0.0.1)
+      - Installs CA to system trust store
+
+    Returns:
+        (success, message) tuple
+    """
+    if os.geteuid() != 0:
+        return False, "Root privileges required. Run with sudo."
+
+    try:
+        # Ensure SSL directory exists
+        SSL_DIR.mkdir(mode=0o700, parents=True, exist_ok=True)
+
+        # Step 1: Generate CA private key
+        result = subprocess.run(
+            ["openssl", "genrsa", "-out", str(CA_KEY), "4096"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            return False, f"Failed to generate CA key: {result.stderr}"
+        os.chmod(str(CA_KEY), 0o600)
+
+        # Step 2: Generate CA certificate
+        result = subprocess.run(
+            [
+                "openssl", "req", "-new", "-x509",
+                "-key", str(CA_KEY),
+                "-out", str(CA_CERT),
+                "-days", str(CA_DAYS),
+                "-subj", "/CN=MeshForge Local CA/O=MeshForge/OU=Mesh Network"
+            ],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            return False, f"Failed to generate CA cert: {result.stderr}"
+
+        # Step 3: Generate server private key
+        result = subprocess.run(
+            ["openssl", "genrsa", "-out", str(SERVER_KEY), "2048"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            return False, f"Failed to generate server key: {result.stderr}"
+        os.chmod(str(SERVER_KEY), 0o600)
+
+        # Step 4: Create CSR with SANs via config
+        openssl_conf = SSL_DIR / "openssl_san.cnf"
+        openssl_conf.write_text(
+            "[req]\n"
+            "default_bits = 2048\n"
+            "prompt = no\n"
+            "distinguished_name = dn\n"
+            "req_extensions = v3_req\n"
+            "\n"
+            "[dn]\n"
+            "CN = localhost\n"
+            "O = MeshForge\n"
+            "OU = meshtasticd\n"
+            "\n"
+            "[v3_req]\n"
+            "subjectAltName = @alt_names\n"
+            "\n"
+            "[alt_names]\n"
+            "DNS.1 = localhost\n"
+            "IP.1 = 127.0.0.1\n"
+            "IP.2 = ::1\n"
+        )
+
+        csr_path = SSL_DIR / "server.csr"
+        result = subprocess.run(
+            [
+                "openssl", "req", "-new",
+                "-key", str(SERVER_KEY),
+                "-out", str(csr_path),
+                "-config", str(openssl_conf)
+            ],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            return False, f"Failed to generate CSR: {result.stderr}"
+
+        # Step 5: Sign server cert with CA (include SANs)
+        ext_conf = SSL_DIR / "v3_ext.cnf"
+        ext_conf.write_text(
+            "authorityKeyIdentifier=keyid,issuer\n"
+            "basicConstraints=CA:FALSE\n"
+            "keyUsage=digitalSignature,keyEncipherment\n"
+            "extendedKeyUsage=serverAuth\n"
+            "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1\n"
+        )
+
+        result = subprocess.run(
+            [
+                "openssl", "x509", "-req",
+                "-in", str(csr_path),
+                "-CA", str(CA_CERT),
+                "-CAkey", str(CA_KEY),
+                "-CAcreateserial",
+                "-out", str(SERVER_CERT),
+                "-days", str(SERVER_DAYS),
+                "-extfile", str(ext_conf)
+            ],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            return False, f"Failed to sign server cert: {result.stderr}"
+
+        # Step 6: Install CA to system trust store
+        SYSTEM_CA_DIR.mkdir(parents=True, exist_ok=True)
+        # Copy CA cert (update-ca-certificates expects .crt extension)
+        import shutil
+        shutil.copy2(str(CA_CERT), str(SYSTEM_CA_LINK))
+
+        result = subprocess.run(
+            ["update-ca-certificates"],
+            capture_output=True, text=True, timeout=30
+        )
+        if result.returncode != 0:
+            logger.warning("update-ca-certificates returned non-zero: %s", result.stderr)
+            # Non-fatal - cert files are still usable
+
+        # Step 7: Clean up temp files
+        for tmp in [csr_path, openssl_conf, ext_conf, SSL_DIR / "meshforge_ca.srl"]:
+            if tmp.exists():
+                tmp.unlink()
+
+        # Set ownership - meshtasticd needs to read these
+        for f in [SERVER_KEY, SERVER_CERT, CA_KEY, CA_CERT]:
+            os.chmod(str(f), 0o600)
+
+        logger.info("SSL certificates generated and installed")
+        return True, (
+            "SSL certificate generated and trusted.\n"
+            f"  CA cert:     {CA_CERT}\n"
+            f"  Server cert: {SERVER_CERT}\n"
+            f"  Server key:  {SERVER_KEY}\n\n"
+            "System trust store updated."
+        )
+
+    except subprocess.TimeoutExpired:
+        return False, "Certificate generation timed out"
+    except Exception as e:
+        return False, f"Certificate generation failed: {e}"
+
+
+def get_meshtasticd_ssl_config() -> str:
+    """Return YAML snippet for meshtasticd SSL configuration."""
+    return (
+        f"  SSLCert: {SERVER_CERT}\n"
+        f"  SSLKey: {SERVER_KEY}\n"
+    )

--- a/tests/test_ssl_cert.py
+++ b/tests/test_ssl_cert.py
@@ -1,0 +1,137 @@
+"""Tests for SSL certificate generation utility."""
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils.ssl_cert import (
+    is_cert_installed,
+    generate_localhost_cert,
+    get_meshtasticd_ssl_config,
+    SSL_DIR,
+    CA_KEY,
+    CA_CERT,
+    SERVER_KEY,
+    SERVER_CERT,
+    SYSTEM_CA_LINK,
+)
+
+
+class TestIsCertInstalled:
+    """Test certificate installation detection."""
+
+    @patch('utils.ssl_cert.SYSTEM_CA_LINK')
+    @patch('utils.ssl_cert.CA_CERT')
+    @patch('utils.ssl_cert.SERVER_CERT')
+    @patch('utils.ssl_cert.SERVER_KEY')
+    def test_all_files_exist(self, mock_key, mock_cert, mock_ca, mock_link):
+        """Returns True when all cert files exist."""
+        for m in [mock_key, mock_cert, mock_ca, mock_link]:
+            m.exists.return_value = True
+        assert is_cert_installed() is True
+
+    @patch('utils.ssl_cert.SYSTEM_CA_LINK')
+    @patch('utils.ssl_cert.CA_CERT')
+    @patch('utils.ssl_cert.SERVER_CERT')
+    @patch('utils.ssl_cert.SERVER_KEY')
+    def test_missing_server_key(self, mock_key, mock_cert, mock_ca, mock_link):
+        """Returns False when server key is missing."""
+        mock_key.exists.return_value = False
+        mock_cert.exists.return_value = True
+        mock_ca.exists.return_value = True
+        mock_link.exists.return_value = True
+        assert is_cert_installed() is False
+
+    @patch('utils.ssl_cert.SYSTEM_CA_LINK')
+    @patch('utils.ssl_cert.CA_CERT')
+    @patch('utils.ssl_cert.SERVER_CERT')
+    @patch('utils.ssl_cert.SERVER_KEY')
+    def test_missing_ca_link(self, mock_key, mock_cert, mock_ca, mock_link):
+        """Returns False when system CA link is missing."""
+        mock_key.exists.return_value = True
+        mock_cert.exists.return_value = True
+        mock_ca.exists.return_value = True
+        mock_link.exists.return_value = False
+        assert is_cert_installed() is False
+
+
+class TestGenerateLocalhostCert:
+    """Test certificate generation."""
+
+    @patch('os.geteuid', return_value=1000)
+    def test_requires_root(self, mock_euid):
+        """Fails when not running as root."""
+        success, msg = generate_localhost_cert()
+        assert success is False
+        assert "Root" in msg or "root" in msg
+
+    @patch('os.geteuid', return_value=0)
+    @patch('os.chmod')
+    @patch('shutil.copy2')
+    @patch('subprocess.run')
+    @patch.object(Path, 'mkdir')
+    @patch.object(Path, 'write_text')
+    @patch.object(Path, 'exists', return_value=True)
+    @patch.object(Path, 'unlink')
+    def test_generates_certs_as_root(
+        self, mock_unlink, mock_exists, mock_write, mock_mkdir,
+        mock_run, mock_copy, mock_chmod, mock_euid
+    ):
+        """Succeeds when running as root with openssl available."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+        success, msg = generate_localhost_cert()
+        assert success is True
+        assert "certificate.pem" in msg or "generated" in msg.lower()
+
+    @patch('os.geteuid', return_value=0)
+    @patch('subprocess.run')
+    @patch.object(Path, 'mkdir')
+    def test_handles_openssl_failure(self, mock_mkdir, mock_run, mock_euid):
+        """Reports error when openssl fails."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="openssl error")
+        success, msg = generate_localhost_cert()
+        assert success is False
+        assert "Failed" in msg
+
+    @patch('os.geteuid', return_value=0)
+    @patch('subprocess.run', side_effect=subprocess.TimeoutExpired('openssl', 30))
+    @patch.object(Path, 'mkdir')
+    def test_handles_timeout(self, mock_mkdir, mock_run, mock_euid):
+        """Handles subprocess timeout gracefully."""
+        success, msg = generate_localhost_cert()
+        assert success is False
+        assert "timed out" in msg.lower()
+
+
+class TestGetMeshtasticdSslConfig:
+    """Test YAML config snippet generation."""
+
+    def test_returns_yaml_snippet(self):
+        """Returns properly formatted YAML with cert paths."""
+        config = get_meshtasticd_ssl_config()
+        assert "SSLCert:" in config
+        assert "SSLKey:" in config
+        assert "certificate.pem" in config
+        assert "private_key.pem" in config
+
+
+class TestCertPaths:
+    """Verify certificate path constants are correct."""
+
+    def test_ssl_dir(self):
+        assert SSL_DIR == Path("/etc/meshtasticd/ssl")
+
+    def test_server_key_path(self):
+        assert SERVER_KEY == Path("/etc/meshtasticd/ssl/private_key.pem")
+
+    def test_server_cert_path(self):
+        assert SERVER_CERT == Path("/etc/meshtasticd/ssl/certificate.pem")
+
+    def test_system_ca_link(self):
+        assert SYSTEM_CA_LINK == Path("/usr/local/share/ca-certificates/meshforge-localhost-ca.crt")


### PR DESCRIPTION
Generates a self-signed CA + localhost server certificate with proper SANs (localhost, 127.0.0.1, ::1) and installs the CA to the system trust store. This eliminates SSL warnings in all browsers including lynx/curl which cannot easily bypass self-signed cert errors.

- New: src/utils/ssl_cert.py - certificate generation utility
- Updated: web_client_mixin.py SSL menu with "Generate Trusted Cert" option
- Auto-updates meshtasticd config.yaml with SSLCert/SSLKey paths
- 12 unit tests for cert generation, path validation, error handling

https://claude.ai/code/session_0162GJqY8FXeKinjk1wMEPU9