### PR TITLE
fix: Filter phantom nodes from protobuf stream + fix panel overflow

### DIFF
--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -1,12 +1,59 @@
 # MeshForge Session Notes
 
 **Last Updated**: 2026-02-10
-**Current Branch**: `claude/fix-scroll-phantom-nodes-krlBn`
+**Current Branch**: `claude/fix-port-9443-nodes-MM2kH`
 **Version**: v0.5.2-beta
-**Tests**: 17 passed (api_proxy_sanitize), full suite not run this session
-**Linter**: Not run this session
+**Tests**: 62 passed (34 api_proxy_sanitize + 28 common), linter clean
+**Linter**: Clean
 
-## Session Focus: Web UI Fixes — Scroll + Phantom Nodes (2026-02-10)
+## Session Focus: Port 9443 Phantom Nodes + Web UI Fixes (2026-02-10)
+
+### Root Cause Found — P0 Phantom Nodes
+The Meshtastic React web client gets node data via **protobuf streaming** (`/api/v1/fromradio`), NOT from `/json/nodes`. The previous fix sanitized JSON but the protobuf packets were forwarded raw to clients. Phantom NodeInfo packets (MQTT nodes without User data) caused React to crash on `node.user.longName`.
+
+### What Was Done
+
+**P0: Phantom Node Fix — TWO-LAYER DEFENSE**
+1. **Server-side protobuf filtering** (`meshtastic_api_proxy.py`):
+   - Added raw protobuf wire format parser (`_read_varint`, `_extract_protobuf_fields`)
+   - `_is_phantom_nodeinfo()` detects `FromRadio.node_info` packets missing User field
+   - `_distribute_packet()` now drops phantom NodeInfo before distributing to clients
+   - Added `phantom_nodes_filtered` stats counter
+2. **Client-side JS error protection** (`map_http_handler.py`):
+   - Injected `window.onerror` + `unhandledrejection` handlers into proxied HTML
+   - Catches "Cannot read properties of null/undefined" as safety net
+   - Prevents React white-screen-of-death from any remaining phantom data
+
+**P1: Right Panel Info Clipping — FIXED** (`web/node_map.html`)
+- Added `max-width: 280px` to `.control-panel`
+- Added `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` to `.stat-row .value`
+- Added `flex-shrink: 0` to `.stat-row .label` so labels don't compress
+- Added `gap: 8px` between label and value for consistent spacing
+
+**P2: Radio Message "Went Nowhere" — IMPROVED** (`map_http_handler.py`, `node_map.html`)
+- Improved error messages: now returns actionable detail (library install, TCP port check)
+- Changed success to "Sent via radio (delivery best-effort)" — sets correct user expectation
+- JS now shows `data.detail` as tooltip, longer display for errors (8s vs 3s)
+- HTTP status codes: 503 for missing library, 502 for send failure
+
+### Changes This Session
+- `src/gateway/meshtastic_api_proxy.py` — protobuf phantom filtering, wire format parser
+- `src/utils/map_http_handler.py` — JS error protection injection, radio API error improvement
+- `web/node_map.html` — panel CSS overflow fix, radio send feedback improvement
+- `tests/test_api_proxy_sanitize.py` — 17 new tests (protobuf filtering + wire format)
+
+### What About ip:9443 Directly?
+Users going to ip:9443 bypass MeshForge entirely — there's no fix possible at the proxy level. Options for next session:
+- **Tell users to use ip:5000/mesh/** — this is now the sanitized path
+- **iptables redirect** 9443→5000 (requires root, add to install script)
+- **Disable meshtasticd web server** and serve exclusively through MeshForge
+
+### P3: rnsd Permission Fix — UNTESTED
+Committed last session. Needs hardware verification on MOC2.
+
+---
+
+## Previous Session: Web UI Fixes — Scroll + Phantom Nodes (2026-02-10)
 
 User reported two issues from hardware testing:
 1. **ip:5000** — Right menu won't scroll, can't see bottom information

--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -71,6 +71,7 @@ class ProxyStats:
     json_proxied: int = 0
     active_clients: int = 0
     errors: int = 0
+    phantom_nodes_filtered: int = 0
     started_at: Optional[datetime] = None
     last_packet_time: Optional[datetime] = None
 
@@ -405,6 +406,136 @@ class MeshtasticApiProxy:
 
         return data
 
+    # ─────────────────────────────────────────────────────────────────
+    # Protobuf-level phantom node filtering
+    # ─────────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def _read_varint(data: bytes, pos: int):
+        """Read a protobuf varint from data at position.
+
+        Returns:
+            (value, new_pos) on success, (None, None) on error.
+        """
+        result = 0
+        shift = 0
+        while pos < len(data):
+            byte = data[pos]
+            pos += 1
+            result |= (byte & 0x7F) << shift
+            if not (byte & 0x80):
+                return result, pos
+            shift += 7
+            if shift > 63:
+                return None, None
+        return None, None
+
+    @staticmethod
+    def _extract_protobuf_fields(data: bytes):
+        """Extract top-level field numbers and payloads from raw protobuf.
+
+        Returns:
+            Dict mapping field_number -> list of (wire_type, value).
+            For wire_type 2 (length-delimited), value is raw bytes.
+            For wire_type 0 (varint), value is int.
+        """
+        fields = {}
+        pos = 0
+        while pos < len(data):
+            tag, new_pos = MeshtasticApiProxy._read_varint(data, pos)
+            if new_pos is None or tag is None:
+                break
+            pos = new_pos
+
+            field_number = tag >> 3
+            wire_type = tag & 0x07
+
+            if wire_type == 0:  # Varint
+                value, new_pos = MeshtasticApiProxy._read_varint(data, pos)
+                if new_pos is None:
+                    break
+                pos = new_pos
+            elif wire_type == 2:  # Length-delimited
+                length, new_pos = MeshtasticApiProxy._read_varint(data, pos)
+                if new_pos is None or length is None:
+                    break
+                pos = new_pos
+                if pos + length > len(data):
+                    break
+                value = data[pos:pos + length]
+                pos += length
+            elif wire_type == 5:  # 32-bit fixed
+                if pos + 4 > len(data):
+                    break
+                value = data[pos:pos + 4]
+                pos += 4
+            elif wire_type == 1:  # 64-bit fixed
+                if pos + 8 > len(data):
+                    break
+                value = data[pos:pos + 8]
+                pos += 8
+            else:
+                break  # Unknown wire type
+
+            if field_number not in fields:
+                fields[field_number] = []
+            fields[field_number].append((wire_type, value))
+
+        return fields
+
+    @staticmethod
+    def _is_phantom_nodeinfo(data: bytes) -> bool:
+        """Check if a FromRadio packet is a phantom NodeInfo without User.
+
+        The Meshtastic React web client crashes when it receives NodeInfo
+        protobuf messages that lack a User sub-message.  These typically
+        come from MQTT phantom nodes.
+
+        Protobuf wire format reference:
+            FromRadio field 4 (node_info) = tag 0x22 (length-delimited)
+            NodeInfo  field 2 (user)      = tag 0x12 (length-delimited)
+
+        Returns:
+            True if the packet is a NodeInfo WITHOUT User (should be filtered).
+            False for all other packets (pass through).
+        """
+        if not data or len(data) < 4:
+            return False
+
+        try:
+            top_fields = MeshtasticApiProxy._extract_protobuf_fields(data)
+        except Exception:
+            return False  # Parse error — don't filter
+
+        # Check for FromRadio field 4 (node_info)
+        if 4 not in top_fields:
+            return False  # Not a NodeInfo packet — pass through
+
+        # Extract the NodeInfo payload
+        for wire_type, value in top_fields[4]:
+            if wire_type != 2 or not isinstance(value, bytes):
+                continue
+
+            # Parse NodeInfo sub-message
+            try:
+                ni_fields = MeshtasticApiProxy._extract_protobuf_fields(value)
+            except Exception:
+                continue
+
+            # Check for NodeInfo field 2 (user)
+            if 2 not in ni_fields:
+                return True  # NodeInfo without User → phantom node
+
+            # User field exists — check if it has any content
+            for uw, uv in ni_fields[2]:
+                if uw == 2 and isinstance(uv, bytes) and len(uv) > 0:
+                    return False  # Has User data → legitimate node
+
+            # User field is present but empty → still phantom
+            return True
+
+        return False
+
     def proxy_static(self, path: str) -> Optional[tuple]:
         """Proxy a static file from meshtasticd's web server.
 
@@ -503,7 +634,16 @@ class MeshtasticApiProxy:
             return None
 
     def _distribute_packet(self, data: bytes):
-        """Copy a FromRadio packet to all registered client buffers."""
+        """Copy a FromRadio packet to all registered client buffers.
+
+        Filters out phantom NodeInfo packets (MQTT nodes without User data)
+        that crash the Meshtastic React web client.
+        """
+        if self._is_phantom_nodeinfo(data):
+            self._stats.phantom_nodes_filtered += 1
+            logger.debug("Filtered phantom NodeInfo (no User field) from fromradio stream")
+            return
+
         with self._lock:
             delivered = 0
             for session in self._clients.values():

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -204,24 +204,36 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
 
             conn = self._get_radio_connection()
             if not conn:
-                self._serve_json({"error": "meshtastic library not available"}, status=500)
+                self._serve_json({
+                    "error": "Radio not available",
+                    "detail": "meshtastic Python library not installed. "
+                              "Install with: pip3 install meshtastic",
+                }, status=503)
                 return
 
             success = conn.send_message(text, destination)
             if success:
                 self._serve_json({
                     "success": True,
-                    "message": "Message sent",
+                    "message": "Sent via radio (delivery best-effort)",
                     "destination": destination,
                     "connection_mode": conn.get_mode()
                 })
             else:
-                self._serve_json({"error": "Failed to send message"}, status=500)
+                self._serve_json({
+                    "error": "Send failed — check meshtasticd TCP connection (port 4403)",
+                    "detail": "The message could not be sent. Verify meshtasticd is running "
+                              "and TCP is enabled.",
+                }, status=502)
 
         except json.JSONDecodeError:
             self._serve_json({"error": "Invalid JSON"}, status=400)
         except Exception as e:
-            self._serve_json({"error": str(e)}, status=500)
+            logger.warning(f"Radio message send error: {e}")
+            self._serve_json({
+                "error": f"Send error: {e}",
+                "detail": "Check meshtasticd logs: journalctl -u meshtasticd -f",
+            }, status=500)
 
     def _serve_static_html(self):
         """Serve static HTML files with no-cache headers."""
@@ -1119,16 +1131,40 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             content, content_type = result
 
             # For the index.html, inject base href so relative paths work
+            # Also inject phantom node error protection as a safety net
             if path == '/' or path.endswith('.html'):
                 if isinstance(content, bytes):
                     content_str = content.decode('utf-8', errors='replace')
-                    # Rewrite API URLs to go through MeshForge proxy
+                    # Rewrite API URLs + inject phantom node protection
                     content_str = content_str.replace(
                         '</head>',
                         '<base href="/mesh/">\n'
                         '<script>\n'
-                        '// MeshForge API proxy: rewrite API calls to go through MeshForge\n'
+                        '// MeshForge API proxy + phantom node protection\n'
                         'window.__MESHFORGE_PROXY__ = true;\n'
+                        '// Safety net: catch null-property errors from incomplete\n'
+                        '// MQTT phantom nodes that slip past protobuf filtering.\n'
+                        '(function(){\n'
+                        '  var origError = window.onerror;\n'
+                        '  window.onerror = function(msg, src, line, col, err) {\n'
+                        '    if (typeof msg === "string" &&\n'
+                        '        (msg.indexOf("Cannot read properties of null") !== -1 ||\n'
+                        '         msg.indexOf("Cannot read properties of undefined") !== -1 ||\n'
+                        '         msg.indexOf("Cannot read property") !== -1)) {\n'
+                        '      console.warn("[MeshForge] Phantom node error caught:", msg);\n'
+                        '      return true;\n'
+                        '    }\n'
+                        '    return origError ? origError(msg, src, line, col, err) : false;\n'
+                        '  };\n'
+                        '  window.addEventListener("unhandledrejection", function(e) {\n'
+                        '    var m = (e.reason && e.reason.message) || String(e.reason || "");\n'
+                        '    if (m.indexOf("Cannot read properties of null") !== -1 ||\n'
+                        '        m.indexOf("Cannot read properties of undefined") !== -1) {\n'
+                        '      console.warn("[MeshForge] Phantom node rejection caught:", m);\n'
+                        '      e.preventDefault();\n'
+                        '    }\n'
+                        '  });\n'
+                        '})();\n'
                         '</script>\n'
                         '</head>'
                     )

--- a/tests/test_api_proxy_sanitize.py
+++ b/tests/test_api_proxy_sanitize.py
@@ -2,18 +2,92 @@
 Tests for MeshtasticApiProxy node sanitization.
 
 The Meshtastic web client crashes when clicking nodes with incomplete
-data (phantom nodes from MQTT). The proxy sanitizes /json/nodes responses
-to ensure all nodes have required fields.
+data (phantom nodes from MQTT). The proxy sanitizes:
+1. /json/nodes responses (JSON-level) — for REST API consumers
+2. /api/v1/fromradio protobuf packets — for the React web client
 
 See: https://github.com/meshtastic/web/issues/862
 """
 
 import json
+import struct
 import pytest
 
 
 # Import the static method directly
 from gateway.meshtastic_api_proxy import MeshtasticApiProxy
+
+
+# ────────────────────────────────────────────────────────────────────
+# Protobuf wire format helpers for building test packets
+# ────────────────────────────────────────────────────────────────────
+
+def _encode_varint(value: int) -> bytes:
+    """Encode an integer as a protobuf varint."""
+    result = bytearray()
+    while value > 0x7F:
+        result.append((value & 0x7F) | 0x80)
+        value >>= 7
+    result.append(value & 0x7F)
+    return bytes(result)
+
+
+def _encode_field_varint(field_number: int, value: int) -> bytes:
+    """Encode a varint field (wire type 0)."""
+    tag = _encode_varint((field_number << 3) | 0)
+    return tag + _encode_varint(value)
+
+
+def _encode_field_bytes(field_number: int, data: bytes) -> bytes:
+    """Encode a length-delimited field (wire type 2)."""
+    tag = _encode_varint((field_number << 3) | 2)
+    return tag + _encode_varint(len(data)) + data
+
+
+def _encode_field_string(field_number: int, text: str) -> bytes:
+    """Encode a string field (wire type 2)."""
+    return _encode_field_bytes(field_number, text.encode('utf-8'))
+
+
+def _build_user_proto(long_name: str = "TestNode", short_name: str = "TST") -> bytes:
+    """Build a User protobuf sub-message."""
+    return (
+        _encode_field_string(2, long_name) +    # long_name = field 2
+        _encode_field_string(3, short_name)     # short_name = field 3
+    )
+
+
+def _build_nodeinfo_proto(num: int, user: bytes = None) -> bytes:
+    """Build a NodeInfo protobuf sub-message."""
+    result = _encode_field_varint(1, num)       # num = field 1
+    if user is not None:
+        result += _encode_field_bytes(2, user)  # user = field 2
+    return result
+
+
+def _build_fromradio_nodeinfo(node_num: int, user: bytes = None) -> bytes:
+    """Build a FromRadio protobuf containing a NodeInfo."""
+    nodeinfo = _build_nodeinfo_proto(node_num, user)
+    return (
+        _encode_field_varint(1, 1) +               # id = field 1
+        _encode_field_bytes(4, nodeinfo)            # node_info = field 4
+    )
+
+
+def _build_fromradio_config_complete(config_id: int = 42) -> bytes:
+    """Build a FromRadio with config_complete_id (field 7, varint)."""
+    return (
+        _encode_field_varint(1, 1) +               # id = field 1
+        _encode_field_varint(7, config_id)          # config_complete_id = field 7
+    )
+
+
+def _build_fromradio_meshpacket(packet_data: bytes = b'\x01\x02') -> bytes:
+    """Build a FromRadio with a MeshPacket (field 9)."""
+    return (
+        _encode_field_varint(1, 2) +               # id = field 1
+        _encode_field_bytes(9, packet_data)         # packet = field 9
+    )
 
 
 class TestSanitizeNodesJson:
@@ -340,3 +414,128 @@ class TestSanitizeNodesJson:
         assert node["role"] == "CLIENT"
         assert node["lastHeard"] == 0
         assert "num" in node
+
+
+class TestProtobufPhantomNodeFilter:
+    """Tests for _is_phantom_nodeinfo protobuf-level filtering.
+
+    The Meshtastic React web client receives node data via protobuf
+    streaming (/api/v1/fromradio), not JSON.  Phantom NodeInfo packets
+    with missing User data crash the React UI when clicked.
+
+    These tests construct real protobuf wire-format packets to verify
+    the filter correctly identifies and drops phantom nodes while
+    passing through all other packet types.
+    """
+
+    def test_phantom_nodeinfo_no_user(self):
+        """NodeInfo without User field is detected as phantom."""
+        packet = _build_fromradio_nodeinfo(node_num=0xDEADBEEF)
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is True
+
+    def test_healthy_nodeinfo_with_user(self):
+        """NodeInfo with User field passes through."""
+        user = _build_user_proto(long_name="Hilltop-1", short_name="HT1")
+        packet = _build_fromradio_nodeinfo(node_num=0xAABBCCDD, user=user)
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is False
+
+    def test_config_complete_passes_through(self):
+        """config_complete_id (field 7) is not a NodeInfo — passes through."""
+        packet = _build_fromradio_config_complete(config_id=42)
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is False
+
+    def test_meshpacket_passes_through(self):
+        """MeshPacket (field 9) is not a NodeInfo — passes through."""
+        packet = _build_fromradio_meshpacket(b'\x08\x01\x10\x02')
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is False
+
+    def test_empty_data_passes_through(self):
+        """Empty data passes through (not a phantom)."""
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(b'') is False
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(b'\x00') is False
+
+    def test_short_data_passes_through(self):
+        """Very short data (< 4 bytes) passes through."""
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(b'\x08\x01') is False
+
+    def test_corrupt_data_passes_through(self):
+        """Corrupted protobuf passes through (don't filter what we can't parse)."""
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(b'\xFF\xFF\xFF\xFF\xFF') is False
+
+    def test_nodeinfo_with_empty_user(self):
+        """NodeInfo with empty User sub-message is detected as phantom."""
+        # User field present but 0 bytes (no long_name/short_name inside)
+        packet = _build_fromradio_nodeinfo(node_num=0x11223344, user=b'')
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is True
+
+    def test_nodeinfo_with_minimal_user(self):
+        """NodeInfo with just a short_name in User is NOT phantom."""
+        user = _encode_field_string(3, "X")  # short_name only
+        packet = _build_fromradio_nodeinfo(node_num=0x55667788, user=user)
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(packet) is False
+
+    def test_multiple_phantom_nodeinfo_sequential(self):
+        """Multiple phantom checks don't interfere with each other."""
+        phantom = _build_fromradio_nodeinfo(node_num=0xAAAA)
+        user = _build_user_proto("Node-A", "NA")
+        healthy = _build_fromradio_nodeinfo(node_num=0xBBBB, user=user)
+        config = _build_fromradio_config_complete(99)
+
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(phantom) is True
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(healthy) is False
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(config) is False
+        assert MeshtasticApiProxy._is_phantom_nodeinfo(phantom) is True
+
+
+class TestProtobufWireFormatHelpers:
+    """Tests for the _read_varint and _extract_protobuf_fields helpers."""
+
+    def test_read_varint_single_byte(self):
+        """Single-byte varint (value < 128)."""
+        val, pos = MeshtasticApiProxy._read_varint(b'\x05', 0)
+        assert val == 5
+        assert pos == 1
+
+    def test_read_varint_multi_byte(self):
+        """Multi-byte varint (value >= 128)."""
+        # 300 = 0b100101100 → encoded as [0xAC, 0x02]
+        val, pos = MeshtasticApiProxy._read_varint(b'\xAC\x02', 0)
+        assert val == 300
+        assert pos == 2
+
+    def test_read_varint_at_offset(self):
+        """Varint read starting at non-zero offset."""
+        val, pos = MeshtasticApiProxy._read_varint(b'\x00\x00\x07', 2)
+        assert val == 7
+        assert pos == 3
+
+    def test_read_varint_empty(self):
+        """Varint from empty data returns None."""
+        val, pos = MeshtasticApiProxy._read_varint(b'', 0)
+        assert val is None
+        assert pos is None
+
+    def test_extract_fields_varint(self):
+        """Extract a varint field from protobuf bytes."""
+        # Field 1, wire type 0, value 42 → tag=0x08, value=0x2A
+        data = _encode_field_varint(1, 42)
+        fields = MeshtasticApiProxy._extract_protobuf_fields(data)
+        assert 1 in fields
+        assert fields[1][0] == (0, 42)  # (wire_type, value)
+
+    def test_extract_fields_length_delimited(self):
+        """Extract a length-delimited field from protobuf bytes."""
+        data = _encode_field_bytes(4, b'\x08\x01')
+        fields = MeshtasticApiProxy._extract_protobuf_fields(data)
+        assert 4 in fields
+        assert fields[4][0] == (2, b'\x08\x01')
+
+    def test_extract_multiple_fields(self):
+        """Extract multiple fields from a single message."""
+        data = (
+            _encode_field_varint(1, 1) +
+            _encode_field_bytes(4, b'\x08\xFF\x01')
+        )
+        fields = MeshtasticApiProxy._extract_protobuf_fields(data)
+        assert 1 in fields
+        assert 4 in fields

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -242,11 +242,13 @@
             border-radius: 10px;
             padding: 16px;
             min-width: 210px;
+            max-width: 280px;
             max-height: calc(100vh - 20px);
             display: flex;
             flex-direction: column;
             box-shadow: 0 4px 20px rgba(0,0,0,0.4);
             transition: transform 0.2s;
+            overflow: hidden;
         }
         .control-panel.collapsed {
             min-width: auto;
@@ -285,11 +287,21 @@
         .stat-row {
             display: flex;
             justify-content: space-between;
+            align-items: baseline;
             padding: 3px 0;
             font-size: 12px;
+            gap: 8px;
         }
-        .stat-row .label { color: #6a7a8a; }
-        .stat-row .value { color: #e0e0e0; font-weight: 600; }
+        .stat-row .label { color: #6a7a8a; white-space: nowrap; flex-shrink: 0; }
+        .stat-row .value {
+            color: #e0e0e0;
+            font-weight: 600;
+            text-align: right;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            min-width: 0;
+        }
         .stat-row .value.online { color: #66bb6a; }
 
         .filter-section {
@@ -4447,20 +4459,24 @@
             const data = await response.json();
 
             if (response.ok && data.success) {
-                statusEl.textContent = 'Message sent!';
+                statusEl.textContent = data.message || 'Sent (best-effort)';
                 statusEl.style.color = '#66bb6a';
                 document.getElementById('radio-message-text').value = '';
+                // Keep success message visible longer
+                setTimeout(() => { statusEl.textContent = ''; }, 5000);
             } else {
                 statusEl.textContent = data.error || 'Send failed';
                 statusEl.style.color = '#ef5350';
+                if (data.detail) {
+                    statusEl.title = data.detail;
+                }
+                setTimeout(() => { statusEl.textContent = ''; }, 8000);
             }
         } catch (e) {
-            statusEl.textContent = 'Network error';
+            statusEl.textContent = 'Network error — is MeshForge running?';
             statusEl.style.color = '#ef5350';
+            setTimeout(() => { statusEl.textContent = ''; }, 5000);
         }
-
-        // Clear status after 3 seconds
-        setTimeout(() => { statusEl.textContent = ''; }, 3000);
     }
 
     // ============================================


### PR DESCRIPTION
Root cause: Meshtastic React web client gets node data via protobuf streaming (/api/v1/fromradio), not /json/nodes. MQTT phantom nodes with missing User data crash React when clicked.

Two-layer defense:
- Server: Parse protobuf wire format in _distribute_packet(), drop NodeInfo packets without User field before reaching web clients
- Client: Inject error handlers into proxied HTML as safety net

Also fixes:
- P1: Right panel stat values clipped (max-width + text-overflow)
- P2: Radio message send now returns actionable error diagnostics

Tests: 34 pass (17 new protobuf filtering tests)

https://claude.ai/code/session_01NXd2qt9mkvjDShj9eMXDu3