### PR TITLE
feat: MQTT-based gateway bridge (zero interference with web client)

### DIFF
--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -63,7 +63,7 @@ def validate_data_speed(speed: int, field_name: str) -> Optional[ConfigValidatio
 
 def validate_bridge_mode(mode: str, field_name: str) -> Optional[ConfigValidationError]:
     """Validate bridge mode."""
-    valid_modes = ["message_bridge", "rns_transport", "mesh_bridge"]
+    valid_modes = ["mqtt_bridge", "message_bridge", "rns_transport", "mesh_bridge"]
     if mode not in valid_modes:
         return ConfigValidationError(field_name, f"Invalid bridge mode '{mode}'. Valid: {valid_modes}")
     return None
@@ -195,6 +195,35 @@ class MeshtasticBridgeConfig:
 
 
 @dataclass
+class MQTTBridgeConfig:
+    """
+    MQTT configuration for gateway bridge transport.
+
+    meshtasticd publishes mesh packets to MQTT natively. The gateway
+    subscribes to receive mesh traffic without holding a TCP connection.
+
+    This is the zero-interference path: meshtasticd simultaneously
+    serves the web client on :9443, accepts TCP on :4403, AND publishes
+    to MQTT. These are independent subsystems.
+
+    Requires:
+        - MQTT broker running (apt install mosquitto)
+        - meshtasticd mqtt.enabled=true, mqtt.json_enabled=true
+    """
+    broker: str = "localhost"
+    port: int = 1883
+    use_tls: bool = False
+    username: str = ""
+    password: str = ""
+    # Topic structure: {root_topic}/{region}/2/json/{channel}/{node_id}
+    root_topic: str = "msh"
+    region: str = "US"
+    channel: str = "LongFast"
+    # JSON mode (recommended - human-readable, no protobuf dependency)
+    json_enabled: bool = True
+
+
+@dataclass
 class RNSConfig:
     """Reticulum Network Stack configuration"""
     config_dir: str = ""  # Empty = default ~/.reticulum
@@ -292,15 +321,19 @@ class GatewayConfig:
     enabled: bool = False
     auto_start: bool = False
 
-    # Bridge mode: "message_bridge", "rns_transport", or "mesh_bridge"
-    # - message_bridge: Translates messages between RNS/LXMF and Meshtastic
+    # Bridge mode: "mqtt_bridge", "message_bridge", "rns_transport", or "mesh_bridge"
+    # - mqtt_bridge: MQTT-based bridge (recommended - zero interference with web client)
+    # - message_bridge: TCP-based message bridge (legacy - blocks web client)
     # - rns_transport: RNS uses Meshtastic as network transport layer
     # - mesh_bridge: Bridges two Meshtastic networks with different presets
-    bridge_mode: str = "message_bridge"
+    bridge_mode: str = "mqtt_bridge"
 
     # Network configurations
     meshtastic: MeshtasticConfig = field(default_factory=MeshtasticConfig)
     rns: RNSConfig = field(default_factory=RNSConfig)
+
+    # MQTT bridge transport (used when bridge_mode="mqtt_bridge")
+    mqtt_bridge: MQTTBridgeConfig = field(default_factory=MQTTBridgeConfig)
 
     # RNS Over Meshtastic transport (used when bridge_mode="rns_transport")
     rns_transport: RNSOverMeshtasticConfig = field(default_factory=RNSOverMeshtasticConfig)
@@ -375,13 +408,18 @@ class GatewayConfig:
                 prefix_format=mesh_bridge_data.get('prefix_format', '[{source_preset}] '),
             )
 
+            # Handle MQTTBridgeConfig
+            mqtt_bridge_data = data.get('mqtt_bridge', {})
+            mqtt_bridge = MQTTBridgeConfig(**mqtt_bridge_data) if mqtt_bridge_data else MQTTBridgeConfig()
+
             # Reconstruct nested dataclasses
             config = cls(
                 enabled=data.get('enabled', False),
                 auto_start=data.get('auto_start', False),
-                bridge_mode=data.get('bridge_mode', 'message_bridge'),
+                bridge_mode=data.get('bridge_mode', 'mqtt_bridge'),
                 meshtastic=MeshtasticConfig(**data.get('meshtastic', {})),
                 rns=RNSConfig(**data.get('rns', {})),
+                mqtt_bridge=mqtt_bridge,
                 rns_transport=rns_transport,
                 mesh_bridge=mesh_bridge,
                 routing_rules=[RoutingRule(**r) for r in data.get('routing_rules', [])],
@@ -441,6 +479,7 @@ class GatewayConfig:
                 'bridge_mode': self.bridge_mode,
                 'meshtastic': asdict(self.meshtastic),
                 'rns': asdict(self.rns),
+                'mqtt_bridge': asdict(self.mqtt_bridge),
                 'rns_transport': rns_transport_data,
                 'mesh_bridge': mesh_bridge_data,
                 'routing_rules': [asdict(r) for r in self.routing_rules],
@@ -639,9 +678,44 @@ class GatewayConfig:
     # =========================================================================
 
     @classmethod
+    def template_mqtt_bridge(cls, broker: str = "localhost",
+                              region: str = "US",
+                              channel: str = "LongFast") -> 'GatewayConfig':
+        """
+        MQTT-based bridge between Meshtastic and RNS (RECOMMENDED).
+
+        Zero interference with meshtasticd web client. Uses MQTT for
+        receiving mesh traffic and meshtastic CLI for sending.
+
+        Use case: Bridge Meshtastic <-> RNS without blocking web client
+        Requirements:
+            - mosquitto running on localhost:1883
+            - meshtasticd with mqtt.enabled=true, mqtt.json_enabled=true
+            - rnsd running (user systemd service)
+
+        Args:
+            broker: MQTT broker address
+            region: LoRa region code (US, EU_868, etc.)
+            channel: Meshtastic channel name
+        """
+        config = cls()
+        config.enabled = True
+        config.bridge_mode = "mqtt_bridge"
+        config.mqtt_bridge.broker = broker
+        config.mqtt_bridge.region = region
+        config.mqtt_bridge.channel = channel
+        config.mqtt_bridge.json_enabled = True
+        config.default_route = "bidirectional"
+        config.routing_rules = config.get_default_rules()
+        return config
+
+    @classmethod
     def template_basic_bridge(cls) -> 'GatewayConfig':
         """
-        Basic message bridge between Meshtastic and RNS.
+        Basic message bridge between Meshtastic and RNS (LEGACY).
+
+        WARNING: Uses TCP connection that blocks meshtasticd web client.
+        Prefer template_mqtt_bridge() instead.
 
         Use case: Simple bidirectional message forwarding
         Requirements: meshtasticd running on localhost:4403, rnsd running
@@ -761,7 +835,8 @@ class GatewayConfig:
     def get_available_templates(cls) -> Dict[str, str]:
         """Get list of available configuration templates with descriptions."""
         return {
-            "basic_bridge": "Simple bidirectional Meshtastic ↔ RNS message bridge",
+            "mqtt_bridge": "MQTT-based Meshtastic <-> RNS bridge (RECOMMENDED, zero interference)",
+            "basic_bridge": "TCP-based Meshtastic <-> RNS bridge (legacy, blocks web client)",
             "rns_over_mesh": "Run RNS apps over LoRa mesh (transport mode)",
             "dual_preset_bridge": "Bridge two Meshtastic networks with different presets",
             "mqtt_monitor": "Monitor Meshtastic network via MQTT (no radio needed)",
@@ -781,6 +856,7 @@ class GatewayConfig:
             GatewayConfig or None if template not found
         """
         templates = {
+            "mqtt_bridge": cls.template_mqtt_bridge,
             "basic_bridge": cls.template_basic_bridge,
             "rns_over_mesh": cls.template_rns_over_mesh,
             "dual_preset_bridge": cls.template_dual_preset_bridge,

--- a/src/gateway/meshtastic_api_proxy.py
+++ b/src/gateway/meshtastic_api_proxy.py
@@ -1,4 +1,14 @@
 """
+DEPRECATED: Meshtastic API Proxy.
+
+This module is DEPRECATED as of v0.5.0. The proxy approach of sitting between
+the user and meshtasticd was the primary source of interference with the web
+client. The MQTT bridge (mqtt_bridge_handler.py) replaces this with a
+zero-interference approach.
+
+See: gateway/mqtt_bridge_handler.py for the replacement.
+
+--- Original description ---
 Meshtastic API Proxy - MeshForge owns the web client API.
 
 Solves the fundamental "single client" limitation of meshtasticd's HTTP API

--- a/src/gateway/mqtt_bridge_handler.py
+++ b/src/gateway/mqtt_bridge_handler.py
@@ -1,0 +1,634 @@
+"""
+MQTT Bridge Handler for RNS Gateway.
+
+Replaces TCP-based MeshtasticHandler with zero-interference MQTT approach.
+
+Receives mesh traffic via MQTT subscription (no TCP connection needed).
+Sends to mesh via meshtastic CLI (transient, no persistent connection).
+
+Architecture:
+    Meshtastic mesh -> meshtasticd -> MQTT broker -> MQTTBridgeHandler
+    MQTTBridgeHandler -> meshtastic CLI -> meshtasticd -> Meshtastic mesh
+
+Zero interference:
+    - No persistent TCP connection to meshtasticd
+    - Web client on :9443 works uninterrupted
+    - Multiple monitoring tools can coexist
+
+Requires:
+    - mosquitto (or any MQTT broker) running locally
+    - meshtasticd configured with mqtt.enabled=true, mqtt.json_enabled=true
+    - paho-mqtt (pip install paho-mqtt)
+
+Usage:
+    handler = MQTTBridgeHandler(config, node_tracker, health, ...)
+    handler.run_loop()  # Blocks, runs in thread
+"""
+
+import json
+import logging
+import subprocess
+import threading
+import time
+from datetime import datetime
+from queue import Full
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from .bridge_health import BridgeHealthMonitor
+    from .config import GatewayConfig
+    from .node_tracker import UnifiedNodeTracker
+
+
+class MQTTBridgeHandler:
+    """
+    MQTT-based Meshtastic handler for the gateway bridge.
+
+    Subscribes to meshtasticd's MQTT topics to receive mesh traffic.
+    Uses meshtastic CLI for sending messages (transient, no interference).
+
+    This replaces the TCP-based MeshtasticHandler that held a persistent
+    connection to port 4403, blocking the web client.
+
+    Args:
+        config: Gateway configuration object
+        node_tracker: Unified node tracker instance
+        health: Bridge health monitor instance
+        stop_event: Threading event for graceful shutdown
+        stats: Shared statistics dictionary
+        stats_lock: Lock for thread-safe stats updates
+        message_queue: Queue for messages to be bridged to RNS
+        message_callback: Callback for received messages
+        status_callback: Callback for status changes
+        should_bridge: Callback to check routing rules
+    """
+
+    def __init__(
+        self,
+        config: 'GatewayConfig',
+        node_tracker: 'UnifiedNodeTracker',
+        health: 'BridgeHealthMonitor',
+        stop_event: threading.Event,
+        stats: Dict[str, Any],
+        stats_lock: threading.Lock,
+        message_queue,
+        message_callback: Optional[Callable] = None,
+        status_callback: Optional[Callable] = None,
+        should_bridge: Optional[Callable] = None,
+    ):
+        self.config = config
+        self.node_tracker = node_tracker
+        self.health = health
+        self._stop_event = stop_event
+        self.stats = stats
+        self._stats_lock = stats_lock
+        self._mesh_to_rns_queue = message_queue
+
+        # Callbacks
+        self._message_callback = message_callback
+        self._status_callback = status_callback
+        self._should_bridge = should_bridge
+
+        # MQTT client
+        self._client = None
+        self._connected = False
+        self._mqtt_lock = threading.Lock()
+
+        # Meshtastic CLI path (cached)
+        self._cli_path: Optional[str] = None
+
+        # Deduplication: track recent message IDs to avoid loops
+        self._recent_ids: Dict[str, float] = {}
+        self._dedup_window = 60  # seconds
+
+    @property
+    def is_connected(self) -> bool:
+        """Check if connected to MQTT broker."""
+        return self._connected
+
+    def run_loop(self) -> None:
+        """
+        Main loop: connect to MQTT and process messages.
+
+        Blocks until stop_event is set. Handles reconnection automatically.
+        """
+        while not self._stop_event.is_set():
+            try:
+                if not self._connected:
+                    logger.info("Connecting to MQTT broker for gateway bridge...")
+                    self._connect()
+
+                    if self._connected:
+                        self.health.record_connection_event("meshtastic", "connected")
+                        logger.info("MQTT bridge handler connected")
+                        self._notify_status("meshtastic_connected")
+                    else:
+                        self.health.record_connection_event("meshtastic", "retry")
+                        self._stop_event.wait(5)
+                        continue
+
+                # MQTT client has its own event loop via loop_start()
+                # We just need to stay alive and do periodic maintenance
+                self._cleanup_dedup()
+                self._stop_event.wait(1)
+
+            except Exception as e:
+                self.health.record_error("meshtastic", e)
+                logger.error(f"MQTT bridge loop error: {e}")
+                self._connected = False
+                self.health.record_connection_event("meshtastic", "error", str(e))
+                self._stop_event.wait(5)
+
+    def _connect(self) -> bool:
+        """Connect to MQTT broker and subscribe to meshtasticd topics."""
+        try:
+            import paho.mqtt.client as mqtt
+        except ImportError:
+            logger.error("paho-mqtt not installed. Install with: pip install paho-mqtt")
+            return False
+
+        mqtt_cfg = self.config.mqtt_bridge
+
+        try:
+            # Create MQTT client
+            client_id = f"meshforge-gateway-{int(time.time()) % 10000}"
+            self._client = mqtt.Client(
+                client_id=client_id,
+                protocol=mqtt.MQTTv311,
+            )
+
+            # Auth if configured
+            if mqtt_cfg.username:
+                self._client.username_pw_set(mqtt_cfg.username, mqtt_cfg.password)
+
+            # TLS if configured
+            if mqtt_cfg.use_tls:
+                self._client.tls_set()
+
+            # Callbacks
+            self._client.on_connect = self._on_connect
+            self._client.on_disconnect = self._on_disconnect
+            self._client.on_message = self._on_message
+
+            # Connect
+            self._client.connect(
+                mqtt_cfg.broker,
+                mqtt_cfg.port,
+                keepalive=60,
+            )
+
+            # Start background thread for MQTT event loop
+            self._client.loop_start()
+
+            # Wait briefly for connection
+            for _ in range(50):
+                if self._connected:
+                    return True
+                if self._stop_event.wait(0.1):
+                    return False
+
+            if not self._connected:
+                logger.warning("MQTT connection timed out")
+                return False
+
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to connect to MQTT broker: {e}")
+            self._connected = False
+            return False
+
+    def _on_connect(self, client, userdata, flags, rc):
+        """MQTT connect callback - subscribe to meshtasticd topics."""
+        if rc == 0:
+            self._connected = True
+            mqtt_cfg = self.config.mqtt_bridge
+
+            # Subscribe to JSON topics (human-readable, recommended)
+            # Topic format: msh/{REGION}/2/json/{CHANNEL}/{NODE_ID}
+            if mqtt_cfg.json_enabled:
+                json_topic = f"{mqtt_cfg.root_topic}/{mqtt_cfg.region}/2/json/{mqtt_cfg.channel}/#"
+                client.subscribe(json_topic)
+                logger.info(f"Subscribed to JSON topic: {json_topic}")
+
+            # Also subscribe to protobuf topics for completeness
+            # Topic format: msh/{REGION}/2/e/{CHANNEL}/{NODE_ID}
+            proto_topic = f"{mqtt_cfg.root_topic}/{mqtt_cfg.region}/2/e/{mqtt_cfg.channel}/#"
+            client.subscribe(proto_topic)
+            logger.info(f"Subscribed to protobuf topic: {proto_topic}")
+
+            logger.info(f"MQTT bridge connected to {mqtt_cfg.broker}:{mqtt_cfg.port}")
+        else:
+            logger.error(f"MQTT connection failed with code {rc}")
+            self._connected = False
+
+    def _on_disconnect(self, client, userdata, rc):
+        """MQTT disconnect callback."""
+        was_connected = self._connected
+        self._connected = False
+        if was_connected:
+            if rc == 0:
+                logger.info("MQTT bridge disconnected cleanly")
+            else:
+                logger.warning(f"MQTT bridge disconnected unexpectedly (rc={rc})")
+                self.health.record_connection_event("meshtastic", "disconnected", f"rc={rc}")
+            self._notify_status("meshtastic_disconnected")
+
+    def _on_message(self, client, userdata, msg):
+        """Handle incoming MQTT message from meshtasticd."""
+        try:
+            topic = msg.topic
+            payload = msg.payload
+
+            # Determine if JSON or protobuf based on topic
+            if "/json/" in topic:
+                self._handle_json_message(topic, payload)
+            else:
+                # Protobuf messages need decoding - skip for now,
+                # JSON mode is the recommended path
+                self._handle_protobuf_message(topic, payload)
+
+        except Exception as e:
+            logger.error(f"Error processing MQTT message: {e}")
+
+    def _handle_json_message(self, topic: str, payload: bytes) -> None:
+        """
+        Handle JSON-encoded message from meshtasticd MQTT.
+
+        JSON messages have this structure:
+        {
+            "channel": 0,
+            "from": 1234567890,
+            "id": 12345678,
+            "payload": {"text": "Hello"},
+            "sender": "!abcd1234",
+            "timestamp": 1234567890,
+            "to": 4294967295,
+            "type": "text"
+        }
+        """
+        try:
+            data = json.loads(payload.decode('utf-8', errors='ignore'))
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            logger.debug(f"Failed to parse MQTT JSON: {e}")
+            return
+
+        msg_type = data.get('type', '')
+        sender = data.get('sender', '')
+        msg_id = str(data.get('id', ''))
+
+        # Dedup check
+        if msg_id and self._is_duplicate(msg_id):
+            return
+
+        # Update node tracking
+        from_num = data.get('from', 0)
+        if from_num:
+            self._update_node_from_mqtt(data)
+
+        # Handle text messages for bridging
+        if msg_type == 'text':
+            self._bridge_text_message(data, topic)
+
+        # Handle telemetry for node tracking
+        elif msg_type == 'telemetry':
+            self._update_telemetry(data)
+
+        # Handle position for maps
+        elif msg_type == 'position':
+            self._update_position(data)
+
+        # Handle nodeinfo for discovery
+        elif msg_type == 'nodeinfo':
+            self._update_nodeinfo(data)
+
+    def _handle_protobuf_message(self, topic: str, payload: bytes) -> None:
+        """
+        Handle protobuf-encoded ServiceEnvelope from meshtasticd MQTT.
+
+        For now, we prefer JSON mode. Protobuf is more complex and requires
+        the meshtastic protobuf definitions. This is a placeholder for
+        future enhancement.
+        """
+        # Log that we received a protobuf message but prefer JSON
+        logger.debug(f"Protobuf message on {topic} ({len(payload)} bytes) - "
+                     "use json_enabled=true for full parsing")
+
+    def _bridge_text_message(self, data: dict, topic: str) -> None:
+        """Bridge a text message from Meshtastic to RNS."""
+        from .rns_bridge import BridgedMessage
+        from .bridge_health import MessageOrigin
+
+        sender = data.get('sender', '')
+        to_num = data.get('to', 0)
+        payload = data.get('payload', {})
+        text = payload.get('text', '') if isinstance(payload, dict) else str(payload)
+        channel = data.get('channel', 0)
+
+        if not text:
+            return
+
+        # Determine destination
+        to_id = f"!{to_num:08x}" if to_num else None
+        is_broadcast = to_num == 0xFFFFFFFF
+
+        msg = BridgedMessage(
+            source_network="meshtastic",
+            source_id=sender,
+            destination_id=to_id,
+            content=text,
+            is_broadcast=is_broadcast,
+            origin=MessageOrigin.MQTT,
+            via_internet=False,  # Local MQTT, not internet relay
+            metadata={
+                'channel': channel,
+                'mqtt_topic': topic,
+                'msg_id': data.get('id'),
+                'timestamp': data.get('timestamp'),
+            },
+        )
+
+        # Store incoming message for UI/history
+        try:
+            from commands import messaging
+            dest = None if is_broadcast else to_id
+            messaging.store_incoming(
+                from_id=sender,
+                content=text,
+                network="meshtastic",
+                to_id=dest,
+                channel=channel,
+            )
+        except Exception as e:
+            logger.debug(f"Could not store incoming message: {e}")
+
+        # Queue for bridging if routing rules allow
+        if self._mesh_to_rns_queue is not None:
+            if self._should_bridge and not self._should_bridge(msg):
+                logger.debug(f"Message from {sender} blocked by routing rules")
+            else:
+                try:
+                    self._mesh_to_rns_queue.put_nowait(msg)
+                except Full:
+                    logger.warning("Mesh->RNS queue full, dropping message")
+                    with self._stats_lock:
+                        self.stats['errors'] += 1
+
+        # Notify callback
+        if self._message_callback:
+            try:
+                self._message_callback(msg)
+            except Exception as e:
+                logger.error(f"Message callback error: {e}")
+
+    def _update_node_from_mqtt(self, data: dict) -> None:
+        """Update node tracker from MQTT message data."""
+        try:
+            from .node_tracker import UnifiedNode
+
+            from_num = data.get('from', 0)
+            sender = data.get('sender', f"!{from_num:08x}")
+
+            node = UnifiedNode(
+                id=sender,
+                name=sender,
+                network="meshtastic",
+                meshtastic_id=sender,
+            )
+            self.node_tracker.add_node(node)
+        except Exception as e:
+            logger.debug(f"Error updating node from MQTT: {e}")
+
+    def _update_telemetry(self, data: dict) -> None:
+        """Update node with telemetry data from MQTT."""
+        try:
+            sender = data.get('sender', '')
+            payload = data.get('payload', {})
+            if not isinstance(payload, dict) or not sender:
+                return
+
+            # Device metrics
+            device = payload.get('device_metrics', {})
+            if device:
+                logger.debug(f"Telemetry from {sender}: "
+                            f"battery={device.get('battery_level')}%, "
+                            f"chUtil={device.get('channel_utilization')}%")
+
+            # Environment metrics
+            env = payload.get('environment_metrics', {})
+            if env:
+                logger.debug(f"Environment from {sender}: "
+                            f"temp={env.get('temperature')}C, "
+                            f"humidity={env.get('relative_humidity')}%")
+        except Exception as e:
+            logger.debug(f"Error processing telemetry: {e}")
+
+    def _update_position(self, data: dict) -> None:
+        """Update node position from MQTT for maps."""
+        try:
+            sender = data.get('sender', '')
+            payload = data.get('payload', {})
+            if not isinstance(payload, dict) or not sender:
+                return
+
+            lat = payload.get('latitude_i', 0) / 1e7 if payload.get('latitude_i') else None
+            lon = payload.get('longitude_i', 0) / 1e7 if payload.get('longitude_i') else None
+            alt = payload.get('altitude')
+
+            if lat and lon:
+                logger.debug(f"Position from {sender}: {lat:.6f}, {lon:.6f}")
+                # Node tracker update with position would go here
+        except Exception as e:
+            logger.debug(f"Error processing position: {e}")
+
+    def _update_nodeinfo(self, data: dict) -> None:
+        """Update node info from MQTT."""
+        try:
+            from .node_tracker import UnifiedNode
+
+            sender = data.get('sender', '')
+            payload = data.get('payload', {})
+            if not isinstance(payload, dict) or not sender:
+                return
+
+            long_name = payload.get('longname', '')
+            short_name = payload.get('shortname', '')
+            hw_model = payload.get('hardware', '')
+
+            node = UnifiedNode(
+                id=sender,
+                name=long_name or short_name or sender,
+                network="meshtastic",
+                meshtastic_id=sender,
+            )
+            self.node_tracker.add_node(node)
+            logger.debug(f"NodeInfo from {sender}: {long_name} ({short_name})")
+        except Exception as e:
+            logger.debug(f"Error processing nodeinfo: {e}")
+
+    def send_text(self, message: str, destination: str = None, channel: int = 0) -> bool:
+        """
+        Send a text message to Meshtastic network via CLI.
+
+        Uses transient meshtastic CLI command - no persistent connection.
+        The CLI connects, sends, disconnects. Web client is unaffected.
+
+        Args:
+            message: Text content to send
+            destination: Destination node ID (None for broadcast)
+            channel: Channel index to send on
+
+        Returns:
+            True if message sent successfully, False otherwise.
+        """
+        cli = self._find_cli()
+        if not cli:
+            logger.error("meshtastic CLI not found. Install with: pip install meshtastic")
+            return False
+
+        try:
+            host = self.config.meshtastic.host
+            cmd = [cli, '--host', host, '--sendtext', message]
+
+            if destination:
+                cmd.extend(['--dest', destination])
+            if channel > 0:
+                cmd.extend(['--ch-index', str(channel)])
+
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            if result.returncode == 0:
+                logger.info(f"Sent to Meshtastic via CLI: {message[:50]}...")
+                return True
+            else:
+                logger.warning(f"CLI send failed (rc={result.returncode}): {result.stderr[:200]}")
+                return False
+
+        except subprocess.TimeoutExpired:
+            logger.error("meshtastic CLI timed out")
+            return False
+        except FileNotFoundError:
+            logger.error(f"meshtastic CLI not found at: {cli}")
+            self._cli_path = None  # Reset cache
+            return False
+        except Exception as e:
+            logger.error(f"CLI send failed: {e}")
+            return False
+
+    def queue_send(self, payload: Dict) -> bool:
+        """
+        Send handler for persistent queue - Meshtastic destination.
+
+        Args:
+            payload: Dictionary with 'message', 'destination', 'channel' keys
+
+        Returns:
+            True if sent successfully, False otherwise.
+        """
+        message = payload.get('message', '')
+        destination = payload.get('destination')
+        channel = payload.get('channel', 0)
+        return self.send_text(message, destination, channel)
+
+    def test_connection(self) -> bool:
+        """Test MQTT broker connectivity."""
+        import socket
+        mqtt_cfg = self.config.mqtt_bridge
+        sock = None
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(5)
+            result = sock.connect_ex((mqtt_cfg.broker, mqtt_cfg.port))
+            return result == 0
+        except (OSError, Exception) as e:
+            logger.debug(f"MQTT broker connection test failed: {e}")
+            return False
+        finally:
+            if sock:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
+
+    def disconnect(self) -> None:
+        """Disconnect from MQTT broker."""
+        if self._client:
+            try:
+                self._client.loop_stop()
+                self._client.disconnect()
+            except Exception as e:
+                logger.debug(f"Error disconnecting MQTT: {e}")
+        self._connected = False
+
+    def _find_cli(self) -> Optional[str]:
+        """Find meshtastic CLI binary (cached)."""
+        if self._cli_path:
+            return self._cli_path
+
+        import shutil
+        path = shutil.which('meshtastic')
+        if path:
+            self._cli_path = path
+            return path
+
+        # Check common locations
+        for candidate in [
+            '/usr/local/bin/meshtastic',
+            '/usr/bin/meshtastic',
+            str(self._get_user_bin() / 'meshtastic'),
+        ]:
+            if self._path_exists(candidate):
+                self._cli_path = candidate
+                return candidate
+
+        return None
+
+    def _get_user_bin(self):
+        """Get user's local bin directory."""
+        try:
+            from utils.paths import get_real_user_home
+            return get_real_user_home() / '.local' / 'bin'
+        except ImportError:
+            from pathlib import Path
+            return Path.home() / '.local' / 'bin'
+
+    @staticmethod
+    def _path_exists(path: str) -> bool:
+        """Check if a file exists at path."""
+        import os
+        return os.path.isfile(path) and os.access(path, os.X_OK)
+
+    def _is_duplicate(self, msg_id: str) -> bool:
+        """Check if message ID was seen recently (dedup)."""
+        now = time.time()
+        with self._mqtt_lock:
+            if msg_id in self._recent_ids:
+                return True
+            self._recent_ids[msg_id] = now
+        return False
+
+    def _cleanup_dedup(self) -> None:
+        """Remove expired entries from dedup cache."""
+        now = time.time()
+        with self._mqtt_lock:
+            expired = [
+                k for k, v in self._recent_ids.items()
+                if now - v > self._dedup_window
+            ]
+            for k in expired:
+                del self._recent_ids[k]
+
+    def _notify_status(self, status: str) -> None:
+        """Notify status callback."""
+        if self._status_callback:
+            try:
+                self._status_callback(status)
+            except Exception as e:
+                logger.error(f"Status callback error: {e}")

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -23,6 +23,14 @@ from .bridge_health import (
 )
 from .meshtastic_handler import MeshtasticHandler
 
+# MQTT bridge handler (zero-interference, recommended)
+try:
+    from .mqtt_bridge_handler import MQTTBridgeHandler
+    HAS_MQTT_BRIDGE = True
+except ImportError:
+    HAS_MQTT_BRIDGE = False
+    MQTTBridgeHandler = None
+
 # Import circuit breaker for destination-level failure handling
 try:
     from .circuit_breaker import CircuitBreakerRegistry
@@ -247,19 +255,40 @@ class RNSMeshtasticBridge:
         # MQTT filtering configuration
         self._filter_mqtt_messages = False  # Set True to drop MQTT-originated messages
 
-        # Initialize Meshtastic handler with dependency injection
-        self._mesh_handler = MeshtasticHandler(
-            config=self.config,
-            node_tracker=self.node_tracker,
-            health=self.health,
-            stop_event=self._stop_event,
-            stats=self.stats,
-            stats_lock=self._stats_lock,
-            message_queue=self._mesh_to_rns_queue,
-            message_callback=self._notify_message,
-            status_callback=lambda status: self._notify_status(status),
-            should_bridge=self._should_bridge,
-        )
+        # Initialize Meshtastic handler based on bridge mode
+        # MQTT bridge (recommended): zero interference with web client
+        # TCP bridge (legacy): holds persistent connection, blocks web client
+        if self.config.bridge_mode == "mqtt_bridge" and HAS_MQTT_BRIDGE:
+            logger.info("Using MQTT bridge handler (zero-interference mode)")
+            self._mesh_handler = MQTTBridgeHandler(
+                config=self.config,
+                node_tracker=self.node_tracker,
+                health=self.health,
+                stop_event=self._stop_event,
+                stats=self.stats,
+                stats_lock=self._stats_lock,
+                message_queue=self._mesh_to_rns_queue,
+                message_callback=self._notify_message,
+                status_callback=lambda status: self._notify_status(status),
+                should_bridge=self._should_bridge,
+            )
+        else:
+            if self.config.bridge_mode == "mqtt_bridge" and not HAS_MQTT_BRIDGE:
+                logger.warning("MQTT bridge requested but paho-mqtt not available, "
+                             "falling back to TCP handler")
+            logger.info("Using TCP Meshtastic handler (legacy mode)")
+            self._mesh_handler = MeshtasticHandler(
+                config=self.config,
+                node_tracker=self.node_tracker,
+                health=self.health,
+                stop_event=self._stop_event,
+                stats=self.stats,
+                stats_lock=self._stats_lock,
+                message_queue=self._mesh_to_rns_queue,
+                message_callback=self._notify_message,
+                status_callback=lambda status: self._notify_status(status),
+                should_bridge=self._should_bridge,
+            )
 
         # Register Meshtastic sender now that handler exists
         if self._persistent_queue:

--- a/src/launcher_tui/gateway_config_mixin.py
+++ b/src/launcher_tui/gateway_config_mixin.py
@@ -62,7 +62,15 @@ class GatewayConfigMixin:
                 ("status", f"Status              {status}"),
                 ("mode", f"Bridge Mode         {mode}"),
                 ("enable", "Enable Gateway" if not config.enabled else "Disable Gateway"),
-                ("meshtastic", "Meshtastic Settings"),
+            ]
+
+            # Show mode-specific settings
+            if config.bridge_mode == "mqtt_bridge":
+                choices.append(("mqtt_bridge", "MQTT Bridge Settings"))
+            else:
+                choices.append(("meshtastic", "Meshtastic Settings"))
+
+            choices.extend([
                 ("rns", "RNS Settings"),
                 ("routing", "Routing Rules"),
                 ("telemetry", "Telemetry Settings"),
@@ -70,7 +78,7 @@ class GatewayConfigMixin:
                 ("validate", "Validate Config"),
                 ("save", "Save Configuration"),
                 ("back", "Back"),
-            ]
+            ])
 
             choice = self.dialog.menu(
                 "Gateway Configuration",
@@ -102,6 +110,7 @@ class GatewayConfigMixin:
                 "status": ("Gateway Status", self._show_gateway_status),
                 "mode": ("Bridge Mode", self._set_bridge_mode),
                 "meshtastic": ("Meshtastic Settings", self._config_meshtastic),
+                "mqtt_bridge": ("MQTT Bridge Settings", self._config_mqtt_bridge),
                 "rns": ("RNS Settings", self._config_rns),
                 "routing": ("Routing Rules", self._config_routing),
                 "telemetry": ("Telemetry Settings", self._config_telemetry),
@@ -122,12 +131,29 @@ class GatewayConfigMixin:
             f"Auto-start:   {config.auto_start}",
             f"Bridge Mode:  {config.bridge_mode}",
             "",
-            "MESHTASTIC:",
-            f"  Host:       {config.meshtastic.host}",
-            f"  Port:       {config.meshtastic.port}",
-            f"  Channel:    {config.meshtastic.channel}",
-            f"  MQTT:       {config.meshtastic.use_mqtt}",
-            "",
+        ]
+
+        if config.bridge_mode == "mqtt_bridge":
+            lines.extend([
+                "MQTT BRIDGE (zero interference):",
+                f"  Broker:     {config.mqtt_bridge.broker}",
+                f"  Port:       {config.mqtt_bridge.port}",
+                f"  Region:     {config.mqtt_bridge.region}",
+                f"  Channel:    {config.mqtt_bridge.channel}",
+                f"  JSON mode:  {config.mqtt_bridge.json_enabled}",
+                f"  TLS:        {config.mqtt_bridge.use_tls}",
+                "",
+            ])
+        else:
+            lines.extend([
+                "MESHTASTIC (TCP - legacy):",
+                f"  Host:       {config.meshtastic.host}",
+                f"  Port:       {config.meshtastic.port}",
+                f"  Channel:    {config.meshtastic.channel}",
+                "",
+            ])
+
+        lines.extend([
             "RNS:",
             f"  Identity:   {config.rns.identity_name}",
             f"  Announce:   every {config.rns.announce_interval}s",
@@ -140,23 +166,28 @@ class GatewayConfigMixin:
             f"  Position:   {config.telemetry.share_position}",
             f"  Battery:    {config.telemetry.share_battery}",
             f"  Interval:   {config.telemetry.update_interval}s",
-        ]
+        ])
 
         self.dialog.msgbox("Gateway Status", "\n".join(lines), width=50, height=25)
 
     def _set_bridge_mode(self, config):
         """Set the bridge operating mode."""
         choices = [
-            ("message_bridge", "Message Bridge      RNS <-> Meshtastic messages"),
-            ("rns_transport", "RNS Transport       RNS over LoRa mesh"),
-            ("mesh_bridge", "Mesh Bridge         Bridge two Meshtastic networks"),
+            ("mqtt_bridge", "MQTT Bridge (Recommended)  Zero interference"),
+            ("message_bridge", "TCP Message Bridge         Legacy, blocks web client"),
+            ("rns_transport", "RNS Transport              RNS over LoRa mesh"),
+            ("mesh_bridge", "Mesh Bridge                Bridge two Meshtastic nets"),
             ("back", "Back"),
         ]
 
         choice = self.dialog.menu(
             "Bridge Mode",
             "Select how the gateway should operate:\n\n"
-            "Message Bridge: Translate messages between networks\n"
+            "MQTT Bridge: Uses MQTT for receive, CLI for send.\n"
+            "  Web client on :9443 works uninterrupted.\n"
+            "  Requires: mosquitto + meshtasticd mqtt.enabled\n\n"
+            "TCP Bridge: Legacy mode, holds TCP connection.\n"
+            "  Blocks meshtasticd web client while running.\n\n"
             "RNS Transport: Use Meshtastic as RNS network layer\n"
             "Mesh Bridge: Connect two Meshtastic presets",
             choices
@@ -169,6 +200,111 @@ class GatewayConfigMixin:
                 f"Bridge mode set to: {choice}\n\n"
                 "Save configuration to persist."
             )
+
+    def _config_mqtt_bridge(self, config):
+        """Configure MQTT bridge settings."""
+        while True:
+            mqtt = config.mqtt_bridge
+            choices = [
+                ("broker", f"Broker              {mqtt.broker}"),
+                ("port", f"Port                {mqtt.port}"),
+                ("region", f"Region              {mqtt.region}"),
+                ("channel", f"Channel             {mqtt.channel}"),
+                ("tls", f"TLS                 {mqtt.use_tls}"),
+                ("auth", f"Auth                {'Set' if mqtt.username else 'None'}"),
+                ("setup", "Run MQTT Setup Guide"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "MQTT Bridge Settings",
+                "Configure MQTT transport for zero-interference bridging.\n\n"
+                "Requires: mosquitto + meshtasticd mqtt.enabled=true",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "broker":
+                val = self.dialog.inputbox(
+                    "MQTT Broker",
+                    "Enter MQTT broker address:",
+                    init=mqtt.broker
+                )
+                if val:
+                    mqtt.broker = val.strip()
+
+            elif choice == "port":
+                val = self.dialog.inputbox(
+                    "MQTT Port",
+                    "Enter MQTT broker port (1883 default, 8883 TLS):",
+                    init=str(mqtt.port)
+                )
+                if val and val.isdigit():
+                    mqtt.port = int(val)
+
+            elif choice == "region":
+                val = self.dialog.inputbox(
+                    "LoRa Region",
+                    "Enter LoRa region code (US, EU_868, etc.):",
+                    init=mqtt.region
+                )
+                if val:
+                    mqtt.region = val.strip()
+
+            elif choice == "channel":
+                val = self.dialog.inputbox(
+                    "Meshtastic Channel",
+                    "Enter Meshtastic channel name:",
+                    init=mqtt.channel
+                )
+                if val:
+                    mqtt.channel = val.strip()
+
+            elif choice == "tls":
+                mqtt.use_tls = not mqtt.use_tls
+                if mqtt.use_tls and mqtt.port == 1883:
+                    mqtt.port = 8883
+
+            elif choice == "auth":
+                user = self.dialog.inputbox(
+                    "MQTT Username",
+                    "Enter MQTT username (blank for none):",
+                    init=mqtt.username
+                )
+                if user is not None:
+                    mqtt.username = user.strip()
+                    if mqtt.username:
+                        pw = self.dialog.inputbox(
+                            "MQTT Password",
+                            "Enter MQTT password:",
+                            init=""
+                        )
+                        if pw is not None:
+                            mqtt.password = pw
+                    else:
+                        mqtt.password = ""
+
+            elif choice == "setup":
+                self.dialog.msgbox(
+                    "MQTT Setup Guide",
+                    "Step 1: Install mosquitto\n"
+                    "  sudo apt install mosquitto mosquitto-clients\n\n"
+                    "Step 2: Configure meshtasticd MQTT\n"
+                    "  meshtastic --set mqtt.enabled true\n"
+                    "  meshtastic --set mqtt.address 127.0.0.1\n"
+                    "  meshtastic --set mqtt.json_enabled true\n\n"
+                    "Step 3: Enable uplink on channel\n"
+                    "  meshtastic --ch-index 0 --ch-set uplink_enabled true\n\n"
+                    "Step 4: Enable downlink (for sending)\n"
+                    "  meshtastic --ch-index 0 --ch-set downlink_enabled true\n\n"
+                    "Step 5: Verify\n"
+                    "  mosquitto_sub -h localhost -t 'msh/#' -v\n\n"
+                    "Or run the setup script:\n"
+                    "  templates/mqtt/meshtasticd-mqtt-setup.sh",
+                    width=60, height=25
+                )
 
     def _config_meshtastic(self, config):
         """Configure Meshtastic connection settings."""
@@ -518,6 +654,7 @@ class GatewayConfigMixin:
                     config.bridge_mode = new_config.bridge_mode
                     config.meshtastic = new_config.meshtastic
                     config.rns = new_config.rns
+                    config.mqtt_bridge = new_config.mqtt_bridge
                     config.rns_transport = new_config.rns_transport
                     config.mesh_bridge = new_config.mesh_bridge
                     config.routing_rules = new_config.routing_rules

--- a/templates/mqtt/meshtasticd-mqtt-setup.sh
+++ b/templates/mqtt/meshtasticd-mqtt-setup.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# MeshForge - Configure meshtasticd MQTT for gateway bridge
+# =========================================================
+#
+# This script configures meshtasticd to publish mesh traffic to a local
+# MQTT broker. MeshForge's gateway subscribes to MQTT instead of using
+# the TCP connection, leaving the web client unaffected.
+#
+# Prerequisites:
+#   - meshtasticd running and accessible
+#   - mosquitto installed and running (sudo apt install mosquitto)
+#   - meshtastic CLI installed (pip install meshtastic)
+#
+# Usage:
+#   chmod +x meshtasticd-mqtt-setup.sh
+#   ./meshtasticd-mqtt-setup.sh
+#
+# After running, verify with:
+#   mosquitto_sub -h localhost -t 'msh/#' -v
+
+set -e
+
+HOST="${1:-localhost}"
+echo "Configuring meshtasticd MQTT on host: ${HOST}"
+
+# Check prerequisites
+if ! command -v meshtastic &>/dev/null; then
+    echo "ERROR: meshtastic CLI not found. Install with: pip install meshtastic"
+    exit 1
+fi
+
+if ! systemctl is-active --quiet mosquitto 2>/dev/null; then
+    echo "WARNING: mosquitto not running. Install with: sudo apt install mosquitto"
+    echo "         Then: sudo systemctl start mosquitto"
+fi
+
+echo ""
+echo "Step 1: Enable MQTT module"
+meshtastic --host "${HOST}" --set mqtt.enabled true
+
+echo ""
+echo "Step 2: Set MQTT broker to localhost"
+meshtastic --host "${HOST}" --set mqtt.address 127.0.0.1
+
+echo ""
+echo "Step 3: Enable JSON output (human-readable, recommended)"
+meshtastic --host "${HOST}" --set mqtt.json_enabled true
+
+echo ""
+echo "Step 4: Disable encryption to MQTT (local broker, not needed)"
+meshtastic --host "${HOST}" --set mqtt.encryption_enabled false
+
+echo ""
+echo "Step 5: Enable uplink on primary channel (mesh -> MQTT)"
+meshtastic --host "${HOST}" --ch-index 0 --ch-set uplink_enabled true
+
+echo ""
+echo "Step 6: Enable downlink on primary channel (MQTT -> mesh)"
+meshtastic --host "${HOST}" --ch-index 0 --ch-set downlink_enabled true
+
+echo ""
+echo "Done! meshtasticd will now publish mesh traffic to MQTT."
+echo ""
+echo "Verify with:"
+echo "  mosquitto_sub -h localhost -t 'msh/#' -v"
+echo ""
+echo "Web client still works at: https://${HOST}:9443"

--- a/templates/mqtt/mosquitto.conf
+++ b/templates/mqtt/mosquitto.conf
@@ -1,0 +1,72 @@
+# MeshForge - Mosquitto MQTT Broker Configuration
+# ================================================
+#
+# Install: sudo apt install mosquitto mosquitto-clients
+# Config:  sudo cp mosquitto.conf /etc/mosquitto/conf.d/meshforge.conf
+# Restart: sudo systemctl restart mosquitto
+#
+# This configures a local MQTT broker for meshtasticd <-> MeshForge
+# communication. Zero interference with meshtasticd's web client.
+#
+# Architecture:
+#   meshtasticd -> MQTT broker (this) -> MeshForge gateway
+#   meshtasticd -> web client (:9443)  [unaffected]
+#   meshtasticd -> TCP client (:4403)  [unaffected]
+
+# =============================================================================
+# Listener - Local connections only (no internet exposure)
+# =============================================================================
+listener 1883 127.0.0.1
+
+# No authentication required for localhost-only
+# For remote access, uncomment and create password file:
+# password_file /etc/mosquitto/passwd
+# allow_anonymous false
+allow_anonymous true
+
+# =============================================================================
+# Persistence - Survive broker restarts
+# =============================================================================
+persistence true
+persistence_location /var/lib/mosquitto/
+
+# =============================================================================
+# Logging
+# =============================================================================
+log_dest syslog
+log_type error
+log_type warning
+# Uncomment for debugging:
+# log_type information
+# log_type subscribe
+# log_type unsubscribe
+
+# =============================================================================
+# Performance
+# =============================================================================
+# Max queued messages per client (prevents memory exhaustion)
+max_queued_messages 1000
+
+# Max packet size (Meshtastic messages are small)
+message_size_limit 65536
+
+# Keepalive timeout
+max_keepalive 120
+
+# =============================================================================
+# meshtasticd MQTT Configuration
+# =============================================================================
+# After installing mosquitto, configure meshtasticd to publish to it:
+#
+#   meshtastic --host localhost --set mqtt.enabled true
+#   meshtastic --host localhost --set mqtt.address 127.0.0.1
+#   meshtastic --host localhost --set mqtt.json_enabled true
+#
+# Enable uplink on the channel you want to monitor:
+#   meshtastic --host localhost --ch-index 0 --ch-set uplink_enabled true
+#
+# Optional - enable downlink for bidirectional gateway:
+#   meshtastic --host localhost --ch-index 0 --ch-set downlink_enabled true
+#
+# Verify MQTT is working:
+#   mosquitto_sub -h localhost -t 'msh/#' -v

--- a/templates/systemd/rnsd-user.service
+++ b/templates/systemd/rnsd-user.service
@@ -1,0 +1,48 @@
+# MeshForge - rnsd User Service
+# ==============================
+#
+# RNS should run as the user, not as root. This is the standard convention.
+#
+# Install:
+#   pip install --user rns
+#   mkdir -p ~/.config/systemd/user
+#   cp rnsd-user.service ~/.config/systemd/user/rnsd.service
+#
+# Enable:
+#   systemctl --user daemon-reload
+#   systemctl --user enable rnsd
+#   systemctl --user start rnsd
+#
+# Persist after logout (required for headless/server):
+#   loginctl enable-linger $USER
+#
+# Config: ~/.reticulum/config
+# Generate example: rnsd --exampleconfig
+#
+# Status:
+#   systemctl --user status rnsd
+#   rnstatus
+
+[Unit]
+Description=Reticulum Network Stack Daemon
+After=default.target network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Restart=always
+RestartSec=3
+
+# rnsd binary installed by pip --user
+ExecStart=%h/.local/bin/rnsd --service
+
+# Use user's config directory
+Environment=HOME=%h
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=rnsd
+
+[Install]
+WantedBy=default.target

--- a/tests/test_bridge_integration.py
+++ b/tests/test_bridge_integration.py
@@ -40,6 +40,7 @@ def bridge_config():
     """Create a test config with bridging enabled."""
     config = GatewayConfig()
     config.enabled = True
+    config.bridge_mode = "message_bridge"  # Use TCP mode for direct packet tests
     config.default_route = "bidirectional"
     config.routing_rules = [
         RoutingRule(


### PR DESCRIPTION
Replace TCP-based MeshtasticHandler with MQTTBridgeHandler that subscribes to meshtasticd's native MQTT topics for receiving mesh traffic and uses meshtastic CLI for sending (transient connections only).

This eliminates the fundamental interference problem: meshtasticd only allows one TCP client, so the old bridge blocked the web client on :9443. MQTT is a completely independent subsystem - web client, TCP, and MQTT all work simultaneously.

New files:
- src/gateway/mqtt_bridge_handler.py - MQTT-based handler
- templates/mqtt/mosquitto.conf - local broker config
- templates/mqtt/meshtasticd-mqtt-setup.sh - one-shot setup
- templates/systemd/rnsd-user.service - user-mode rnsd

Changes:
- gateway/config.py: MQTTBridgeConfig, mqtt_bridge default mode
- gateway/rns_bridge.py: auto-select MQTT or TCP handler
- gateway_config_mixin.py: MQTT settings menu, setup guide
- meshtastic_api_proxy.py: deprecated (source of interference)
- test_bridge_integration.py: explicit message_bridge for TCP tests

Architecture: meshtasticd -> MQTT broker -> MeshForge -> rnsd

https://claude.ai/code/session_01FddBxRq9CrTE7cqjCPQy14