### PR TITLE
refactor: MeshForge owns the browser — serve web client from disk

### DIFF
--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -1,12 +1,98 @@
 # MeshForge Session Notes
 
 **Last Updated**: 2026-02-10
-**Current Branch**: `claude/fix-port-9443-nodes-MM2kH`
+**Current Branch**: `claude/session-management-system-TW5ho`
 **Version**: v0.5.2-beta
-**Tests**: 62 passed (34 api_proxy_sanitize + 28 common), linter clean
+**Tests**: 151 passed (21 web_client_ownership + 34 api_proxy_sanitize + 78 message_queue + 18 security), linter clean
 **Linter**: Clean
 
-## Session Focus: Port 9443 Phantom Nodes + Web UI Fixes (2026-02-10)
+## Session Focus: MeshForge Owns the Browser (2026-02-10)
+
+### The Problem
+meshtasticd's protobuf stream (`/api/v1/fromradio`) is single-consumer. When MeshForge opens it for the NOC, the web client at port 9443 starves. Users going to ip:9443 directly also bypass MeshForge's phantom node filtering. The hybrid browser at ip:5000 tried to replicate messaging that the Meshtastic web client already does well.
+
+### Architecture Decision: Own the Browser
+MeshForge now **owns the delivery** of the Meshtastic web client:
+```
+User → ip:5000 ─┬─ /          → MeshForge NOC dashboard
+                 ├─ /mesh/     → Meshtastic web client (from disk)
+                 ├─ /mesh/api/v1/*  → multiplexed proxy (phantom filtered)
+                 └─ /mesh/json/*    → sanitized proxy
+meshtasticd:9443 → localhost only (iptables blocks external)
+```
+
+### What Was Done
+
+**1. Static file serving from disk** (`map_http_handler.py`)
+- Replaced `_proxy_mesh_client()` (fragile HTML proxy + JS injection) with `_serve_mesh_web_client()`
+- Serves files directly from `/usr/share/meshtasticd/web/` — no proxying HTML/JS/CSS
+- SPA fallback: non-file routes get index.html (React router support)
+- Path traversal protection (reject `..`, resolve symlinks, check dir boundary)
+- Proper cache headers (no-cache for HTML, 1hr for static assets)
+- CORS headers on all responses
+
+**2. Removed fragile code**
+- Deleted `_proxy_mesh_client()` — 101 lines of HTML proxying + JS injection
+- Deleted `_serve_mesh_client_fallback()` — replaced with `_serve_mesh_client_unavailable()`
+- Removed `<base href="/mesh/">` injection hack
+- Removed `window.onerror` / `unhandledrejection` JS injection
+- Removed `window.__MESHFORGE_PROXY__` flag
+- Renamed `proxy_static()` → `proxy_endpoint()` (clarity: it proxies action endpoints, not static files)
+
+**3. API routing preserved**
+- `/mesh/api/v1/fromradio` → multiplexed proxy (stream sharing)
+- `/mesh/api/v1/toradio` → forwarded to meshtasticd
+- `/mesh/json/nodes` → sanitized proxy (phantom node filtering)
+- `/mesh/json/report`, `/mesh/json/blink` → proxied
+- All root-level routes unchanged (`/api/v1/*`, `/json/*`)
+
+**4. Radio panel removed from NOC** (`node_map.html`)
+- Removed radio control HTML panel (status, mode, send message form)
+- Removed `refreshRadioStatus()` and `sendRadioMessage()` JS functions
+- Removed `setInterval(refreshRadioStatus, 30000)` init call
+- Added "Open Meshtastic Web Client" link to `/mesh/`
+
+**5. TUI updated** (`web_client_mixin.py`)
+- URLs now point to `http://ip:5000/mesh/` instead of `https://ip:9443`
+- Health check verifies both port 5000 (MeshForge) and port 9443 (meshtasticd API)
+- Menu text updated to reflect MeshForge-owned serving
+- URL display shows `/mesh/` path and NOC at `/`
+
+**6. Port lockdown** (`service_check.py`)
+- Added `lock_port_external(port)` — iptables rule blocks external access
+- Added `unlock_port_external(port)` — removes the rule
+- Idempotent (no duplicate rules), handles missing iptables
+- Default: port 9443 (meshtasticd)
+
+**7. Tests** (`test_web_client_ownership.py`)
+- 13 tests for static file serving (root, assets, API routing, SPA fallback, path traversal, caching, no injection)
+- 6 tests for port lockdown (add, idempotent, custom port, no iptables, unlock)
+- 2 tests for proxy_endpoint rename verification
+- All 151 tests pass
+
+### Files Changed
+- `src/utils/map_http_handler.py` — static file handler, removed HTML proxy
+- `src/gateway/meshtastic_api_proxy.py` — proxy_static → proxy_endpoint rename
+- `web/node_map.html` — removed radio panel, added web client link
+- `src/launcher_tui/web_client_mixin.py` — URLs to port 5000/mesh/
+- `src/utils/service_check.py` — lock_port_external/unlock_port_external
+- `tests/test_web_client_ownership.py` — 21 new tests
+
+### Hardware Testing Needed
+- Verify `/mesh/` serves meshtasticd's React app from `/usr/share/meshtasticd/web/`
+- Verify the web client can send/receive messages through the multiplexed proxy
+- Verify `lock_port_external(9443)` blocks external access
+- Test from mobile device: `http://ip:5000/mesh/`
+
+### Remaining / Next Session
+- **iptables persistence**: Rule is not persistent across reboot — needs `iptables-persistent` or systemd service
+- **TUI menu**: Add "Lock Port 9443" option to service management menu
+- **HTTPS on port 5000**: Currently HTTP only — may need SSL for production
+- **Startup integration**: Auto-call `lock_port_external(9443)` when MeshForge starts
+
+---
+
+## Previous Session: Port 9443 Phantom Nodes + Web UI Fixes (2026-02-10)
 
 ### Root Cause Found — P0 Phantom Nodes
 The Meshtastic React web client gets node data via **protobuf streaming** (`/api/v1/fromradio`), NOT from `/json/nodes`. The previous fix sanitized JSON but the protobuf packets were forwarded raw to clients. Phantom NodeInfo packets (MQTT nodes without User data) caused React to crash on `node.user.longName`.

--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -536,8 +536,10 @@ class MeshtasticApiProxy:
 
         return False
 
-    def proxy_static(self, path: str) -> Optional[tuple]:
-        """Proxy a static file from meshtasticd's web server.
+    def proxy_endpoint(self, path: str) -> Optional[tuple]:
+        """Proxy a GET request to meshtasticd and return the response.
+
+        Used for action endpoints like /json/blink, /restart, etc.
 
         Returns:
             Tuple of (content_bytes, content_type) or None on error.

--- a/src/launcher_tui/web_client_mixin.py
+++ b/src/launcher_tui/web_client_mixin.py
@@ -24,7 +24,12 @@ class WebClientMixin:
     """Mixin providing meshtasticd web client tools for the TUI launcher."""
 
     def _open_web_client(self):
-        """Show/open meshtasticd web client for full radio configuration."""
+        """Show/open Meshtastic web client served by MeshForge.
+
+        MeshForge owns the browser — the Meshtastic web client is served
+        at http://ip:5000/mesh/ through MeshForge's multiplexed API proxy.
+        This ensures phantom node filtering and proper stream sharing.
+        """
         # Get local IP for network access
         local_ip = "localhost"
         try:
@@ -38,38 +43,56 @@ class WebClientMixin:
         except OSError as e:
             logger.debug("Local IP detection failed: %s", e)
 
-        web_url = f"https://{local_ip}:9443"
-        localhost_url = "https://localhost:9443"
+        meshforge_port = 5000
+        web_url = f"http://{local_ip}:{meshforge_port}/mesh/"
+        localhost_url = f"http://localhost:{meshforge_port}/mesh/"
 
-        # Check if web server is responding (try localhost first, then IP)
-        port_ok = False
-        for check_host in ["localhost", local_ip]:
-            if check_host == local_ip and local_ip == "localhost":
-                continue  # Skip duplicate check
+        # Check MeshForge web server is running (port 5000)
+        meshforge_ok = False
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                try:
-                    sock.settimeout(2)
-                    if sock.connect_ex((check_host, 9443)) == 0:
-                        port_ok = True
-                        break
-                finally:
-                    sock.close()
-            except Exception as e:
-                logger.debug(f"Socket check for web client ({check_host}): {e}")
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", meshforge_port)) == 0:
+                    meshforge_ok = True
+            finally:
+                sock.close()
+        except Exception as e:
+            logger.debug("Socket check for MeshForge web server: %s", e)
 
-        if not port_ok:
-            # Web client not responding - show setup help
+        # Check meshtasticd is running (needed for API backend)
+        meshtasticd_ok = False
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            try:
+                sock.settimeout(2)
+                if sock.connect_ex(("localhost", 9443)) == 0:
+                    meshtasticd_ok = True
+            finally:
+                sock.close()
+        except Exception as e:
+            logger.debug("Socket check for meshtasticd: %s", e)
+
+        if not meshforge_ok:
             self.dialog.msgbox(
-                "Web Client Not Running",
-                "meshtasticd Web Client is NOT responding.\n\n"
-                "To enable the web interface:\n\n"
+                "MeshForge Web Server Not Running",
+                "MeshForge web server is NOT responding on port 5000.\n\n"
+                "The web server starts with the NOC map.\n"
+                "Check Maps & Viz > NOC Node Map to start it.\n\n"
+                "Or start it from command line:\n"
+                "  sudo python3 src/launcher_tui/main.py"
+            )
+            return
+
+        if not meshtasticd_ok:
+            self.dialog.msgbox(
+                "meshtasticd Not Running",
+                "meshtasticd is NOT responding on port 9443.\n\n"
+                "The web client needs meshtasticd for radio access.\n\n"
                 "1. Start meshtasticd:\n"
                 "   sudo systemctl start meshtasticd\n\n"
                 "2. Check status:\n"
                 "   sudo systemctl status meshtasticd\n\n"
-                "3. View logs for errors:\n"
-                "   sudo journalctl -u meshtasticd -f\n\n"
                 "Note: Ensure config has Webserver section with Port: 9443"
             )
             return
@@ -77,7 +100,6 @@ class WebClientMixin:
         # Pre-flight health check — detect issues that hang/crash the web client
         warnings = self._web_client_preflight()
         if warnings:
-            # Show warnings and let user choose to continue or fix
             warning_text = "\n".join(warnings)
             if not self.dialog.yesno(
                 "Web Client Health Check",
@@ -87,7 +109,7 @@ class WebClientMixin:
             ):
                 return
 
-        # Web client is running - show options
+        # Both services running - show options
         while True:
             choices = [
                 ("open", "Open in Browser      Launch in default browser"),
@@ -98,11 +120,11 @@ class WebClientMixin:
 
             choice = self.dialog.menu(
                 "Meshtastic Web Client",
-                "Web Client is RUNNING on port 9443\n\n"
+                "Web Client available at port 5000/mesh/\n"
+                "Served by MeshForge (multiplexed API proxy)\n\n"
                 "Full radio configuration via browser:\n"
-                "  Config, Channels, Device, Position\n\n"
+                "  Config, Channels, Device, Position, Messaging\n\n"
                 "Requires a graphical browser (JavaScript).\n"
-                "Text browsers (lynx) cannot render the UI.\n"
                 "Use Show URLs to access from another device.",
                 choices,
                 height=20, width=65
@@ -186,13 +208,13 @@ class WebClientMixin:
         self.dialog.msgbox(
             "Web Client URLs",
             f"Access from THIS device:\n"
-            f"  https://localhost:9443\n\n"
+            f"  http://localhost:5000/mesh/\n\n"
             f"Access from OTHER devices on network:\n"
-            f"  https://{local_ip}:9443\n\n"
-            f"Mobile/tablet (same WiFi):\n"
-            f"  Use the IP address above\n\n"
+            f"  http://{local_ip}:5000/mesh/\n\n"
+            f"MeshForge NOC Map:\n"
+            f"  http://{local_ip}:5000/\n\n"
             f"Requires graphical browser (JavaScript).\n"
-            f"Port 9443 = HTTPS Web UI\n"
+            f"Port 5000 = MeshForge (web client + NOC)\n"
             f"Port 4403 = TCP API (CLI/SDK)",
             height=18, width=60
         )

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -20,9 +20,13 @@ Endpoints:
 Meshtastic API Proxy (MeshForge-owned):
 - GET  /api/v1/fromradio -> multiplexed protobuf packets from meshtasticd
 - PUT  /api/v1/toradio   -> forwarded to meshtasticd
-- GET  /json/nodes       -> proxied from meshtasticd
+- GET  /json/nodes       -> proxied + sanitized from meshtasticd
 - GET  /json/report      -> proxied from meshtasticd
-- GET  /mesh/*           -> meshtastic web client (proxied from meshtasticd)
+
+Meshtastic Web Client (MeshForge-owned, served from disk):
+- GET  /mesh/            -> meshtastic web client (from /usr/share/meshtasticd/web/)
+- GET  /mesh/api/v1/*    -> routed through MeshForge multiplexed proxy
+- GET  /mesh/json/*      -> routed through MeshForge sanitized proxy
 
 Radio Control API (MeshForge-owned):
 - GET /api/radio/info     -> radio device information
@@ -35,6 +39,7 @@ Radio Control API (MeshForge-owned):
 import json
 import logging
 import math
+import mimetypes
 import time
 from datetime import datetime
 from http.server import SimpleHTTPRequestHandler
@@ -42,6 +47,10 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+# Default path where meshtasticd installs its web client files.
+# MeshForge serves these directly from disk instead of proxying HTML.
+MESHTASTICD_WEB_DIR = '/usr/share/meshtasticd/web'
 
 
 class MapRequestHandler(SimpleHTTPRequestHandler):
@@ -121,7 +130,7 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         elif self.path == '/json/blink' or self.path == '/json/blink/':
             self._proxy_json('/json/blink')
         elif self.path.startswith('/mesh/') or self.path == '/mesh':
-            self._proxy_mesh_client()
+            self._serve_mesh_web_client()
         elif self.path == '/api/proxy/status' or self.path == '/api/proxy/status/':
             self._serve_proxy_status()
         # ─────────────────────────────────────────────────────────────
@@ -1068,7 +1077,7 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             self.send_error(503, "Meshtastic API proxy not running")
             return
 
-        result = self.api_proxy.proxy_static(path)
+        result = self.api_proxy.proxy_endpoint(path)
         if result:
             content, content_type = result
             self.send_response(200)
@@ -1080,36 +1089,29 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         else:
             self.send_error(502, f"Could not proxy {path}")
 
-    def _proxy_mesh_client(self):
-        """Serve the Meshtastic web client proxied from meshtasticd.
+    def _serve_mesh_web_client(self):
+        """Serve the Meshtastic web client from disk.
 
-        /mesh/         -> meshtasticd's index.html
-        /mesh/assets/* -> meshtasticd's static assets
+        MeshForge owns the browser — serves meshtasticd's web client files
+        directly from /usr/share/meshtasticd/web/ instead of proxying HTML
+        through the network.  API calls are routed through MeshForge's
+        multiplexed proxy so the web client gets proper phantom-node
+        filtering and stream multiplexing.
 
-        API endpoints under /mesh/ are routed through MeshForge's proper
-        handlers (sanitized, multiplexed) instead of raw proxy_static():
-        - /mesh/json/nodes   -> proxy_json (sanitizes phantom nodes)
-        - /mesh/json/report  -> proxy_json
-        - /mesh/api/v1/fromradio -> multiplexed fromradio
-        - /mesh/api/v1/toradio   -> forwarded toradio
+        Static files:  /mesh/*           -> disk read from MESHTASTICD_WEB_DIR
+        API proxied:   /mesh/api/v1/*    -> MeshForge multiplexed proxy
+                       /mesh/json/*      -> MeshForge sanitized proxy
         """
-        if not self.api_proxy:
-            # Return a helpful page instead of an error
-            self._serve_mesh_client_fallback()
-            return
-
-        # Map /mesh/ to / on meshtasticd
+        # Map /mesh/ to / within the web client dir
         path = self.path
         if path == '/mesh' or path == '/mesh/':
-            path = '/'
+            path = '/index.html'
         elif path.startswith('/mesh/'):
-            path = path[5:]  # Strip /mesh prefix
+            path = path[5:]  # Strip /mesh prefix -> /index.html, /static/...
 
-        # Route API endpoints through proper handlers instead of raw proxy.
-        # The web client makes relative fetch() calls which resolve under
-        # /mesh/ due to <base href="/mesh/">.  Without this routing,
-        # /mesh/json/nodes bypasses sanitization and phantom nodes crash
-        # the React UI.
+        # Route API endpoints through MeshForge's sanitized, multiplexed
+        # proxy.  The web client's fetch() calls resolve here because
+        # they are relative to the /mesh/ origin.
         if path == '/json/nodes' or path == '/json/nodes/':
             self._proxy_json('/json/nodes')
             return
@@ -1126,64 +1128,59 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             self._proxy_toradio()
             return
 
-        result = self.api_proxy.proxy_static(path)
-        if result:
-            content, content_type = result
+        # Serve static files from meshtasticd's web directory on disk
+        web_dir = Path(MESHTASTICD_WEB_DIR)
+        if not web_dir.is_dir():
+            self._serve_mesh_client_unavailable()
+            return
 
-            # For the index.html, inject base href so relative paths work
-            # Also inject phantom node error protection as a safety net
-            if path == '/' or path.endswith('.html'):
-                if isinstance(content, bytes):
-                    content_str = content.decode('utf-8', errors='replace')
-                    # Rewrite API URLs + inject phantom node protection
-                    content_str = content_str.replace(
-                        '</head>',
-                        '<base href="/mesh/">\n'
-                        '<script>\n'
-                        '// MeshForge API proxy + phantom node protection\n'
-                        'window.__MESHFORGE_PROXY__ = true;\n'
-                        '// Safety net: catch null-property errors from incomplete\n'
-                        '// MQTT phantom nodes that slip past protobuf filtering.\n'
-                        '(function(){\n'
-                        '  var origError = window.onerror;\n'
-                        '  window.onerror = function(msg, src, line, col, err) {\n'
-                        '    if (typeof msg === "string" &&\n'
-                        '        (msg.indexOf("Cannot read properties of null") !== -1 ||\n'
-                        '         msg.indexOf("Cannot read properties of undefined") !== -1 ||\n'
-                        '         msg.indexOf("Cannot read property") !== -1)) {\n'
-                        '      console.warn("[MeshForge] Phantom node error caught:", msg);\n'
-                        '      return true;\n'
-                        '    }\n'
-                        '    return origError ? origError(msg, src, line, col, err) : false;\n'
-                        '  };\n'
-                        '  window.addEventListener("unhandledrejection", function(e) {\n'
-                        '    var m = (e.reason && e.reason.message) || String(e.reason || "");\n'
-                        '    if (m.indexOf("Cannot read properties of null") !== -1 ||\n'
-                        '        m.indexOf("Cannot read properties of undefined") !== -1) {\n'
-                        '      console.warn("[MeshForge] Phantom node rejection caught:", m);\n'
-                        '      e.preventDefault();\n'
-                        '    }\n'
-                        '  });\n'
-                        '})();\n'
-                        '</script>\n'
-                        '</head>'
-                    )
-                    content = content_str.encode('utf-8')
-                    content_type = 'text/html; charset=utf-8'
+        # Reject path traversal
+        if '..' in path:
+            self.send_error(400, "Invalid path")
+            return
+
+        file_path = web_dir / path.lstrip('/')
+
+        # SPA fallback: non-file routes get index.html (React router)
+        if not file_path.is_file():
+            file_path = web_dir / 'index.html'
+            if not file_path.is_file():
+                self._serve_mesh_client_unavailable()
+                return
+
+        # Prevent path traversal via symlinks
+        try:
+            resolved = file_path.resolve()
+            if not str(resolved).startswith(str(web_dir.resolve())):
+                self.send_error(403, "Forbidden")
+                return
+        except (OSError, ValueError):
+            self.send_error(400, "Invalid path")
+            return
+
+        # Read and serve the file
+        content_type = mimetypes.guess_type(str(file_path))[0] or 'application/octet-stream'
+        try:
+            data = file_path.read_bytes()
 
             self.send_response(200)
             self.send_header('Content-Type', content_type)
-            self.send_header('Content-Length', str(len(content)))
+            self.send_header('Content-Length', str(len(data)))
             self._send_cors_header()
             if content_type.startswith('text/html'):
                 self.send_header('Cache-Control', 'no-cache')
+            else:
+                # Cache static assets (JS/CSS/fonts/images) for 1 hour
+                self.send_header('Cache-Control', 'public, max-age=3600')
             self.end_headers()
-            self.wfile.write(content)
-        else:
-            self.send_error(502, "Could not proxy from meshtasticd web server")
+            self.wfile.write(data)
 
-    def _serve_mesh_client_fallback(self):
-        """Serve a fallback page when meshtasticd web server is unavailable."""
+        except (OSError, PermissionError) as e:
+            logger.error("Failed to serve mesh web client file %s: %s", file_path, e)
+            self.send_error(500, "Failed to read file")
+
+    def _serve_mesh_client_unavailable(self):
+        """Serve a page when meshtasticd web client files are not on disk."""
         html = """<!DOCTYPE html>
 <html><head><title>MeshForge - Meshtastic Web Client</title>
 <style>
@@ -1198,19 +1195,20 @@ code { background: #1a2a3a; padding: 2px 8px; border-radius: 4px; }
 </style></head><body>
 <div class="card">
 <h1>Meshtastic Web Client</h1>
-<p>The meshtasticd web server is not reachable.</p>
-<p>Make sure meshtasticd is running with its web server enabled:</p>
+<p>Web client files not found at <code>%s</code></p>
+<p>Install meshtasticd to get the web client:</p>
 <pre style="text-align:left;background:#1a2a3a;padding:1em;border-radius:8px;">
-# /etc/meshtasticd/config.yaml
+sudo apt install meshtasticd</pre>
+<p>Or check your <code>/etc/meshtasticd/config.yaml</code>:</p>
+<pre style="text-align:left;background:#1a2a3a;padding:1em;border-radius:8px;">
 Webserver:
   Port: 9443
-</pre>
-<p>Then restart: <code>sudo systemctl restart meshtasticd</code></p>
+  RootPath: /usr/share/meshtasticd/web</pre>
 <p style="margin-top:2em;">
   <a href="/">MeshForge NOC Map</a> |
   <a href="/api/proxy/status">Proxy Status</a>
 </p>
-</div></body></html>"""
+</div></body></html>""" % MESHTASTICD_WEB_DIR
         data = html.encode('utf-8')
         self.send_response(200)
         self.send_header('Content-Type', 'text/html; charset=utf-8')

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -48,6 +48,9 @@ __all__ = [
     'daemon_reload',             # Reload systemd daemon
     'enable_service',            # Enable service at boot
     'apply_config_and_restart',  # Reload daemon + restart service
+    # Port lockdown (MeshForge owns the browser)
+    'lock_port_external',        # Block external access to a port
+    'unlock_port_external',      # Restore external access to a port
     # Data classes
     'ServiceStatus',        # Return type from check_service
     'ServiceState',         # Status enum (AVAILABLE, DEGRADED, FAILED, etc.)
@@ -850,4 +853,95 @@ def enable_service(service_name: str, start: bool = False, timeout: int = 30) ->
         return False, "systemctl not found - is this a systemd system?"
     except Exception as e:
         logger.error(f"Error enabling {service_name}: {e}")
+        return False, f"Error: {e}"
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Port lockdown — MeshForge owns the browser
+# ─────────────────────────────────────────────────────────────────────
+
+def lock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str]:
+    """Block external access to a port, allowing only localhost.
+
+    Used to prevent users from accessing meshtasticd's web server directly
+    at port 9443.  MeshForge serves the web client at port 5000/mesh/
+    with multiplexed API proxying and phantom node filtering.
+
+    This adds an iptables INPUT rule that rejects non-localhost traffic
+    to the specified port.  The rule is idempotent — calling multiple
+    times won't create duplicate rules.
+
+    Args:
+        port: TCP port to lock down (default: 9443 for meshtasticd)
+        timeout: subprocess timeout in seconds
+
+    Returns:
+        Tuple of (success, message)
+    """
+    rule_args = ['-p', 'tcp', '--dport', str(port),
+                 '!', '-s', '127.0.0.1', '-j', 'REJECT']
+
+    try:
+        # Check if rule already exists (idempotent)
+        check = subprocess.run(
+            ['iptables', '-C', 'INPUT'] + rule_args,
+            capture_output=True, text=True, timeout=timeout
+        )
+        if check.returncode == 0:
+            logger.info("iptables rule for port %d already in place", port)
+            return True, f"Port {port} already locked to localhost"
+
+        # Add the rule
+        result = subprocess.run(
+            ['iptables', '-A', 'INPUT'] + rule_args,
+            capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode == 0:
+            logger.info("Locked external access to port %d (localhost only)", port)
+            return True, f"Port {port} locked — external access blocked"
+        else:
+            error = result.stderr.strip() or "iptables command failed"
+            logger.error("Failed to lock port %d: %s", port, error)
+            return False, f"iptables error: {error}"
+
+    except FileNotFoundError:
+        logger.warning("iptables not found — port lockdown unavailable")
+        return False, "iptables not found (install iptables package)"
+    except subprocess.TimeoutExpired:
+        return False, "iptables command timed out"
+    except Exception as e:
+        logger.error("Port lockdown error: %s", e)
+        return False, f"Error: {e}"
+
+
+def unlock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str]:
+    """Remove the iptables rule blocking external access to a port.
+
+    Args:
+        port: TCP port to unlock (default: 9443)
+        timeout: subprocess timeout in seconds
+
+    Returns:
+        Tuple of (success, message)
+    """
+    rule_args = ['-p', 'tcp', '--dport', str(port),
+                 '!', '-s', '127.0.0.1', '-j', 'REJECT']
+
+    try:
+        result = subprocess.run(
+            ['iptables', '-D', 'INPUT'] + rule_args,
+            capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode == 0:
+            logger.info("Unlocked external access to port %d", port)
+            return True, f"Port {port} unlocked — external access restored"
+        else:
+            # Rule may not exist — that's fine
+            return True, f"Port {port} was already unlocked"
+
+    except FileNotFoundError:
+        return False, "iptables not found"
+    except subprocess.TimeoutExpired:
+        return False, "iptables command timed out"
+    except Exception as e:
         return False, f"Error: {e}"

--- a/tests/test_web_client_ownership.py
+++ b/tests/test_web_client_ownership.py
@@ -1,0 +1,322 @@
+"""
+Tests for MeshForge web client ownership architecture.
+
+Validates that MeshForge correctly serves the Meshtastic web client
+from disk and routes API calls through the multiplexed proxy.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ─────────────────────────────────────────────────────────────────
+# Static file serving from disk
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestMeshWebClientServing:
+    """Test _serve_mesh_web_client() static file handler."""
+
+    def _make_handler(self, path, web_dir=None, api_proxy=None):
+        """Create a minimal mock handler for testing."""
+        from utils.map_http_handler import MapRequestHandler, MESHTASTICD_WEB_DIR
+
+        handler = MagicMock(spec=MapRequestHandler)
+        handler.path = path
+        handler.api_proxy = api_proxy
+        handler.wfile = MagicMock()
+        handler.headers = {}
+        handler.client_address = ('127.0.0.1', 12345)
+
+        # Bind the real methods
+        handler._serve_mesh_web_client = MapRequestHandler._serve_mesh_web_client.__get__(handler)
+        handler._serve_mesh_client_unavailable = MapRequestHandler._serve_mesh_client_unavailable.__get__(handler)
+        handler._send_cors_header = MagicMock()
+        handler._proxy_json = MagicMock()
+        handler._proxy_fromradio = MagicMock()
+        handler._proxy_toradio = MagicMock()
+
+        return handler
+
+    def test_mesh_root_serves_index(self, tmp_path):
+        """GET /mesh/ should serve index.html from disk."""
+        # Create a fake web dir with index.html
+        index = tmp_path / "index.html"
+        index.write_text("<html><body>Meshtastic</body></html>")
+
+        handler = self._make_handler('/mesh/')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler.send_response.assert_called_with(200)
+        handler.wfile.write.assert_called_once()
+        written = handler.wfile.write.call_args[0][0]
+        assert b'Meshtastic' in written
+
+    def test_mesh_no_trailing_slash(self, tmp_path):
+        """GET /mesh should also serve index.html."""
+        index = tmp_path / "index.html"
+        index.write_text("<html>OK</html>")
+
+        handler = self._make_handler('/mesh')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler.send_response.assert_called_with(200)
+
+    def test_mesh_static_asset(self, tmp_path):
+        """GET /mesh/static/app.js should serve from disk."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        js_file = static_dir / "app.js"
+        js_file.write_text("console.log('hello');")
+
+        handler = self._make_handler('/mesh/static/app.js')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler.send_response.assert_called_with(200)
+        written = handler.wfile.write.call_args[0][0]
+        assert b"console.log" in written
+
+    def test_mesh_api_fromradio_routes_to_proxy(self, tmp_path):
+        """GET /mesh/api/v1/fromradio should route to multiplexed proxy."""
+        handler = self._make_handler('/mesh/api/v1/fromradio')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler._proxy_fromradio.assert_called_once()
+        handler.wfile.write.assert_not_called()
+
+    def test_mesh_api_toradio_routes_to_proxy(self, tmp_path):
+        """GET /mesh/api/v1/toradio should route to proxy."""
+        handler = self._make_handler('/mesh/api/v1/toradio')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler._proxy_toradio.assert_called_once()
+
+    def test_mesh_json_nodes_routes_to_proxy(self, tmp_path):
+        """GET /mesh/json/nodes should route to sanitized proxy."""
+        handler = self._make_handler('/mesh/json/nodes')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler._proxy_json.assert_called_once_with('/json/nodes')
+
+    def test_mesh_json_report_routes_to_proxy(self, tmp_path):
+        """GET /mesh/json/report should route to sanitized proxy."""
+        handler = self._make_handler('/mesh/json/report')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler._proxy_json.assert_called_once_with('/json/report')
+
+    def test_path_traversal_rejected(self, tmp_path):
+        """Path traversal attempts should be rejected."""
+        index = tmp_path / "index.html"
+        index.write_text("<html>OK</html>")
+
+        handler = self._make_handler('/mesh/../../../etc/passwd')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler.send_error.assert_called_with(400, "Invalid path")
+
+    def test_missing_web_dir_shows_unavailable(self):
+        """Missing web dir should show helpful unavailable page."""
+        handler = self._make_handler('/mesh/')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', '/nonexistent/path'):
+            handler._serve_mesh_web_client()
+
+        # Should serve the unavailable page (200 with helpful HTML)
+        handler.send_response.assert_called_with(200)
+        written = handler.wfile.write.call_args[0][0]
+        assert b'not found' in written.lower() or b'meshtasticd' in written.lower()
+
+    def test_spa_fallback_serves_index(self, tmp_path):
+        """Non-file paths should get index.html (React router)."""
+        index = tmp_path / "index.html"
+        index.write_text("<html>SPA</html>")
+
+        handler = self._make_handler('/mesh/some/react/route')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        handler.send_response.assert_called_with(200)
+        written = handler.wfile.write.call_args[0][0]
+        assert b'SPA' in written
+
+    def test_html_gets_no_cache_header(self, tmp_path):
+        """HTML files should have no-cache header."""
+        index = tmp_path / "index.html"
+        index.write_text("<html>OK</html>")
+
+        handler = self._make_handler('/mesh/')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        # Verify Cache-Control: no-cache was set for HTML
+        cache_calls = [
+            c for c in handler.send_header.call_args_list
+            if c[0][0] == 'Cache-Control'
+        ]
+        assert any('no-cache' in str(c) for c in cache_calls)
+
+    def test_js_gets_cache_header(self, tmp_path):
+        """JS files should have caching header."""
+        static_dir = tmp_path / "static"
+        static_dir.mkdir()
+        js_file = static_dir / "app.js"
+        js_file.write_text("// app")
+
+        handler = self._make_handler('/mesh/static/app.js')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        cache_calls = [
+            c for c in handler.send_header.call_args_list
+            if c[0][0] == 'Cache-Control'
+        ]
+        assert any('max-age' in str(c) for c in cache_calls)
+
+    def test_no_base_href_injection(self, tmp_path):
+        """HTML should NOT have base href injected (old fragile approach)."""
+        index = tmp_path / "index.html"
+        index.write_text("<html><head></head><body>OK</body></html>")
+
+        handler = self._make_handler('/mesh/')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        written = handler.wfile.write.call_args[0][0]
+        assert b'<base href' not in written
+        assert b'window.onerror' not in written
+        assert b'__MESHFORGE_PROXY__' not in written
+
+
+# ─────────────────────────────────────────────────────────────────
+# Port lockdown (iptables)
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestPortLockdown:
+    """Test lock_port_external() and unlock_port_external()."""
+
+    @patch('subprocess.run')
+    def test_lock_port_adds_rule(self, mock_run):
+        """lock_port_external should add iptables rule."""
+        from utils.service_check import lock_port_external
+
+        # First call (check) returns 1 (rule doesn't exist)
+        # Second call (add) returns 0 (success)
+        mock_run.side_effect = [
+            MagicMock(returncode=1),  # -C check: not found
+            MagicMock(returncode=0),  # -A add: success
+        ]
+
+        ok, msg = lock_port_external(9443)
+
+        assert ok is True
+        assert "locked" in msg.lower() or "blocked" in msg.lower()
+        assert mock_run.call_count == 2
+
+    @patch('subprocess.run')
+    def test_lock_port_idempotent(self, mock_run):
+        """lock_port_external should be idempotent."""
+        from utils.service_check import lock_port_external
+
+        # Check returns 0 (rule already exists)
+        mock_run.return_value = MagicMock(returncode=0)
+
+        ok, msg = lock_port_external(9443)
+
+        assert ok is True
+        assert "already" in msg.lower()
+        assert mock_run.call_count == 1  # Only the check, no add
+
+    @patch('subprocess.run')
+    def test_lock_port_custom_port(self, mock_run):
+        """lock_port_external should work with custom port."""
+        from utils.service_check import lock_port_external
+
+        mock_run.side_effect = [
+            MagicMock(returncode=1),
+            MagicMock(returncode=0),
+        ]
+
+        ok, msg = lock_port_external(8080)
+
+        assert ok is True
+        # Verify the port was in the command
+        add_call = mock_run.call_args_list[1]
+        assert '8080' in add_call[0][0]
+
+    @patch('subprocess.run', side_effect=FileNotFoundError)
+    def test_lock_port_no_iptables(self, mock_run):
+        """lock_port_external should handle missing iptables."""
+        from utils.service_check import lock_port_external
+
+        ok, msg = lock_port_external()
+
+        assert ok is False
+        assert "not found" in msg.lower()
+
+    @patch('subprocess.run')
+    def test_unlock_port(self, mock_run):
+        """unlock_port_external should remove iptables rule."""
+        from utils.service_check import unlock_port_external
+
+        mock_run.return_value = MagicMock(returncode=0)
+
+        ok, msg = unlock_port_external(9443)
+
+        assert ok is True
+        assert "unlocked" in msg.lower() or "restored" in msg.lower()
+
+    @patch('subprocess.run')
+    def test_unlock_port_already_unlocked(self, mock_run):
+        """unlock_port_external should succeed even if rule doesn't exist."""
+        from utils.service_check import unlock_port_external
+
+        mock_run.return_value = MagicMock(returncode=1)  # Rule not found
+
+        ok, msg = unlock_port_external(9443)
+
+        assert ok is True  # Still success — desired state achieved
+
+
+# ─────────────────────────────────────────────────────────────────
+# proxy_endpoint rename verification
+# ─────────────────────────────────────────────────────────────────
+
+
+class TestProxyEndpointRename:
+    """Verify proxy_static was renamed to proxy_endpoint."""
+
+    def test_proxy_endpoint_exists(self):
+        """MeshtasticApiProxy should have proxy_endpoint method."""
+        from gateway.meshtastic_api_proxy import MeshtasticApiProxy
+        assert hasattr(MeshtasticApiProxy, 'proxy_endpoint')
+
+    def test_proxy_static_removed(self):
+        """MeshtasticApiProxy should NOT have proxy_static method."""
+        from gateway.meshtastic_api_proxy import MeshtasticApiProxy
+        assert not hasattr(MeshtasticApiProxy, 'proxy_static')

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -1432,36 +1432,11 @@
                 </div>
             </div>
 
-            <!-- Radio Control Panel -->
-            <div class="radio-section" style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #2a3a4a;">
-                <div class="section-title">📻 Radio Control</div>
-                <div class="stat-row">
-                    <span class="label">Status:</span>
-                    <span class="value" id="radio-status">Checking...</span>
-                </div>
-                <div class="stat-row">
-                    <span class="label">Mode:</span>
-                    <span class="value" id="radio-mode">--</span>
-                </div>
-                <div id="radio-info-section" style="display: none;">
-                    <div class="stat-row">
-                        <span class="label">Node:</span>
-                        <span class="value" id="radio-node-name">--</span>
-                    </div>
-                    <div class="stat-row">
-                        <span class="label">Hardware:</span>
-                        <span class="value" id="radio-hardware">--</span>
-                    </div>
-                </div>
-                <div id="radio-message-form" style="display: none; margin-top: 8px;">
-                    <input type="text" id="radio-message-text" placeholder="Message..."
-                           style="width: 100%; padding: 6px; margin-bottom: 6px; background: #1a2a3a; border: 1px solid #2a3a4a; color: #fff; border-radius: 4px;">
-                    <input type="text" id="radio-message-dest" placeholder="Destination (^all or !nodeId)"
-                           style="width: 100%; padding: 6px; margin-bottom: 6px; background: #1a2a3a; border: 1px solid #2a3a4a; color: #fff; border-radius: 4px;">
-                    <button class="btn-action primary" onclick="sendRadioMessage()" style="width: 100%;">Send Message</button>
-                    <div id="radio-send-status" style="font-size: 10px; color: #888; margin-top: 4px;"></div>
-                </div>
-                <button class="btn-action" onclick="refreshRadioStatus()" style="margin-top: 6px;">Refresh Radio</button>
+            <!-- Radio: use the Meshtastic web client for messaging -->
+            <div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #2a3a4a;">
+                <a href="/mesh/" class="btn-action" style="display: block; text-align: center; text-decoration: none;">
+                    Open Meshtastic Web Client
+                </a>
             </div>
         </div>
     </div>
@@ -4383,110 +4358,12 @@
         refreshNodes();
     }
 
-    // ============================================
-    // Radio Control Functions
-    // ============================================
-
-    async function refreshRadioStatus() {
-        const statusEl = document.getElementById('radio-status');
-        const modeEl = document.getElementById('radio-mode');
-        const infoSection = document.getElementById('radio-info-section');
-        const messageForm = document.getElementById('radio-message-form');
-
-        try {
-            const response = await fetch('/api/radio/status');
-            if (!response.ok) throw new Error('Radio API not available');
-
-            const data = await response.json();
-
-            if (data.connected) {
-                statusEl.textContent = 'Connected';
-                statusEl.style.color = '#66bb6a';
-                modeEl.textContent = data.mode.toUpperCase();
-
-                // Show message form when connected
-                messageForm.style.display = 'block';
-
-                // Try to get radio info
-                try {
-                    const infoRes = await fetch('/api/radio/info');
-                    if (infoRes.ok) {
-                        const info = await infoRes.json();
-                        if (info.name || info.hardware) {
-                            document.getElementById('radio-node-name').textContent = info.name || info.node_num || '--';
-                            document.getElementById('radio-hardware').textContent = info.hardware || '--';
-                            infoSection.style.display = 'block';
-                        }
-                    }
-                } catch (e) { /* info not available */ }
-            } else {
-                statusEl.textContent = 'Disconnected';
-                statusEl.style.color = '#ef5350';
-                modeEl.textContent = data.mode || 'none';
-                infoSection.style.display = 'none';
-                messageForm.style.display = 'none';
-            }
-        } catch (e) {
-            statusEl.textContent = 'API unavailable';
-            statusEl.style.color = '#888';
-            modeEl.textContent = '--';
-            infoSection.style.display = 'none';
-            messageForm.style.display = 'none';
-        }
-    }
-
-    async function sendRadioMessage() {
-        const text = document.getElementById('radio-message-text').value.trim();
-        const dest = document.getElementById('radio-message-dest').value.trim() || '^all';
-        const statusEl = document.getElementById('radio-send-status');
-
-        if (!text) {
-            statusEl.textContent = 'Please enter a message';
-            statusEl.style.color = '#ef5350';
-            return;
-        }
-
-        statusEl.textContent = 'Sending...';
-        statusEl.style.color = '#888';
-
-        try {
-            const response = await fetch('/api/radio/message', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ text: text, destination: dest })
-            });
-
-            const data = await response.json();
-
-            if (response.ok && data.success) {
-                statusEl.textContent = data.message || 'Sent (best-effort)';
-                statusEl.style.color = '#66bb6a';
-                document.getElementById('radio-message-text').value = '';
-                // Keep success message visible longer
-                setTimeout(() => { statusEl.textContent = ''; }, 5000);
-            } else {
-                statusEl.textContent = data.error || 'Send failed';
-                statusEl.style.color = '#ef5350';
-                if (data.detail) {
-                    statusEl.title = data.detail;
-                }
-                setTimeout(() => { statusEl.textContent = ''; }, 8000);
-            }
-        } catch (e) {
-            statusEl.textContent = 'Network error — is MeshForge running?';
-            statusEl.style.color = '#ef5350';
-            setTimeout(() => { statusEl.textContent = ''; }, 5000);
-        }
-    }
+    // Radio control removed — use the Meshtastic web client at /mesh/
+    // for messaging, channel config, and device control.
 
     // ============================================
     // Initialization
     // ============================================
-
-    // Initialize radio status
-    refreshRadioStatus();
-    // Refresh radio status every 30 seconds
-    setInterval(refreshRadioStatus, 30000);
 
     refreshNodes();
 


### PR DESCRIPTION
Replace fragile HTML proxy with direct disk serving of the Meshtastic web client.  meshtasticd is the radio backend; MeshForge owns the browser experience.

Architecture:
- /mesh/ serves files from /usr/share/meshtasticd/web/ (no network proxy)
- /mesh/api/v1/* routes through multiplexed proxy (stream sharing)
- /mesh/json/* routes through sanitized proxy (phantom filtering)
- Port 9443 lockable to localhost via iptables

Removed:
- _proxy_mesh_client() HTML proxy + JS injection (101 lines)
- <base href="/mesh/"> hack
- window.onerror phantom node error suppression
- Radio messaging panel from NOC (use web client at /mesh/ instead)

Added:
- _serve_mesh_web_client() static file handler with SPA fallback
- lock_port_external() / unlock_port_external() iptables management
- 21 tests for static serving, API routing, port lockdown
- TUI now directs users to http://ip:5000/mesh/

Tests: 151 passed (21 new + 130 existing), linter clean

https://claude.ai/code/session_018R89gJXFyPQzmxFGc4wdAg