### PR TITLE
fix: Fix scroll on port 5000 right menu and phantom node proxy routing

### DIFF
--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -313,8 +313,9 @@ class MeshtasticApiProxy:
         The Meshtastic web client (React) crashes when clicking nodes
         that have incomplete data — typically phantom nodes heard via
         MQTT that lack a 'user' object or role field. The web client
-        tries to access properties like user.longName or role without
-        null checks, triggering "Cannot read properties of undefined".
+        tries to access properties like user.longName, role,
+        position.latitude, and deviceMetrics without null checks,
+        triggering "Cannot read properties of undefined".
 
         This method ensures every node has the minimum required fields
         so the web client can render them without crashing.
@@ -342,6 +343,8 @@ class MeshtasticApiProxy:
                     'longName': f'Node {node_key[-4:] if len(str(node_key)) >= 4 else node_key}',
                     'shortName': '????',
                     'hwModel': 'UNSET',
+                    'macaddr': '',
+                    'publicKey': '',
                 }
                 modified = True
             else:
@@ -361,6 +364,39 @@ class MeshtasticApiProxy:
             # Ensure 'role' field exists (prevents CLIENT_BASE crash)
             if 'role' not in node_data:
                 node_data['role'] = 'CLIENT'
+                modified = True
+
+            # Ensure 'position' is a dict if present but null/invalid.
+            # The web client accesses position.latitude etc. without
+            # null checks.  A missing position is fine (web client
+            # handles undefined), but a null/non-dict value crashes.
+            if 'position' in node_data and not isinstance(node_data.get('position'), dict):
+                node_data['position'] = {}
+                modified = True
+
+            # Ensure 'deviceMetrics' is a dict if present but
+            # null/invalid.  The web client reads batteryLevel,
+            # voltage, etc. from this object.
+            if 'deviceMetrics' in node_data and not isinstance(node_data.get('deviceMetrics'), dict):
+                node_data['deviceMetrics'] = {}
+                modified = True
+
+            # Ensure 'lastHeard' exists — the web client uses this
+            # for "last seen" display and sorts by it.
+            if 'lastHeard' not in node_data:
+                node_data['lastHeard'] = 0
+                modified = True
+
+            # Ensure 'num' field exists — used as internal node ID
+            if 'num' not in node_data:
+                # Try to parse from hex key like "!aabbccdd"
+                try:
+                    if node_key.startswith('!'):
+                        node_data['num'] = int(node_key[1:], 16)
+                    else:
+                        node_data['num'] = int(node_key, 16)
+                except (ValueError, TypeError):
+                    node_data['num'] = 0
                 modified = True
 
         if modified:

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -152,9 +152,11 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         # ─────────────────────────────────────────────────────────────
         if self.path.startswith('/api/v1/toradio'):
             self._proxy_toradio()
-        elif self.path == '/json/blink' or self.path == '/json/blink/':
+        elif self.path.startswith('/mesh/api/v1/toradio'):
+            self._proxy_toradio()
+        elif self.path in ('/json/blink', '/json/blink/', '/mesh/json/blink', '/mesh/json/blink/'):
             self._proxy_toradio_json('/json/blink')
-        elif self.path == '/restart' or self.path == '/restart/':
+        elif self.path in ('/restart', '/restart/', '/mesh/restart', '/mesh/restart/'):
             # Restrict device restart to localhost only
             if self.client_address[0] not in ('127.0.0.1', '::1'):
                 self.send_error(403, "Restart only allowed from localhost")
@@ -171,6 +173,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
     def do_PUT(self):
         """Handle PUT requests (meshtastic web client uses PUT for toradio)."""
         if self.path.startswith('/api/v1/toradio'):
+            self._proxy_toradio()
+        elif self.path.startswith('/mesh/api/v1/toradio'):
             self._proxy_toradio()
         else:
             self.send_error(404, "Not Found")
@@ -1069,6 +1073,13 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
 
         /mesh/         -> meshtasticd's index.html
         /mesh/assets/* -> meshtasticd's static assets
+
+        API endpoints under /mesh/ are routed through MeshForge's proper
+        handlers (sanitized, multiplexed) instead of raw proxy_static():
+        - /mesh/json/nodes   -> proxy_json (sanitizes phantom nodes)
+        - /mesh/json/report  -> proxy_json
+        - /mesh/api/v1/fromradio -> multiplexed fromradio
+        - /mesh/api/v1/toradio   -> forwarded toradio
         """
         if not self.api_proxy:
             # Return a helpful page instead of an error
@@ -1081,6 +1092,27 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             path = '/'
         elif path.startswith('/mesh/'):
             path = path[5:]  # Strip /mesh prefix
+
+        # Route API endpoints through proper handlers instead of raw proxy.
+        # The web client makes relative fetch() calls which resolve under
+        # /mesh/ due to <base href="/mesh/">.  Without this routing,
+        # /mesh/json/nodes bypasses sanitization and phantom nodes crash
+        # the React UI.
+        if path == '/json/nodes' or path == '/json/nodes/':
+            self._proxy_json('/json/nodes')
+            return
+        if path == '/json/report' or path == '/json/report/':
+            self._proxy_json('/json/report')
+            return
+        if path == '/json/blink' or path == '/json/blink/':
+            self._proxy_json('/json/blink')
+            return
+        if path.startswith('/api/v1/fromradio'):
+            self._proxy_fromradio()
+            return
+        if path.startswith('/api/v1/toradio'):
+            self._proxy_toradio()
+            return
 
         result = self.api_proxy.proxy_static(path)
         if result:

--- a/tests/test_api_proxy_sanitize.py
+++ b/tests/test_api_proxy_sanitize.py
@@ -223,3 +223,120 @@ class TestSanitizeNodesJson:
 
         # Should use last 4 chars of key for default name
         assert "ccdd" in parsed["!aabbccdd"]["user"]["longName"]
+
+    def test_null_position_replaced_with_dict(self):
+        """Node with null position gets empty dict to prevent crash."""
+        nodes = {
+            "!aabb0022": {
+                "num": 100,
+                "user": {
+                    "id": "!aabb0022",
+                    "longName": "TestNode",
+                    "shortName": "TST",
+                    "hwModel": "RAK4631",
+                },
+                "role": "CLIENT",
+                "position": None,
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed["!aabb0022"]["position"], dict)
+
+    def test_null_device_metrics_replaced_with_dict(self):
+        """Node with null deviceMetrics gets empty dict."""
+        nodes = {
+            "!aabb0033": {
+                "num": 200,
+                "user": {
+                    "id": "!aabb0033",
+                    "longName": "TestNode2",
+                    "shortName": "TS2",
+                    "hwModel": "HELTEC_V3",
+                },
+                "role": "ROUTER",
+                "deviceMetrics": None,
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed["!aabb0033"]["deviceMetrics"], dict)
+
+    def test_missing_last_heard_gets_default(self):
+        """Phantom node missing lastHeard gets default 0."""
+        nodes = {
+            "!aabb0044": {
+                "num": 300,
+                # No user, no role, no lastHeard — full phantom
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert parsed["!aabb0044"]["lastHeard"] == 0
+
+    def test_missing_num_parsed_from_hex_key(self):
+        """Node missing 'num' gets it parsed from hex node key."""
+        nodes = {
+            "!deadbeef": {
+                "user": {
+                    "id": "!deadbeef",
+                    "longName": "Phantom",
+                    "shortName": "PHT",
+                    "hwModel": "UNSET",
+                },
+                "role": "CLIENT",
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        assert parsed["!deadbeef"]["num"] == 0xdeadbeef
+
+    def test_valid_position_dict_unchanged(self):
+        """Node with valid position dict is not replaced."""
+        nodes = {
+            "!aabb0055": {
+                "num": 400,
+                "user": {
+                    "id": "!aabb0055",
+                    "longName": "GPS Node",
+                    "shortName": "GPS",
+                    "hwModel": "RAK4631",
+                },
+                "role": "CLIENT",
+                "position": {"latitude": 21.3069, "longitude": -157.8583, "altitude": 5},
+                "lastHeard": 1707500000,
+            }
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        # Position preserved exactly
+        assert parsed["!aabb0055"]["position"]["latitude"] == 21.3069
+        assert parsed["!aabb0055"]["position"]["longitude"] == -157.8583
+
+    def test_full_phantom_node_all_fields_patched(self):
+        """Completely bare phantom node gets all required fields."""
+        nodes = {
+            "!ff001122": {}
+        }
+        data = json.dumps(nodes).encode()
+        result = MeshtasticApiProxy._sanitize_nodes_json(data)
+        parsed = json.loads(result)
+
+        node = parsed["!ff001122"]
+        assert isinstance(node["user"], dict)
+        assert node["user"]["longName"]
+        assert node["user"]["shortName"] == "????"
+        assert node["user"]["hwModel"] == "UNSET"
+        assert node["role"] == "CLIENT"
+        assert node["lastHeard"] == 0
+        assert "num" in node

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -242,12 +242,20 @@
             border-radius: 10px;
             padding: 16px;
             min-width: 210px;
+            max-height: calc(100vh - 20px);
+            display: flex;
+            flex-direction: column;
             box-shadow: 0 4px 20px rgba(0,0,0,0.4);
             transition: transform 0.2s;
         }
         .control-panel.collapsed {
             min-width: auto;
             padding: 8px 12px;
+        }
+        .panel-body {
+            overflow-y: auto;
+            flex: 1;
+            min-height: 0;
         }
         .control-panel.collapsed .panel-body {
             display: none;
@@ -435,6 +443,7 @@
                 right: 10px;
                 left: 10px;
                 min-width: auto;
+                max-height: 60vh;
             }
             .legend {
                 bottom: auto;


### PR DESCRIPTION
Port 5000 NOC Map:
- Add max-height and overflow-y to control panel so right menu scrolls within viewport instead of extending off-screen
- Mobile: cap panel at 60vh

Port 9443 phantom nodes (the real bug):
- /mesh/ proxy route was sending ALL requests through proxy_static(), bypassing sanitization entirely. /mesh/json/nodes went directly to meshtasticd without phantom node patching, crashing the React UI.
- Route /mesh/json/nodes through proxy_json() (sanitized)
- Route /mesh/api/v1/fromradio through multiplexed _proxy_fromradio()
- Route /mesh/api/v1/toradio through _proxy_toradio()
- Handle PUT/POST for /mesh/ prefixed API paths

Enhanced sanitization (_sanitize_nodes_json):
- Patch null/non-dict position and deviceMetrics to empty dict
- Add missing lastHeard (default 0) for sort/display
- Parse missing num from hex node key
- Add macaddr/publicKey defaults to user object

Tests: 17 passed (11 existing + 6 new)

https://claude.ai/code/session_016WWaQxqHcLCc6HbWoSkVcC