### PR TITLE
feat: Add port 9443 lock menu, auto-lock on startup, and iptables per…

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -393,6 +393,9 @@ class MeshForgeLauncher(
         # Auto-start Config API Server on localhost
         self._maybe_auto_start_config_api()
 
+        # Auto-lock port 9443 so meshtasticd web is only via MeshForge proxy
+        self._maybe_auto_lock_port()
+
         try:
             self._run_main_menu()
         finally:
@@ -599,6 +602,26 @@ class MeshForgeLauncher(
             except Exception as e:
                 logger.debug("Config API stop failed: %s", e)
             self._config_api_server = None
+
+    def _maybe_auto_lock_port(self):
+        """Auto-lock port 9443 on startup so meshtasticd web is MeshForge-only.
+
+        Silent operation - logs result but no dialogs on failure.
+        """
+        try:
+            from utils.service_check import lock_port_external
+        except ImportError:
+            logger.debug("Port lockdown not available (missing service_check)")
+            return
+
+        try:
+            success, msg = lock_port_external(9443)
+            if success:
+                logger.info("Startup port lock: %s", msg)
+            else:
+                logger.warning("Startup port lock failed: %s", msg)
+        except Exception as e:
+            logger.debug("Auto port lock error: %s", e)
 
     def _config_api_menu(self):
         """Config API Server start/stop/status menu."""

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -270,6 +270,7 @@ class ServiceMenuMixin:
                 ("install", "Install meshtasticd"),
                 ("mqtt-setup", "MQTT Setup           Install & configure broker"),
                 ("openhamclock", "OpenHamClock Docker  Start/stop/status"),
+                ("lock-9443", "Lock Port 9443       Restrict to localhost"),
                 ("back", "Back"),
             ]
 
@@ -292,6 +293,7 @@ class ServiceMenuMixin:
                 "restart-rns": ("Restart rnsd", self._restart_rnsd_service),
                 "meshtasticd": ("Manage meshtasticd", lambda: self._manage_service("meshtasticd")),
                 "rnsd": ("Manage rnsd", lambda: self._manage_service("rnsd")),
+                "lock-9443": ("Port 9443 Lockdown", self._manage_port_lockdown),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -387,6 +389,85 @@ class ServiceMenuMixin:
             except (subprocess.SubprocessError, OSError) as e:
                 logger.debug("rnsd failure log check failed: %s", e)
         self._wait_for_enter()
+
+    def _manage_port_lockdown(self):
+        """Lock/unlock external access to meshtasticd port 9443."""
+        try:
+            from utils.service_check import (
+                lock_port_external, unlock_port_external,
+                check_port_locked, persist_iptables,
+            )
+        except ImportError:
+            self.dialog.msgbox(
+                "Unavailable",
+                "Port lockdown requires utils.service_check module."
+            )
+            return
+
+        while True:
+            locked = check_port_locked(9443)
+            status_str = "\033[0;32mLOCKED\033[0m (localhost only)" if locked else "\033[0;31mOPEN\033[0m (external access allowed)"
+
+            choices = [
+                ("lock", "Lock Port 9443       Block external access"),
+                ("unlock", "Unlock Port 9443     Allow external access"),
+                ("persist", "Save Rules           Survive reboot"),
+                ("status", "Check Status         Current lock state"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Port 9443 Lockdown",
+                f"Current: {status_str}\n\n"
+                "MeshForge proxies meshtasticd at :5000/mesh/\n"
+                "Locking port 9443 forces traffic through MeshForge.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "lock":
+                subprocess.run(['clear'], check=False, timeout=5)
+                success, msg = lock_port_external(9443)
+                if success:
+                    print(f"\033[0;32m✓\033[0m {msg}")
+                    # Offer to persist
+                    print("\nTo survive reboot, select 'Save Rules' from the menu.")
+                else:
+                    print(f"\033[0;31m✗\033[0m {msg}")
+                self._wait_for_enter()
+
+            elif choice == "unlock":
+                subprocess.run(['clear'], check=False, timeout=5)
+                success, msg = unlock_port_external(9443)
+                if success:
+                    print(f"\033[0;32m✓\033[0m {msg}")
+                else:
+                    print(f"\033[0;31m✗\033[0m {msg}")
+                self._wait_for_enter()
+
+            elif choice == "persist":
+                subprocess.run(['clear'], check=False, timeout=5)
+                print("Saving iptables rules for reboot persistence...\n")
+                success, msg = persist_iptables()
+                if success:
+                    print(f"\033[0;32m✓\033[0m {msg}")
+                else:
+                    print(f"\033[0;31m✗\033[0m {msg}")
+                self._wait_for_enter()
+
+            elif choice == "status":
+                subprocess.run(['clear'], check=False, timeout=5)
+                print("=== Port 9443 Status ===\n")
+                if locked:
+                    print("  \033[0;32m●\033[0m Port 9443: LOCKED (localhost only)")
+                else:
+                    print("  \033[0;31m●\033[0m Port 9443: OPEN (external access allowed)")
+                print()
+                print("  Lock blocks external access via iptables.")
+                print("  MeshForge proxies at :5000/mesh/ with filtering.")
+                self._wait_for_enter()
 
     def _restart_meshtasticd_service(self):
         """Restart the meshtasticd service."""

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -28,6 +28,7 @@ import socket
 import subprocess
 import logging
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional, Tuple
 from enum import Enum
 
@@ -51,6 +52,8 @@ __all__ = [
     # Port lockdown (MeshForge owns the browser)
     'lock_port_external',        # Block external access to a port
     'unlock_port_external',      # Restore external access to a port
+    'check_port_locked',         # Check if port is locked to localhost
+    'persist_iptables',          # Save iptables rules to survive reboot
     # Data classes
     'ServiceStatus',        # Return type from check_service
     'ServiceState',         # Status enum (AVAILABLE, DEGRADED, FAILED, etc.)
@@ -944,4 +947,82 @@ def unlock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str
     except subprocess.TimeoutExpired:
         return False, "iptables command timed out"
     except Exception as e:
+        return False, f"Error: {e}"
+
+
+def check_port_locked(port: int = 9443, timeout: int = 10) -> bool:
+    """Check if the iptables rule blocking external access exists.
+
+    Args:
+        port: TCP port to check (default: 9443)
+        timeout: subprocess timeout in seconds
+
+    Returns:
+        True if the port is locked to localhost, False otherwise.
+    """
+    rule_args = ['-p', 'tcp', '--dport', str(port),
+                 '!', '-s', '127.0.0.1', '-j', 'REJECT']
+    try:
+        result = subprocess.run(
+            ['iptables', '-C', 'INPUT'] + rule_args,
+            capture_output=True, text=True, timeout=timeout
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception):
+        return False
+
+
+def persist_iptables(timeout: int = 30) -> Tuple[bool, str]:
+    """Save current iptables rules so they survive reboot.
+
+    Tries netfilter-persistent first, then falls back to iptables-save
+    to /etc/iptables/rules.v4.
+
+    Returns:
+        Tuple of (success, message)
+    """
+    # Method 1: netfilter-persistent (Debian/Ubuntu with iptables-persistent)
+    try:
+        result = subprocess.run(
+            ['netfilter-persistent', 'save'],
+            capture_output=True, text=True, timeout=timeout
+        )
+        if result.returncode == 0:
+            logger.info("iptables rules saved via netfilter-persistent")
+            return True, "Rules saved (netfilter-persistent)"
+    except FileNotFoundError:
+        pass  # Not installed, try fallback
+    except subprocess.TimeoutExpired:
+        return False, "netfilter-persistent save timed out"
+
+    # Method 2: Manual iptables-save to rules.v4
+    import shutil
+    if not shutil.which('iptables-save'):
+        return False, (
+            "No persistence tool found.\n"
+            "Install: sudo apt install iptables-persistent"
+        )
+
+    try:
+        rules_dir = Path('/etc/iptables')
+        rules_dir.mkdir(parents=True, exist_ok=True)
+        rules_file = rules_dir / 'rules.v4'
+
+        save_result = subprocess.run(
+            ['iptables-save'],
+            capture_output=True, text=True, timeout=timeout
+        )
+        if save_result.returncode != 0:
+            return False, f"iptables-save failed: {save_result.stderr.strip()}"
+
+        rules_file.write_text(save_result.stdout)
+        logger.info("iptables rules saved to %s", rules_file)
+        return True, f"Rules saved to {rules_file}"
+
+    except subprocess.TimeoutExpired:
+        return False, "iptables-save timed out"
+    except OSError as e:
+        return False, f"Failed to write rules file: {e}"
+    except Exception as e:
+        logger.error("persist_iptables error: %s", e)
         return False, f"Error: {e}"


### PR DESCRIPTION
…sistence

Port 9443 (meshtasticd web) should be accessed only via MeshForge's proxy at :5000/mesh/ which provides phantom node filtering. This adds:

- TUI menu: Configuration > Services > Lock Port 9443 (lock/unlock/persist/status)
- Auto-lock: lock_port_external(9443) called silently on MeshForge startup
- Persistence: persist_iptables() saves rules via netfilter-persistent or iptables-save fallback so the lock survives reboot
- check_port_locked() utility to query current iptables state

https://claude.ai/code/session_01CiGyogP4GBPJihkVa2NAns