### PR TITLE
fix: Add RNS cache/announces to storage permission check

### DIFF
--- a/src/core/diagnostics/checks/rns.py
+++ b/src/core/diagnostics/checks/rns.py
@@ -131,8 +131,9 @@ def check_rns_storage_permissions() -> CheckResult:
     """Check that RNS storage directories exist with correct permissions.
 
     RNS Identity.persist_job() requires the 'ratchets' subdirectory under
-    the storage directory. If missing or not writable, rnsd crashes with
-    PermissionError in a background thread.
+    the storage directory. Transport jobs require 'cache/announces/'.
+    If missing or not writable, rnsd crashes with PermissionError in a
+    background thread.
     """
     start = time.time()
 
@@ -147,18 +148,20 @@ def check_rns_storage_permissions() -> CheckResult:
             duration_ms=(time.time() - start) * 1000
         )
 
-    ratchets_dir = etc_storage / 'ratchets'
+    # All subdirectories RNS Transport needs to write to
+    required_dirs = [
+        (etc_storage, "storage/"),
+        (etc_storage / 'ratchets', "storage/ratchets/"),
+        (etc_storage / 'cache', "storage/cache/"),
+        (etc_storage / 'cache' / 'announces', "storage/cache/announces/"),
+    ]
     issues = []
 
-    if not etc_storage.exists():
-        issues.append("storage/ directory missing")
-    elif not os.access(str(etc_storage), os.W_OK):
-        issues.append("storage/ not writable")
-
-    if not ratchets_dir.exists():
-        issues.append("storage/ratchets/ directory missing")
-    elif not os.access(str(ratchets_dir), os.W_OK):
-        issues.append("storage/ratchets/ not writable")
+    for dir_path, label in required_dirs:
+        if not dir_path.exists():
+            issues.append(f"{label} directory missing")
+        elif not os.access(str(dir_path), os.W_OK):
+            issues.append(f"{label} not writable")
 
     duration = (time.time() - start) * 1000
 
@@ -169,8 +172,8 @@ def check_rns_storage_permissions() -> CheckResult:
             status=CheckStatus.FAIL,
             message="; ".join(issues),
             fix_hint=(
-                "sudo mkdir -p /etc/reticulum/storage/ratchets && "
-                "sudo chmod 755 /etc/reticulum/storage /etc/reticulum/storage/ratchets"
+                "sudo mkdir -p /etc/reticulum/storage/{ratchets,cache/announces} && "
+                "sudo chown -R $(whoami) /etc/reticulum/storage/"
             ),
             duration_ms=duration
         )
@@ -179,7 +182,7 @@ def check_rns_storage_permissions() -> CheckResult:
         name="RNS storage permissions",
         category=CheckCategory.RNS,
         status=CheckStatus.PASS,
-        message="storage/ and ratchets/ directories OK",
+        message="storage/, ratchets/, cache/announces/ directories OK",
         duration_ms=duration
     )
 

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -110,6 +110,8 @@ class ReticulumPaths:
     ETC_BASE = Path('/etc/reticulum')
     ETC_STORAGE = ETC_BASE / 'storage'
     ETC_RATCHETS = ETC_STORAGE / 'ratchets'
+    ETC_CACHE = ETC_STORAGE / 'cache'
+    ETC_ANNOUNCE_CACHE = ETC_CACHE / 'announces'
     ETC_INTERFACES = ETC_BASE / 'interfaces'
 
     @classmethod
@@ -121,8 +123,9 @@ class ReticulumPaths:
         must exist with proper permissions before rnsd can start.
 
         The 'ratchets' subdirectory is required by RNS Identity.persist_job()
-        for key ratcheting support (added in newer RNS versions). Without it,
-        rnsd crashes with PermissionError in a background thread.
+        for key ratcheting support. The 'cache/announces' subdirectory is
+        required by Transport jobs for announce caching. Without these,
+        rnsd crashes with PermissionError in background threads.
 
         Returns:
             True if directories exist or were created, False on permission error.
@@ -134,6 +137,8 @@ class ReticulumPaths:
             cls.ETC_BASE.mkdir(mode=0o755, parents=True, exist_ok=True)
             cls.ETC_STORAGE.mkdir(mode=0o755, parents=True, exist_ok=True)
             cls.ETC_RATCHETS.mkdir(mode=0o755, parents=True, exist_ok=True)
+            cls.ETC_CACHE.mkdir(mode=0o755, parents=True, exist_ok=True)
+            cls.ETC_ANNOUNCE_CACHE.mkdir(mode=0o755, parents=True, exist_ok=True)
             cls.ETC_INTERFACES.mkdir(mode=0o755, parents=True, exist_ok=True)
             return True
         except PermissionError:


### PR DESCRIPTION
rnsd Transport jobs write to /etc/reticulum/storage/cache/announces/ which was not covered by the existing permission check. When this directory is root-owned (from previously running rnsd as root), the service spams "Permission denied" errors on every Transport cycle.

Changes:
- Extend check_rns_storage_permissions() to verify cache/ and cache/announces/ directories exist and are writable
- Update fix_hint to use chown -R instead of chmod (fixes ownership)
- Add ETC_CACHE and ETC_ANNOUNCE_CACHE to ReticulumPaths
- Include cache dirs in ensure_system_dirs()

https://claude.ai/code/session_01J74qJhJD9fr8N92CxYh27J