### PR TITLE
refactor: extract MessageRouter from rns_bridge.py, add except loggin…

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -46,42 +46,9 @@ Many files still use `Path.home()`. Priority fixes completed:
 
 ---
 
-## Issue #2: WebKit Disabled When Running as Root (MOOT — GTK removed)
+## Issue #2: WebKit Disabled When Running as Root (MOOT — GTK removed) — ARCHIVED (GTK removed)
 
-> **Status**: No longer relevant. GTK4 UI was removed; TUI is the only interface.
-> Kept for historical reference only.
-
-### Symptom
-Embedded web views (HamClock live view) show "Open in Browser" instead of embedded content.
-
-### Root Cause
-WebKit uses Chromium's sandbox which refuses to run as root for security reasons. Since MeshForge is launched with `sudo python3 src/launcher.py`, WebKit is always disabled.
-
-### Impact
-- HamClock embedded view never works
-- Any WebKit-based features fail silently
-- Users think features are "broken"
-
-### Proper Fix
-1. **Accept the limitation** - WebKit cannot run as root
-2. **Provide clear UX feedback** explaining why and offering alternatives
-3. **Long-term**: Consider polkit for privileged operations so app runs as user
-
-### Implementation Pattern
-```python
-_is_root = os.geteuid() == 0
-
-if _is_root:
-    # WebKit won't work - explain why and provide alternative
-    label = Gtk.Label(label="Embedded view disabled (running as root)")
-    label.set_tooltip_text("WebKit cannot run embedded when MeshForge is started with sudo.")
-    # Offer "Open in Browser" button
-```
-
-### Prevention
-- Document this limitation in UI
-- Test both as root and as user
-- Consider alternative rendering for web content
+> Archived to `persistent_issues_archive.md`. Gtk removed
 
 ---
 
@@ -436,67 +403,9 @@ The `c=component` creates a new binding at each iteration, capturing the current
 
 ---
 
-## Issue #11: GTK4/Libadwaita Taskbar Icon Shows Generic
+## Issue #11: GTK4/Libadwaita Taskbar Icon Shows Generic — ARCHIVED (GTK removed)
 
-### Symptom
-MeshForge shows a generic application icon in the taskbar/dock instead of the custom MeshForge icon, despite multiple fix attempts.
-
-### Root Cause
-GTK4/libadwaita has strict requirements for taskbar icons:
-1. Icon must be in hicolor theme structure (`~/.local/share/icons/hicolor/scalable/apps/`)
-2. Icon filename must match `application_id` (e.g., `org.meshforge.app.svg`)
-3. Desktop entry `StartupWMClass` must match the window's actual WM_CLASS
-4. Icon cache must be updated after installation
-5. Some desktop environments cache icons aggressively
-
-### Attempts Made (2026-01-12)
-- [x] Install icon to `~/.local/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
-- [x] Add icon theme search path with `icon_theme.add_search_path()`
-- [x] Set `Gtk.Window.set_default_icon_name("org.meshforge.app")`
-- [x] Update icon cache with `gtk-update-icon-cache`
-- [x] Fix ownership when running as root with sudo
-- [ ] **NOT YET TRIED**: Verify WM_CLASS matches StartupWMClass in .desktop file
-- [ ] **NOT YET TRIED**: Use GResource to bundle icon into application
-- [ ] **NOT YET TRIED**: Check if issue is desktop-environment specific (GNOME vs KDE vs XFCE)
-
-### Files Involved
-- `src/launcher_vte.py` - VTE terminal wrapper (main GTK window)
-- `src/gtk_ui/app.py` - Main GTK application
-- `org.meshforge.app.desktop` - Desktop entry file
-- `assets/meshforge-icon.svg` - Source icon
-
-### Next Steps to Try
-1. **Verify WM_CLASS**: Run `xprop WM_CLASS` and click the MeshForge window - ensure it matches `org.meshforge.app`
-2. **Check GApplication**: Ensure `application_id='org.meshforge.app'` is set correctly in Adw.Application
-3. **Try GResource**: Bundle icon as GResource instead of file system installation
-4. **Desktop-specific**: Test on different DEs to isolate if it's environment-specific
-
-### Fix (2026-01-13)
-
-Run the desktop integration installer:
-
-```bash
-cd /opt/meshforge
-sudo ./scripts/install-desktop.sh
-```
-
-This installs icons to:
-- `/usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
-- `/usr/share/icons/hicolor/{48,64,128,256}x{48,64,128,256}/apps/`
-- `/usr/share/pixmaps/`
-
-Then clear the icon cache:
-
-```bash
-gtk-update-icon-cache -f /usr/share/icons/hicolor
-# Log out and back in, or restart desktop environment
-```
-
-### If Still Not Working
-
-1. Verify icon installed: `ls /usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
-2. Check WM_CLASS: `xprop WM_CLASS` → click MeshForge window → should show `org.meshforge.app`
-3. Clear DE cache: Some DEs (GNOME, KDE) cache icons aggressively
+> Archived to `persistent_issues_archive.md`. Gtk removed
 
 ---
 
@@ -533,248 +442,21 @@ This allows connecting to rnsd without trying to bind ports.
 
 ---
 
-## Issue #13: Meshtastic CLI Auto-Detection Freezes GTK
+## Issue #13: Meshtastic CLI Auto-Detection Freezes GTK — ARCHIVED (GTK removed)
 
-### Symptom
-GTK UI freezes when checking node count, especially if meshtasticd TCP is not running on port 4403.
-
-### Root Cause
-The `_get_node_count()` method in `src/gtk_ui/app.py` calls the meshtastic CLI. Without `--host localhost`, the CLI does USB/serial auto-detection which:
-1. Takes 10-15+ seconds per call
-2. Blocks threads
-3. Causes thread pile-up when status timer fires every 5 seconds
-4. Eventually exhausts resources and freezes GTK
-
-### Wrong Approach
-```python
-# WRONG - causes freeze
-result = subprocess.run(
-    [cli_path, '--nodes'],  # No --host = auto-detection
-    timeout=15  # Too long
-)
-```
-
-### Proper Fix
-1. **Quick port check FIRST** - Skip CLI entirely if port 4403 not reachable
-2. **Use --host localhost** - Prevents USB/serial scanning
-3. **Short timeout** - 10 seconds max
-4. **Cache results** - 30 second TTL prevents rapid CLI calls
-
-```python
-# CORRECT pattern
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.settimeout(1.0)
-try:
-    sock.connect(("localhost", 4403))
-    port_reachable = True
-except:
-    port_reachable = False
-finally:
-    sock.close()
-
-if not port_reachable:
-    return cached_value  # Don't call CLI at all
-
-# Only call CLI if port is reachable
-result = subprocess.run(
-    [cli_path, '--host', 'localhost', '--nodes'],
-    timeout=10
-)
-```
-
-### Files Fixed (2026-01-14)
-- [x] `src/gtk_ui/app.py` - `_get_node_count()` method
-- [x] Added `import shutil` (was missing, caused NameError fallback)
-
-### Regression Tests
-- `tests/test_gtk_crash_fixes.py::TestNodeCountThreadSafety`
-- `tests/test_gtk_crash_fixes.py::TestNodeCountCodePattern`
-
-### Prevention
-- Always use `--host localhost` when calling meshtastic CLI in GUI contexts
-- Do quick port checks before expensive subprocess calls
-- Keep timeouts shorter than timer intervals to prevent thread pile-up
-- Run `test_gtk_crash_fixes.py` to verify patterns are correct
+> Archived to `persistent_issues_archive.md`. Gtk removed
 
 ---
 
-## Issue #14: GTK Panel Lifecycle - Missing Cleanup Methods
+## Issue #14: GTK Panel Lifecycle - Missing Cleanup Methods — ARCHIVED (GTK removed)
 
-### Symptom
-- GTK freezes or crashes when closing window
-- Memory growth during extended use
-- Timers continue firing after panels are destroyed
-- Orphaned signal handlers causing callbacks on destroyed widgets
-
-### Root Cause
-Panel cleanup was fragmented:
-1. Only 9 of 24 panels had cleanup() methods
-2. app.py used a hard-coded list for cleanup (missed 15 panels)
-3. No standardized timer/signal tracking pattern
-4. Each panel reinvented resource management
-
-### Impact
-- Timer leaks: GLib.timeout_add() handlers never cancelled
-- Signal leaks: GTK signals never disconnected
-- Thread races: Callbacks firing after widget destruction
-- File descriptor exhaustion (errno 24)
-
-### Architectural Fix (2026-01-14)
-
-**1. Created PanelBase class** (`src/gtk_ui/panel_base.py`):
-```python
-class PanelBase(Gtk.Box):
-    def __init__(self, main_window):
-        self._pending_timers = []
-        self._signal_handlers = {}
-        self._is_destroyed = False
-        self.connect("unrealize", self._on_unrealize)
-
-    def _schedule_timer(self, delay_ms, callback, *args):
-        """Timer tracking with auto-cleanup"""
-        timer_id = GLib.timeout_add(delay_ms, callback, *args)
-        self._pending_timers.append(timer_id)
-        return timer_id
-
-    def _connect_signal(self, widget, signal_name, callback):
-        """Signal tracking with auto-cleanup"""
-        handler_id = widget.connect(signal_name, callback)
-        self._signal_handlers[widget].append(handler_id)
-        return handler_id
-
-    def cleanup(self):
-        """Auto-called on unrealize"""
-        self._cancel_all_timers()
-        self._disconnect_all_signals()
-```
-
-**2. Auto-discover panels in app.py** (replaces hard-coded list):
-```python
-def _on_close_request(self, window):
-    # Auto-discover ALL panels with cleanup()
-    for attr_name in dir(self):
-        if attr_name.endswith('_panel'):
-            panel = getattr(self, attr_name, None)
-            if panel and hasattr(panel, 'cleanup'):
-                panel.cleanup()
-```
-
-**3. Added cleanup() to all 24 panels**
-
-### Files Changed
-- [NEW] `src/gtk_ui/panel_base.py` - PanelBase class with resource management
-- [MOD] `src/gtk_ui/app.py` - Auto-discover cleanup
-- [MOD] All 24 panel files - Added cleanup() methods
-
-### Regression Tests
-- `tests/test_gtk_crash_fixes.py::TestPanelBaseResourceManagement`
-- `tests/test_gtk_crash_fixes.py::TestPanelCleanupCoverage`
-- `tests/test_gtk_crash_fixes.py::TestAppAutoDiscoverCleanup`
-- `tests/test_gtk_crash_fixes.py::TestTimerCleanupPatterns`
-
-### Migration Path for New Panels
-New panels should inherit from PanelBase:
-```python
-from gtk_ui.panel_base import PanelBase
-
-class MyNewPanel(PanelBase):
-    def __init__(self, main_window):
-        super().__init__(main_window)
-        # Use self._schedule_timer() instead of GLib.timeout_add()
-        # Use self._connect_signal() instead of widget.connect()
-
-    def cleanup(self):
-        # Your cleanup code here
-        super().cleanup()  # ALWAYS call parent cleanup
-```
-
-### Prevention
-- Run `python3 -m unittest tests/test_gtk_crash_fixes.py -v` before releasing
-- New panels must inherit from PanelBase or implement cleanup()
-- Use `_schedule_timer()` and `_connect_signal()` for resource tracking
+> Archived to `persistent_issues_archive.md`. Gtk removed
 
 ---
 
-## Issue #15: GTK Startup Performance - Thundering Herd
+## Issue #15: GTK Startup Performance - Thundering Herd — ARCHIVED (GTK removed)
 
-### Symptom
-- GTK app takes 5-10+ seconds to become responsive after launch
-- UI renders but feels sluggish immediately after startup
-- Multiple threads spawning simultaneously during initialization
-- CPU spikes on startup
-
-### Root Cause (Identified via scientific analysis 2026-01-14)
-**Thundering Herd Problem**: All 21+ panels instantiated at startup, each spawning threads:
-
-1. **Panel init triggers async work**: 12+ panels call `_refresh_data()`, `_check_status()`, `_load_*()` in `__init__`
-2. **Multiple concurrent timers**: 5+ timers running (1s, 2s, 3s, 5s, 30s intervals)
-3. **Status timer overhead**: app.py `_update_status` made 3-5 subprocess calls every 5 seconds
-4. **No lazy loading**: Panels instantiated whether user visits them or not
-
-### Quantified Impact
-- 21 panels loaded at startup
-- 12+ panels spawn threads immediately on `__init__`
-- 143 `threading.Thread` calls found in GTK UI code
-- 5+ recurring timers competing for CPU
-- Each status update: 3-5 subprocess calls with combined 15+ second timeout
-
-### Architectural Fix (2026-01-14)
-
-**1. Lazy Panel Loading** - Only instantiate panels on first navigation:
-```python
-# Store loaders but don't call them
-self._panel_loaders = {"service": self._add_service_page, ...}
-self._loaded_panels = set()
-
-# Create lightweight placeholders
-for name in self._panel_loaders.keys():
-    placeholder = self._create_loading_placeholder(name)
-    self.content_stack.add_named(placeholder, name)
-
-# Only load dashboard (default view) at startup
-self._load_panel("dashboard")
-
-# Lazy load on navigation
-def _on_nav_selected(self, listbox, row):
-    if page_name not in self._loaded_panels:
-        self._load_panel(page_name)
-    self.content_stack.set_visible_child_name(page_name)
-```
-
-**2. Deferred Initial Refresh** - Let UI render first:
-```python
-# WRONG - thread spawns immediately
-def __init__(self, main_window):
-    self._build_ui()
-    self._refresh_data()  # Spawns thread NOW
-
-# CORRECT - defer 500ms
-def __init__(self, main_window):
-    self._build_ui()
-    GLib.timeout_add(500, self._initial_refresh)
-```
-
-**3. Optimized Status Timer**:
-- Increased interval from 5s to 10s
-- Delayed first update by 2 seconds
-- Removed redundant subprocess calls (pgrep, socket check)
-- Added overlap prevention flag
-
-### Files Changed
-- [MOD] `src/gtk_ui/app.py` - Lazy loading, optimized timers
-- [MOD] `src/gtk_ui/panels/dashboard.py` - Deferred initial refresh
-
-### Expected Improvement
-- Startup time: 5-10s → <2s
-- Initial responsiveness: Immediate
-- Thread count at startup: 12+ → 1-2
-- Subprocess calls at startup: 10+ → 1-2
-
-### Prevention
-- New panels must NOT spawn threads in `__init__`
-- Use `GLib.timeout_add(500, self._initial_refresh)` for deferred loading
-- Prefer single comprehensive status calls over multiple subprocess invocations
-- Test startup performance: `time python3 src/launcher.py --gtk`
+> Archived to `persistent_issues_archive.md`. Gtk removed
 
 ---
 
@@ -1476,78 +1158,15 @@ The gateway diagnostic (`src/utils/gateway_diagnostic.py`) should be updated to:
 
 ---
 
-## Issue #25: rnsd PermissionError on /etc/reticulum/storage/ratchets
+## Issue #25: rnsd PermissionError on /etc/reticulum/storage/ratchets — ARCHIVED (resolved)
 
-### Symptom
-rnsd crashes in a background thread with:
-```
-PermissionError: [Errno 13] Permission denied: '/etc/reticulum/storage/ratchets'
-```
-Additionally, `/etc/reticulum/identity` is never created, and the TUI "Show local identity" shows "No identity provided, cannot continue."
-
-### Root Cause
-RNS added **key ratcheting** support which requires a `ratchets/` subdirectory under storage. `Identity.persist_job()` runs in a background thread and calls `os.makedirs(ratchetdir)`. The install script didn't create this directory, and `ReticulumPaths.ensure_system_dirs()` was defined but never called at runtime.
-
-### Fix (v0.5.x, 2026-02-09)
-**Self-healing at runtime** — MeshForge now creates the directories automatically:
-1. `startup_checks.check_all()` calls `ensure_system_dirs()` at TUI launch
-2. `rns_bridge._init_rns_main_thread()` calls it before RNS init
-3. `install_noc.sh` creates `storage/ratchets/` during install
-4. `check_rns_storage_permissions()` diagnostic detects the issue
-5. After fixing dirs, MeshForge auto-restarts rnsd via `apply_config_and_restart()`
-
-### Files
-- `src/utils/paths.py` — `ETC_RATCHETS`, `ensure_system_dirs()`
-- `src/gateway/rns_bridge.py` — Self-heal in `_init_rns_main_thread()`
-- `src/launcher_tui/startup_checks.py` — Self-heal in `check_all()`
-- `src/core/diagnostics/checks/rns.py` — `check_rns_storage_permissions()`
-- `scripts/install_noc.sh` — Pre-create dirs
-- `src/launcher_tui/rns_menu_mixin.py` — Fixed `rnid` invocation
-
-### Status: RESOLVED
+> Archived to `persistent_issues_archive.md`. Resolved
 
 ---
 
-## Issue #26: ReticulumPaths Fallback Copies Cause Config Divergence
+## Issue #26: ReticulumPaths Fallback Copies Cause Config Divergence — ARCHIVED (resolved)
 
-### Symptom
-`.reticulum` interface configuration is "lost" between sessions. RNS config changes made in the TUI have no effect. rnsd uses a different config file than what MeshForge reads/writes.
-
-### Root Cause
-**Four separate copies** of `ReticulumPaths` existed in the codebase:
-1. `src/utils/paths.py` — **Canonical** (correct: checks `/etc/reticulum`, XDG, `~/.reticulum`)
-2. `src/launcher_tui/main.py` — Fallback (missing `get_interfaces_dir`, `ensure_system_dirs`)
-3. `src/launcher_tui/rns_menu_mixin.py` — Fallback (missing `ensure_system_dirs`)
-4. `src/core/diagnostics/checks/rns.py` — Fallback (**WRONG: skipped `/etc/reticulum` and XDG entirely**)
-5. `src/gateway/rns_bridge.py` — Fallback (missing `get_interfaces_dir`, `ensure_system_dirs`)
-
-The diagnostics fallback (`rns.py`) was the worst — it went directly to `~/.reticulum` without checking `/etc/reticulum/config` first. If a user had both `/etc/reticulum/config` (used by rnsd) and `~/.reticulum/config` (fallback), the diagnostics would read the wrong file and report incorrect status.
-
-Additionally, when running with sudo:
-- User edits: `/home/user/.reticulum/config`
-- rnsd reads: `/root/.reticulum/config` OR `/etc/reticulum/config`
-- Result: silent divergence, changes have no effect
-
-### Fix (v0.5.x, 2026-02-09)
-**Eliminated all fallback copies.** Every file now imports directly:
-```python
-# NO try/except, NO fallback class
-from utils.paths import ReticulumPaths
-```
-This ensures ONE definition is used everywhere. If `utils.paths` is unavailable, the import fails immediately with a clear `ImportError` — better than silently using a wrong path.
-
-### Files Changed
-- `src/launcher_tui/main.py` — Removed 16-line fallback
-- `src/launcher_tui/rns_menu_mixin.py` — Removed 20-line fallback
-- `src/gateway/rns_bridge.py` — Removed 20-line fallback
-- `src/core/diagnostics/checks/rns.py` — Removed 20-line WRONG fallback
-
-### Prevention
-- **NEVER** duplicate `ReticulumPaths`. Always import from `utils/paths.py`.
-- `utils/paths.py` is the SINGLE SOURCE OF TRUTH for all path resolution.
-- If a file needs `ReticulumPaths`, import it. No try/except fallback.
-
-### Status: RESOLVED
+> Archived to `persistent_issues_archive.md`. Resolved
 
 ---
 
@@ -1601,69 +1220,6 @@ RNS handles encrypted mesh-independent routing.
 
 ---
 
-## Issue #28: API Proxy Steals fromradio Packets from Native Web Client
+## Issue #28: API Proxy Steals fromradio Packets from Native Web Client — ARCHIVED (resolved)
 
-**Date Identified**: 2026-02-10
-**Severity**: Critical (breaks meshtasticd web client at :9443)
-
-### Symptom
-When MeshForge is running, the Meshtastic web client at `ip:9443` shows
-no data. Wireshark/traffic inspector shows empty responses. The gateway
-bridge works fine (RX green), NomadNet talks to other RNS nodes normally.
-Only the native web client is broken.
-
-### Root Cause
-`MeshtasticApiProxy` (in `gateway/meshtastic_api_proxy.py`) was **enabled
-by default** (`enable_api_proxy=True` in `MapServer.__init__`).
-
-When enabled, it runs a background thread that continuously polls
-`GET /api/v1/fromradio` from meshtasticd's HTTP API on port 9443.
-This endpoint is **queue-based** — each GET pops the next protobuf packet.
-Once MeshForge consumes a packet, it's gone from meshtasticd's buffer.
-
-The proxy code literally documents this: *"MeshForge becomes the sole
-consumer of meshtasticd's /api/v1/fromradio"*.
-
-Result: the native web client polls the same endpoint but gets nothing
-because MeshForge already drained the queue.
-
-**Why the gateway is unaffected:** The gateway uses TCP port 4403 (the
-meshtastic Python library's `TCPInterface`), which is a completely
-separate channel from the HTTP API on port 9443.
-
-### Connection Architecture
-```
-Port 4403 (TCP protobuf) ── Gateway Bridge (meshtastic_handler.py)
-                            └── Works independently, unaffected
-
-Port 9443 (HTTP API)     ── MeshtasticApiProxy (DRAINS THE QUEUE)
-                            └── Native web client gets nothing
-```
-
-### Fix Applied
-1. **Default `enable_api_proxy` to `False`** in `MapServer.__init__`
-2. **Added `--enable-api-proxy` CLI flag** for explicit opt-in
-3. **`/mesh/` redirects to native `:9443`** when proxy is disabled
-4. **Clear logging** when proxy is disabled explaining coexistence
-
-### When to Enable the Proxy
-Only enable when you specifically need:
-- Multiple browser tabs viewing the web client simultaneously
-- Phantom node filtering (MQTT nodes without User data crash React)
-- MeshForge-owned packet inspection/logging
-
-```bash
-# Opt in to API proxy (disables native web client at :9443)
-python -m utils.map_data_service --enable-api-proxy
-```
-
-### Files Involved
-- `src/utils/map_data_service.py` — `enable_api_proxy` default changed to `False`
-- `src/utils/map_http_handler.py` — `/mesh/` redirects to native :9443
-- `src/gateway/meshtastic_api_proxy.py` — the proxy itself (unchanged)
-
-### Prevention
-Never enable the API proxy by default. The gateway (TCP:4403) and
-web client (HTTP:9443) are separate channels and should coexist.
-
-### Status: RESOLVED
+> Archived to `persistent_issues_archive.md`. Resolved

--- a/.claude/foundations/persistent_issues_archive.md
+++ b/.claude/foundations/persistent_issues_archive.md
@@ -1,0 +1,505 @@
+# MeshForge Persistent Issues — Archive
+
+> **Purpose**: Historical record of resolved, moot, or documented issues.
+> These were moved from `persistent_issues.md` to reduce file size.
+> Date archived: 2026-02-12
+
+---
+
+## Issue #2: WebKit Disabled When Running as Root (MOOT — GTK removed)
+
+> **Status**: No longer relevant. GTK4 UI was removed; TUI is the only interface.
+> Kept for historical reference only.
+
+### Symptom
+Embedded web views (HamClock live view) show "Open in Browser" instead of embedded content.
+
+### Root Cause
+WebKit uses Chromium's sandbox which refuses to run as root for security reasons. Since MeshForge is launched with `sudo python3 src/launcher.py`, WebKit is always disabled.
+
+### Impact
+- HamClock embedded view never works
+- Any WebKit-based features fail silently
+- Users think features are "broken"
+
+### Proper Fix
+1. **Accept the limitation** - WebKit cannot run as root
+2. **Provide clear UX feedback** explaining why and offering alternatives
+3. **Long-term**: Consider polkit for privileged operations so app runs as user
+
+### Implementation Pattern
+```python
+_is_root = os.geteuid() == 0
+
+if _is_root:
+    # WebKit won't work - explain why and provide alternative
+    label = Gtk.Label(label="Embedded view disabled (running as root)")
+    label.set_tooltip_text("WebKit cannot run embedded when MeshForge is started with sudo.")
+    # Offer "Open in Browser" button
+```
+
+### Prevention
+- Document this limitation in UI
+- Test both as root and as user
+- Consider alternative rendering for web content
+
+
+---
+
+## Issue #11: GTK4/Libadwaita Taskbar Icon Shows Generic
+
+### Symptom
+MeshForge shows a generic application icon in the taskbar/dock instead of the custom MeshForge icon, despite multiple fix attempts.
+
+### Root Cause
+GTK4/libadwaita has strict requirements for taskbar icons:
+1. Icon must be in hicolor theme structure (`~/.local/share/icons/hicolor/scalable/apps/`)
+2. Icon filename must match `application_id` (e.g., `org.meshforge.app.svg`)
+3. Desktop entry `StartupWMClass` must match the window's actual WM_CLASS
+4. Icon cache must be updated after installation
+5. Some desktop environments cache icons aggressively
+
+### Attempts Made (2026-01-12)
+- [x] Install icon to `~/.local/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
+- [x] Add icon theme search path with `icon_theme.add_search_path()`
+- [x] Set `Gtk.Window.set_default_icon_name("org.meshforge.app")`
+- [x] Update icon cache with `gtk-update-icon-cache`
+- [x] Fix ownership when running as root with sudo
+- [ ] **NOT YET TRIED**: Verify WM_CLASS matches StartupWMClass in .desktop file
+- [ ] **NOT YET TRIED**: Use GResource to bundle icon into application
+- [ ] **NOT YET TRIED**: Check if issue is desktop-environment specific (GNOME vs KDE vs XFCE)
+
+### Files Involved
+- `src/launcher_vte.py` - VTE terminal wrapper (main GTK window)
+- `src/gtk_ui/app.py` - Main GTK application
+- `org.meshforge.app.desktop` - Desktop entry file
+- `assets/meshforge-icon.svg` - Source icon
+
+### Next Steps to Try
+1. **Verify WM_CLASS**: Run `xprop WM_CLASS` and click the MeshForge window - ensure it matches `org.meshforge.app`
+2. **Check GApplication**: Ensure `application_id='org.meshforge.app'` is set correctly in Adw.Application
+3. **Try GResource**: Bundle icon as GResource instead of file system installation
+4. **Desktop-specific**: Test on different DEs to isolate if it's environment-specific
+
+### Fix (2026-01-13)
+
+Run the desktop integration installer:
+
+```bash
+cd /opt/meshforge
+sudo ./scripts/install-desktop.sh
+```
+
+This installs icons to:
+- `/usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
+- `/usr/share/icons/hicolor/{48,64,128,256}x{48,64,128,256}/apps/`
+- `/usr/share/pixmaps/`
+
+Then clear the icon cache:
+
+```bash
+gtk-update-icon-cache -f /usr/share/icons/hicolor
+# Log out and back in, or restart desktop environment
+```
+
+### If Still Not Working
+
+1. Verify icon installed: `ls /usr/share/icons/hicolor/scalable/apps/org.meshforge.app.svg`
+2. Check WM_CLASS: `xprop WM_CLASS` → click MeshForge window → should show `org.meshforge.app`
+3. Clear DE cache: Some DEs (GNOME, KDE) cache icons aggressively
+
+
+---
+
+## Issue #13: Meshtastic CLI Auto-Detection Freezes GTK
+
+### Symptom
+GTK UI freezes when checking node count, especially if meshtasticd TCP is not running on port 4403.
+
+### Root Cause
+The `_get_node_count()` method in `src/gtk_ui/app.py` calls the meshtastic CLI. Without `--host localhost`, the CLI does USB/serial auto-detection which:
+1. Takes 10-15+ seconds per call
+2. Blocks threads
+3. Causes thread pile-up when status timer fires every 5 seconds
+4. Eventually exhausts resources and freezes GTK
+
+### Wrong Approach
+```python
+# WRONG - causes freeze
+result = subprocess.run(
+    [cli_path, '--nodes'],  # No --host = auto-detection
+    timeout=15  # Too long
+)
+```
+
+### Proper Fix
+1. **Quick port check FIRST** - Skip CLI entirely if port 4403 not reachable
+2. **Use --host localhost** - Prevents USB/serial scanning
+3. **Short timeout** - 10 seconds max
+4. **Cache results** - 30 second TTL prevents rapid CLI calls
+
+```python
+# CORRECT pattern
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.settimeout(1.0)
+try:
+    sock.connect(("localhost", 4403))
+    port_reachable = True
+except:
+    port_reachable = False
+finally:
+    sock.close()
+
+if not port_reachable:
+    return cached_value  # Don't call CLI at all
+
+# Only call CLI if port is reachable
+result = subprocess.run(
+    [cli_path, '--host', 'localhost', '--nodes'],
+    timeout=10
+)
+```
+
+### Files Fixed (2026-01-14)
+- [x] `src/gtk_ui/app.py` - `_get_node_count()` method
+- [x] Added `import shutil` (was missing, caused NameError fallback)
+
+### Regression Tests
+- `tests/test_gtk_crash_fixes.py::TestNodeCountThreadSafety`
+- `tests/test_gtk_crash_fixes.py::TestNodeCountCodePattern`
+
+### Prevention
+- Always use `--host localhost` when calling meshtastic CLI in GUI contexts
+- Do quick port checks before expensive subprocess calls
+- Keep timeouts shorter than timer intervals to prevent thread pile-up
+- Run `test_gtk_crash_fixes.py` to verify patterns are correct
+
+
+---
+
+## Issue #14: GTK Panel Lifecycle - Missing Cleanup Methods
+
+### Symptom
+- GTK freezes or crashes when closing window
+- Memory growth during extended use
+- Timers continue firing after panels are destroyed
+- Orphaned signal handlers causing callbacks on destroyed widgets
+
+### Root Cause
+Panel cleanup was fragmented:
+1. Only 9 of 24 panels had cleanup() methods
+2. app.py used a hard-coded list for cleanup (missed 15 panels)
+3. No standardized timer/signal tracking pattern
+4. Each panel reinvented resource management
+
+### Impact
+- Timer leaks: GLib.timeout_add() handlers never cancelled
+- Signal leaks: GTK signals never disconnected
+- Thread races: Callbacks firing after widget destruction
+- File descriptor exhaustion (errno 24)
+
+### Architectural Fix (2026-01-14)
+
+**1. Created PanelBase class** (`src/gtk_ui/panel_base.py`):
+```python
+class PanelBase(Gtk.Box):
+    def __init__(self, main_window):
+        self._pending_timers = []
+        self._signal_handlers = {}
+        self._is_destroyed = False
+        self.connect("unrealize", self._on_unrealize)
+
+    def _schedule_timer(self, delay_ms, callback, *args):
+        """Timer tracking with auto-cleanup"""
+        timer_id = GLib.timeout_add(delay_ms, callback, *args)
+        self._pending_timers.append(timer_id)
+        return timer_id
+
+    def _connect_signal(self, widget, signal_name, callback):
+        """Signal tracking with auto-cleanup"""
+        handler_id = widget.connect(signal_name, callback)
+        self._signal_handlers[widget].append(handler_id)
+        return handler_id
+
+    def cleanup(self):
+        """Auto-called on unrealize"""
+        self._cancel_all_timers()
+        self._disconnect_all_signals()
+```
+
+**2. Auto-discover panels in app.py** (replaces hard-coded list):
+```python
+def _on_close_request(self, window):
+    # Auto-discover ALL panels with cleanup()
+    for attr_name in dir(self):
+        if attr_name.endswith('_panel'):
+            panel = getattr(self, attr_name, None)
+            if panel and hasattr(panel, 'cleanup'):
+                panel.cleanup()
+```
+
+**3. Added cleanup() to all 24 panels**
+
+### Files Changed
+- [NEW] `src/gtk_ui/panel_base.py` - PanelBase class with resource management
+- [MOD] `src/gtk_ui/app.py` - Auto-discover cleanup
+- [MOD] All 24 panel files - Added cleanup() methods
+
+### Regression Tests
+- `tests/test_gtk_crash_fixes.py::TestPanelBaseResourceManagement`
+- `tests/test_gtk_crash_fixes.py::TestPanelCleanupCoverage`
+- `tests/test_gtk_crash_fixes.py::TestAppAutoDiscoverCleanup`
+- `tests/test_gtk_crash_fixes.py::TestTimerCleanupPatterns`
+
+### Migration Path for New Panels
+New panels should inherit from PanelBase:
+```python
+from gtk_ui.panel_base import PanelBase
+
+class MyNewPanel(PanelBase):
+    def __init__(self, main_window):
+        super().__init__(main_window)
+        # Use self._schedule_timer() instead of GLib.timeout_add()
+        # Use self._connect_signal() instead of widget.connect()
+
+    def cleanup(self):
+        # Your cleanup code here
+        super().cleanup()  # ALWAYS call parent cleanup
+```
+
+### Prevention
+- Run `python3 -m unittest tests/test_gtk_crash_fixes.py -v` before releasing
+- New panels must inherit from PanelBase or implement cleanup()
+- Use `_schedule_timer()` and `_connect_signal()` for resource tracking
+
+
+---
+
+## Issue #15: GTK Startup Performance - Thundering Herd
+
+### Symptom
+- GTK app takes 5-10+ seconds to become responsive after launch
+- UI renders but feels sluggish immediately after startup
+- Multiple threads spawning simultaneously during initialization
+- CPU spikes on startup
+
+### Root Cause (Identified via scientific analysis 2026-01-14)
+**Thundering Herd Problem**: All 21+ panels instantiated at startup, each spawning threads:
+
+1. **Panel init triggers async work**: 12+ panels call `_refresh_data()`, `_check_status()`, `_load_*()` in `__init__`
+2. **Multiple concurrent timers**: 5+ timers running (1s, 2s, 3s, 5s, 30s intervals)
+3. **Status timer overhead**: app.py `_update_status` made 3-5 subprocess calls every 5 seconds
+4. **No lazy loading**: Panels instantiated whether user visits them or not
+
+### Quantified Impact
+- 21 panels loaded at startup
+- 12+ panels spawn threads immediately on `__init__`
+- 143 `threading.Thread` calls found in GTK UI code
+- 5+ recurring timers competing for CPU
+- Each status update: 3-5 subprocess calls with combined 15+ second timeout
+
+### Architectural Fix (2026-01-14)
+
+**1. Lazy Panel Loading** - Only instantiate panels on first navigation:
+```python
+# Store loaders but don't call them
+self._panel_loaders = {"service": self._add_service_page, ...}
+self._loaded_panels = set()
+
+# Create lightweight placeholders
+for name in self._panel_loaders.keys():
+    placeholder = self._create_loading_placeholder(name)
+    self.content_stack.add_named(placeholder, name)
+
+# Only load dashboard (default view) at startup
+self._load_panel("dashboard")
+
+# Lazy load on navigation
+def _on_nav_selected(self, listbox, row):
+    if page_name not in self._loaded_panels:
+        self._load_panel(page_name)
+    self.content_stack.set_visible_child_name(page_name)
+```
+
+**2. Deferred Initial Refresh** - Let UI render first:
+```python
+# WRONG - thread spawns immediately
+def __init__(self, main_window):
+    self._build_ui()
+    self._refresh_data()  # Spawns thread NOW
+
+# CORRECT - defer 500ms
+def __init__(self, main_window):
+    self._build_ui()
+    GLib.timeout_add(500, self._initial_refresh)
+```
+
+**3. Optimized Status Timer**:
+- Increased interval from 5s to 10s
+- Delayed first update by 2 seconds
+- Removed redundant subprocess calls (pgrep, socket check)
+- Added overlap prevention flag
+
+### Files Changed
+- [MOD] `src/gtk_ui/app.py` - Lazy loading, optimized timers
+- [MOD] `src/gtk_ui/panels/dashboard.py` - Deferred initial refresh
+
+### Expected Improvement
+- Startup time: 5-10s → <2s
+- Initial responsiveness: Immediate
+- Thread count at startup: 12+ → 1-2
+- Subprocess calls at startup: 10+ → 1-2
+
+### Prevention
+- New panels must NOT spawn threads in `__init__`
+- Use `GLib.timeout_add(500, self._initial_refresh)` for deferred loading
+- Prefer single comprehensive status calls over multiple subprocess invocations
+- Test startup performance: `time python3 src/launcher.py --gtk`
+
+
+---
+
+## Issue #25: rnsd PermissionError on /etc/reticulum/storage/ratchets
+
+### Symptom
+rnsd crashes in a background thread with:
+```
+PermissionError: [Errno 13] Permission denied: '/etc/reticulum/storage/ratchets'
+```
+Additionally, `/etc/reticulum/identity` is never created, and the TUI "Show local identity" shows "No identity provided, cannot continue."
+
+### Root Cause
+RNS added **key ratcheting** support which requires a `ratchets/` subdirectory under storage. `Identity.persist_job()` runs in a background thread and calls `os.makedirs(ratchetdir)`. The install script didn't create this directory, and `ReticulumPaths.ensure_system_dirs()` was defined but never called at runtime.
+
+### Fix (v0.5.x, 2026-02-09)
+**Self-healing at runtime** — MeshForge now creates the directories automatically:
+1. `startup_checks.check_all()` calls `ensure_system_dirs()` at TUI launch
+2. `rns_bridge._init_rns_main_thread()` calls it before RNS init
+3. `install_noc.sh` creates `storage/ratchets/` during install
+4. `check_rns_storage_permissions()` diagnostic detects the issue
+5. After fixing dirs, MeshForge auto-restarts rnsd via `apply_config_and_restart()`
+
+### Files
+- `src/utils/paths.py` — `ETC_RATCHETS`, `ensure_system_dirs()`
+- `src/gateway/rns_bridge.py` — Self-heal in `_init_rns_main_thread()`
+- `src/launcher_tui/startup_checks.py` — Self-heal in `check_all()`
+- `src/core/diagnostics/checks/rns.py` — `check_rns_storage_permissions()`
+- `scripts/install_noc.sh` — Pre-create dirs
+- `src/launcher_tui/rns_menu_mixin.py` — Fixed `rnid` invocation
+
+### Status: RESOLVED
+
+
+---
+
+## Issue #26: ReticulumPaths Fallback Copies Cause Config Divergence
+
+### Symptom
+`.reticulum` interface configuration is "lost" between sessions. RNS config changes made in the TUI have no effect. rnsd uses a different config file than what MeshForge reads/writes.
+
+### Root Cause
+**Four separate copies** of `ReticulumPaths` existed in the codebase:
+1. `src/utils/paths.py` — **Canonical** (correct: checks `/etc/reticulum`, XDG, `~/.reticulum`)
+2. `src/launcher_tui/main.py` — Fallback (missing `get_interfaces_dir`, `ensure_system_dirs`)
+3. `src/launcher_tui/rns_menu_mixin.py` — Fallback (missing `ensure_system_dirs`)
+4. `src/core/diagnostics/checks/rns.py` — Fallback (**WRONG: skipped `/etc/reticulum` and XDG entirely**)
+5. `src/gateway/rns_bridge.py` — Fallback (missing `get_interfaces_dir`, `ensure_system_dirs`)
+
+The diagnostics fallback (`rns.py`) was the worst — it went directly to `~/.reticulum` without checking `/etc/reticulum/config` first. If a user had both `/etc/reticulum/config` (used by rnsd) and `~/.reticulum/config` (fallback), the diagnostics would read the wrong file and report incorrect status.
+
+Additionally, when running with sudo:
+- User edits: `/home/user/.reticulum/config`
+- rnsd reads: `/root/.reticulum/config` OR `/etc/reticulum/config`
+- Result: silent divergence, changes have no effect
+
+### Fix (v0.5.x, 2026-02-09)
+**Eliminated all fallback copies.** Every file now imports directly:
+```python
+# NO try/except, NO fallback class
+from utils.paths import ReticulumPaths
+```
+This ensures ONE definition is used everywhere. If `utils.paths` is unavailable, the import fails immediately with a clear `ImportError` — better than silently using a wrong path.
+
+### Files Changed
+- `src/launcher_tui/main.py` — Removed 16-line fallback
+- `src/launcher_tui/rns_menu_mixin.py` — Removed 20-line fallback
+- `src/gateway/rns_bridge.py` — Removed 20-line fallback
+- `src/core/diagnostics/checks/rns.py` — Removed 20-line WRONG fallback
+
+### Prevention
+- **NEVER** duplicate `ReticulumPaths`. Always import from `utils/paths.py`.
+- `utils/paths.py` is the SINGLE SOURCE OF TRUTH for all path resolution.
+- If a file needs `ReticulumPaths`, import it. No try/except fallback.
+
+### Status: RESOLVED
+
+
+---
+
+## Issue #28: API Proxy Steals fromradio Packets from Native Web Client
+
+**Date Identified**: 2026-02-10
+**Severity**: Critical (breaks meshtasticd web client at :9443)
+
+### Symptom
+When MeshForge is running, the Meshtastic web client at `ip:9443` shows
+no data. Wireshark/traffic inspector shows empty responses. The gateway
+bridge works fine (RX green), NomadNet talks to other RNS nodes normally.
+Only the native web client is broken.
+
+### Root Cause
+`MeshtasticApiProxy` (in `gateway/meshtastic_api_proxy.py`) was **enabled
+by default** (`enable_api_proxy=True` in `MapServer.__init__`).
+
+When enabled, it runs a background thread that continuously polls
+`GET /api/v1/fromradio` from meshtasticd's HTTP API on port 9443.
+This endpoint is **queue-based** — each GET pops the next protobuf packet.
+Once MeshForge consumes a packet, it's gone from meshtasticd's buffer.
+
+The proxy code literally documents this: *"MeshForge becomes the sole
+consumer of meshtasticd's /api/v1/fromradio"*.
+
+Result: the native web client polls the same endpoint but gets nothing
+because MeshForge already drained the queue.
+
+**Why the gateway is unaffected:** The gateway uses TCP port 4403 (the
+meshtastic Python library's `TCPInterface`), which is a completely
+separate channel from the HTTP API on port 9443.
+
+### Connection Architecture
+```
+Port 4403 (TCP protobuf) ── Gateway Bridge (meshtastic_handler.py)
+                            └── Works independently, unaffected
+
+Port 9443 (HTTP API)     ── MeshtasticApiProxy (DRAINS THE QUEUE)
+                            └── Native web client gets nothing
+```
+
+### Fix Applied
+1. **Default `enable_api_proxy` to `False`** in `MapServer.__init__`
+2. **Added `--enable-api-proxy` CLI flag** for explicit opt-in
+3. **`/mesh/` redirects to native `:9443`** when proxy is disabled
+4. **Clear logging** when proxy is disabled explaining coexistence
+
+### When to Enable the Proxy
+Only enable when you specifically need:
+- Multiple browser tabs viewing the web client simultaneously
+- Phantom node filtering (MQTT nodes without User data crash React)
+- MeshForge-owned packet inspection/logging
+
+```bash
+# Opt in to API proxy (disables native web client at :9443)
+python -m utils.map_data_service --enable-api-proxy
+```
+
+### Files Involved
+- `src/utils/map_data_service.py` — `enable_api_proxy` default changed to `False`
+- `src/utils/map_http_handler.py` — `/mesh/` redirects to native :9443
+- `src/gateway/meshtastic_api_proxy.py` — the proxy itself (unchanged)
+
+### Prevention
+Never enable the API proxy by default. The gateway (TCP:4403) and
+web client (HTTP:9443) are separate channels and should coexist.
+
+### Status: RESOLVED
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ directly from `utils.service_check` — no try/except compatibility shims needed
 Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md` Issue #6):
 
 **File size audit (2026-02-12):**
-- ⚠️ `rns_bridge.py` (1,694 lines) - Over threshold, needs extraction
+- ✅ `rns_bridge.py` (1,495 lines) - MessageRouter extracted to message_routing.py
 - ⚠️ `knowledge_content.py` (1,824 lines) - Content file by design, acceptable
 - ✅ `map_data_collector.py` (1,509 lines) - Borderline, monitor
 - ✅ `launcher_tui/main.py` (1,488 lines) - 30 mixins, dead code removed
@@ -216,7 +216,7 @@ Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md
 
 **Refactoring history:**
 - `launcher_tui/main.py` (was 2,822 → 1,336 → 1,799 → 1,433 → 1,488)
-- `rns_bridge.py` (was 1,991 → 1,614 → 1,694, MeshtasticHandler extracted, needs further split)
+- `rns_bridge.py` (was 1,991 → 1,614 → 1,694 → 1,495, MeshtasticHandler + MessageRouter extracted)
 - `node_tracker.py` (was 1,808 → 930, node_models.py extracted)
 - `rns_menu_mixin.py` (was 1,524 → 1,210, rns_sniffer_mixin.py extracted)
 - `metrics_export.py` (was 1,762 → 96, split to common/prometheus/influxdb)

--- a/src/gateway/message_routing.py
+++ b/src/gateway/message_routing.py
@@ -1,0 +1,256 @@
+"""
+Message routing and classification for the RNS-Meshtastic bridge.
+
+Extracted from rns_bridge.py to keep file sizes manageable.
+Handles routing rule compilation, confidence-scored classification,
+and legacy regex-based routing logic.
+"""
+
+import re
+import logging
+from typing import Optional, Dict, Any
+
+from .bridge_health import MessageOrigin
+
+# Import routing classifier with confidence scoring
+try:
+    from utils.classifier import (
+        RoutingClassifier, RoutingCategory,
+        create_routing_system, ClassificationResult
+    )
+    CLASSIFIER_AVAILABLE = True
+except ImportError:
+    CLASSIFIER_AVAILABLE = False
+
+# Import centralized path utility
+from utils.paths import get_real_user_home
+
+logger = logging.getLogger(__name__)
+
+
+class MessageRouter:
+    """
+    Routes messages between RNS and Meshtastic based on rules and classification.
+
+    Supports two modes:
+    1. Confidence-scored classifier (when utils.classifier is available)
+    2. Legacy regex-based routing rules (fallback)
+    """
+
+    # Maximum input length for regex matching to bound execution time
+    _REGEX_INPUT_LIMIT = 512
+
+    def __init__(self, config, stats: dict, stats_lock):
+        """
+        Args:
+            config: GatewayConfig instance with routing_rules and settings.
+            stats: Shared stats dict (bridge owns it, router updates 'bounced').
+            stats_lock: Threading lock for stats updates.
+        """
+        self.config = config
+        self.stats = stats
+        self._stats_lock = stats_lock
+
+        # Pre-compile routing rule regexes to avoid re-compilation per message
+        # and catch invalid patterns at startup rather than at runtime
+        self._compiled_rules = self._compile_routing_rules()
+
+        # Routing classifier with confidence scoring
+        self._classifier = None
+        self._last_classification: Optional[ClassificationResult] = None
+        if CLASSIFIER_AVAILABLE:
+            fixes_path = get_real_user_home() / '.config' / 'meshforge' / 'routing_fixes.json'
+            rules = [
+                {
+                    'name': rule.name,
+                    'enabled': rule.enabled,
+                    'direction': rule.direction,
+                    'source_filter': rule.source_filter,
+                    'dest_filter': rule.dest_filter,
+                    'message_filter': rule.message_filter,
+                    'priority': rule.priority
+                }
+                for rule in self.config.routing_rules
+            ]
+            self._classifier = create_routing_system(
+                rules=rules,
+                bounce_threshold=0.3,
+                fixes_path=fixes_path
+            )
+            logger.info("Routing classifier initialized with confidence scoring")
+
+    def should_bridge(self, msg) -> bool:
+        """
+        Check if message should be bridged based on routing rules.
+
+        Uses confidence-scored classifier when available:
+        - High confidence (>0.7): Route immediately
+        - Low confidence (<0.3): Bounce to queue for review
+        - Medium confidence: Route with logging
+        """
+        if not self.config.enabled:
+            return False
+
+        # Use classifier if available
+        if self._classifier:
+            return self._classify_message(msg)
+
+        # Fallback to legacy logic
+        return self._should_bridge_legacy(msg)
+
+    def _classify_message(self, msg) -> bool:
+        """Classify message using confidence-scored routing."""
+        msg_id = f"{msg.source_network}:{msg.source_id}:{msg.timestamp.isoformat()}"
+
+        result = self._classifier.classify(msg_id, {
+            'source_network': msg.source_network,
+            'source_id': msg.source_id,
+            'destination_id': msg.destination_id,
+            'content': msg.content,
+            'is_broadcast': msg.is_broadcast,
+            'metadata': msg.metadata
+        })
+
+        self._last_classification = result
+
+        # Handle bounced messages
+        if result.bounced:
+            with self._stats_lock:
+                self.stats['bounced'] += 1
+            logger.info(
+                f"Message bounced (confidence {result.confidence:.2f}): "
+                f"{msg.source_id[:8]}... -> {result.bounce_reason}"
+            )
+            # Bounced messages go to queue category, don't bridge immediately
+            return result.category == RoutingCategory.QUEUE.value
+
+        # Log classification decision
+        if result.confidence < 0.7:
+            logger.debug(
+                f"Routing decision (confidence {result.confidence:.2f}): "
+                f"{result.category} - {result.reason}"
+            )
+
+        # Determine if we should bridge based on category
+        if result.category == RoutingCategory.DROP.value:
+            return False
+        elif result.category in (RoutingCategory.BRIDGE_RNS.value, RoutingCategory.BRIDGE_MESH.value):
+            return True
+        elif result.category == RoutingCategory.QUEUE.value:
+            # Queued items need manual review
+            return False
+
+        return False
+
+    def _compile_routing_rules(self) -> dict:
+        """Pre-compile regex patterns from routing rules at init time.
+
+        Returns a dict mapping rule name to compiled filter patterns.
+        Invalid patterns are logged and skipped — the rule will never match.
+        """
+        compiled = {}
+        for rule in self.config.routing_rules:
+            filters = {}
+            for field in ('source_filter', 'dest_filter', 'message_filter'):
+                pattern = getattr(rule, field, '')
+                if pattern:
+                    try:
+                        filters[field] = re.compile(pattern)
+                    except re.error as e:
+                        logger.warning(
+                            f"Invalid regex in rule '{rule.name}' "
+                            f"field '{field}': {e} — rule will be skipped"
+                        )
+                        filters[field] = None  # Mark as broken
+            compiled[rule.name] = filters
+        return compiled
+
+    def _should_bridge_legacy(self, msg) -> bool:
+        """Legacy routing logic (fallback when classifier unavailable)."""
+        # Re-compile if routing rules changed since last compile
+        current_names = {r.name for r in self.config.routing_rules}
+        if current_names != set(self._compiled_rules.keys()):
+            self._compiled_rules = self._compile_routing_rules()
+
+        for rule in self.config.routing_rules:
+            if not rule.enabled:
+                continue
+
+            # Check direction
+            if msg.source_network == "meshtastic" and rule.direction == "rns_to_mesh":
+                continue
+            if msg.source_network == "rns" and rule.direction == "mesh_to_rns":
+                continue
+
+            # Get pre-compiled filters for this rule
+            filters = self._compiled_rules.get(rule.name, {})
+
+            # Skip rule entirely if any of its patterns failed to compile
+            if any(v is None for v in filters.values()):
+                continue
+
+            # Apply pre-compiled regex filters with bounded input
+            # Source filter
+            if rule.source_filter:
+                compiled = filters.get('source_filter')
+                if not compiled or not msg.source_id:
+                    continue
+                if not compiled.search(msg.source_id[:self._REGEX_INPUT_LIMIT]):
+                    continue
+
+            # Destination filter
+            if rule.dest_filter:
+                compiled = filters.get('dest_filter')
+                if not compiled:
+                    continue
+                dest = (msg.destination_id or "")[:self._REGEX_INPUT_LIMIT]
+                if not compiled.search(dest):
+                    continue
+
+            # Message content filter
+            if rule.message_filter:
+                compiled = filters.get('message_filter')
+                if not compiled or not msg.content:
+                    continue
+                if not compiled.search(msg.content[:self._REGEX_INPUT_LIMIT]):
+                    continue
+
+            # All filters passed - this rule matches
+            return True
+
+        return self.config.default_route in ("bidirectional", f"{msg.source_network}_to_*")
+
+    def get_routing_stats(self) -> Dict[str, Any]:
+        """Get routing classifier statistics."""
+        stats = dict(self.stats)
+        if self._classifier:
+            classifier_stats = self._classifier.get_stats()
+            stats['classifier'] = classifier_stats
+            stats['bouncer_queue'] = len(self._classifier.bouncer.get_queue())
+        return stats
+
+    def get_last_classification(self) -> Optional[Dict]:
+        """Get the last classification result for debugging."""
+        if self._last_classification:
+            return self._last_classification.to_dict()
+        return None
+
+    def fix_routing(self, msg_id: str, correct_category: str) -> bool:
+        """
+        Record a user correction for routing decisions.
+
+        This is the 'fix button' - allows users to correct mistakes
+        and improve the system over time.
+        """
+        if not self._classifier or not self._classifier.fix_registry:
+            return False
+
+        # Create a dummy result for the fix
+        result = ClassificationResult(
+            input_id=msg_id,
+            category="unknown",
+            confidence=0.5
+        )
+        self._classifier.fix_registry.add_fix(result, correct_category)
+        logger.info(f"Routing fix recorded: {msg_id} -> {correct_category}")
+        return True

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -3,7 +3,6 @@ RNS-Meshtastic Bridge Service
 Bridges Reticulum Network Stack and Meshtastic networks
 """
 
-import re
 import threading
 import time
 import logging
@@ -54,15 +53,7 @@ except ImportError:
     PersistentMessageQueue = None
     MessagePriority = None
 
-# Import routing classifier with confidence scoring
-try:
-    from utils.classifier import (
-        RoutingClassifier, RoutingCategory,
-        create_routing_system, ClassificationResult
-    )
-    CLASSIFIER_AVAILABLE = True
-except ImportError:
-    CLASSIFIER_AVAILABLE = False
+from .message_routing import MessageRouter, CLASSIFIER_AVAILABLE
 
 logger = logging.getLogger(__name__)
 
@@ -221,33 +212,8 @@ class RNSMeshtasticBridge:
             except Exception as e:
                 logger.warning(f"Failed to initialize persistent queue: {e}")
 
-        # Pre-compile routing rule regexes to avoid re-compilation per message
-        # and catch invalid patterns at startup rather than at runtime
-        self._compiled_rules = self._compile_routing_rules()
-
-        # Routing classifier with confidence scoring
-        self._classifier = None
-        self._last_classification: Optional[ClassificationResult] = None
-        if CLASSIFIER_AVAILABLE:
-            fixes_path = get_real_user_home() / '.config' / 'meshforge' / 'routing_fixes.json'
-            rules = [
-                {
-                    'name': rule.name,
-                    'enabled': rule.enabled,
-                    'direction': rule.direction,
-                    'source_filter': rule.source_filter,
-                    'dest_filter': rule.dest_filter,
-                    'message_filter': rule.message_filter,
-                    'priority': rule.priority
-                }
-                for rule in self.config.routing_rules
-            ]
-            self._classifier = create_routing_system(
-                rules=rules,
-                bounce_threshold=0.3,
-                fixes_path=fixes_path
-            )
-            logger.info("Routing classifier initialized with confidence scoring")
+        # Message routing and classification (extracted to message_routing.py)
+        self._router = MessageRouter(self.config, self.stats, self._stats_lock)
 
         # Circuit breaker for destination-level failure handling
         self._circuit_breaker = None
@@ -276,7 +242,7 @@ class RNSMeshtasticBridge:
                 message_queue=self._mesh_to_rns_queue,
                 message_callback=self._notify_message,
                 status_callback=lambda status: self._notify_status(status),
-                should_bridge=self._should_bridge,
+                should_bridge=self._router.should_bridge,
             )
         elif HAS_MESHTASTIC_LIB:
             if self.config.bridge_mode == "mqtt_bridge" and not HAS_MQTT_BRIDGE:
@@ -293,7 +259,7 @@ class RNSMeshtasticBridge:
                 message_queue=self._mesh_to_rns_queue,
                 message_callback=self._notify_message,
                 status_callback=lambda status: self._notify_status(status),
-                should_bridge=self._should_bridge,
+                should_bridge=self._router.should_bridge,
             )
         else:
             raise ImportError(
@@ -1154,7 +1120,7 @@ class RNSMeshtasticBridge:
                 logger.debug(f"Could not store incoming RNS message: {e}")
 
             # Queue for bridging if enabled (non-blocking to prevent deadlock)
-            if self._should_bridge(msg):
+            if self._router.should_bridge(msg):
                 try:
                     self._rns_to_mesh_queue.put_nowait(msg)
                 except Full:
@@ -1208,184 +1174,19 @@ class RNSMeshtasticBridge:
         except Exception as e:
             logger.error(f"Error processing RNS announce: {e}")
 
-    def _should_bridge(self, msg: BridgedMessage) -> bool:
-        """
-        Check if message should be bridged based on routing rules.
-
-        Uses confidence-scored classifier when available:
-        - High confidence (>0.7): Route immediately
-        - Low confidence (<0.3): Bounce to queue for review
-        - Medium confidence: Route with logging
-        """
-        if not self.config.enabled:
-            return False
-
-        # Use classifier if available
-        if self._classifier:
-            return self._classify_message(msg)
-
-        # Fallback to legacy logic
-        return self._should_bridge_legacy(msg)
-
-    def _classify_message(self, msg: BridgedMessage) -> bool:
-        """Classify message using confidence-scored routing."""
-        msg_id = f"{msg.source_network}:{msg.source_id}:{msg.timestamp.isoformat()}"
-
-        result = self._classifier.classify(msg_id, {
-            'source_network': msg.source_network,
-            'source_id': msg.source_id,
-            'destination_id': msg.destination_id,
-            'content': msg.content,
-            'is_broadcast': msg.is_broadcast,
-            'metadata': msg.metadata
-        })
-
-        self._last_classification = result
-
-        # Handle bounced messages
-        if result.bounced:
-            with self._stats_lock:
-                self.stats['bounced'] += 1
-            logger.info(
-                f"Message bounced (confidence {result.confidence:.2f}): "
-                f"{msg.source_id[:8]}... -> {result.bounce_reason}"
-            )
-            # Bounced messages go to queue category, don't bridge immediately
-            return result.category == RoutingCategory.QUEUE.value
-
-        # Log classification decision
-        if result.confidence < 0.7:
-            logger.debug(
-                f"Routing decision (confidence {result.confidence:.2f}): "
-                f"{result.category} - {result.reason}"
-            )
-
-        # Determine if we should bridge based on category
-        if result.category == RoutingCategory.DROP.value:
-            return False
-        elif result.category in (RoutingCategory.BRIDGE_RNS.value, RoutingCategory.BRIDGE_MESH.value):
-            return True
-        elif result.category == RoutingCategory.QUEUE.value:
-            # Queued items need manual review
-            return False
-
-        return False
-
-    def _compile_routing_rules(self) -> dict:
-        """Pre-compile regex patterns from routing rules at init time.
-
-        Returns a dict mapping rule name to compiled filter patterns.
-        Invalid patterns are logged and skipped — the rule will never match.
-        """
-        compiled = {}
-        for rule in self.config.routing_rules:
-            filters = {}
-            for field in ('source_filter', 'dest_filter', 'message_filter'):
-                pattern = getattr(rule, field, '')
-                if pattern:
-                    try:
-                        filters[field] = re.compile(pattern)
-                    except re.error as e:
-                        logger.warning(
-                            f"Invalid regex in rule '{rule.name}' "
-                            f"field '{field}': {e} — rule will be skipped"
-                        )
-                        filters[field] = None  # Mark as broken
-            compiled[rule.name] = filters
-        return compiled
-
-    # Maximum input length for regex matching to bound execution time
-    _REGEX_INPUT_LIMIT = 512
-
-    def _should_bridge_legacy(self, msg: BridgedMessage) -> bool:
-        """Legacy routing logic (fallback when classifier unavailable)."""
-        # Re-compile if routing rules changed since last compile
-        current_names = {r.name for r in self.config.routing_rules}
-        if current_names != set(self._compiled_rules.keys()):
-            self._compiled_rules = self._compile_routing_rules()
-
-        for rule in self.config.routing_rules:
-            if not rule.enabled:
-                continue
-
-            # Check direction
-            if msg.source_network == "meshtastic" and rule.direction == "rns_to_mesh":
-                continue
-            if msg.source_network == "rns" and rule.direction == "mesh_to_rns":
-                continue
-
-            # Get pre-compiled filters for this rule
-            filters = self._compiled_rules.get(rule.name, {})
-
-            # Skip rule entirely if any of its patterns failed to compile
-            if any(v is None for v in filters.values()):
-                continue
-
-            # Apply pre-compiled regex filters with bounded input
-            # Source filter
-            if rule.source_filter:
-                compiled = filters.get('source_filter')
-                if not compiled or not msg.source_id:
-                    continue
-                if not compiled.search(msg.source_id[:self._REGEX_INPUT_LIMIT]):
-                    continue
-
-            # Destination filter
-            if rule.dest_filter:
-                compiled = filters.get('dest_filter')
-                if not compiled:
-                    continue
-                dest = (msg.destination_id or "")[:self._REGEX_INPUT_LIMIT]
-                if not compiled.search(dest):
-                    continue
-
-            # Message content filter
-            if rule.message_filter:
-                compiled = filters.get('message_filter')
-                if not compiled or not msg.content:
-                    continue
-                if not compiled.search(msg.content[:self._REGEX_INPUT_LIMIT]):
-                    continue
-
-            # All filters passed - this rule matches
-            return True
-
-        return self.config.default_route in ("bidirectional", f"{msg.source_network}_to_*")
+    # Routing delegated to MessageRouter (see gateway/message_routing.py)
 
     def get_routing_stats(self) -> Dict[str, Any]:
         """Get routing classifier statistics."""
-        stats = dict(self.stats)
-        if self._classifier:
-            classifier_stats = self._classifier.get_stats()
-            stats['classifier'] = classifier_stats
-            stats['bouncer_queue'] = len(self._classifier.bouncer.get_queue())
-        return stats
+        return self._router.get_routing_stats()
 
     def get_last_classification(self) -> Optional[Dict]:
         """Get the last classification result for debugging."""
-        if self._last_classification:
-            return self._last_classification.to_dict()
-        return None
+        return self._router.get_last_classification()
 
     def fix_routing(self, msg_id: str, correct_category: str) -> bool:
-        """
-        Record a user correction for routing decisions.
-
-        This is the 'fix button' - allows users to correct mistakes
-        and improve the system over time.
-        """
-        if not self._classifier or not self._classifier.fix_registry:
-            return False
-
-        # Create a dummy result for the fix
-        result = ClassificationResult(
-            input_id=msg_id,
-            category="unknown",
-            confidence=0.5
-        )
-        self._classifier.fix_registry.add_fix(result, correct_category)
-        logger.info(f"Routing fix recorded: {msg_id} -> {correct_category}")
-        return True
+        """Record a user correction for routing decisions."""
+        return self._router.fix_routing(msg_id, correct_category)
 
     def _process_mesh_to_rns(self, msg: BridgedMessage):
         """Process message from Meshtastic to RNS.

--- a/src/monitoring/mqtt_subscriber.py
+++ b/src/monitoring/mqtt_subscriber.py
@@ -370,16 +370,16 @@ class MQTTNodelessSubscriber:
                 # Disconnect first (tells broker we're leaving)
                 try:
                     client.disconnect()
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug(f"MQTT disconnect error: {e}")
 
                 # loop_stop() can hang in some edge cases, use timeout thread
                 def stop_loop():
                     try:
                         # paho-mqtt v2.x removed the force parameter
                         client.loop_stop()
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"MQTT loop_stop error: {e}")
 
                 stop_thread = threading.Thread(target=stop_loop, daemon=True)
                 stop_thread.start()
@@ -399,8 +399,8 @@ class MQTTNodelessSubscriber:
                 self._stop_event.set()
                 self._client.disconnect()
                 self._client.loop_stop()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"MQTT atexit cleanup error: {e}")
             self._client = None
 
     def _on_connect(self, client, userdata, flags, rc):
@@ -630,8 +630,8 @@ class MQTTNodelessSubscriber:
                     f"Merged relay node {partial_id} -> {full_node_id} "
                     f"({partial_node.long_name} -> {full_node.long_name or 'unknown'})"
                 )
-        except (ValueError, TypeError, KeyError):
-            pass
+        except (ValueError, TypeError, KeyError) as e:
+            logger.debug(f"Relay node merge failed: {e}")
 
     def _discover_relay_node(self, relay_byte: int, data: Dict) -> Optional[MQTTNode]:
         """
@@ -708,8 +708,8 @@ class MQTTNodelessSubscriber:
                         del self._nodes[partial_id]
                         logger.info(f"Merged relay node {partial_id} -> {full_node_id}")
                         return True
-        except (ValueError, TypeError):
-            pass
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Relay node match failed for {partial_id}: {e}")
         return False
 
     def _safe_float(self, value: Any, min_val: float, max_val: float) -> Optional[float]:

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -366,8 +366,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
                 sock.settimeout(1)
                 tcp_available = sock.connect_ex(('localhost', 4403)) == 0
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug(f"TCP port check failed: {e}")
 
         # Check USB serial device
         import glob
@@ -679,8 +679,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
                     with open(queue_cache) as f:
                         data = json.load(f)
                     messages = data.get("messages", [])
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Queue cache read failed: {e}")
 
         self._serve_json({
             "messages": messages,
@@ -1057,8 +1057,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
                     if data:
                         self._serve_json(data)
                         return
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug(f"Protobuf client JSON request failed: {e}")
             self.send_error(503, "Meshtastic API proxy not running")
             return
 

--- a/tests/test_bridge_integration.py
+++ b/tests/test_bridge_integration.py
@@ -377,7 +377,7 @@ class TestRoutingDecisions:
     def test_direction_filter_mesh_to_rns_only(self, bridge):
         """Direction filter blocks wrong-direction messages."""
         # Disable classifier to test legacy routing
-        bridge._classifier = None
+        bridge._router._classifier = None
         bridge.config.routing_rules = [
             RoutingRule(
                 name="mesh_to_rns_only",
@@ -402,7 +402,7 @@ class TestRoutingDecisions:
     def test_source_filter_matches(self, bridge):
         """Source filter allows matching nodes."""
         # Disable classifier to test legacy routing
-        bridge._classifier = None
+        bridge._router._classifier = None
         bridge.config.routing_rules = [
             RoutingRule(
                 name="filter_node",

--- a/tests/test_classifier_integration.py
+++ b/tests/test_classifier_integration.py
@@ -65,20 +65,20 @@ class TestBridgeClassifierIntegration:
     def test_classifier_initialized(self, bridge):
         """Test classifier is initialized when available."""
         if CLASSIFIER_AVAILABLE:
-            assert bridge._classifier is not None
+            assert bridge._router._classifier is not None
         else:
-            assert bridge._classifier is None
+            assert bridge._router._classifier is None
 
     def test_should_bridge_mesh_message(self, bridge, mesh_message):
         """Test bridging decision for Meshtastic message."""
-        result = bridge._should_bridge(mesh_message)
+        result = bridge._router.should_bridge(mesh_message)
 
         # With classifier, should get a decision
         assert isinstance(result, bool)
 
     def test_should_bridge_rns_message(self, bridge, rns_message):
         """Test bridging decision for RNS message."""
-        result = bridge._should_bridge(rns_message)
+        result = bridge._router.should_bridge(rns_message)
 
         assert isinstance(result, bool)
 
@@ -87,14 +87,14 @@ class TestBridgeClassifierIntegration:
         config = GatewayConfig(enabled=False)
         bridge = RNSMeshtasticBridge(config)
 
-        result = bridge._should_bridge(mesh_message)
+        result = bridge._router.should_bridge(mesh_message)
 
         assert result is False
 
     @pytest.mark.skipif(not CLASSIFIER_AVAILABLE, reason="Classifier not available")
     def test_classification_recorded(self, bridge, mesh_message):
         """Test that classification is recorded."""
-        bridge._should_bridge(mesh_message)
+        bridge._router.should_bridge(mesh_message)
 
         last = bridge.get_last_classification()
         assert last is not None
@@ -104,7 +104,7 @@ class TestBridgeClassifierIntegration:
     @pytest.mark.skipif(not CLASSIFIER_AVAILABLE, reason="Classifier not available")
     def test_routing_stats_include_classifier(self, bridge, mesh_message):
         """Test routing stats include classifier data."""
-        bridge._should_bridge(mesh_message)
+        bridge._router.should_bridge(mesh_message)
 
         stats = bridge.get_routing_stats()
 
@@ -124,7 +124,7 @@ class TestBridgeClassifierIntegration:
             destination_id=None,
             content=""
         )
-        bridge._should_bridge(msg)
+        bridge._router.should_bridge(msg)
 
         # Should see some stats activity
         stats = bridge.get_routing_stats()
@@ -143,12 +143,12 @@ class TestBridgeClassifierIntegration:
         bridge = RNSMeshtasticBridge(config)
 
         # Temporarily disable classifier
-        original = bridge._classifier
-        bridge._classifier = None
+        original = bridge._router._classifier
+        bridge._router._classifier = None
 
-        result = bridge._should_bridge(mesh_message)
+        result = bridge._router.should_bridge(mesh_message)
 
-        bridge._classifier = original
+        bridge._router._classifier = original
 
         # Should still get a decision from legacy logic
         assert isinstance(result, bool)
@@ -338,8 +338,8 @@ class TestEndToEndIntegration:
         )
 
         # Both should get routing decisions
-        assert isinstance(bridge._should_bridge(emergency), bool)
-        assert isinstance(bridge._should_bridge(normal), bool)
+        assert isinstance(bridge._router.should_bridge(emergency), bool)
+        assert isinstance(bridge._router.should_bridge(normal), bool)
 
     def test_diagnostics_with_category(self):
         """Test diagnostics with check category."""
@@ -377,10 +377,10 @@ class TestEndToEndIntegration:
                 content=f"Message {i}",
                 is_broadcast=True
             )
-            bridge._should_bridge(msg)
+            bridge._router.should_bridge(msg)
 
         # Check receipts
-        receipts = bridge._classifier.get_receipts()
+        receipts = bridge._router._classifier.get_receipts()
         assert len(receipts) == 5
 
     def test_bounce_queue_accessible(self):

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -157,6 +157,7 @@ def bridge():
          patch("gateway.rns_bridge.CircuitBreakerRegistry") as MockCB, \
          patch("gateway.rns_bridge.HAS_PERSISTENT_QUEUE", False), \
          patch("gateway.rns_bridge.CLASSIFIER_AVAILABLE", False), \
+         patch("gateway.message_routing.CLASSIFIER_AVAILABLE", False), \
          patch("gateway.rns_bridge.HAS_SERVICE_CHECK", False), \
          patch("gateway.rns_bridge.HAS_EVENT_BUS", False), \
          patch("gateway.rns_bridge.HAS_RNS_SNIFFER", False):
@@ -192,6 +193,7 @@ def bridge_no_cb():
          patch("gateway.rns_bridge.CircuitBreakerRegistry", None), \
          patch("gateway.rns_bridge.HAS_PERSISTENT_QUEUE", False), \
          patch("gateway.rns_bridge.CLASSIFIER_AVAILABLE", False), \
+         patch("gateway.message_routing.CLASSIFIER_AVAILABLE", False), \
          patch("gateway.rns_bridge.HAS_SERVICE_CHECK", False), \
          patch("gateway.rns_bridge.HAS_EVENT_BUS", False), \
          patch("gateway.rns_bridge.HAS_RNS_SNIFFER", False):
@@ -514,6 +516,7 @@ class TestRoutingLegacy:
              patch("gateway.rns_bridge.CircuitBreakerRegistry", None), \
              patch("gateway.rns_bridge.HAS_PERSISTENT_QUEUE", False), \
              patch("gateway.rns_bridge.CLASSIFIER_AVAILABLE", False), \
+             patch("gateway.message_routing.CLASSIFIER_AVAILABLE", False), \
              patch("gateway.rns_bridge.HAS_SERVICE_CHECK", False), \
              patch("gateway.rns_bridge.HAS_EVENT_BUS", False), \
              patch("gateway.rns_bridge.HAS_RNS_SNIFFER", False):
@@ -548,77 +551,77 @@ class TestRoutingLegacy:
     def test_disabled_config_blocks_all(self):
         b = self._make_bridge_with_rules([], enabled=False)
         msg = self._make_msg()
-        assert b._should_bridge(msg) is False
+        assert b._router.should_bridge(msg) is False
 
     def test_no_rules_default_bidirectional(self):
         b = self._make_bridge_with_rules([], default_route="bidirectional")
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is True
+        assert b._router._should_bridge_legacy(msg) is True
 
     def test_no_rules_default_blocks(self):
         b = self._make_bridge_with_rules([], default_route="none")
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is False
+        assert b._router._should_bridge_legacy(msg) is False
 
     def test_matching_rule_passes(self):
         rule = self._make_rule(name="all", direction="bidirectional")
         b = self._make_bridge_with_rules([rule])
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is True
+        assert b._router._should_bridge_legacy(msg) is True
 
     def test_direction_filter_mesh_to_rns_blocks_rns_source(self):
         rule = self._make_rule(name="m2r", direction="mesh_to_rns")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg_rns = self._make_msg(source_network="rns")
-        assert b._should_bridge_legacy(msg_rns) is False
+        assert b._router._should_bridge_legacy(msg_rns) is False
 
     def test_direction_filter_rns_to_mesh_blocks_mesh_source(self):
         rule = self._make_rule(name="r2m", direction="rns_to_mesh")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg_mesh = self._make_msg(source_network="meshtastic")
-        assert b._should_bridge_legacy(msg_mesh) is False
+        assert b._router._should_bridge_legacy(msg_mesh) is False
 
     def test_direction_filter_allows_correct_direction(self):
         rule = self._make_rule(name="m2r", direction="mesh_to_rns")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg = self._make_msg(source_network="meshtastic")
-        assert b._should_bridge_legacy(msg) is True
+        assert b._router._should_bridge_legacy(msg) is True
 
     def test_source_filter_regex(self):
         rule = self._make_rule(name="src", direction="bidirectional", source_filter="!aabb.*")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg_match = self._make_msg(source_id="!aabb0042")
         msg_no_match = self._make_msg(source_id="!ccdd0099")
-        assert b._should_bridge_legacy(msg_match) is True
-        assert b._should_bridge_legacy(msg_no_match) is False
+        assert b._router._should_bridge_legacy(msg_match) is True
+        assert b._router._should_bridge_legacy(msg_no_match) is False
 
     def test_dest_filter_regex(self):
         rule = self._make_rule(name="dst", direction="bidirectional", dest_filter="!dest.*")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg_match = self._make_msg(destination_id="!dest1234")
         msg_no_match = self._make_msg(destination_id="!other")
-        assert b._should_bridge_legacy(msg_match) is True
-        assert b._should_bridge_legacy(msg_no_match) is False
+        assert b._router._should_bridge_legacy(msg_match) is True
+        assert b._router._should_bridge_legacy(msg_no_match) is False
 
     def test_message_filter_regex(self):
         rule = self._make_rule(name="msg", direction="bidirectional", message_filter="URGENT.*")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg_match = self._make_msg(content="URGENT: help needed")
         msg_no_match = self._make_msg(content="casual chat")
-        assert b._should_bridge_legacy(msg_match) is True
-        assert b._should_bridge_legacy(msg_no_match) is False
+        assert b._router._should_bridge_legacy(msg_match) is True
+        assert b._router._should_bridge_legacy(msg_no_match) is False
 
     def test_disabled_rule_skipped(self):
         rule = self._make_rule(name="off", direction="bidirectional", enabled=False)
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is False
+        assert b._router._should_bridge_legacy(msg) is False
 
     def test_invalid_regex_skipped(self):
         rule = self._make_rule(name="bad", direction="bidirectional", source_filter="[invalid")
         b = self._make_bridge_with_rules([rule], default_route="none")
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is False
+        assert b._router._should_bridge_legacy(msg) is False
 
     def test_multiple_rules_first_match_wins(self):
         rule1 = self._make_rule(name="r1", direction="bidirectional", source_filter="!aabb.*")
@@ -626,19 +629,19 @@ class TestRoutingLegacy:
         b = self._make_bridge_with_rules([rule1, rule2], default_route="none")
         msg = self._make_msg(source_id="!ccdd0099")
         # rule1 doesn't match source, but rule2 matches all
-        assert b._should_bridge_legacy(msg) is True
+        assert b._router._should_bridge_legacy(msg) is True
 
     def test_recompiles_when_rules_change(self):
         rule = self._make_rule(name="r1", direction="bidirectional")
         b = self._make_bridge_with_rules([rule], default_route="none")
         # First call compiles
         msg = self._make_msg()
-        assert b._should_bridge_legacy(msg) is True
+        assert b._router._should_bridge_legacy(msg) is True
         # Add new rule and verify recompilation
         new_rule = self._make_rule(name="r2", direction="bidirectional", source_filter="!xyz.*")
         b.config.routing_rules.append(new_rule)
         msg2 = self._make_msg(source_id="!xyz9999")
-        assert b._should_bridge_legacy(msg2) is True
+        assert b._router._should_bridge_legacy(msg2) is True
 
 
 # ---------------------------------------------------------------------------
@@ -652,7 +655,7 @@ class TestCompileRoutingRules:
         from gateway.config import RoutingRule
         rule = RoutingRule(name="test", source_filter="!aabb.*", dest_filter="", message_filter="hello")
         bridge.config.routing_rules = [rule]
-        compiled = bridge._compile_routing_rules()
+        compiled = bridge._router._compile_routing_rules()
         assert "test" in compiled
         assert 'source_filter' in compiled['test']
         assert compiled['test']['source_filter'] is not None
@@ -661,14 +664,14 @@ class TestCompileRoutingRules:
         from gateway.config import RoutingRule
         rule = RoutingRule(name="bad", source_filter="[invalid")
         bridge.config.routing_rules = [rule]
-        compiled = bridge._compile_routing_rules()
+        compiled = bridge._router._compile_routing_rules()
         assert compiled['bad']['source_filter'] is None
 
     def test_empty_patterns_not_compiled(self, bridge):
         from gateway.config import RoutingRule
         rule = RoutingRule(name="empty", source_filter="", dest_filter="", message_filter="")
         bridge.config.routing_rules = [rule]
-        compiled = bridge._compile_routing_rules()
+        compiled = bridge._router._compile_routing_rules()
         assert compiled['empty'] == {}
 
 
@@ -1017,29 +1020,29 @@ class TestRoutingStats:
     """Tests for routing stats and classification methods."""
 
     def test_get_routing_stats_no_classifier(self, bridge):
-        bridge._classifier = None
+        bridge._router._classifier = None
         stats = bridge.get_routing_stats()
         assert 'messages_mesh_to_rns' in stats
         assert 'classifier' not in stats
 
     def test_get_last_classification_none(self, bridge):
-        bridge._last_classification = None
+        bridge._router._last_classification = None
         assert bridge.get_last_classification() is None
 
     def test_get_last_classification_returns_dict(self, bridge):
         mock_result = MagicMock()
         mock_result.to_dict.return_value = {"category": "bridge_rns", "confidence": 0.9}
-        bridge._last_classification = mock_result
+        bridge._router._last_classification = mock_result
         result = bridge.get_last_classification()
         assert result["category"] == "bridge_rns"
 
     def test_fix_routing_no_classifier(self, bridge):
-        bridge._classifier = None
+        bridge._router._classifier = None
         assert bridge.fix_routing("msg-1", "bridge_rns") is False
 
     def test_fix_routing_no_fix_registry(self, bridge):
-        bridge._classifier = MagicMock()
-        bridge._classifier.fix_registry = None
+        bridge._router._classifier = MagicMock()
+        bridge._router._classifier.fix_registry = None
         assert bridge.fix_routing("msg-1", "bridge_rns") is False
 
 
@@ -1460,8 +1463,8 @@ class TestRegexInputLimit:
     """Tests for regex input length bounding."""
 
     def test_limit_is_set(self):
-        from gateway.rns_bridge import RNSMeshtasticBridge
-        assert RNSMeshtasticBridge._REGEX_INPUT_LIMIT == 512
+        from gateway.message_routing import MessageRouter
+        assert MessageRouter._REGEX_INPUT_LIMIT == 512
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…g, archive resolved issues

- Extract routing/classification logic to gateway/message_routing.py (MessageRouter class) rns_bridge.py: 1,694 → 1,495 lines (under 1,500 threshold)
- Add debug logging to 8 bare except:pass blocks in mqtt_subscriber and map_http_handler
- Archive 8 resolved/moot issues from persistent_issues.md (1,669 → 1,225 lines)
- Update CLAUDE.md file size audit
- All 4009 tests pass

https://claude.ai/code/session_01MnEyd6jNzsdvYB79Gw2Urk