### PR TITLE
fix: eliminate TUI screen flashing and contradicting service status

### DIFF
--- a/src/launcher_tui/amateur_radio_mixin.py
+++ b/src/launcher_tui/amateur_radio_mixin.py
@@ -11,6 +11,7 @@ Emergency Mode for EMCOMM operations.
 """
 
 import subprocess
+from backend import clear_screen
 
 
 class AmateurRadioMixin:
@@ -62,7 +63,7 @@ class AmateurRadioMixin:
             return
 
         callsign = callsign.strip().upper()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Callsign Lookup: {callsign} ===\n")
 
         try:
@@ -109,7 +110,7 @@ class AmateurRadioMixin:
 
     def _band_plan_display(self):
         """Display Part 97 band plan reference."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Part 97 Band Plan (ISM/LoRa Relevant) ===\n")
 
         try:
@@ -155,7 +156,7 @@ class AmateurRadioMixin:
 
     def _compliance_check(self):
         """Check compliance for current radio configuration."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Compliance Check ===\n")
 
         try:
@@ -251,7 +252,7 @@ class AmateurRadioMixin:
 
     def _ics213_compose(self):
         """Compose an ICS-213 formal traffic message."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== ICS-213 General Message Form ===\n")
 
         try:
@@ -290,7 +291,7 @@ class AmateurRadioMixin:
             return
 
         # Display formatted message
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== ICS-213 GENERAL MESSAGE ===")
         print(f"  Priority:  {priority}")
         print(f"  To:        {to_field}")
@@ -320,7 +321,7 @@ class AmateurRadioMixin:
 
     def _net_checklist(self):
         """Display net control operator checklist."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Net Control Operator Checklist ===\n")
 
         try:
@@ -353,7 +354,7 @@ class AmateurRadioMixin:
 
     def _ares_net_status(self):
         """Show current ARES/RACES net status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== ARES/RACES Net Status ===\n")
 
         try:

--- a/src/launcher_tui/aredn_mixin.py
+++ b/src/launcher_tui/aredn_mixin.py
@@ -6,6 +6,7 @@ Extracted from main.py to reduce file size per CLAUDE.md guidelines.
 
 import logging
 import subprocess
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +69,7 @@ class AREDNMixin:
 
     def _aredn_node_status(self):
         """Show local AREDN node status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== AREDN Node Status ===\n")
 
         try:
@@ -112,7 +113,7 @@ class AREDNMixin:
 
     def _aredn_neighbors(self):
         """Show AREDN neighbor links."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== AREDN Neighbors ===\n")
 
         try:
@@ -147,7 +148,7 @@ class AREDNMixin:
 
     def _aredn_services(self):
         """Show AREDN advertised services."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== AREDN Services ===\n")
 
         try:
@@ -207,7 +208,7 @@ class AREDNMixin:
 
     def _aredn_scan(self):
         """Scan for AREDN nodes on network."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== AREDN Network Scan ===\n")
         print("Scanning 10.0.0.0/24 for AREDN nodes...\n")
 
@@ -239,7 +240,7 @@ class AREDNMixin:
         AREDN nodes are displayed alongside Meshtastic and RNS nodes
         on the MeshForge map. Nodes must have location configured.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== AREDN Network Map ===\n")
 
         # Check for AREDN node

--- a/src/launcher_tui/backend.py
+++ b/src/launcher_tui/backend.py
@@ -9,10 +9,21 @@ import logging
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 from typing import Tuple, Optional, List
 
 logger = logging.getLogger(__name__)
+
+
+def clear_screen() -> None:
+    """Clear the terminal using ANSI escape codes.
+
+    Much faster than subprocess.run(['clear']) — no subprocess spawn,
+    no visible flash between clear and redraw.
+    """
+    sys.stdout.write('\033[H\033[2J')
+    sys.stdout.flush()
 
 
 class DialogBackend:

--- a/src/launcher_tui/dashboard_mixin.py
+++ b/src/launcher_tui/dashboard_mixin.py
@@ -7,6 +7,7 @@ Provides the display methods used by the Dashboard submenu.
 
 import logging
 import subprocess
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class DashboardMixin:
 
     def _service_status_display(self):
         """Show comprehensive service status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Service Status ===\n")
 
         # Import here to avoid circular imports at module level
@@ -54,7 +55,7 @@ class DashboardMixin:
 
     def _show_node_counts(self):
         """Show node counts from all sources."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Node Counts ===\n")
 
         # Meshtastic nodes via HTTP API
@@ -89,7 +90,7 @@ class DashboardMixin:
 
     def _data_path_diagnostic(self):
         """Test all data collection paths to diagnose zero-data issues."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Data Path Diagnostic ===\n")
         print("Testing all data sources...\n")
 
@@ -386,7 +387,7 @@ class DashboardMixin:
 
     def _show_alerts(self):
         """Show current alerts from environment state and EAS."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Current Alerts ===\n")
 
         # System/environment alerts

--- a/src/launcher_tui/device_backup_mixin.py
+++ b/src/launcher_tui/device_backup_mixin.py
@@ -6,6 +6,7 @@ Provides UI for commands/device_backup.py functionality.
 """
 
 import subprocess
+from backend import clear_screen
 
 
 class DeviceBackupMixin:
@@ -147,7 +148,7 @@ class DeviceBackupMixin:
             return
 
         # Display backups in terminal for better formatting
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Device Backups ===\n")
 
         for backup in backups:

--- a/src/launcher_tui/emergency_mode_mixin.py
+++ b/src/launcher_tui/emergency_mode_mixin.py
@@ -16,6 +16,7 @@ import sys
 import time
 import logging
 from typing import Optional
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -105,7 +106,7 @@ class EmergencyModeMixin:
         ):
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"Broadcasting: {full_msg}\n")
         try:
             cli_path = self._get_emcomm_cli()
@@ -169,7 +170,7 @@ class EmergencyModeMixin:
         ):
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"Sending to {dest_clean}: {full_msg}\n")
         try:
             cli_path = self._get_emcomm_cli()
@@ -189,7 +190,7 @@ class EmergencyModeMixin:
 
     def _emcomm_status(self):
         """Show which nodes are currently online."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== NODES ONLINE ===\n")
         try:
             cli_path = self._get_emcomm_cli()
@@ -210,7 +211,7 @@ class EmergencyModeMixin:
 
     def _emcomm_messages(self):
         """Show recent messages from the mesh."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== RECENT MESSAGES ===\n")
 
         # Try to get messages from meshtasticd journal
@@ -248,7 +249,7 @@ class EmergencyModeMixin:
 
     def _emcomm_position(self):
         """Show current GPS position."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== MY POSITION ===\n")
         try:
             cli_path = self._get_emcomm_cli()
@@ -294,7 +295,7 @@ class EmergencyModeMixin:
         if info.strip():
             beacon_msg += f" - {info.strip()}"
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== SOS BEACON ACTIVE ===\n")
         print(f"Message: {beacon_msg}")
         print(f"Interval: 60 seconds")
@@ -336,7 +337,7 @@ class EmergencyModeMixin:
         Uses the EAS Alerts plugin to fetch current NOAA/NWS weather alerts.
         Designed for field operations: never crashes, always returns to menu.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== WEATHER / EAS ALERTS ===\n")
 
         try:

--- a/src/launcher_tui/hardware_menu_mixin.py
+++ b/src/launcher_tui/hardware_menu_mixin.py
@@ -8,6 +8,7 @@ import logging
 import shutil
 import subprocess
 from pathlib import Path
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,7 @@ class HardwareMenuMixin:
 
     def _detect_hardware(self):
         """Run hardware detection - terminal-native."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Hardware Detection ===\n")
 
         # SPI

--- a/src/launcher_tui/logs_menu_mixin.py
+++ b/src/launcher_tui/logs_menu_mixin.py
@@ -6,6 +6,7 @@ Extracted from main.py to reduce file size per CLAUDE.md guidelines.
 
 import subprocess
 from pathlib import Path
+from backend import clear_screen
 
 # Import centralized path utility
 try:
@@ -68,7 +69,7 @@ class LogsMenuMixin:
 
     def _view_live_meshtasticd(self):
         """View live meshtasticd log stream."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== meshtasticd live log (Ctrl+C to stop) ===\n")
         try:
             subprocess.run(
@@ -80,7 +81,7 @@ class LogsMenuMixin:
 
     def _view_live_rnsd(self):
         """View live rnsd log stream."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== rnsd live log (Ctrl+C to stop) ===\n")
         try:
             subprocess.run(
@@ -92,7 +93,7 @@ class LogsMenuMixin:
 
     def _view_live_all(self):
         """View live log stream for all services."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== All services live log (Ctrl+C to stop) ===\n")
         try:
             subprocess.run(
@@ -104,7 +105,7 @@ class LogsMenuMixin:
 
     def _view_error_logs(self):
         """View error-level logs from the last hour."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Errors (last hour, priority err+) ===\n")
         subprocess.run(
             ['journalctl', '-p', 'err', '--since', '1 hour ago', '--no-pager'],
@@ -114,7 +115,7 @@ class LogsMenuMixin:
 
     def _view_meshtasticd_recent(self):
         """View recent meshtasticd log lines."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== meshtasticd (last 50 lines) ===\n")
         subprocess.run(
             ['journalctl', '-u', 'meshtasticd', '-n', '50', '--no-pager'],
@@ -124,7 +125,7 @@ class LogsMenuMixin:
 
     def _view_rnsd_recent(self):
         """View recent rnsd log lines."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== rnsd (last 50 lines) ===\n")
         subprocess.run(
             ['journalctl', '-u', 'rnsd', '-n', '50', '--no-pager'],
@@ -134,7 +135,7 @@ class LogsMenuMixin:
 
     def _view_boot_messages(self):
         """View boot messages from this boot."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Boot messages (this boot) ===\n")
         subprocess.run(
             ['journalctl', '-b', '-n', '100', '--no-pager'],
@@ -144,7 +145,7 @@ class LogsMenuMixin:
 
     def _view_kernel_messages(self):
         """View kernel messages via dmesg."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Kernel messages (dmesg) ===\n")
         subprocess.run(['dmesg', '--time-format=reltime'], timeout=10)
         self._wait_for_enter()
@@ -169,7 +170,7 @@ class LogsMenuMixin:
             content = latest_log.read_text()
             lines = content.strip().split('\n')[-50:]  # Last 50 lines
 
-            subprocess.run(['clear'], check=False, timeout=5)
+            clear_screen()
             print(f"=== MeshForge Log: {latest_log.name} ===\n")
             print('\n'.join(lines))
             print("\n" + "=" * 50)

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -63,7 +63,7 @@ except ImportError:
     _HAS_APPLY_RESTART = False
 
 # Import dialog backend directly (not through package namespace)
-from backend import DialogBackend
+from backend import DialogBackend, clear_screen
 
 # Import startup checks and conflict resolution (v0.4.8)
 try:
@@ -1083,7 +1083,7 @@ class MeshForgeLauncher(
 
     def _drop_to_shell(self):
         """Drop to a bash shell."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Dropping to shell. Type 'exit' to return to MeshForge.\n")
         subprocess.run(['bash'], check=False)  # Interactive shell - no timeout
 
@@ -1167,7 +1167,7 @@ DOCUMENTATION:
 SUPPORT:
   Issues: github.com/Nursedude/meshforge/issues
 """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(help_text)
         self._wait_for_enter()
 
@@ -1226,7 +1226,7 @@ SUPPORT:
 
     def _view_active_config(self):
         """Show the active meshtasticd config.yaml."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== meshtasticd config.yaml ===\n")
 
         config_path = Path('/etc/meshtasticd/config.yaml')
@@ -1246,7 +1246,7 @@ SUPPORT:
 
     def _view_config_overlays(self):
         """Show config.d/ overlay files."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== config.d/ Overlays ===\n")
 
         config_d = Path('/etc/meshtasticd/config.d')
@@ -1280,7 +1280,7 @@ SUPPORT:
 
     def _view_available_hats(self):
         """Show available HAT configurations from meshtasticd package."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Available HAT Configs ===\n")
 
         available_d = Path('/etc/meshtasticd/available.d')
@@ -1315,7 +1315,7 @@ SUPPORT:
 
     def _run_diagnostics(self):
         """Run the MeshForge diagnostic tool."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         try:
             result = subprocess.run(
                 [sys.executable, str(self.src_dir / 'cli' / 'diagnose.py')],
@@ -1337,7 +1337,7 @@ SUPPORT:
 
     def _run_terminal_status(self):
         """Run meshforge-status (terminal-native one-shot status)."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         try:
             # Run status script directly, showing output in real-time
             result = subprocess.run(

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -10,6 +10,7 @@ import logging
 import subprocess
 import sys
 from pathlib import Path
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -904,7 +905,7 @@ Press Cancel to keep current values."""
             return
 
         # Clear screen and run nano
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         subprocess.run(['nano', path])  # Interactive editor - no timeout
 
         # Ask to restart service
@@ -1055,7 +1056,7 @@ Press Cancel to keep current values."""
 
     def _mqtt_view_settings(self):
         """View current MQTT settings."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== MQTT Settings ===\n")
         cli = self._get_meshtastic_cli()
         try:
@@ -1085,7 +1086,7 @@ Press Cancel to keep current values."""
             return
 
         cli = self._get_meshtastic_cli()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== {'Enabling' if enabled else 'Disabling'} MQTT ===\n")
         try:
             result = subprocess.run(
@@ -1126,7 +1127,7 @@ Press Cancel to keep current values."""
             return
 
         cli = self._get_meshtastic_cli()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Setting MQTT Broker ===\n")
         try:
             result = subprocess.run(
@@ -1162,7 +1163,7 @@ Press Cancel to keep current values."""
             return
 
         cli = self._get_meshtastic_cli()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Setting MQTT Credentials ===\n")
         try:
             cmd = [cli, '--host', 'localhost']
@@ -1197,7 +1198,7 @@ Press Cancel to keep current values."""
             return
 
         cli = self._get_meshtastic_cli()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Setting MQTT Topic ===\n")
         try:
             result = subprocess.run(
@@ -1243,7 +1244,7 @@ Press Cancel to keep current values."""
             return
 
         cli = self._get_meshtastic_cli()
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         if choice == "json":
             print("=== Setting JSON Mode ===\n")
@@ -1291,7 +1292,7 @@ Press Cancel to keep current values."""
             default_no=True
         ):
             cli = self._get_meshtastic_cli()
-            subprocess.run(['clear'], check=False, timeout=5)
+            clear_screen()
             print("=== Enabling Uplink ===\n")
             try:
                 subprocess.run(
@@ -1322,7 +1323,7 @@ Press Cancel to keep current values."""
             default_no=True
         ):
             cli = self._get_meshtastic_cli()
-            subprocess.run(['clear'], check=False, timeout=5)
+            clear_screen()
             print("=== Enabling Downlink ===\n")
             try:
                 subprocess.run(

--- a/src/launcher_tui/metrics_mixin.py
+++ b/src/launcher_tui/metrics_mixin.py
@@ -12,6 +12,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Dict, Any, List
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -554,7 +555,7 @@ class MetricsMixin:
         port = self._prometheus_port
         url = f"http://localhost:{port}/metrics"
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Testing Prometheus Endpoint ===")
         print(f"URL: {url}\n")
 

--- a/src/launcher_tui/network_tools_mixin.py
+++ b/src/launcher_tui/network_tools_mixin.py
@@ -15,6 +15,7 @@ import logging
 import socket as sock
 import subprocess
 from pathlib import Path
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -170,22 +171,22 @@ class NetworkToolsMixin:
             # Inline system commands
             try:
                 if choice == "ports":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Listening Ports ===\n")
                     subprocess.run(['ss', '-tlnp'], timeout=10)
                     self._wait_for_enter()
                 elif choice == "ifaces":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Network Interfaces ===\n")
                     subprocess.run(['ip', '-c', 'addr'], timeout=10)
                     self._wait_for_enter()
                 elif choice == "conns":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Active Connections ===\n")
                     subprocess.run(['ss', '-tunp'], timeout=10)
                     self._wait_for_enter()
                 elif choice == "routes":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Routing Table ===\n")
                     subprocess.run(['ip', 'route'], timeout=10)
                     self._wait_for_enter()
@@ -199,7 +200,7 @@ class NetworkToolsMixin:
 
     def _run_terminal_network(self):
         """Show network diagnostics directly in terminal."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("MeshForge Network Status")
         print("=" * 50)
         print()

--- a/src/launcher_tui/node_health_mixin.py
+++ b/src/launcher_tui/node_health_mixin.py
@@ -12,6 +12,7 @@ Provides menu methods callable from Dashboard and Maps submenus.
 import logging
 import subprocess
 import time
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class NodeHealthMixin:
 
     def _service_latency_probe(self):
         """Probe all NOC services and display latency/health."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Service Latency Probe ===\n")
         print("Probing services (2s timeout each)...\n")
 
@@ -105,7 +106,7 @@ class NodeHealthMixin:
 
     def _battery_forecast_display(self):
         """Show battery forecasts with drain rates and maintenance recommendations."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Battery Forecast & Maintenance ===\n")
 
         try:
@@ -275,7 +276,7 @@ class NodeHealthMixin:
 
     def _signal_trending_display(self):
         """Show signal trend analysis for nodes with stability scoring."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Signal Trending Analysis ===\n")
 
         try:

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -21,6 +21,7 @@ import subprocess
 import time
 import logging
 from pathlib import Path
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -256,7 +257,7 @@ class NomadNetClientMixin:
 
     def _nomadnet_status(self):
         """Show comprehensive NomadNet status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== NomadNet Status ===\n")
 
         # Installation
@@ -389,7 +390,7 @@ class NomadNetClientMixin:
         rns_config_path = self._get_rns_config_for_user()
 
         # Clear screen before launching
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Launching NomadNet ===")
         if rns_config_path:
             print(f"Using RNS config: {rns_config_path}")
@@ -647,7 +648,7 @@ class NomadNetClientMixin:
 
     def _view_nomadnet_config(self):
         """View NomadNet configuration."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== NomadNet Configuration ===\n")
 
         config_path = self._get_nomadnet_config_path()
@@ -799,7 +800,7 @@ class NomadNetClientMixin:
         ):
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Installing NomadNet ===\n")
 
         # Determine if we should install as a different user (when running via sudo)

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -22,6 +22,7 @@ import sys
 import subprocess
 import logging
 from pathlib import Path
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -84,7 +85,7 @@ class QuickActionsMixin:
 
         Uses centralized service_check module when available.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Quick Service Status ===\n")
 
         services = ['meshtasticd', 'rnsd', 'mosquitto', 'meshforge']
@@ -153,7 +154,7 @@ class QuickActionsMixin:
 
     def _qa_node_list(self):
         """Quick: show meshtastic node list."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Node List ===\n")
         try:
             cli_path = self._get_meshtastic_cli()
@@ -173,7 +174,7 @@ class QuickActionsMixin:
 
     def _qa_follow_logs(self):
         """Quick: follow meshtasticd journal logs."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== meshtasticd Logs (Ctrl+C to stop, auto-exits after 2 min) ===\n")
         try:
             subprocess.run(
@@ -190,7 +191,7 @@ class QuickActionsMixin:
 
     def _qa_restart_meshtasticd(self):
         """Quick: restart meshtasticd service."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Restarting meshtasticd...\n")
         try:
             subprocess.run(
@@ -213,7 +214,7 @@ class QuickActionsMixin:
 
     def _qa_restart_rnsd(self):
         """Quick: restart rnsd service."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Restarting rnsd...\n")
         try:
             subprocess.run(
@@ -240,7 +241,7 @@ class QuickActionsMixin:
         Uses centralized service_check module when available.
         """
         import socket as sock
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Port Check ===\n")
 
         ports = [
@@ -274,7 +275,7 @@ class QuickActionsMixin:
 
     def _qa_generate_report(self):
         """Quick: generate and display a status report."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Generating status report...\n")
 
         try:
@@ -303,7 +304,7 @@ class QuickActionsMixin:
 
     def _qa_node_inventory(self):
         """Quick: show tracked node inventory."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Node Inventory ===\n")
 
         try:
@@ -355,7 +356,7 @@ class QuickActionsMixin:
 
     def _qa_gps_position(self):
         """Quick: show GPS position and distance to nodes."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== GPS Position ===\n")
 
         try:
@@ -406,7 +407,7 @@ class QuickActionsMixin:
 
     def _qa_run_diagnostics(self):
         """Quick: run diagnostic engine health check."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Diagnostic Health Check ===\n")
 
         try:
@@ -440,7 +441,7 @@ class QuickActionsMixin:
 
     def _qa_channel_scan(self):
         """Quick: show channel activity scan."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Channel Activity ===\n")
 
         try:

--- a/src/launcher_tui/radio_menu_mixin.py
+++ b/src/launcher_tui/radio_menu_mixin.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 from pathlib import Path
+from backend import clear_screen
 
 # Import centralized path utility
 try:
@@ -122,7 +123,7 @@ class RadioMenuMixin:
 
     def _radio_run(self, cmd: list, title: str):
         """Run a meshtastic CLI command and show output in terminal."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== {title} ===")
         print("(Ctrl+C to abort)\n")
         try:
@@ -158,7 +159,7 @@ class RadioMenuMixin:
 
     def _install_meshtastic_cli(self):
         """Install meshtastic CLI via pipx with live terminal output."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Installing Meshtastic CLI ===\n")
 
         # Determine if we should install as a different user (when running via sudo)

--- a/src/launcher_tui/rf_awareness_mixin.py
+++ b/src/launcher_tui/rf_awareness_mixin.py
@@ -14,6 +14,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Optional, Dict, Any, List
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -247,7 +248,7 @@ class RFAwarenessMixin:
             return
 
         # Show waterfall in terminal (exit TUI temporarily)
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== RF Waterfall Display ===")
         print(f"Band: {band.description}")
         print(f"Center: {band.center_freq / 1e6:.3f} MHz")

--- a/src/launcher_tui/rf_tools_mixin.py
+++ b/src/launcher_tui/rf_tools_mixin.py
@@ -6,6 +6,7 @@ to reduce file size and improve maintainability.
 """
 
 import math
+from backend import clear_screen
 
 
 class RFToolsMixin:
@@ -482,7 +483,7 @@ Note: Check local regulations."""
             antennas.append(antenna)
 
         # Generate comparison table
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         table = format_antenna_comparison(antennas, base_range, azimuth)
         print(table)
         print(f"\n  Base range (stock whip): {base_range:.1f} km")
@@ -568,7 +569,7 @@ Note: Check local regulations."""
 
         from utils.antenna_patterns import ANTENNA_PRESETS, get_antenna_preset
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Antenna Specifications ===\n")
         print(f"  {'Name':<22} {'Type':<14} {'Gain':>6} {'H Beam':>7} {'V Beam':>7} {'F/B':>5}")
         print(f"  {'-'*65}")

--- a/src/launcher_tui/rns_interfaces_mixin.py
+++ b/src/launcher_tui/rns_interfaces_mixin.py
@@ -12,6 +12,7 @@ import re
 import sys
 import subprocess
 import logging
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -63,7 +64,7 @@ class RNSInterfacesMixin:
 
     def _rns_list_interfaces(self):
         """Display all configured RNS interfaces."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Configured RNS Interfaces ===\n")
 
         result = self._rns_cmd_list_interfaces()

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -28,6 +28,7 @@ except ImportError:
 # See: utils/paths.py (ReticulumPaths, get_real_user_home)
 # NO FALLBACK: stale fallback copies caused config divergence bugs (Issue #25+)
 from utils.paths import get_real_user_home, ReticulumPaths
+from backend import clear_screen
 
 
 class RNSMenuMixin(RNSSnifferMixin):
@@ -94,12 +95,12 @@ class RNSMenuMixin(RNSSnifferMixin):
             # Inline RNS tool commands
             try:
                 if choice == "status":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== RNS Status ===\n")
                     self._run_rns_tool(['rnstatus'], 'rnstatus')
                     self._wait_for_enter()
                 elif choice == "paths":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== RNS Path Table ===\n")
                     self._run_rns_tool(['rnpath', '-t'], 'rnpath')
                     self._wait_for_enter()
@@ -115,7 +116,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _rns_probe_destination(self):
         """Probe an RNS destination to test reachability."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Probe RNS Destination ===\n")
         print("Probe tests reachability of a destination on the RNS network.")
         print("Enter the full destination hash (32 hex chars), or a partial hash.\n")
@@ -140,7 +141,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _rns_identity_info(self):
         """Show RNS identity information."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== RNS Identity Info ===\n")
 
         while True:
@@ -162,7 +163,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
             try:
                 if choice == "show":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Local RNS Identity ===\n")
 
                     # Find the rnsd identity file
@@ -196,7 +197,7 @@ class RNSMenuMixin(RNSSnifferMixin):
                     self._wait_for_enter()
 
                 elif choice == "path":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== RNS Identity Paths ===\n")
                     config_dir = ReticulumPaths.get_config_dir()
                     identity_path = config_dir / 'identity'
@@ -225,7 +226,7 @@ class RNSMenuMixin(RNSSnifferMixin):
                     self._wait_for_enter()
 
                 elif choice == "recall":
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     print("=== Recall RNS Identity ===\n")
                     print("Look up a known identity by its destination hash.\n")
                     try:
@@ -249,7 +250,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _rns_known_destinations(self):
         """Show known RNS destinations from the running rnsd instance."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Known RNS Destinations ===\n")
 
         try:
@@ -294,7 +295,7 @@ class RNSMenuMixin(RNSSnifferMixin):
         Sideband nodes with GPS sharing will be auto-populated.
         """
         while True:
-            subprocess.run(['clear'], check=False, timeout=5)
+            clear_screen()
             print("=== Set RNS Node Positions ===\n")
             print("NomadNet nodes don't broadcast GPS. Set positions manually")
             print("so your RNS nodes appear on the live network map.\n")
@@ -351,7 +352,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _set_single_node_position(self, node):
         """Set position for a single RNS node."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Set Position for {node.name} ===\n")
         print(f"Node ID: {node.id}")
         if node.position.is_valid():
@@ -449,7 +450,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _rns_diagnostics(self):
         """Run comprehensive RNS diagnostics."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== RNS Diagnostics ===\n")
 
         try:
@@ -519,7 +520,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _rns_config_drift_check(self):
         """Check for config drift between gateway and rnsd."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== RNS Config Drift Check ===\n")
         print("Comparing gateway config path vs rnsd actual path...\n")
 
@@ -886,7 +887,7 @@ class RNSMenuMixin(RNSSnifferMixin):
 
     def _view_rns_config(self):
         """View current Reticulum config."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Reticulum Configuration ===\n")
 
         config_path = ReticulumPaths.get_config_file()

--- a/src/launcher_tui/rns_sniffer_mixin.py
+++ b/src/launcher_tui/rns_sniffer_mixin.py
@@ -6,6 +6,7 @@ Extracted from rns_menu_mixin.py to reduce file size per CLAUDE.md guidelines.
 
 import re
 import subprocess
+from backend import clear_screen
 
 
 class RNSSnifferMixin:
@@ -446,7 +447,7 @@ class RNSSnifferMixin:
             self.dialog.msgbox("Filtered Packets", "\n".join(lines), height=22, width=55)
 
         elif choice == "4":
-            subprocess.run(['clear'], check=False, timeout=5)
+            clear_screen()
             print(f"=== Probing {identity_hash} ===\n")
             self._run_rns_tool(['rnprobe', identity_hash], 'rnprobe')
             self._wait_for_enter()

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -11,6 +11,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from typing import Optional
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +163,7 @@ class ServiceMenuMixin:
                 "Stop it first to run in foreground.")
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Starting Gateway Bridge (foreground)...")
         print("Press Ctrl+C to stop\n")
         try:
@@ -251,7 +252,7 @@ class ServiceMenuMixin:
             self.dialog.msgbox("No Logs", "No gateway log found.")
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         try:
             subprocess.run(['less', '-R', '-X', '+G', str(log_path)], timeout=300)
         except KeyboardInterrupt:
@@ -300,10 +301,15 @@ class ServiceMenuMixin:
                 self._safe_call(*entry)
 
     def _show_all_service_status(self):
-        """Show status of all mesh services."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        """Show status of all mesh services.
+
+        Uses check_service() as the single source of truth to avoid
+        contradictions between lightweight and detailed status checks.
+        """
+        clear_screen()
         print("=== Service Status ===\n")
         warnings = []
+        failed_services = []
         use_direct_rnsd = not self._has_systemd_unit('rnsd')
 
         for svc in ['meshtasticd', 'rnsd', 'meshforge']:
@@ -317,8 +323,24 @@ class ServiceMenuMixin:
 
             try:
                 if _HAS_SERVICE_CHECK:
-                    is_running, is_enabled = check_systemd_service(svc)
-                    status = 'active' if is_running else 'inactive'
+                    # Use detailed check_service() as single source of truth
+                    svc_status = check_service(svc)
+                    _, is_enabled = check_systemd_service(svc)
+
+                    boot_info = ""
+                    if svc_status.available and not is_enabled:
+                        boot_info = "  (not enabled at boot)"
+                        warnings.append(svc)
+
+                    if svc_status.available:
+                        print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
+                    elif svc_status.state in (ServiceState.FAILED, ServiceState.DEGRADED):
+                        print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
+                        failed_services.append(svc)
+                    elif svc_status.state == ServiceState.NOT_RUNNING:
+                        print(f"  \033[2m○\033[0m {svc:<18} stopped")
+                    else:
+                        print(f"  \033[2m○\033[0m {svc:<18} {svc_status.state.value}")
                 else:
                     result = subprocess.run(
                         ['systemctl', 'is-active', svc],
@@ -331,17 +353,18 @@ class ServiceMenuMixin:
                     )
                     is_enabled = enabled_result.returncode == 0
 
-                boot_info = ""
-                if status == 'active' and not is_enabled:
-                    boot_info = "  (not enabled at boot)"
-                    warnings.append(svc)
+                    boot_info = ""
+                    if status == 'active' and not is_enabled:
+                        boot_info = "  (not enabled at boot)"
+                        warnings.append(svc)
 
-                if status == 'active':
-                    print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
-                elif status == 'failed':
-                    print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
-                else:
-                    print(f"  \033[2m○\033[0m {svc:<18} {status}")
+                    if status == 'active':
+                        print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
+                    elif status == 'failed':
+                        print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
+                        failed_services.append(svc)
+                    else:
+                        print(f"  \033[2m○\033[0m {svc:<18} {status}")
             except (subprocess.SubprocessError, OSError) as e:
                 logger.debug("Service status check for %s failed: %s", svc, e)
                 print(f"  ? {svc:<18} unknown")
@@ -351,43 +374,17 @@ class ServiceMenuMixin:
             print(f"  \033[0;33mWarning:\033[0m {', '.join(warnings)} won't start on reboot.")
             print(f"  Fix: sudo systemctl enable {' '.join(warnings)}\n")
 
-        for svc in ['meshtasticd']:
+        # Show failure logs for services already identified as failed (no re-check)
+        for svc in failed_services:
             try:
-                if _HAS_SERVICE_CHECK:
-                    status = check_service(svc)
-                    is_failed = status.state == ServiceState.FAILED
-                else:
-                    r = subprocess.run(['systemctl', 'is-active', svc],
-                                       capture_output=True, text=True, timeout=5)
-                    is_failed = r.stdout.strip() == 'failed'
-                if is_failed:
-                    print(f"\033[0;31m{svc} failure:\033[0m")
-                    subprocess.run(
-                        ['journalctl', '-u', svc, '-n', '5', '--no-pager'],
-                        timeout=10
-                    )
-                    print()
+                print(f"\033[0;31m{svc} failure:\033[0m")
+                subprocess.run(
+                    ['journalctl', '-u', svc, '-n', '5', '--no-pager'],
+                    timeout=10
+                )
+                print()
             except (subprocess.SubprocessError, OSError) as e:
                 logger.debug("Failure log check for %s failed: %s", svc, e)
-
-        if not use_direct_rnsd:
-            try:
-                if _HAS_SERVICE_CHECK:
-                    status = check_service('rnsd')
-                    is_failed = status.state == ServiceState.FAILED
-                else:
-                    r = subprocess.run(['systemctl', 'is-active', 'rnsd'],
-                                       capture_output=True, text=True, timeout=5)
-                    is_failed = r.stdout.strip() == 'failed'
-                if is_failed:
-                    print(f"\033[0;31mrnsd failure:\033[0m")
-                    subprocess.run(
-                        ['journalctl', '-u', 'rnsd', '-n', '5', '--no-pager'],
-                        timeout=10
-                    )
-                    print()
-            except (subprocess.SubprocessError, OSError) as e:
-                logger.debug("rnsd failure log check failed: %s", e)
         self._wait_for_enter()
 
     def _manage_port_lockdown(self):
@@ -428,7 +425,7 @@ class ServiceMenuMixin:
                 break
 
             if choice == "lock":
-                subprocess.run(['clear'], check=False, timeout=5)
+                clear_screen()
                 success, msg = lock_port_external(9443)
                 if success:
                     print(f"\033[0;32m✓\033[0m {msg}")
@@ -439,7 +436,7 @@ class ServiceMenuMixin:
                 self._wait_for_enter()
 
             elif choice == "unlock":
-                subprocess.run(['clear'], check=False, timeout=5)
+                clear_screen()
                 success, msg = unlock_port_external(9443)
                 if success:
                     print(f"\033[0;32m✓\033[0m {msg}")
@@ -448,7 +445,7 @@ class ServiceMenuMixin:
                 self._wait_for_enter()
 
             elif choice == "persist":
-                subprocess.run(['clear'], check=False, timeout=5)
+                clear_screen()
                 print("Saving iptables rules for reboot persistence...\n")
                 success, msg = persist_iptables()
                 if success:
@@ -458,7 +455,7 @@ class ServiceMenuMixin:
                 self._wait_for_enter()
 
             elif choice == "status":
-                subprocess.run(['clear'], check=False, timeout=5)
+                clear_screen()
                 print("=== Port 9443 Status ===\n")
                 if locked:
                     print("  \033[0;32m●\033[0m Port 9443: LOCKED (localhost only)")
@@ -471,7 +468,7 @@ class ServiceMenuMixin:
 
     def _restart_meshtasticd_service(self):
         """Restart the meshtasticd service."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Restarting meshtasticd...\n")
         subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30)
         subprocess.run(['systemctl', 'status', 'meshtasticd', '--no-pager', '-l'], timeout=10)
@@ -479,7 +476,7 @@ class ServiceMenuMixin:
 
     def _start_rnsd_service(self):
         """Start the rnsd service."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Starting rnsd...\n")
         if not self._has_systemd_unit('rnsd'):
             self._start_rnsd_direct()
@@ -490,7 +487,7 @@ class ServiceMenuMixin:
 
     def _restart_rnsd_service(self):
         """Restart the rnsd service."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("Restarting rnsd...\n")
         if not self._has_systemd_unit('rnsd'):
             self._stop_rnsd_direct()
@@ -889,7 +886,7 @@ WantedBy=multi-user.target
         For rnsd: Uses direct process control if no systemd unit exists.
         For other services: Uses systemctl.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         # Check if rnsd needs direct process handling
         use_direct_rnsd = (service_name == 'rnsd' and
@@ -933,7 +930,7 @@ WantedBy=multi-user.target
 
         elif action == "stop":
             if self.dialog.yesno("Confirm", f"Stop {service_name}?", default_no=True):
-                subprocess.run(['clear'], check=False, timeout=5)
+                clear_screen()
                 print(f"Stopping {service_name}...\n")
                 if use_direct_rnsd:
                     self._stop_rnsd_direct()
@@ -1048,7 +1045,7 @@ WantedBy=multi-user.target
 
     def _openhamclock_docker_status(self):
         """Show OpenHamClock Docker container status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== OpenHamClock Docker Status ===\n")
 
         try:
@@ -1069,7 +1066,7 @@ WantedBy=multi-user.target
 
     def _start_openhamclock_docker(self):
         """Start OpenHamClock Docker container."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Starting OpenHamClock ===\n")
 
         # Check if container already exists
@@ -1127,7 +1124,7 @@ WantedBy=multi-user.target
 
     def _stop_openhamclock_docker(self):
         """Stop OpenHamClock Docker container."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Stopping OpenHamClock ===\n")
 
         try:
@@ -1148,7 +1145,7 @@ WantedBy=multi-user.target
 
     def _openhamclock_docker_logs(self):
         """Show OpenHamClock Docker container logs."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== OpenHamClock Logs (last 30) ===\n")
 
         try:
@@ -1271,7 +1268,7 @@ WantedBy=multi-user.target
 
         Returns True if installation succeeded.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Installing Mosquitto MQTT Broker ===\n")
 
         try:
@@ -1375,7 +1372,7 @@ WantedBy=multi-user.target
 
         Returns True if configuration succeeded.
         """
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Configuring meshtasticd for Local MQTT ===\n")
 
         cli = shutil.which('meshtastic') or 'meshtastic'

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Optional
 
 import logging
+from backend import clear_screen
 logger = logging.getLogger(__name__)
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH
@@ -137,7 +138,7 @@ class SystemToolsMixin:
 
     def _run_interactive_tool(self, tool: str):
         """Run an interactive monitoring tool."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         tool_commands = {
             'btop': ['btop'],
@@ -207,7 +208,7 @@ class SystemToolsMixin:
 
     def _run_process_command(self, cmd_type: str):
         """Run process-related command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         commands = {
             'ps_all': (['ps', 'aux', '--forest'], "All Processes (ps aux --forest)"),
@@ -256,7 +257,7 @@ class SystemToolsMixin:
 
     def _show_mesh_processes(self):
         """Show mesh-related processes."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Mesh-Related Processes ===\n")
 
         patterns = ['meshtastic', 'rnsd', 'lxmf', 'nomadnet', 'meshforge', 'python.*mesh']
@@ -316,7 +317,7 @@ class SystemToolsMixin:
             self.dialog.msgbox("Error", "Port must be a number between 1 and 65535")
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Who's Using Port {port}? ===\n")
 
         try:
@@ -388,7 +389,7 @@ class SystemToolsMixin:
 
     def _run_network_command(self, cmd_type: str):
         """Run network diagnostic command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         simple_commands = {
             'ss': (['ss', '-tuln'], "Listening Ports (ss -tuln)"),
@@ -447,7 +448,7 @@ class SystemToolsMixin:
             self.dialog.msgbox("Error", "Invalid hostname or IP address.")
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== DNS Lookup: {host} ===\n")
 
         # Try multiple DNS tools
@@ -493,7 +494,7 @@ class SystemToolsMixin:
             self.dialog.msgbox("Error", "Invalid hostname or IP address.")
             return
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Traceroute to {host} ===\n")
         print("(Ctrl+C to stop)\n")
 
@@ -538,7 +539,7 @@ class SystemToolsMixin:
         except ValueError:
             count = 5
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Ping {host} ===\n")
 
         cmd = ['ping', host]
@@ -556,7 +557,7 @@ class SystemToolsMixin:
 
     def _wifi_status(self):
         """Show WiFi status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== WiFi Status ===\n")
 
         # Try iw first (modern), then iwconfig (legacy)
@@ -578,7 +579,7 @@ class SystemToolsMixin:
 
     def _tcp_monitor_view(self):
         """Display TCP connections related to Meshtastic."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== TCP Connection Monitor ===\n")
         print("Monitoring connections to meshtasticd (port 4403) and web interfaces\n")
 
@@ -659,7 +660,7 @@ class SystemToolsMixin:
 
     def _network_scan_view(self):
         """Scan network for meshtasticd devices."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Network Device Discovery ===\n")
         print("Scanning for Meshtastic devices on the local network...\n")
 
@@ -682,7 +683,7 @@ class SystemToolsMixin:
             ""
         )
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== Scanning Network ===\n")
 
         scanner = NetworkScanner(timeout=1.0, max_threads=50)
@@ -780,7 +781,7 @@ class SystemToolsMixin:
 
     def _run_hardware_command(self, cmd_type: str):
         """Run hardware info command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         simple_commands = {
             'lscpu': (['lscpu'], "CPU Information"),
@@ -819,7 +820,7 @@ class SystemToolsMixin:
 
     def _gpio_status(self):
         """Show GPIO status for Pi/SBC."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== GPIO Status ===\n")
 
         # Try raspi-gpio first, then gpioinfo
@@ -847,7 +848,7 @@ class SystemToolsMixin:
 
     def _spi_i2c_status(self):
         """Show SPI and I2C status."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== SPI/I2C Status ===\n")
 
         # SPI
@@ -914,7 +915,7 @@ class SystemToolsMixin:
 
     def _run_performance_command(self, cmd_type: str):
         """Run performance monitoring command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         simple_commands = {
             'free': (['free', '-h'], "Memory Usage"),
@@ -983,7 +984,7 @@ class SystemToolsMixin:
         except ValueError:
             duration = 10
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print(f"=== Stress Test ({duration}s) ===\n")
         print("Running CPU stress test...\n")
 
@@ -1030,7 +1031,7 @@ class SystemToolsMixin:
 
     def _run_storage_command(self, cmd_type: str):
         """Run storage command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         if cmd_type == 'df':
             print("=== Disk Free Space ===\n")
@@ -1120,7 +1121,7 @@ class SystemToolsMixin:
 
     def _run_service_command(self, cmd_type: str):
         """Run service management command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         if cmd_type == 'status_all':
             print("=== All Services Status ===\n")
@@ -1218,7 +1219,7 @@ class SystemToolsMixin:
 
     def _run_advanced_log_command(self, cmd_type: str):
         """Run advanced log command."""
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
 
         if cmd_type == 'journal_size':
             print("=== Journal Disk Usage ===\n")
@@ -1326,7 +1327,7 @@ class SystemToolsMixin:
             "  systemctl status meshtasticd"
         )
 
-        subprocess.run(['clear'], check=False, timeout=5)
+        clear_screen()
         print("=== MeshForge Shell ===")
         print("Type 'exit' to return to the menu.\n")
 

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -16,6 +16,7 @@ import threading
 import webbrowser
 from pathlib import Path
 from typing import Optional, Dict, Any, List
+from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
@@ -757,7 +758,7 @@ class TopologyMixin:
                 )
                 if choice == "lynx":
                     # Open with lynx in foreground
-                    subprocess.run(['clear'], check=False, timeout=5)
+                    clear_screen()
                     subprocess.run(['lynx', output_path], timeout=300)
                 elif choice == "path":
                     self.dialog.msgbox(

--- a/tests/test_quick_actions.py
+++ b/tests/test_quick_actions.py
@@ -192,15 +192,12 @@ class TestQuickActionMethods:
         ]
         assert len(restart_calls) == 1
 
-    @patch('subprocess.run')
     @patch('builtins.input', return_value='')
-    def test_port_check_runs(self, mock_input, mock_run):
-        mock_run.return_value = MagicMock(returncode=0)
+    def test_port_check_runs(self, mock_input):
         launcher = MockLauncher()
         # Port check uses socket, not subprocess for the actual checks
         launcher._qa_port_check()
-        # Should at least call clear
-        mock_run.assert_called()
+        # Should complete without error
 
     @patch('builtins.input', return_value='')
     def test_generate_report_runs(self, mock_input):


### PR DESCRIPTION
Two issues fixed:

1. Service status contradiction: _show_all_service_status() was calling check_systemd_service() (lightweight) then check_service() (detailed) independently — they could disagree, showing "running" and "FAILED" simultaneously. Now uses check_service() once as single source of truth and reuses the result for failure log display.

2. Screen flashing: Replaced 134 subprocess.run(['clear']) calls across 23 TUI files with ANSI escape codes (clear_screen() in backend.py). No subprocess spawn = no visible flash between clear and redraw.

https://claude.ai/code/session_016Wp5XjEhYisdpkmPy9U4KQ