### PR TITLE
fix: Fix /mesh/ blank white screen by rewriting Vite root-absolute paths

### DIFF
--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -41,6 +41,7 @@ import logging
 import math
 import mimetypes
 import os
+import re
 import time
 from datetime import datetime
 from http.server import SimpleHTTPRequestHandler
@@ -52,6 +53,13 @@ logger = logging.getLogger(__name__)
 # Default path where meshtasticd installs its web client files.
 # MeshForge serves these directly from disk instead of proxying HTML.
 MESHTASTICD_WEB_DIR = '/usr/share/meshtasticd/web'
+
+# Ensure modern web asset MIME types are recognized (Python may lack these)
+mimetypes.add_type('application/javascript', '.mjs')
+mimetypes.add_type('font/woff2', '.woff2')
+mimetypes.add_type('application/wasm', '.wasm')
+mimetypes.add_type('image/webp', '.webp')
+mimetypes.add_type('image/avif', '.avif')
 
 
 class MapRequestHandler(SimpleHTTPRequestHandler):
@@ -1158,17 +1166,20 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         try:
             data = file_path.read_bytes()
 
-            # Inject <base href="/mesh/"> into index.html so the React SPA
-            # resolves its asset paths (JS/CSS/fonts) relative to /mesh/
-            # instead of /.  Without this, asset requests go to
-            # http://ip:5000/static/... (MeshForge NOC dir) instead of
-            # http://ip:5000/mesh/static/... (meshtasticd web dir),
-            # producing a blank white screen.
+            # Rewrite HTML so the React SPA works under the /mesh/ subpath.
+            #
+            # meshtasticd builds its web client for serving at root /.
+            # Vite produces root-absolute paths: src="/assets/index-xxx.js"
+            # <base href> does NOT affect root-absolute paths, only relative
+            # ones.  So we must:
+            #   1. Set <base href="/mesh/"> (replace existing or inject)
+            #   2. Strip the leading / from src= and href= values, making
+            #      them relative so the <base> tag takes effect:
+            #      "/assets/x.js" -> "assets/x.js" -> resolves to /mesh/assets/x.js
             if content_type and content_type.startswith('text/html'):
                 html = data.decode('utf-8', errors='replace')
-                if '<base' not in html.lower():
-                    html = html.replace('<head>', '<head><base href="/mesh/">', 1)
-                    data = html.encode('utf-8')
+                html = self._rewrite_mesh_html(html)
+                data = html.encode('utf-8')
 
             self.send_response(200)
             self.send_header('Content-Type', content_type)
@@ -1185,6 +1196,57 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         except (OSError, PermissionError) as e:
             logger.error("Failed to serve mesh web client file %s: %s", file_path, e)
             self.send_error(500, "Failed to read file")
+
+    @staticmethod
+    def _rewrite_mesh_html(html: str) -> str:
+        """Rewrite HTML asset paths so the meshtastic SPA works at /mesh/.
+
+        Vite/CRA build tools emit root-absolute paths (src="/assets/x.js").
+        The HTML <base> tag only affects *relative* URLs, not root-absolute
+        ones, so we must also strip the leading "/" to make them relative.
+
+        Steps:
+          1. Replace or inject <base href="/mesh/">
+          2. Convert root-absolute src/href values to relative paths
+             e.g. src="/assets/x.js" -> src="assets/x.js"
+             The browser then resolves "assets/x.js" via <base> as
+             /mesh/assets/x.js — which routes to _serve_mesh_web_client.
+        """
+        base_tag = '<base href="/mesh/">'
+
+        # Step 1: Ensure correct <base> tag
+        if re.search(r'<base\b', html, re.IGNORECASE):
+            # Replace existing <base> (e.g. <base href="/">) with ours
+            html = re.sub(
+                r'<base\b[^>]*>',
+                base_tag, html, count=1, flags=re.IGNORECASE,
+            )
+        else:
+            # Inject after <head> (handles <head lang="en">, <head\n>, etc.)
+            html = re.sub(
+                r'(<head\b[^>]*>)',
+                rf'\1{base_tag}',
+                html, count=1, flags=re.IGNORECASE,
+            )
+
+        # Step 2: Strip leading "/" from root-absolute src= and href= values
+        # so they become relative and resolve through <base href="/mesh/">.
+        #
+        #   src="/assets/index.js"  -> src="assets/index.js"
+        #   href="/favicon.svg"     -> href="favicon.svg"
+        #
+        # Preserved (not rewritten):
+        #   /mesh/...  (already correct)
+        #   //cdn...   (protocol-relative)
+        #   href="/"   (bare root — requires [^"']+ i.e. at least 1 char)
+        html = re.sub(
+            r'((?:src|href)\s*=\s*["\'])/((?!mesh/|/)[^"\']+)',
+            r'\1\2',
+            html,
+            flags=re.IGNORECASE,
+        )
+
+        return html
 
     def _serve_mesh_client_unavailable(self):
         """Serve a page when meshtasticd web client files are not on disk."""

--- a/tests/test_map_data_service.py
+++ b/tests/test_map_data_service.py
@@ -970,3 +970,130 @@ class TestHTTPFeatureFormat:
         )
         assert feature_with_sensor["properties"]["temperature"] == 25.5
         assert feature_with_sensor["properties"]["humidity"] == 65.0
+
+
+class TestRewriteMeshHtml:
+    """Test _rewrite_mesh_html fixes asset paths for /mesh/ subpath."""
+
+    @staticmethod
+    def _rewrite(html: str) -> str:
+        from utils.map_http_handler import MapRequestHandler
+        return MapRequestHandler._rewrite_mesh_html(html)
+
+    def test_injects_base_tag_when_missing(self):
+        """Injects <base href="/mesh/"> after <head>."""
+        html = '<!DOCTYPE html><html><head><title>Test</title></head></html>'
+        result = self._rewrite(html)
+        assert '<base href="/mesh/">' in result
+        assert result.index('<base') > result.index('<head>')
+
+    def test_replaces_existing_base_tag(self):
+        """Replaces <base href="/"> with <base href="/mesh/">."""
+        html = '<html><head><base href="/"><title>T</title></head></html>'
+        result = self._rewrite(html)
+        assert '<base href="/mesh/">' in result
+        assert 'href="/"' not in result.split('<base')[0] + result.split('">')[1]
+
+    def test_handles_head_with_attributes(self):
+        """Handles <head lang="en"> and similar."""
+        html = '<html><head lang="en"><title>T</title></head></html>'
+        result = self._rewrite(html)
+        assert '<base href="/mesh/">' in result
+
+    def test_strips_leading_slash_from_src(self):
+        """Converts src="/assets/x.js" to src="assets/x.js"."""
+        html = '<head></head><script src="/assets/index-abc.js"></script>'
+        result = self._rewrite(html)
+        assert 'src="assets/index-abc.js"' in result
+
+    def test_strips_leading_slash_from_href(self):
+        """Converts href="/assets/x.css" to href="assets/x.css"."""
+        html = '<head></head><link href="/assets/index-abc.css">'
+        result = self._rewrite(html)
+        assert 'href="assets/index-abc.css"' in result
+
+    def test_strips_favicon_path(self):
+        """Converts href="/favicon.svg" to href="favicon.svg"."""
+        html = '<head></head><link rel="icon" href="/favicon.svg">'
+        result = self._rewrite(html)
+        assert 'href="favicon.svg"' in result
+
+    def test_preserves_mesh_prefix(self):
+        """Does NOT strip /mesh/ paths (already correct)."""
+        html = '<head></head><a href="/mesh/api/status">link</a>'
+        result = self._rewrite(html)
+        assert 'href="/mesh/api/status"' in result
+
+    def test_preserves_protocol_relative_urls(self):
+        """Does NOT strip //cdn.example.com paths."""
+        html = '<head></head><script src="//cdn.example.com/lib.js"></script>'
+        result = self._rewrite(html)
+        assert 'src="//cdn.example.com/lib.js"' in result
+
+    def test_preserves_bare_root(self):
+        """Does NOT break href="/" (bare root link)."""
+        html = '<head></head><a href="/">Home</a>'
+        result = self._rewrite(html)
+        assert 'href="/"' in result
+
+    def test_preserves_relative_paths(self):
+        """Already-relative paths are not modified."""
+        html = '<head></head><script src="app.js"></script>'
+        result = self._rewrite(html)
+        assert 'src="app.js"' in result
+
+    def test_vite_build_index_html(self):
+        """Full Vite-style index.html gets properly rewritten."""
+        html = (
+            '<!DOCTYPE html>\n'
+            '<html lang="en">\n'
+            '  <head>\n'
+            '    <meta charset="UTF-8" />\n'
+            '    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />\n'
+            '    <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n'
+            '    <title>Meshtastic</title>\n'
+            '    <script type="module" crossorigin src="/assets/index-DqxB3FhK.js"></script>\n'
+            '    <link rel="stylesheet" crossorigin href="/assets/index-C4kz1b2q.css">\n'
+            '  </head>\n'
+            '  <body><div id="root"></div></body>\n'
+            '</html>'
+        )
+        result = self._rewrite(html)
+
+        # Base tag injected
+        assert '<base href="/mesh/">' in result
+        # All root-absolute paths converted to relative
+        assert 'href="favicon.svg"' in result
+        assert 'src="assets/index-DqxB3FhK.js"' in result
+        assert 'href="assets/index-C4kz1b2q.css"' in result
+        # No root-absolute asset paths remain
+        assert 'src="/assets' not in result
+        assert 'href="/assets' not in result
+        assert 'href="/favicon' not in result
+
+    def test_cra_build_index_html(self):
+        """Create React App style index.html with existing base tag."""
+        html = (
+            '<!DOCTYPE html>\n'
+            '<html><head>\n'
+            '<base href="/">\n'
+            '<link rel="icon" href="/favicon.ico" />\n'
+            '<script defer src="/static/js/main.12345.js"></script>\n'
+            '<link href="/static/css/main.abcde.css" rel="stylesheet">\n'
+            '</head><body><div id="root"></div></body></html>'
+        )
+        result = self._rewrite(html)
+
+        # Existing base tag replaced
+        assert '<base href="/mesh/">' in result
+        assert '<base href="/">' not in result
+        # Root-absolute paths made relative
+        assert 'href="favicon.ico"' in result
+        assert 'src="static/js/main.12345.js"' in result
+        assert 'href="static/css/main.abcde.css"' in result
+
+    def test_single_quotes(self):
+        """Handles single-quoted attribute values."""
+        html = "<head></head><script src='/assets/app.js'></script>"
+        result = self._rewrite(html)
+        assert "src='assets/app.js'" in result


### PR DESCRIPTION
The old <base href="/mesh/"> injection only fixed relative URLs. Vite/CRA build tools emit root-absolute paths (src="/assets/x.js") which <base> does NOT affect, so JS/CSS loaded from MeshForge's NOC web/ dir instead of meshtasticd's — producing a blank white screen.

Fix: new _rewrite_mesh_html() that (1) replaces or injects <base>, handling existing tags and <head> with attributes, and (2) strips the leading "/" from src= and href= values so they become relative and resolve through <base> to /mesh/assets/x.js.

Also registers MIME types for .mjs, .woff2, .wasm, .webp, .avif.

https://claude.ai/code/session_01REgLccHXBYqYJsvGEb7uBR