### PR TITLE
feat: Add web client pre-flight checks and diagnostic knowledge

### DIFF
--- a/src/launcher_tui/web_client_mixin.py
+++ b/src/launcher_tui/web_client_mixin.py
@@ -74,6 +74,19 @@ class WebClientMixin:
             )
             return
 
+        # Pre-flight health check — detect issues that hang/crash the web client
+        warnings = self._web_client_preflight()
+        if warnings:
+            # Show warnings and let user choose to continue or fix
+            warning_text = "\n".join(warnings)
+            if not self.dialog.yesno(
+                "Web Client Health Check",
+                f"Potential issues detected:\n\n{warning_text}\n\n"
+                "Open web client anyway?",
+                default_no=True
+            ):
+                return
+
         # Web client is running - show options
         while True:
             choices = [
@@ -395,3 +408,59 @@ class WebClientMixin:
             "This must be done per-browser.\n"
             "Generate a trusted cert to avoid this entirely."
         )
+
+    def _web_client_preflight(self):
+        """Pre-flight check for issues that hang/crash the web client.
+
+        Checks:
+        1. Phantom nodes (incomplete data → React crash on click)
+        2. MQTT queue overflow from logs (downlink echo → browser hang)
+
+        Returns:
+            List of warning strings, empty if all clear.
+        """
+        warnings = []
+
+        # Check 1: Phantom nodes via HTTP API
+        try:
+            from utils.meshtastic_http import get_http_client
+            client = get_http_client()
+            if client.is_available:
+                nodes = client.get_nodes()
+                phantom_count = 0
+                for node in nodes:
+                    has_name = bool(
+                        (node.long_name or "").strip()
+                        or (node.short_name or "").strip()
+                    )
+                    if not has_name:
+                        phantom_count += 1
+
+                if phantom_count > 0:
+                    warnings.append(
+                        f"[!] {phantom_count} phantom node(s) with no name data.\n"
+                        "    Clicking these in search will crash the web client.\n"
+                        "    Fix: Meshtasticd > Node DB Cleanup > Scan"
+                    )
+        except Exception as e:
+            logger.debug("Preflight phantom node check failed: %s", e)
+
+        # Check 2: MQTT tophone queue overflow in recent logs
+        try:
+            result = subprocess.run(
+                ['journalctl', '-u', 'meshtasticd', '--since', '5 min ago',
+                 '--no-pager', '-q'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0 and 'queue is full' in result.stdout:
+                warnings.append(
+                    "[!] MQTT queue overflow detected (tophone queue full).\n"
+                    "    Browser will hang. MQTT downlink is flooding the device.\n"
+                    "    Fix: Meshtasticd > Node DB Cleanup > Check MaxNodes\n"
+                    "    Or disable downlink: meshtastic --ch-index 0\n"
+                    "         --ch-set downlink_enabled false"
+                )
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+            logger.debug("Preflight journal check failed: %s", e)
+
+        return warnings

--- a/src/utils/diagnostic_rules.py
+++ b/src/utils/diagnostic_rules.py
@@ -899,3 +899,79 @@ def load_mesh_rules(engine: "DiagnosticEngine") -> None:
         ],
         confidence_base=0.9,
     ))
+
+    # ===== MESHTASTIC WEB CLIENT RULES =====
+
+    engine.add_rule(DiagnosticRule(
+        name="mqtt_downlink_queue_flood",
+        pattern=r"(?i)(tophone|to.?phone).*(queue|buffer).*(full|overflow|discard)",
+        category=Category.PERFORMANCE,
+        cause_template=(
+            "MQTT downlink is flooding the device radio queue. "
+            "When MQTT downlink is enabled, the broker echoes every published "
+            "packet back into the device's tophone queue, overwhelming the radio. "
+            "This causes the meshtasticd web client to hang and packets to be dropped."
+        ),
+        evidence_checks=[
+            make_service_active_check("meshtasticd"),
+        ],
+        suggestions=[
+            "Disable MQTT downlink on primary channel: "
+            "meshtastic --host localhost --ch-index 0 --ch-set downlink_enabled false",
+            "Or reduce MaxMessageQueue in /etc/meshtasticd/config.yaml",
+            "Downlink is only needed for MQTT→radio injection (remote apps sending to mesh)",
+            "For uplink-only monitoring (mesh→MQTT), downlink should be OFF",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.9,
+    ))
+
+    engine.add_rule(DiagnosticRule(
+        name="web_client_phantom_node_crash",
+        pattern=r"(?i)(web.*client|browser).*(crash|error|embarrass|broke|hang)",
+        category=Category.CONFIGURATION,
+        cause_template=(
+            "The meshtasticd web client crashes when clicking on phantom nodes — "
+            "nodes heard via MQTT with incomplete data (no user object, missing role). "
+            "The React UI accesses undefined properties and triggers an error boundary. "
+            "This is an upstream bug (meshtastic/web#862)."
+        ),
+        evidence_checks=[
+            make_port_check("localhost", 9443),
+            make_service_active_check("meshtasticd"),
+        ],
+        suggestions=[
+            "Use MeshForge Node DB Cleanup: Meshtasticd > Node DB Cleanup > Scan",
+            "Reset node database: meshtastic --host localhost --reset-nodedb",
+            "Reduce MaxNodes in config.yaml to limit phantom accumulation",
+            "Disable MQTT downlink to stop phantom node ingestion",
+            "MeshForge API proxy sanitizes nodes when web client is routed through it",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.85,
+    ))
+
+    engine.add_rule(DiagnosticRule(
+        name="web_client_fromradio_contention",
+        pattern=r"(?i)(web.*client|browser).*(hang|freeze|stuck|loading|spinning)",
+        category=Category.CONNECTIVITY,
+        cause_template=(
+            "Multiple clients competing for meshtasticd's /api/v1/fromradio endpoint. "
+            "The HTTP API is single-consumer — only one client gets each packet. "
+            "If another client (gateway bridge, Python SDK) is connected, the web client "
+            "gets starved and hangs waiting for packets that never arrive."
+        ),
+        evidence_checks=[
+            make_port_check("localhost", 9443),
+            make_port_check("localhost", 4403),
+            make_service_active_check("meshtasticd"),
+        ],
+        suggestions=[
+            "Route web client through MeshForge API proxy (multiplexes packets to all clients)",
+            "Disconnect other meshtasticd clients before using web UI",
+            "Stop gateway bridge temporarily: systemctl stop meshforge-gateway",
+            "Check for MQTT downlink flooding: look for 'tophone queue is full' in logs",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.75,
+    ))

--- a/src/utils/knowledge_content.py
+++ b/src/utils/knowledge_content.py
@@ -1713,3 +1713,112 @@ For MeshForge MQTT subscriber:
         related_entries=["MQTT for Meshtastic"],
         expertise_level="intermediate",
     ))
+
+    kb._add_entry(KnowledgeEntry(
+        topic=KnowledgeTopic.MQTT,
+        title="MQTT Downlink Echo Loop",
+        content="""
+MQTT Downlink Echo Loop — the #1 cause of meshtasticd web client hangs.
+
+The Problem:
+When MQTT uplink AND downlink are both enabled on the same channel,
+the device publishes packets to the broker (uplink), then the broker
+echoes them right back (downlink). This creates a feedback loop that
+floods the device's tophone queue.
+
+Symptoms:
+- meshtasticd logs: "tophone queue status queue is full, discard oldest"
+- Web client at :9443 hangs/freezes after partial load
+- Node names appear but UI is unresponsive
+- Packet loss on the RF mesh (dropped from full queue)
+
+Root Cause:
+  Device TX → MQTT broker (uplink publish)
+                  ↓
+  MQTT broker → Device RX queue (downlink subscribe)  ← LOOP
+
+The device subscribes to the same topic it publishes to.
+Every outgoing packet comes back in as an incoming packet,
+filling the queue faster than the radio can drain it.
+
+Fix:
+  # Disable downlink on primary channel
+  meshtastic --host localhost --ch-index 0 --ch-set downlink_enabled false
+
+  # Or in MeshForge TUI:
+  Meshtasticd > MQTT > Configure Downlink
+
+When to use downlink:
+- Only if you need MQTT→radio message injection
+- Remote apps sending commands to mesh nodes
+- Never on a monitoring/broker node that only collects data
+
+When to DISABLE downlink:
+- Broker/monitoring nodes (most common)
+- Nodes that only publish to MQTT
+- Any node experiencing queue overflow
+""",
+        keywords=["mqtt", "downlink", "echo", "loop", "queue", "full", "overflow",
+                 "tophone", "hang", "web client", "freeze", "flood"],
+        related_entries=["MQTT for Meshtastic", "Web Client Phantom Nodes"],
+        expertise_level="intermediate",
+    ))
+
+    kb._add_entry(KnowledgeEntry(
+        topic=KnowledgeTopic.MESHTASTIC,
+        title="Web Client Phantom Nodes",
+        content="""
+Phantom Nodes — why the meshtasticd web client crashes on search.
+
+The Problem:
+The meshtasticd web client (React app at :9443) crashes with
+"This is a little embarrassing..." when clicking certain nodes
+in the search results. The nodes appear in search but clicking
+them triggers a JavaScript error.
+
+Root Cause:
+Phantom nodes are incomplete entries in the device's node database —
+typically received via MQTT from distant nodes. They have a node ID
+but are missing required fields:
+- No 'user' object (longName, shortName, hwModel missing)
+- No 'role' field
+- No position data
+
+The React web client tries to render these fields without null checks:
+  node.user.longName.replace(...)  → crashes on undefined
+
+This is upstream bug: https://github.com/meshtastic/web/issues/862
+
+How phantom nodes accumulate:
+1. MQTT downlink enabled → broker sends nodeinfo from entire mesh
+2. Many nodes on public MQTT have incomplete data
+3. Device stores them in nodedb with missing fields
+4. MaxNodes: 200 (default) allows hundreds of phantoms
+
+Fixes:
+1. MeshForge Node DB Cleanup:
+   Meshtasticd > Node DB Cleanup > Scan for Phantom Nodes
+   Identifies and removes nodes with no name data.
+
+2. Reset node database (nuclear option):
+   meshtastic --host localhost --reset-nodedb
+   Clears ALL nodes. Legitimate nodes re-appear within minutes.
+
+3. Reduce MaxNodes in /etc/meshtasticd/config.yaml:
+   General:
+     MaxNodes: 100  # Down from 200
+
+4. Disable MQTT downlink (prevents new phantoms):
+   meshtastic --host localhost --ch-index 0 --ch-set downlink_enabled false
+
+5. MeshForge API proxy sanitization:
+   When web client is routed through MeshForge's proxy, the
+   _sanitize_nodes_json() method fills in missing fields with
+   safe defaults, preventing the React crash entirely.
+""",
+        keywords=["phantom", "ghost", "node", "crash", "web client", "search",
+                 "embarrassing", "react", "undefined", "missing", "user",
+                 "longName", "role", "M3GO", "nodedb", "cleanup"],
+        related_entries=["MQTT Downlink Echo Loop", "MQTT for Meshtastic"],
+        expertise_level="intermediate",
+    ))


### PR DESCRIPTION
MeshForge now detects and warns about conditions that hang/crash the meshtasticd web client BEFORE opening the browser:

Pre-flight checks (web_client_mixin.py):
- Scans /json/nodes for phantom nodes (no name data → React crash)
- Checks journalctl for "queue is full" (MQTT flood → browser hang)
- Shows warnings with fix instructions, lets user choose to continue

Diagnostic rules (3 new rules):
- mqtt_downlink_queue_flood: Detects tophone queue overflow from MQTT echo loop, suggests disabling downlink
- web_client_phantom_node_crash: Detects web client crash pattern, points to Node DB Cleanup and proxy sanitization
- web_client_fromradio_contention: Detects browser hang from single-consumer API competition

Knowledge base (2 new entries):
- "MQTT Downlink Echo Loop": Full explanation of the uplink→broker→ downlink feedback loop, symptoms, root cause diagram, and fixes
- "Web Client Phantom Nodes": Explains phantom node accumulation, upstream bug reference, and all available remediation options

https://claude.ai/code/session_01J74qJhJD9fr8N92CxYh27J