### PR TITLE
fix: improve meshtasticd HTTP API detection and diagnostic guidance

### DIFF
--- a/src/launcher_tui/dashboard_mixin.py
+++ b/src/launcher_tui/dashboard_mixin.py
@@ -15,6 +15,30 @@ logger = logging.getLogger(__name__)
 class DashboardMixin:
     """TUI mixin for dashboard display methods."""
 
+    @staticmethod
+    def _check_webserver_config() -> str:
+        """Check if meshtasticd config.yaml has Webserver section enabled."""
+        from pathlib import Path
+        config_path = Path("/etc/meshtasticd/config.yaml")
+        if not config_path.exists():
+            return "Fix: /etc/meshtasticd/config.yaml not found"
+        try:
+            content = config_path.read_text()
+            if 'Webserver:' not in content:
+                return "Fix: Add 'Webserver: Port: 443' to /etc/meshtasticd/config.yaml"
+            # Webserver section exists but might be commented out
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith('#'):
+                    continue
+                if 'Webserver:' in stripped:
+                    return "Config has Webserver section — check meshtasticd logs"
+            return "Fix: Webserver section may be commented out in config.yaml"
+        except PermissionError:
+            return "Cannot read config (try running with sudo)"
+        except Exception:
+            return "Fix: Check Webserver section in /etc/meshtasticd/config.yaml"
+
     def _service_status_display(self):
         """Show comprehensive service status."""
         clear_screen()
@@ -143,15 +167,22 @@ class DashboardMixin:
         # Test 3: meshtasticd HTTP API
         print("[3/6] Testing meshtasticd HTTP API...")
         try:
-            from utils.meshtastic_http import get_http_client
+            from utils.meshtastic_http import get_http_client, reset_http_client
+            # Reset singleton so we get a fresh probe (not stale cached state)
+            reset_http_client()
             client = get_http_client()
             if client.is_available:
                 nodes = client.get_nodes()
-                results.append(("meshtasticd HTTP", "OK", f"{len(nodes)} nodes via /json/nodes"))
-                print(f"      \033[0;32mOK\033[0m - {len(nodes)} nodes found")
+                results.append(("meshtasticd HTTP", "OK",
+                               f"{len(nodes)} nodes via {client._base_url}"))
+                print(f"      \033[0;32mOK\033[0m - {len(nodes)} nodes at {client._base_url}")
             else:
-                results.append(("meshtasticd HTTP", "FAIL", "HTTP API not reachable"))
-                print("      \033[0;31mFAIL\033[0m - HTTP API not reachable")
+                # Provide actionable fix guidance
+                hint = self._check_webserver_config()
+                detail = f"Not reachable (tried ports 9443,443,80,4403). {hint}"
+                results.append(("meshtasticd HTTP", "FAIL", detail))
+                print(f"      \033[0;31mFAIL\033[0m - HTTP API not reachable")
+                print(f"      \033[2m{hint}\033[0m")
         except ImportError:
             results.append(("meshtasticd HTTP", "SKIP", "meshtastic_http module not available"))
             print("      \033[0;33mSKIP\033[0m - Module not available")

--- a/src/utils/meshtastic_http.py
+++ b/src/utils/meshtastic_http.py
@@ -217,22 +217,50 @@ class MeshtasticHTTPClient:
         )
 
     def _probe_url(self, url: str) -> bool:
-        """Check if a URL responds with valid data."""
+        """Check if a URL responds with valid meshtasticd data."""
+        ctx = self._ssl_ctx if url.startswith("https") else None
+
+        # Primary probe: /json/report — accept any valid JSON object
         try:
             req = urllib.request.Request(
                 f"{url}/json/report",
                 method='GET',
                 headers={'Accept': 'application/json'},
             )
-            ctx = self._ssl_ctx if url.startswith("https") else None
             with urllib.request.urlopen(req, timeout=CONNECT_TIMEOUT, context=ctx) as resp:
                 if resp.status == 200:
                     data = resp.read(4096)
-                    # Verify it looks like a meshtasticd response
-                    if data and (b'airtime' in data or b'memory' in data or b'power' in data):
-                        return True
+                    if data:
+                        # Accept any JSON object (meshtasticd always returns {})
+                        parsed = json.loads(data)
+                        if isinstance(parsed, dict):
+                            return True
+        except (json.JSONDecodeError, ValueError):
+            # Server responded but not valid JSON — might still be meshtasticd
+            # Fall through to secondary probe
+            pass
         except Exception:
             pass
+
+        # Secondary probe: /api/v1/fromradio — protobuf endpoint always exists
+        # on meshtasticd webserver even if JSON endpoints are unavailable
+        try:
+            req = urllib.request.Request(
+                f"{url}/api/v1/fromradio",
+                method='GET',
+                headers={'Accept': 'application/x-protobuf'},
+            )
+            with urllib.request.urlopen(req, timeout=CONNECT_TIMEOUT, context=ctx) as resp:
+                # 200 = data available, 204 = no data but server is alive
+                if resp.status in (200, 204):
+                    return True
+        except urllib.error.HTTPError as e:
+            # 400/404 still means the webserver is running
+            if e.code in (400, 404, 405):
+                return True
+        except Exception:
+            pass
+
         return False
 
     @property


### PR DESCRIPTION
The HTTP API probe was rejecting valid responses because it checked for specific field names (airtime/memory/power) that may differ across meshtasticd firmware versions. Now accepts any valid JSON object from /json/report, with a secondary probe to /api/v1/fromradio as fallback.

The diagnostic now provides actionable fix suggestions when the HTTP API is unreachable (missing config, commented-out Webserver section, etc.) and resets the singleton client to avoid stale cached state.

https://claude.ai/code/session_01BVyVbkbezTgC2cGnjrbf8P