### PR TITLE
fix: update paths now deploy service files for existing installs

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -14,7 +14,8 @@
 #   1. Fetches latest code from GitHub
 #   2. Updates Python dependencies if changed
 #   3. Reinstalls desktop integration (icons/launchers)
-#   4. Preserves: /etc/meshforge/, ~/.config/meshforge/, radio configs
+#   4. Updates systemd service files (rnsd, meshforge, nomadnet)
+#   5. Preserves: /etc/meshforge/, ~/.config/meshforge/, radio configs
 #
 # What it does NOT do:
 #   - Reinstall meshtasticd or rnsd (use install_noc.sh for that)
@@ -118,7 +119,7 @@ echo -e "Current branch: ${CYAN}$CURRENT_BRANCH${NC} ($CURRENT_COMMIT)"
 # Step 1: Fetch updates
 # ─────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${CYAN}[1/4] Fetching updates...${NC}"
+echo -e "${CYAN}[1/5] Fetching updates...${NC}"
 
 git config --global --add safe.directory "$INSTALL_DIR" 2>/dev/null || true
 
@@ -165,7 +166,7 @@ fi
 # Step 2: Update Python dependencies
 # ─────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${CYAN}[2/4] Checking Python dependencies...${NC}"
+echo -e "${CYAN}[2/5] Checking Python dependencies...${NC}"
 
 if [[ "$SKIP_DEPS" == "true" ]]; then
     echo -e "${YELLOW}Skipped (--skip-deps)${NC}"
@@ -199,7 +200,7 @@ fi
 # Step 3: Update desktop integration
 # ─────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${CYAN}[3/4] Updating desktop integration...${NC}"
+echo -e "${CYAN}[3/5] Updating desktop integration...${NC}"
 
 if [[ "$SKIP_DESKTOP" == "true" ]]; then
     echo -e "${YELLOW}Skipped (--skip-desktop)${NC}"
@@ -211,10 +212,84 @@ else
 fi
 
 # ─────────────────────────────────────────────────────────────────
-# Step 4: Verify installation
+# Step 4: Update service files
 # ─────────────────────────────────────────────────────────────────
 echo ""
-echo -e "${CYAN}[4/4] Verifying installation...${NC}"
+echo -e "${CYAN}[4/5] Updating systemd service files...${NC}"
+
+SVC_UPDATED=false
+
+# Update meshforge.service from repo template (if it exists in /etc/systemd/system/)
+if [[ -f /etc/systemd/system/meshforge.service ]] && [[ -f "$INSTALL_DIR/scripts/meshforge.service" ]]; then
+    cp "$INSTALL_DIR/scripts/meshforge.service" /etc/systemd/system/meshforge.service
+    echo -e "  ${GREEN}✓ meshforge.service updated${NC}"
+    SVC_UPDATED=true
+fi
+
+# Update rnsd.service (system-level) if it exists
+if [[ -f /etc/systemd/system/rnsd.service ]]; then
+    RNSD_BIN=$(command -v rnsd 2>/dev/null || echo "/usr/local/bin/rnsd")
+    # Only update if the current service lacks crash-loop protection
+    if ! grep -q "StartLimitBurst" /etc/systemd/system/rnsd.service 2>/dev/null; then
+        cat > /etc/systemd/system/rnsd.service << RNSD_SVC
+[Unit]
+Description=Reticulum Network Stack Daemon
+Documentation=https://reticulum.network
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+ExecStart=${RNSD_BIN} --service
+Restart=on-failure
+RestartSec=5
+
+# Stop crash-looping after 5 failures in 60 seconds
+StartLimitIntervalSec=60
+StartLimitBurst=5
+
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=rnsd
+
+[Install]
+WantedBy=multi-user.target
+RNSD_SVC
+        echo -e "  ${GREEN}✓ rnsd.service updated (added crash-loop protection)${NC}"
+        SVC_UPDATED=true
+    else
+        echo -e "  ${GREEN}✓ rnsd.service already current${NC}"
+    fi
+fi
+
+# Deploy user-level service templates
+REAL_USER="${SUDO_USER:-$USER}"
+REAL_HOME=$(eval echo "~${REAL_USER}")
+USER_SYSTEMD_DIR="${REAL_HOME}/.config/systemd/user"
+if [[ -d "$INSTALL_DIR/templates/systemd" ]]; then
+    mkdir -p "$USER_SYSTEMD_DIR"
+    for tmpl in "$INSTALL_DIR/templates/systemd/"*-user.service; do
+        if [[ -f "$tmpl" ]]; then
+            svc_name=$(basename "$tmpl" | sed 's/-user\.service/.service/')
+            cp "$tmpl" "$USER_SYSTEMD_DIR/$svc_name" 2>/dev/null || true
+        fi
+    done
+    chown -R "${REAL_USER}:" "$USER_SYSTEMD_DIR" 2>/dev/null || true
+    echo -e "  ${GREEN}✓ User service templates deployed${NC}"
+fi
+
+# Reload systemd if anything changed
+if $SVC_UPDATED; then
+    systemctl daemon-reload 2>/dev/null || true
+    echo -e "  ${GREEN}✓ systemctl daemon-reload${NC}"
+fi
+
+# ─────────────────────────────────────────────────────────────────
+# Step 5: Verify installation
+# ─────────────────────────────────────────────────────────────────
+echo ""
+echo -e "${CYAN}[5/5] Verifying installation...${NC}"
 
 # Check version
 VERSION=$(python3 -c "import sys; sys.path.insert(0, '$INSTALL_DIR/src'); from __version__ import __version__; print(__version__)" 2>/dev/null || echo "unknown")

--- a/src/launcher_tui/updates_mixin.py
+++ b/src/launcher_tui/updates_mixin.py
@@ -341,13 +341,14 @@ class UpdatesMixin:
             "Update MeshForge",
             "This will:\n\n"
             "1. Pull latest code from GitHub (git pull)\n"
-            "2. Install/update Python dependencies\n\n"
+            "2. Install/update Python dependencies\n"
+            "3. Update systemd service files\n\n"
             "Continue?"
         ):
             return
 
         # Step 1: Git pull
-        self.dialog.infobox("Updating MeshForge", "Step 1/2: Pulling latest code from GitHub...")
+        self.dialog.infobox("Updating MeshForge", "Step 1/3: Pulling latest code from GitHub...")
 
         try:
             result = subprocess.run(
@@ -374,7 +375,7 @@ class UpdatesMixin:
             return
 
         # Step 2: Install dependencies
-        self.dialog.infobox("Updating MeshForge", "Step 2/2: Installing Python dependencies...")
+        self.dialog.infobox("Updating MeshForge", "Step 2/3: Installing Python dependencies...")
 
         requirements_file = meshforge_dir / 'requirements.txt'
         if not requirements_file.exists():
@@ -415,11 +416,52 @@ class UpdatesMixin:
             self.dialog.msgbox("Error", f"Pip install failed: {e}")
             return
 
+        # Step 3: Deploy updated service files
+        self.dialog.infobox("Updating MeshForge", "Step 3/3: Updating service files...")
+
+        svc_msgs = []
+        try:
+            # Update meshforge.service from repo
+            svc_src = meshforge_dir / 'scripts' / 'meshforge.service'
+            svc_dst = Path('/etc/systemd/system/meshforge.service')
+            if svc_src.exists() and svc_dst.exists():
+                import shutil
+                shutil.copy2(str(svc_src), str(svc_dst))
+                svc_msgs.append("meshforge.service")
+
+            # Update user-level service templates
+            from utils.paths import get_real_user_home
+            user_svc_dir = get_real_user_home() / '.config' / 'systemd' / 'user'
+            templates_dir = meshforge_dir / 'templates' / 'systemd'
+            if templates_dir.exists():
+                user_svc_dir.mkdir(parents=True, exist_ok=True)
+                for tmpl in templates_dir.glob('*-user.service'):
+                    svc_name = tmpl.name.replace('-user.service', '.service')
+                    dst = user_svc_dir / svc_name
+                    shutil.copy2(str(tmpl), str(dst))
+                    svc_msgs.append(svc_name)
+
+            # Reload systemd
+            if svc_msgs:
+                subprocess.run(
+                    ['systemctl', 'daemon-reload'],
+                    capture_output=True, timeout=10
+                )
+        except (OSError, PermissionError) as e:
+            svc_msgs.append(f"(warning: {e})")
+        except Exception:
+            pass
+
+        svc_info = ""
+        if svc_msgs:
+            svc_info = f"\nServices updated: {', '.join(svc_msgs)}\n"
+
         # Success!
         self.dialog.msgbox(
             "Update Complete",
             "MeshForge has been updated!\n\n"
-            f"Git: {git_output.strip()[:200]}\n\n"
+            f"Git: {git_output.strip()[:200]}\n"
+            f"{svc_info}\n"
             "Please restart MeshForge to apply changes.\n\n"
             "Run: sudo meshforge"
         )


### PR DESCRIPTION
Existing MeshForge installations (moc2, moc3, desktop) running git pull or TUI update got new code but stale systemd service files — no crash-loop protection, no rnsd startup ordering.

update.sh (new step 4/5):
- Copies meshforge.service from repo to /etc/systemd/system/
- Updates rnsd.service with StartLimitBurst if missing
- Deploys user-level templates (rnsd, nomadnet) to ~/.config/systemd/user/
- Runs systemctl daemon-reload

TUI Updates > Update MeshForge (new step 3/3):
- Deploys meshforge.service from scripts/
- Copies *-user.service templates for rnsd and nomadnet
- Runs daemon-reload

Now all update paths deliver service fixes:
- reinstall.sh: ✅ (was already working)
- update.sh: ✅ (fixed)
- TUI update: ✅ (fixed)
- git pull: code only (user must run update.sh or TUI)

https://claude.ai/code/session_01VtEDAkiPA657PpRxtqs15E