### PR TITLE
fix: Fix MapDataCollector type error and /mesh/ scrollbar covering si…

### DIFF
--- a/src/launcher_tui/dashboard_mixin.py
+++ b/src/launcher_tui/dashboard_mixin.py
@@ -184,7 +184,7 @@ class DashboardMixin:
             total = props.get('total_nodes', 0)
             with_gps = props.get('nodes_with_position', 0)
             sources = props.get('sources', {})
-            active_sources = [k for k, v in sources.items() if v > 0]
+            active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
             if total > 0:
                 results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
                 print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -1125,7 +1125,10 @@ class MapDataCollector:
 
         # Determine if this is a "gateway" type node
         # AREDN nodes with tunnels act as gateways
-        is_gateway = node.tunnel_count > 0
+        try:
+            is_gateway = int(node.tunnel_count) > 0
+        except (TypeError, ValueError):
+            is_gateway = False
 
         return self._make_feature(
             node_id=f"aredn_{node.hostname}",

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -1246,6 +1246,22 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             flags=re.IGNORECASE,
         )
 
+        # Step 3: Inject CSS to prevent body-level scrollbar.
+        # The meshtastic SPA is full-viewport; all scrolling happens inside
+        # React components.  A body scrollbar steals width from the right
+        # side, partially covering the sidebar/drawer menu.
+        scrollbar_fix = (
+            '<style data-meshforge>'
+            'html,body{overflow:hidden;margin:0;padding:0;'
+            'height:100%;width:100%}'
+            '</style>'
+        )
+        html = re.sub(
+            r'(</head>)',
+            rf'{scrollbar_fix}\1',
+            html, count=1, flags=re.IGNORECASE,
+        )
+
         return html
 
     def _serve_mesh_client_unavailable(self):

--- a/tests/test_map_data_service.py
+++ b/tests/test_map_data_service.py
@@ -1070,6 +1070,9 @@ class TestRewriteMeshHtml:
         assert 'src="/assets' not in result
         assert 'href="/assets' not in result
         assert 'href="/favicon' not in result
+        # Scrollbar fix CSS injected before </head>
+        assert 'data-meshforge' in result
+        assert 'overflow:hidden' in result
 
     def test_cra_build_index_html(self):
         """Create React App style index.html with existing base tag."""


### PR DESCRIPTION
…debar

1. MapDataCollector '>' TypeError: _get_source_summary() adds a "meshtasticd_via" key with string value ("http"/"tcp") to the sources dict. Dashboard test_data_sources iterated all values with `v > 0`, crashing on "http" > 0. Fix: filter to numeric values only. Also hardened AREDN tunnel_count comparison.

2. /mesh/ scrollbar covering right menu: The meshtastic web client is a full-viewport SPA where all scrolling is internal to React. A body-level scrollbar steals width, partially covering the sidebar/drawer. Fix: inject overflow:hidden CSS on html/body.

https://claude.ai/code/session_01REgLccHXBYqYJsvGEb7uBR