### PR TITLE
fix: Fix rnsd permission errors and /mesh/ blank white screen

### DIFF
--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -312,16 +312,35 @@ class StartupChecker:
 
     @staticmethod
     def _has_permission_issues(dir_path: Path) -> bool:
-        """Check if any files inside dir_path are not writable.
+        """Check if any files inside dir_path are not writable by non-root users.
 
         Returns True if there are files that could cause PermissionError
         for rnsd Transport jobs.
+
+        Note: Cannot use os.access(os.W_OK) here because MeshForge runs
+        as root (sudo), and root always passes access checks regardless
+        of actual file mode bits.  Instead, inspect the mode directly:
+        files need 0o666 (world-writable) and directories need 0o777.
         """
+        import stat
+
         try:
             if not dir_path.is_dir():
                 return False
+
+            # Check directory itself — needs world-writable for rnsd
+            dir_mode = dir_path.stat().st_mode
+            if not (dir_mode & stat.S_IWOTH):
+                return True
+
             for entry in dir_path.iterdir():
-                if entry.is_file() and not os.access(str(entry), os.W_OK):
+                try:
+                    mode = entry.stat().st_mode
+                    if entry.is_file() and not (mode & stat.S_IWOTH):
+                        return True
+                    elif entry.is_dir() and not (mode & stat.S_IWOTH):
+                        return True
+                except (PermissionError, OSError):
                     return True
         except (PermissionError, OSError):
             return True

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -40,6 +40,7 @@ import json
 import logging
 import math
 import mimetypes
+import os
 import time
 from datetime import datetime
 from http.server import SimpleHTTPRequestHandler
@@ -973,10 +974,7 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             self._send_cors_header()
             self.send_header('Cache-Control', 'no-cache, no-store')
             if needs_cookie:
-                import hashlib
-                session = hashlib.sha256(
-                    f"{self.client_address}{time.time()}".encode()
-                ).hexdigest()[:16]
+                session = os.urandom(8).hex()
                 self.send_header('Set-Cookie',
                                  f'meshforge_session={session}; Path=/; SameSite=Lax')
             self.end_headers()
@@ -989,10 +987,7 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             self._send_cors_header()
             self.send_header('Cache-Control', 'no-cache, no-store')
             if needs_cookie:
-                import hashlib
-                session = hashlib.sha256(
-                    f"{self.client_address}{time.time()}".encode()
-                ).hexdigest()[:16]
+                session = os.urandom(8).hex()
                 self.send_header('Set-Cookie',
                                  f'meshforge_session={session}; Path=/; SameSite=Lax')
             self.end_headers()
@@ -1163,11 +1158,23 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         try:
             data = file_path.read_bytes()
 
+            # Inject <base href="/mesh/"> into index.html so the React SPA
+            # resolves its asset paths (JS/CSS/fonts) relative to /mesh/
+            # instead of /.  Without this, asset requests go to
+            # http://ip:5000/static/... (MeshForge NOC dir) instead of
+            # http://ip:5000/mesh/static/... (meshtasticd web dir),
+            # producing a blank white screen.
+            if content_type and content_type.startswith('text/html'):
+                html = data.decode('utf-8', errors='replace')
+                if '<base' not in html.lower():
+                    html = html.replace('<head>', '<head><base href="/mesh/">', 1)
+                    data = html.encode('utf-8')
+
             self.send_response(200)
             self.send_header('Content-Type', content_type)
             self.send_header('Content-Length', str(len(data)))
             self._send_cors_header()
-            if content_type.startswith('text/html'):
+            if content_type and content_type.startswith('text/html'):
                 self.send_header('Cache-Control', 'no-cache')
             else:
                 # Cache static assets (JS/CSS/fonts/images) for 1 hour

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -139,10 +139,13 @@ class ReticulumPaths:
         """
         try:
             cls.ETC_BASE.mkdir(mode=0o755, parents=True, exist_ok=True)
-            cls.ETC_STORAGE.mkdir(mode=0o755, parents=True, exist_ok=True)
-            cls.ETC_RATCHETS.mkdir(mode=0o755, parents=True, exist_ok=True)
-            cls.ETC_CACHE.mkdir(mode=0o755, parents=True, exist_ok=True)
-            cls.ETC_ANNOUNCE_CACHE.mkdir(mode=0o755, parents=True, exist_ok=True)
+            # Storage directories need world-writable so rnsd (which may
+            # run as a non-root service user) can create and modify cache
+            # files, ratchets, and announce entries.
+            cls.ETC_STORAGE.mkdir(mode=0o777, parents=True, exist_ok=True)
+            cls.ETC_RATCHETS.mkdir(mode=0o777, parents=True, exist_ok=True)
+            cls.ETC_CACHE.mkdir(mode=0o777, parents=True, exist_ok=True)
+            cls.ETC_ANNOUNCE_CACHE.mkdir(mode=0o777, parents=True, exist_ok=True)
             cls.ETC_INTERFACES.mkdir(mode=0o755, parents=True, exist_ok=True)
 
             # Fix file permissions inside storage/ — rnsd Transport jobs
@@ -168,7 +171,6 @@ class ReticulumPaths:
         - The actual secrets (identity, keys) are in the parent config dir
         - This matches RNS's own behavior of creating world-readable storage
         """
-        import os
         import stat
 
         storage_dirs = [cls.ETC_STORAGE, cls.ETC_RATCHETS,
@@ -178,8 +180,9 @@ class ReticulumPaths:
             if not dir_path.is_dir():
                 continue
             try:
-                # Fix directory permissions
-                dir_path.chmod(0o755)
+                # Fix directory permissions — rnsd needs write access to
+                # create/modify cache files inside these directories.
+                dir_path.chmod(0o777)
                 # Fix file permissions within
                 for entry in dir_path.iterdir():
                     try:
@@ -189,7 +192,7 @@ class ReticulumPaths:
                             if not (current & stat.S_IWOTH):
                                 entry.chmod(0o666)
                         elif entry.is_dir():
-                            entry.chmod(0o755)
+                            entry.chmod(0o777)
                     except (PermissionError, OSError):
                         pass  # Best effort — some files may be locked
             except (PermissionError, OSError):

--- a/tests/test_web_client_ownership.py
+++ b/tests/test_web_client_ownership.py
@@ -196,8 +196,8 @@ class TestMeshWebClientServing:
         ]
         assert any('max-age' in str(c) for c in cache_calls)
 
-    def test_no_base_href_injection(self, tmp_path):
-        """HTML should NOT have base href injected (old fragile approach)."""
+    def test_base_href_injection(self, tmp_path):
+        """HTML should have <base href="/mesh/"> for SPA subpath serving."""
         index = tmp_path / "index.html"
         index.write_text("<html><head></head><body>OK</body></html>")
 
@@ -207,9 +207,23 @@ class TestMeshWebClientServing:
             handler._serve_mesh_web_client()
 
         written = handler.wfile.write.call_args[0][0]
-        assert b'<base href' not in written
+        assert b'<base href="/mesh/">' in written
+        # Old fragile JS injection should NOT be present
         assert b'window.onerror' not in written
         assert b'__MESHFORGE_PROXY__' not in written
+
+    def test_base_href_not_duplicated(self, tmp_path):
+        """If HTML already has a <base> tag, don't inject another one."""
+        index = tmp_path / "index.html"
+        index.write_text('<html><head><base href="/"></head><body>OK</body></html>')
+
+        handler = self._make_handler('/mesh/')
+
+        with patch('utils.map_http_handler.MESHTASTICD_WEB_DIR', str(tmp_path)):
+            handler._serve_mesh_web_client()
+
+        written = handler.wfile.write.call_args[0][0]
+        assert written.count(b'<base') == 1  # Only the original, no duplication
 
 
 # ─────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Three bugs fixed:

1. rnsd permission denied on announce cache files:
   - _has_permission_issues() used os.access(W_OK) which always returns True when running as root (sudo), so the healing never triggered
   - Now checks actual file mode bits (stat.S_IWOTH) instead
   - Storage directories created with 0o777 instead of 0o755 so rnsd (running as non-root service user) can write cache/announces/

2. /mesh/ blank white screen:
   - Meshtastic React SPA expects to be served at / but is served at /mesh/
   - Asset paths like /static/js/main.js resolved against MeshForge's web dir instead of meshtasticd's web dir
   - Re-added <base href="/mesh/"> injection into index.html (the injection is clean — the old fragile HTML proxying was the problem, not the tag)
   - Skips injection if <base> already exists to prevent duplication

3. Session cookie entropy:
   - Replaced hashlib.sha256(client_address+time) with os.urandom(8).hex()
   - Cleaner idiom for generating unique per-tab session identifiers

Tests: 87 passed (paths, proxy, web_client_ownership, security), linter clean

https://claude.ai/code/session_012hmzoFNCiBBK3yxbp53pNT