### PR TITLE
feat: TUI-driven RNS identity creation and bridge pre-flight checks

### DIFF
--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -145,8 +145,19 @@ class RNSMenuMixin(RNSSnifferMixin):
         print("=== RNS Identity Info ===\n")
 
         while True:
+            # Check identity status for menu hints
+            config_dir = ReticulumPaths.get_config_dir()
+            rnsd_exists = (config_dir / 'identity').exists()
+            try:
+                from commands.rns import get_identity_path
+                gw_exists = get_identity_path().exists()
+            except ImportError:
+                gw_exists = False
+
             choices = [
                 ("show", "Show local identity"),
+                ("create", "Create identities" + (
+                    "" if not rnsd_exists or not gw_exists else " (all exist)")),
                 ("path", "Show identity file paths"),
                 ("recall", "Recall identity by hash"),
                 ("back", "Back"),
@@ -162,13 +173,15 @@ class RNSMenuMixin(RNSSnifferMixin):
                 break
 
             try:
-                if choice == "show":
+                if choice == "create":
+                    self._create_rns_identities()
+
+                elif choice == "show":
                     clear_screen()
                     print("=== Local RNS Identity ===\n")
 
                     # Find the rnsd identity file
                     # RNS stores it at <configdir>/identity
-                    config_dir = ReticulumPaths.get_config_dir()
                     rnsd_identity = config_dir / 'identity'
                     if rnsd_identity.exists():
                         print(f"rnsd identity: {rnsd_identity}")
@@ -178,11 +191,9 @@ class RNSMenuMixin(RNSSnifferMixin):
                         )
                     else:
                         print(f"rnsd identity: {rnsd_identity}")
-                        print("  Not found — rnsd has not created one yet.")
-                        print("  Ensure rnsd can write to its config directory.\n")
+                        print("  Not found — use 'Create identities' to generate.\n")
 
                     try:
-                        from commands.rns import get_identity_path
                         gw_id = get_identity_path()
                         print(f"\nMeshForge gateway identity: {gw_id}")
                         if gw_id.exists():
@@ -191,7 +202,7 @@ class RNSMenuMixin(RNSSnifferMixin):
                                 'rnid'
                             )
                         else:
-                            print("  Status: not created (starts on first bridge run)")
+                            print("  Not created — use 'Create identities' to generate.")
                     except ImportError:
                         pass
                     self._wait_for_enter()
@@ -247,6 +258,52 @@ class RNSMenuMixin(RNSSnifferMixin):
                     "Identity Error",
                     f"Operation failed:\n{type(e).__name__}: {e}"
                 )
+
+    def _create_rns_identities(self):
+        """Create RNS and gateway identities from the TUI.
+
+        Calls commands.rns.create_identities() which generates keypairs
+        for both the rnsd identity and the MeshForge gateway identity.
+        No manual commands needed.
+        """
+        clear_screen()
+        print("=== Create RNS Identities ===\n")
+
+        try:
+            from commands.rns import create_identities, get_identity_path
+            config_dir = ReticulumPaths.get_config_dir()
+
+            # Show current state
+            rns_id = config_dir / 'identity'
+            gw_id = get_identity_path()
+            print(f"RNS identity:     {rns_id}")
+            print(f"  Status: {'EXISTS' if rns_id.exists() else 'MISSING'}")
+            print(f"Gateway identity: {gw_id}")
+            print(f"  Status: {'EXISTS' if gw_id.exists() else 'MISSING'}\n")
+
+            if rns_id.exists() and gw_id.exists():
+                print("Both identities already exist. Nothing to create.")
+                self._wait_for_enter()
+                return
+
+            result = create_identities()
+            if result.success:
+                print(f"OK: {result.message}")
+                created = result.data.get('created', [])
+                if 'rns' in created:
+                    print(f"  Created: {result.data['rns_identity']}")
+                if 'gateway' in created:
+                    print(f"  Created: {result.data['gateway_identity']}")
+                if not created:
+                    print("  All identities already existed.")
+            else:
+                print(f"ERROR: {result.message}")
+        except ImportError:
+            print("ERROR: RNS module not installed.")
+            print("  Install: pip install rns")
+        except Exception as e:
+            print(f"ERROR: {type(e).__name__}: {e}")
+        self._wait_for_enter()
 
     def _rns_known_destinations(self):
         """Show known RNS destinations from the running rnsd instance."""
@@ -1364,25 +1421,43 @@ class RNSMenuMixin(RNSSnifferMixin):
             return False
 
     def _diagnose_rns_port_conflict(self):
-        """Print diagnostic info for RNS Address-in-use port conflicts."""
+        """Diagnose and offer to fix RNS port conflicts from the TUI."""
+        import time
         try:
             # Check NomadNet first — most common cause of port conflicts
             if self._check_nomadnet_conflict():
-                print("CAUSE: NomadNet is running and owns the RNS shared instance.")
-                print("")
-                print("NomadNet creates its own Reticulum instance on port 37428.")
-                print("When rnsd also tries to bind that port, it crash-loops.")
-                print("")
-                print("Options:")
-                print("  1. Stop NomadNet before starting rnsd:")
-                print("     pkill -f nomadnet && sudo systemctl restart rnsd")
-                print("")
-                print("  2. Run rnsd as a client (no shared instance):")
-                print("     Set 'share_instance = No' in rnsd config,")
-                print("     then NomadNet acts as the shared instance for all RNS tools.")
-                print("")
-                print("  3. Stop rnsd and let NomadNet be the shared instance:")
-                print("     sudo systemctl stop rnsd && sudo systemctl disable rnsd")
+                print("CAUSE: NomadNet is running and owns port 37428.")
+                print("rnsd can't start because NomadNet has the port.\n")
+
+                if self.dialog.yesno(
+                    "Fix Port Conflict",
+                    "NomadNet is holding port 37428.\n\n"
+                    "MeshForge can fix this:\n"
+                    "  1. Stop NomadNet\n"
+                    "  2. Start rnsd (becomes shared instance)\n"
+                    "  3. Restart NomadNet (connects as client)\n\n"
+                    "Fix now?"
+                ):
+                    print("Stopping NomadNet...")
+                    subprocess.run(
+                        ['pkill', '-f', 'nomadnet'],
+                        capture_output=True, timeout=5
+                    )
+                    time.sleep(1)
+
+                    print("Starting rnsd...")
+                    subprocess.run(
+                        ['systemctl', 'start', 'rnsd'],
+                        capture_output=True, text=True, timeout=15
+                    )
+                    time.sleep(2)
+
+                    print("Restarting NomadNet as client...")
+                    subprocess.run(
+                        ['systemctl', '--user', 'start', 'nomadnet'],
+                        capture_output=True, text=True, timeout=10
+                    )
+                    print("Done. Startup order: rnsd -> NomadNet -> MeshForge\n")
                 return
 
             # Use centralized service check when available

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -109,10 +109,162 @@ class ServiceMenuMixin:
             logger.debug("Bridge process check failed: %s", e)
             return False
 
+    def _bridge_preflight(self) -> bool:
+        """Pre-flight checks before starting the gateway bridge.
+
+        Checks prerequisites and offers to fix issues from the TUI
+        so the user never needs to run manual commands.
+
+        Returns True if all checks pass and bridge can start.
+        """
+        import time
+        issues = []
+
+        # 1. Check rnsd is running
+        rnsd_running = False
+        if _HAS_SERVICE_CHECK:
+            status = check_service('rnsd')
+            rnsd_running = status.available
+        else:
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                rnsd_running = result.returncode == 0
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        if not rnsd_running:
+            issues.append("rnsd is not running (required for RNS connectivity)")
+
+        # 2. Check for NomadNet port conflict
+        nomadnet_conflict = False
+        try:
+            result = subprocess.run(
+                ['pgrep', '-f', 'nomadnet'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0 and not rnsd_running:
+                nomadnet_conflict = True
+                issues.append("NomadNet is holding port 37428 (rnsd can't start)")
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        # 3. Check gateway identity exists
+        try:
+            from commands.rns import get_identity_path
+            gw_id = get_identity_path()
+            if not gw_id.exists():
+                issues.append("Gateway identity not created yet")
+        except ImportError:
+            pass
+
+        if not issues:
+            return True
+
+        # Build fix menu
+        msg = "Pre-flight checks found issues:\n\n"
+        for i, issue in enumerate(issues, 1):
+            msg += f"  {i}. {issue}\n"
+        msg += "\nMeshForge can fix these automatically."
+
+        if not self.dialog.yesno("Bridge Pre-Flight", msg + "\n\nFix now?"):
+            return False
+
+        clear_screen()
+        print("=== Bridge Pre-Flight Fix ===\n")
+
+        # Fix NomadNet conflict first (must stop before rnsd can start)
+        if nomadnet_conflict:
+            print("[1] Stopping NomadNet (holds port 37428)...")
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'nomadnet'],
+                    capture_output=True, timeout=5
+                )
+                time.sleep(1)
+                print("  NomadNet stopped.")
+                print("  It will reconnect as a client after rnsd starts.\n")
+            except (subprocess.SubprocessError, OSError) as e:
+                print(f"  Warning: {e}")
+
+        # Start rnsd if not running
+        if not rnsd_running:
+            print("[2] Starting rnsd (shared instance)...")
+            try:
+                if _HAS_SERVICE_CHECK:
+                    from utils.service_check import apply_config_and_restart
+                    success, msg_text = apply_config_and_restart('rnsd')
+                    if success:
+                        print("  rnsd started via systemctl.")
+                    else:
+                        # Try direct start
+                        subprocess.run(
+                            ['systemctl', 'start', 'rnsd'],
+                            capture_output=True, text=True, timeout=15
+                        )
+                else:
+                    subprocess.run(
+                        ['systemctl', 'start', 'rnsd'],
+                        capture_output=True, text=True, timeout=15
+                    )
+                time.sleep(2)
+                # Verify
+                if _HAS_SERVICE_CHECK:
+                    status = check_service('rnsd')
+                    if status.available:
+                        print("  rnsd is now running.\n")
+                    else:
+                        print(f"  Warning: {status.message}\n")
+                else:
+                    print("  rnsd start command sent.\n")
+            except (subprocess.SubprocessError, OSError) as e:
+                print(f"  Error starting rnsd: {e}")
+                print("  Bridge may fail to connect.\n")
+
+        # Create gateway identity if missing
+        try:
+            from commands.rns import create_identities, get_identity_path
+            gw_id = get_identity_path()
+            if not gw_id.exists():
+                print("[3] Creating gateway identity...")
+                result = create_identities()
+                if result.success:
+                    print(f"  {result.message}\n")
+                else:
+                    print(f"  Warning: {result.message}\n")
+        except ImportError:
+            pass
+
+        # Restart NomadNet as client (if we stopped it)
+        if nomadnet_conflict:
+            print("[4] Restarting NomadNet as rnsd client...")
+            try:
+                # Check if nomadnet is a systemd user service
+                result = subprocess.run(
+                    ['systemctl', '--user', 'start', 'nomadnet'],
+                    capture_output=True, text=True, timeout=10
+                )
+                if result.returncode == 0:
+                    print("  NomadNet restarted via systemctl --user.\n")
+                else:
+                    print("  NomadNet not managed by systemd.")
+                    print("  Start manually: nomadnet --daemon &\n")
+            except (subprocess.SubprocessError, OSError):
+                print("  Start NomadNet manually: nomadnet --daemon &\n")
+
+        print("Pre-flight complete. Starting bridge...\n")
+        time.sleep(1)
+        return True
+
     def _start_bridge_background(self):
         """Start gateway bridge as a background process."""
         if self._is_bridge_running():
             self.dialog.msgbox("Already Running", "Gateway bridge is already running.")
+            return
+
+        if not self._bridge_preflight():
             return
 
         self.dialog.infobox("Starting", "Starting gateway bridge in background...")
@@ -161,6 +313,9 @@ class ServiceMenuMixin:
             self.dialog.msgbox("Already Running",
                 "Gateway bridge is already running in background.\n\n"
                 "Stop it first to run in foreground.")
+            return
+
+        if not self._bridge_preflight():
             return
 
         clear_screen()


### PR DESCRIPTION
MeshForge should be the single pane of glass — no manual shell commands.

Identity menu:
- Add "Create identities" option that calls commands.rns.create_identities()
- Shows current status (EXISTS/MISSING) before creating
- Replaces "starts on first bridge run" message with actionable option

Bridge pre-flight (_bridge_preflight):
- Checks rnsd is running before bridge start
- Detects NomadNet port conflict (holding 37428)
- Verifies gateway identity exists
- Offers one-click fix: stop NomadNet → start rnsd → create identity → restart NomadNet as client
- Wired into both background and foreground bridge startup paths

Port conflict diagnosis:
- _diagnose_rns_port_conflict now offers interactive fix via dialog
- Replaces manual "pkill -f nomadnet" instructions with TUI action

https://claude.ai/code/session_01VtEDAkiPA657PpRxtqs15E