### PR TITLE
fix: Prevent meshtasticd web client crash on phantom node search

### DIFF
--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -38,6 +38,7 @@ Reference:
 """
 
 import collections
+import json
 import logging
 import ssl
 import threading
@@ -269,6 +270,10 @@ class MeshtasticApiProxy:
     def proxy_json(self, path: str) -> Optional[bytes]:
         """Proxy a JSON endpoint from meshtasticd.
 
+        For /json/nodes, sanitizes the response to ensure all nodes have
+        required fields. Incomplete "phantom" nodes (from MQTT) crash the
+        Meshtastic web client's React UI when clicked.
+
         Args:
             path: URL path (e.g., '/json/nodes', '/json/report')
 
@@ -291,11 +296,78 @@ class MeshtasticApiProxy:
             with urllib.request.urlopen(req, timeout=READ_TIMEOUT, context=ctx) as resp:
                 if resp.status == 200:
                     self._stats.json_proxied += 1
-                    return resp.read()
+                    data = resp.read()
+                    # Sanitize /json/nodes to prevent web client crash
+                    if path == '/json/nodes':
+                        data = self._sanitize_nodes_json(data)
+                    return data
             return None
         except Exception as e:
             logger.debug(f"JSON proxy failed for {path}: {e}")
             return None
+
+    @staticmethod
+    def _sanitize_nodes_json(data: bytes) -> bytes:
+        """Sanitize /json/nodes response to prevent web client crash.
+
+        The Meshtastic web client (React) crashes when clicking nodes
+        that have incomplete data — typically phantom nodes heard via
+        MQTT that lack a 'user' object or role field. The web client
+        tries to access properties like user.longName or role without
+        null checks, triggering "Cannot read properties of undefined".
+
+        This method ensures every node has the minimum required fields
+        so the web client can render them without crashing.
+
+        See: https://github.com/meshtastic/web/issues/862
+        """
+        try:
+            parsed = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return data  # Not valid JSON, pass through unchanged
+
+        if not isinstance(parsed, dict):
+            return data  # Unexpected format, pass through
+
+        modified = False
+        for node_key, node_data in parsed.items():
+            if not isinstance(node_data, dict):
+                continue
+
+            # Ensure 'user' object exists with required fields
+            if 'user' not in node_data or not isinstance(node_data.get('user'), dict):
+                node_id = node_data.get('num', node_key)
+                node_data['user'] = {
+                    'id': str(node_id),
+                    'longName': f'Node {node_key[-4:] if len(str(node_key)) >= 4 else node_key}',
+                    'shortName': '????',
+                    'hwModel': 'UNSET',
+                }
+                modified = True
+            else:
+                user = node_data['user']
+                # Fill in missing required user fields
+                if not user.get('longName'):
+                    node_id = user.get('id', node_key)
+                    user['longName'] = f'Node {str(node_id)[-4:]}'
+                    modified = True
+                if not user.get('shortName'):
+                    user['shortName'] = '????'
+                    modified = True
+                if not user.get('hwModel'):
+                    user['hwModel'] = 'UNSET'
+                    modified = True
+
+            # Ensure 'role' field exists (prevents CLIENT_BASE crash)
+            if 'role' not in node_data:
+                node_data['role'] = 'CLIENT'
+                modified = True
+
+        if modified:
+            logger.debug("Sanitized /json/nodes: patched incomplete node records")
+            return json.dumps(parsed).encode('utf-8')
+
+        return data
 
     def proxy_static(self, path: str) -> Optional[tuple]:
         """Proxy a static file from meshtasticd's web server.

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -44,6 +44,7 @@ class MeshtasticdConfigMixin:
                 ("channels", "Channel Config"),
                 ("mqtt", "MQTT Uplink/Downlink"),
                 ("gateway", "Gateway Template"),
+                ("cleanup", "Node DB Cleanup"),
                 ("edit", "Edit Config Files"),
                 ("restart", "Restart Service"),
                 ("back", "Back"),
@@ -67,6 +68,7 @@ class MeshtasticdConfigMixin:
                 "channels": ("Channel Config", self._channel_config_menu),
                 "mqtt": ("MQTT Config", self._mqtt_device_config),
                 "gateway": ("Gateway Template", self._gateway_template_menu),
+                "cleanup": ("Node DB Cleanup", self._node_db_cleanup_menu),
                 "edit": ("Edit Config Files", self._edit_config_menu),
                 "restart": ("Restart Service", self._restart_meshtasticd),
             }
@@ -519,6 +521,354 @@ Press Cancel to keep current values."""
                     self.dialog.msgbox(f"Config: {choice}", content)
                 except Exception as e:
                     self.dialog.msgbox("Error", str(e))
+
+    def _node_db_cleanup_menu(self):
+        """Node database cleanup — identify and remove phantom/incomplete nodes.
+
+        Phantom nodes appear via MQTT with incomplete data (no name, no user
+        info). Clicking them in the meshtasticd web client crashes the React
+        UI because it tries to render undefined properties.
+        """
+        while True:
+            choices = [
+                ("scan", "Scan for Phantom Nodes"),
+                ("reset", "Reset Node Database (removes ALL nodes)"),
+                ("maxnodes", "Check MaxNodes Setting"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Node DB Cleanup",
+                "Clean up the meshtasticd node database.\n\n"
+                "Phantom nodes (incomplete data from MQTT) can\n"
+                "crash the web client when clicked.\n\n"
+                "Scan identifies nodes with missing info.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "scan": ("Scan Phantom Nodes", self._scan_phantom_nodes),
+                "reset": ("Reset Node DB", self._reset_node_database),
+                "maxnodes": ("Check MaxNodes", self._check_maxnodes),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self._safe_call(*entry)
+
+    def _scan_phantom_nodes(self):
+        """Scan for phantom/incomplete nodes via HTTP API."""
+        self.dialog.infobox("Scanning", "Fetching node list from meshtasticd...")
+
+        try:
+            from utils.meshtastic_http import get_http_client
+            client = get_http_client()
+
+            if not client.is_available:
+                self.dialog.msgbox(
+                    "Not Available",
+                    "meshtasticd HTTP API not reachable.\n\n"
+                    "Ensure meshtasticd is running:\n"
+                    "  sudo systemctl start meshtasticd"
+                )
+                return
+
+            nodes = client.get_nodes()
+
+            if not nodes:
+                self.dialog.msgbox("No Nodes", "No nodes found in the device database.")
+                return
+
+            # Identify phantom nodes: no long_name AND no short_name
+            phantom = []
+            healthy = []
+            for node in nodes:
+                has_name = bool(node.long_name.strip()) or bool(node.short_name.strip())
+                if not has_name:
+                    phantom.append(node)
+                else:
+                    healthy.append(node)
+
+            if not phantom:
+                self.dialog.msgbox(
+                    "All Clear",
+                    f"All {len(nodes)} nodes have valid names.\n\n"
+                    "No phantom nodes detected.\n\n"
+                    "If the web client still crashes on search,\n"
+                    "this may be an upstream Meshtastic bug.\n"
+                    "See: github.com/meshtastic/web/issues/862"
+                )
+                return
+
+            # Build report
+            lines = [
+                f"Found {len(phantom)} phantom node(s) "
+                f"(of {len(nodes)} total)\n",
+                "Phantom nodes have no name data and can crash",
+                "the web client when clicked in search results.\n",
+            ]
+
+            for node in phantom[:20]:
+                node_id = node.node_id
+                hw = node.hw_model or "unknown hw"
+                heard = ""
+                if node.last_heard > 0:
+                    import time
+                    age = time.time() - node.last_heard
+                    if age < 3600:
+                        heard = f"{age / 60:.0f}m ago"
+                    elif age < 86400:
+                        heard = f"{age / 3600:.0f}h ago"
+                    else:
+                        heard = f"{age / 86400:.0f}d ago"
+                mqtt_tag = " [MQTT]" if node.via_mqtt else ""
+                lines.append(f"  {node_id} ({hw}) {heard}{mqtt_tag}")
+
+            if len(phantom) > 20:
+                lines.append(f"  ... and {len(phantom) - 20} more")
+
+            lines.append("")
+            lines.append("Options:")
+            lines.append("  - Remove individually (if CLI supports it)")
+            lines.append("  - Reset entire node DB (re-discovers all)")
+            lines.append("  - Reduce MaxNodes to limit MQTT phantoms")
+
+            self.dialog.msgbox("Phantom Nodes Found", "\n".join(lines))
+
+            # Offer to remove phantom nodes
+            if self.dialog.yesno(
+                "Remove Phantom Nodes?",
+                f"Try to remove {len(phantom)} phantom node(s)?\n\n"
+                "Uses 'meshtastic --remove-node' for each.\n"
+                "If that command isn't available, will offer\n"
+                "to reset the full node database instead.",
+                default_no=True
+            ):
+                self._remove_phantom_nodes(phantom)
+
+        except ImportError:
+            self.dialog.msgbox(
+                "Module Not Available",
+                "HTTP client module not found.\n\n"
+                "Ensure src/utils/meshtastic_http.py exists."
+            )
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Scan failed:\n{e}")
+
+    def _remove_phantom_nodes(self, phantom_nodes):
+        """Try to remove phantom nodes individually via CLI."""
+        cli = self._get_meshtastic_cli()
+        removed = 0
+        failed = 0
+        cli_unsupported = False
+
+        self.dialog.infobox(
+            "Removing",
+            f"Removing {len(phantom_nodes)} phantom node(s)..."
+        )
+
+        for node in phantom_nodes:
+            # Extract numeric node ID (meshtastic CLI expects decimal nodeNum)
+            node_id = node.node_id
+            try:
+                if node_id.startswith('!'):
+                    node_num = str(int(node_id[1:], 16))
+                else:
+                    node_num = node_id
+            except ValueError:
+                node_num = node_id
+
+            try:
+                result = subprocess.run(
+                    [cli, '--host', 'localhost:4403',
+                     '--remove-node', node_num],
+                    capture_output=True, text=True, timeout=15
+                )
+                if result.returncode == 0:
+                    removed += 1
+                else:
+                    stderr = result.stderr or ""
+                    if "unrecognized" in stderr.lower() or "unknown" in stderr.lower():
+                        cli_unsupported = True
+                        break
+                    failed += 1
+            except FileNotFoundError:
+                self.dialog.msgbox(
+                    "CLI Not Found",
+                    "meshtastic CLI not installed.\n\n"
+                    "Install: pip install meshtastic"
+                )
+                return
+            except subprocess.TimeoutExpired:
+                failed += 1
+
+        if cli_unsupported:
+            # --remove-node not supported in this CLI version
+            if self.dialog.yesno(
+                "CLI Too Old",
+                "'meshtastic --remove-node' not available.\n\n"
+                "Your meshtastic CLI version doesn't support\n"
+                "individual node removal.\n\n"
+                "Options:\n"
+                "  - Upgrade: pip install --upgrade meshtastic\n"
+                "  - Reset entire node DB (re-discovers all)\n\n"
+                "Reset entire node database now?",
+                default_no=True
+            ):
+                self._reset_node_database()
+        elif removed > 0 or failed > 0:
+            self.dialog.msgbox(
+                "Cleanup Complete",
+                f"Removed: {removed} phantom node(s)\n"
+                f"Failed:  {failed}\n\n"
+                "The device will re-discover legitimate nodes\n"
+                "through normal mesh traffic."
+            )
+        else:
+            self.dialog.msgbox("No Changes", "No nodes were removed.")
+
+    def _reset_node_database(self):
+        """Reset the entire node database (nuclear option)."""
+        confirm = self.dialog.yesno(
+            "Reset Node Database",
+            "This will CLEAR ALL known nodes from the device.\n\n"
+            "The device will re-discover nodes through\n"
+            "normal mesh traffic (may take minutes to hours).\n\n"
+            "This fixes web client crashes caused by phantom\n"
+            "nodes with incomplete data.\n\n"
+            "Proceed?",
+            default_no=True
+        )
+
+        if not confirm:
+            return
+
+        cli = self._get_meshtastic_cli()
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost:4403', '--reset-nodedb'],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                self.dialog.msgbox(
+                    "Database Reset",
+                    "Node database cleared.\n\n"
+                    "Nodes will re-appear as they are heard\n"
+                    "over the mesh (a few minutes for nearby nodes)."
+                )
+            else:
+                self.dialog.msgbox(
+                    "Reset Failed",
+                    f"Command failed:\n{result.stderr or result.stdout}"
+                )
+        except FileNotFoundError:
+            self.dialog.msgbox("Error", "meshtastic CLI not found.")
+        except subprocess.TimeoutExpired:
+            self.dialog.msgbox("Error", "Command timed out.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Reset failed:\n{e}")
+
+    def _check_maxnodes(self):
+        """Check and optionally reduce MaxNodes in config.yaml."""
+        config_path = Path('/etc/meshtasticd/config.yaml')
+
+        if not config_path.exists():
+            self.dialog.msgbox(
+                "Config Not Found",
+                f"{config_path} not found.\n\n"
+                "meshtasticd may not be installed."
+            )
+            return
+
+        try:
+            content = config_path.read_text()
+        except OSError as e:
+            self.dialog.msgbox("Error", f"Cannot read config:\n{e}")
+            return
+
+        # Find current MaxNodes value
+        import re
+        match = re.search(r'MaxNodes:\s*(\d+)', content)
+        current = int(match.group(1)) if match else None
+
+        if current is None:
+            self.dialog.msgbox(
+                "MaxNodes Not Set",
+                "MaxNodes is not configured in config.yaml.\n\n"
+                "Default is typically 200 (device dependent).\n\n"
+                "Add to General section:\n"
+                "  General:\n"
+                "    MaxNodes: 100"
+            )
+            return
+
+        text = (
+            f"Current MaxNodes: {current}\n\n"
+            "MaxNodes limits how many nodes the device tracks.\n"
+            "High values accumulate phantom MQTT nodes that\n"
+            "can crash the web client.\n\n"
+            "Recommended values:\n"
+            "  50  — Small local mesh\n"
+            "  100 — Medium mesh with MQTT\n"
+            "  200 — Large mesh (default)\n\n"
+        )
+
+        if current > 100:
+            text += (
+                f"Your value ({current}) is high. Reducing to 100\n"
+                "limits phantom node accumulation."
+            )
+
+        new_val = self.dialog.inputbox(
+            "MaxNodes Setting",
+            text + "\n\nEnter new MaxNodes value (or Cancel to keep):",
+            str(current)
+        )
+
+        if new_val is None:
+            return
+
+        try:
+            new_int = int(new_val)
+            if new_int < 10 or new_int > 500:
+                self.dialog.msgbox("Invalid", "MaxNodes must be between 10 and 500.")
+                return
+        except ValueError:
+            self.dialog.msgbox("Invalid", "Enter a number between 10 and 500.")
+            return
+
+        if new_int == current:
+            self.dialog.msgbox("No Change", f"MaxNodes remains at {current}.")
+            return
+
+        # Update config.yaml
+        try:
+            new_content = re.sub(
+                r'(MaxNodes:\s*)\d+',
+                rf'\g<1>{new_int}',
+                content
+            )
+            config_path.write_text(new_content)
+
+            if self.dialog.yesno(
+                "Restart Service?",
+                f"MaxNodes updated: {current} → {new_int}\n\n"
+                "Restart meshtasticd to apply?",
+                default_no=False
+            ):
+                self._restart_meshtasticd()
+            else:
+                self.dialog.msgbox(
+                    "Config Updated",
+                    f"MaxNodes set to {new_int}.\n\n"
+                    "Restart meshtasticd to apply:\n"
+                    "  sudo systemctl restart meshtasticd"
+                )
+
+        except OSError as e:
+            self.dialog.msgbox("Error", f"Failed to update config:\n{e}")
 
     def _edit_config_menu(self):
         """Edit config files directly."""

--- a/tests/test_api_proxy_sanitize.py
+++ b/tests/test_api_proxy_sanitize.py
@@ -1,0 +1,225 @@
+"""
+Tests for MeshtasticApiProxy node sanitization.
+
+The Meshtastic web client crashes when clicking nodes with incomplete
+data (phantom nodes from MQTT). The proxy sanitizes /json/nodes responses
+to ensure all nodes have required fields.
+
+See: https://github.com/meshtastic/web/issues/862
+"""
+
+import json
+import pytest
+
+
+# Import the static method directly
+from gateway.meshtastic_api_proxy import MeshtasticApiProxy
+
+
+class TestSanitizeNodesJson:
+    """Tests for _sanitize_nodes_json static method."""
+
+    def test_healthy_nodes_unchanged(self):
+        """Nodes with complete data should pass through unmodified."""
+        nodes = {
+            "!aabbccdd": {
+                "num": 2864434397,
+                "user": {
+                    "id": "!aabbccdd",
+                    "longName": "Hilltop-1",
+                    "shortName": "HT1",
+                    "hwModel": "RAK4631",
+                },
+                "role": "CLIENT",
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert parsed["!aabbccdd"]["user"]["longName"] == "Hilltop-1"
+        assert parsed["!aabbccdd"]["user"]["shortName"] == "HT1"
+        assert parsed["!aabbccdd"]["role"] == "CLIENT"
+
+    def test_phantom_node_no_user(self):
+        """Phantom node with no 'user' object gets defaults."""
+        nodes = {
+            "!deadbeef": {
+                "num": 3735928559,
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        node = parsed["!deadbeef"]
+        assert "user" in node
+        assert node["user"]["longName"]  # Not empty
+        assert node["user"]["shortName"] == "????"
+        assert node["user"]["hwModel"] == "UNSET"
+        assert node["role"] == "CLIENT"
+
+    def test_phantom_node_empty_user(self):
+        """Node with empty user fields gets defaults filled in."""
+        nodes = {
+            "!11223344": {
+                "num": 287454020,
+                "user": {
+                    "id": "!11223344",
+                    "longName": "",
+                    "shortName": "",
+                    "hwModel": "",
+                },
+                "role": "ROUTER",
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        user = parsed["!11223344"]["user"]
+        assert user["longName"]  # Should be filled with default
+        assert user["shortName"] == "????"
+        assert user["hwModel"] == "UNSET"
+        # Existing role should be preserved
+        assert parsed["!11223344"]["role"] == "ROUTER"
+
+    def test_missing_role_gets_default(self):
+        """Node with missing 'role' field gets CLIENT default."""
+        nodes = {
+            "!aabb0011": {
+                "num": 2864054289,
+                "user": {
+                    "id": "!aabb0011",
+                    "longName": "M3GO",
+                    "shortName": "M3GO",
+                    "hwModel": "HELTEC_V3",
+                },
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert parsed["!aabb0011"]["role"] == "CLIENT"
+        # User data should be preserved
+        assert parsed["!aabb0011"]["user"]["longName"] == "M3GO"
+
+    def test_mixed_healthy_and_phantom(self):
+        """Mix of healthy and phantom nodes — only phantoms get patched."""
+        nodes = {
+            "!healthy01": {
+                "num": 1,
+                "user": {
+                    "id": "!healthy01",
+                    "longName": "Good Node",
+                    "shortName": "GOOD",
+                    "hwModel": "RAK4631",
+                },
+                "role": "CLIENT",
+            },
+            "!phantom01": {
+                "num": 2,
+                # No user object at all
+            },
+            "!phantom02": {
+                "num": 3,
+                "user": {
+                    "id": "!phantom02",
+                    "longName": "",
+                    "shortName": "",
+                },
+            },
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        # Healthy node preserved exactly
+        assert parsed["!healthy01"]["user"]["longName"] == "Good Node"
+        assert parsed["!healthy01"]["role"] == "CLIENT"
+
+        # Phantom nodes patched
+        assert parsed["!phantom01"]["user"]["longName"]  # Has a default
+        assert parsed["!phantom01"]["role"] == "CLIENT"
+        assert parsed["!phantom02"]["user"]["shortName"] == "????"
+
+    def test_invalid_json_passes_through(self):
+        """Non-JSON data passes through unchanged."""
+        data = b"this is not json"
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        assert result == data
+
+    def test_non_dict_json_passes_through(self):
+        """JSON that isn't a dict (e.g., list) passes through."""
+        data = json.dumps([1, 2, 3]).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        assert result == data
+
+    def test_empty_dict_passes_through(self):
+        """Empty node dict passes through."""
+        data = json.dumps({}).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        assert json.loads(result) == {}
+
+    def test_user_is_none_gets_replaced(self):
+        """Node where 'user' is null/None gets a proper user object."""
+        nodes = {
+            "!nulluser": {
+                "num": 99,
+                "user": None,
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed["!nulluser"]["user"], dict)
+        assert parsed["!nulluser"]["user"]["longName"]
+        assert parsed["!nulluser"]["user"]["shortName"] == "????"
+
+    def test_partial_user_preserves_existing(self):
+        """Node with some user fields keeps existing data."""
+        nodes = {
+            "!partial": {
+                "num": 50,
+                "user": {
+                    "id": "!partial",
+                    "longName": "M3shGO",
+                    # shortName missing
+                    # hwModel missing
+                },
+                "role": "ROUTER_CLIENT",
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        # Existing fields preserved
+        assert parsed["!partial"]["user"]["longName"] == "M3shGO"
+        assert parsed["!partial"]["role"] == "ROUTER_CLIENT"
+        # Missing fields filled
+        assert parsed["!partial"]["user"]["shortName"] == "????"
+        assert parsed["!partial"]["user"]["hwModel"] == "UNSET"
+
+    def test_long_name_default_uses_last_4_chars(self):
+        """Default longName uses last 4 chars of node key."""
+        nodes = {
+            "!aabbccdd": {
+                "num": 2864434397,
+                "user": {
+                    "id": "!aabbccdd",
+                    "longName": "",
+                    "shortName": "TEST",
+                    "hwModel": "HELTEC_V3",
+                },
+                "role": "CLIENT",
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        # Should use last 4 chars of key for default name
+        assert "ccdd" in parsed["!aabbccdd"]["user"]["longName"]


### PR DESCRIPTION
The Meshtastic web client (React) crashes with "This is a little embarrassing..." when clicking nodes with incomplete data — typically phantom nodes heard via MQTT that lack a user object or role field.

Changes:
- Add proxy-level sanitization of /json/nodes responses to fill in missing required fields (user, longName, shortName, hwModel, role) so the web client can render them without crashing
- Add Node DB Cleanup menu to meshtasticd config (scan phantom nodes, remove individually via --remove-node, reset entire DB, check/adjust MaxNodes to limit phantom accumulation)
- Add 11 tests for proxy node sanitization covering phantom nodes, partial data, null user, mixed healthy/phantom, edge cases

Upstream ref: https://github.com/meshtastic/web/issues/862

https://claude.ai/code/session_01J74qJhJD9fr8N92CxYh27J