### PR TITLE
fix: Disable API proxy by default to stop stealing fromradio packets …

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1595,3 +1595,72 @@ Both MQTT and RNS can coexist. The private broker handles Meshtastic transport,
 RNS handles encrypted mesh-independent routing.
 
 ### Status: DOCUMENTED
+
+---
+
+## Issue #28: API Proxy Steals fromradio Packets from Native Web Client
+
+**Date Identified**: 2026-02-10
+**Severity**: Critical (breaks meshtasticd web client at :9443)
+
+### Symptom
+When MeshForge is running, the Meshtastic web client at `ip:9443` shows
+no data. Wireshark/traffic inspector shows empty responses. The gateway
+bridge works fine (RX green), NomadNet talks to other RNS nodes normally.
+Only the native web client is broken.
+
+### Root Cause
+`MeshtasticApiProxy` (in `gateway/meshtastic_api_proxy.py`) was **enabled
+by default** (`enable_api_proxy=True` in `MapServer.__init__`).
+
+When enabled, it runs a background thread that continuously polls
+`GET /api/v1/fromradio` from meshtasticd's HTTP API on port 9443.
+This endpoint is **queue-based** — each GET pops the next protobuf packet.
+Once MeshForge consumes a packet, it's gone from meshtasticd's buffer.
+
+The proxy code literally documents this: *"MeshForge becomes the sole
+consumer of meshtasticd's /api/v1/fromradio"*.
+
+Result: the native web client polls the same endpoint but gets nothing
+because MeshForge already drained the queue.
+
+**Why the gateway is unaffected:** The gateway uses TCP port 4403 (the
+meshtastic Python library's `TCPInterface`), which is a completely
+separate channel from the HTTP API on port 9443.
+
+### Connection Architecture
+```
+Port 4403 (TCP protobuf) ── Gateway Bridge (meshtastic_handler.py)
+                            └── Works independently, unaffected
+
+Port 9443 (HTTP API)     ── MeshtasticApiProxy (DRAINS THE QUEUE)
+                            └── Native web client gets nothing
+```
+
+### Fix Applied
+1. **Default `enable_api_proxy` to `False`** in `MapServer.__init__`
+2. **Added `--enable-api-proxy` CLI flag** for explicit opt-in
+3. **`/mesh/` redirects to native `:9443`** when proxy is disabled
+4. **Clear logging** when proxy is disabled explaining coexistence
+
+### When to Enable the Proxy
+Only enable when you specifically need:
+- Multiple browser tabs viewing the web client simultaneously
+- Phantom node filtering (MQTT nodes without User data crash React)
+- MeshForge-owned packet inspection/logging
+
+```bash
+# Opt in to API proxy (disables native web client at :9443)
+python -m utils.map_data_service --enable-api-proxy
+```
+
+### Files Involved
+- `src/utils/map_data_service.py` — `enable_api_proxy` default changed to `False`
+- `src/utils/map_http_handler.py` — `/mesh/` redirects to native :9443
+- `src/gateway/meshtastic_api_proxy.py` — the proxy itself (unchanged)
+
+### Prevention
+Never enable the API proxy by default. The gateway (TCP:4403) and
+web client (HTTP:9443) are separate channels and should coexist.
+
+### Status: RESOLVED

--- a/src/utils/map_data_service.py
+++ b/src/utils/map_data_service.py
@@ -142,7 +142,7 @@ class MapServer:
                  enable_message_listener: bool = True,
                  enable_websocket: bool = True,
                  websocket_port: int = 5001,
-                 enable_api_proxy: bool = True,
+                 enable_api_proxy: bool = False,
                  meshtasticd_host: str = 'localhost',
                  meshtasticd_port: int = 9443,
                  meshtasticd_tls: bool = True):
@@ -161,7 +161,10 @@ class MapServer:
             enable_message_listener: Start MessageListener for inbound messages (default True)
             enable_websocket: Start WebSocket server for real-time message push (default True)
             websocket_port: WebSocket server port (default 5001)
-            enable_api_proxy: Start Meshtastic API proxy for web client (default True)
+            enable_api_proxy: Start Meshtastic API proxy for web client (default False).
+                When False, meshtasticd's native web client at :9443 works normally.
+                When True, MeshForge consumes all fromradio packets and multiplexes
+                them — the native web client will show no data in this mode.
             meshtasticd_host: meshtasticd host for API proxy (default 'localhost')
             meshtasticd_port: meshtasticd web port for API proxy (default 9443)
             meshtasticd_tls: Use TLS for API proxy (default True)
@@ -236,8 +239,19 @@ class MapServer:
         MeshForge becomes the sole consumer of meshtasticd's HTTP API,
         multiplexing packets to all connected web clients. This fixes
         the 'waiting for delivery' bug and enables multi-client access.
+
+        WARNING: When enabled, this consumes ALL fromradio packets from
+        meshtasticd's HTTP API (port 9443). The native web client will
+        show no data — use /mesh/ on MeshForge's port instead.
+
+        Default is DISABLED so the native web client at :9443 works.
         """
         if not self.enable_api_proxy:
+            logger.info(
+                "API proxy disabled — meshtasticd web client at :%d works natively. "
+                "Gateway uses TCP:%d (separate channel).",
+                self.meshtasticd_port, 4403
+            )
             return
 
         try:
@@ -387,13 +401,22 @@ class MapServer:
             print("  Access via any of these URLs:")
             for ip in ips:
                 print(f"    NOC Map:    http://{ip}:{self.port}/")
-                print(f"    Mesh Client: http://{ip}:{self.port}/mesh/")
+                if self.enable_api_proxy:
+                    print(f"    Mesh Client: http://{ip}:{self.port}/mesh/")
+                else:
+                    print(f"    Mesh Client: https://{ip}:{self.meshtasticd_port}/ (native)")
         elif self.host in ("127.0.0.1", "localhost"):
             print(f"  NOC Map:     http://localhost:{self.port}/")
-            print(f"  Mesh Client: http://localhost:{self.port}/mesh/")
+            if self.enable_api_proxy:
+                print(f"  Mesh Client: http://localhost:{self.port}/mesh/")
+            else:
+                print(f"  Mesh Client: https://localhost:{self.meshtasticd_port}/ (native)")
         else:
             print(f"  NOC Map:     http://{self.host}:{self.port}/")
-            print(f"  Mesh Client: http://{self.host}:{self.port}/mesh/")
+            if self.enable_api_proxy:
+                print(f"  Mesh Client: http://{self.host}:{self.port}/mesh/")
+            else:
+                print(f"  Mesh Client: https://{self.host}:{self.meshtasticd_port}/ (native)")
         print("  Press Ctrl+C to stop")
 
         try:
@@ -485,6 +508,10 @@ Examples:
     parser.add_argument("--pid-file", type=str,
                         default="/run/meshforge/map-server.pid",
                         help="PID file location (default: /run/meshforge/map-server.pid)")
+    parser.add_argument("--enable-api-proxy", action="store_true",
+                        help="Enable API proxy (MeshForge consumes fromradio packets "
+                             "and serves web client at /mesh/). "
+                             "Disables native web client at :9443.")
     parser.add_argument("-v", "--verbose", action="store_true",
                         help="Enable verbose logging")
     args = parser.parse_args()
@@ -527,7 +554,11 @@ Examples:
         _write_pid_file(args.pid_file)
 
     # Create and start server
-    server = MapServer(port=args.port, host=args.host)
+    server = MapServer(
+        port=args.port,
+        host=args.host,
+        enable_api_proxy=args.enable_api_proxy,
+    )
 
     # Signal handlers for graceful shutdown
     def handle_signal(signum, frame):

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -1101,10 +1101,24 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         multiplexed proxy so the web client gets proper phantom-node
         filtering and stream multiplexing.
 
+        When API proxy is disabled, redirects to meshtasticd's native
+        web client at :9443 so MeshForge doesn't consume fromradio packets.
+
         Static files:  /mesh/*           -> disk read from MESHTASTICD_WEB_DIR
         API proxied:   /mesh/api/v1/*    -> MeshForge multiplexed proxy
                        /mesh/json/*      -> MeshForge sanitized proxy
         """
+        # When API proxy is disabled, redirect to native meshtasticd web client.
+        # This avoids MeshForge consuming fromradio packets that the native
+        # web client needs.
+        if not self.api_proxy:
+            host = self.headers.get('Host', 'localhost:5000').split(':')[0]
+            redirect_url = f"https://{host}:9443/"
+            self.send_response(302)
+            self.send_header('Location', redirect_url)
+            self.end_headers()
+            return
+
         # Map /mesh/ to / within the web client dir
         path = self.path
         if path == '/mesh' or path == '/mesh/':

--- a/tests/test_web_client_ownership.py
+++ b/tests/test_web_client_ownership.py
@@ -21,13 +21,23 @@ import pytest
 class TestMeshWebClientServing:
     """Test _serve_mesh_web_client() static file handler."""
 
-    def _make_handler(self, path, web_dir=None, api_proxy=None):
-        """Create a minimal mock handler for testing."""
+    def _make_handler(self, path, web_dir=None, api_proxy='_default_mock_'):
+        """Create a minimal mock handler for testing.
+
+        Args:
+            api_proxy: Set to None to test redirect behavior (proxy disabled).
+                       Default provides a mock proxy for testing serving behavior.
+        """
         from utils.map_http_handler import MapRequestHandler, MESHTASTICD_WEB_DIR
 
         handler = MagicMock(spec=MapRequestHandler)
         handler.path = path
-        handler.api_proxy = api_proxy
+        # Default to a mock proxy so tests exercise the serving path.
+        # Pass api_proxy=None explicitly to test the redirect behavior.
+        if api_proxy == '_default_mock_':
+            handler.api_proxy = MagicMock()
+        else:
+            handler.api_proxy = api_proxy
         handler.wfile = MagicMock()
         handler.headers = {}
         handler.client_address = ('127.0.0.1', 12345)
@@ -35,6 +45,7 @@ class TestMeshWebClientServing:
         # Bind the real methods
         handler._serve_mesh_web_client = MapRequestHandler._serve_mesh_web_client.__get__(handler)
         handler._serve_mesh_client_unavailable = MapRequestHandler._serve_mesh_client_unavailable.__get__(handler)
+        handler._rewrite_mesh_html = MapRequestHandler._rewrite_mesh_html
         handler._send_cors_header = MagicMock()
         handler._proxy_json = MagicMock()
         handler._proxy_fromradio = MagicMock()
@@ -211,6 +222,21 @@ class TestMeshWebClientServing:
         # Old fragile JS injection should NOT be present
         assert b'window.onerror' not in written
         assert b'__MESHFORGE_PROXY__' not in written
+
+    def test_mesh_redirects_to_native_when_proxy_disabled(self):
+        """GET /mesh/ should redirect to native :9443 when API proxy is off."""
+        handler = self._make_handler('/mesh/', api_proxy=None)
+        handler.headers = {'Host': '192.168.1.100:5000'}
+
+        handler._serve_mesh_web_client()
+
+        handler.send_response.assert_called_with(302)
+        location_calls = [
+            c for c in handler.send_header.call_args_list
+            if c[0][0] == 'Location'
+        ]
+        assert len(location_calls) == 1
+        assert ':9443' in location_calls[0][0][1]
 
     def test_base_href_not_duplicated(self, tmp_path):
         """If HTML already has a <base> tag, don't inject another one."""


### PR DESCRIPTION
…from native web client

The MeshtasticApiProxy was enabled by default, continuously polling GET /api/v1/fromradio from meshtasticd's HTTP API (port 9443). This queue-based endpoint gets drained — the native web client at :9443 sees no data because MeshForge already consumed all packets.

The gateway bridge is unaffected (uses TCP:4403, separate channel).

Changes:
- Default enable_api_proxy to False in MapServer
- Add --enable-api-proxy CLI flag for explicit opt-in
- /mesh/ redirects to native :9443 when proxy is disabled
- Startup messages show native web client URL
- Fix test mock to bind _rewrite_mesh_html method
- Add test for redirect behavior when proxy disabled
- Document as Issue #28 in persistent_issues.md

https://claude.ai/code/session_01U7RcpFjfoarVrRrJkU56XQ