### PR TITLE
fix: add /etc/reticulum/storage/resources to self-healing dirs

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -981,14 +981,18 @@ if $INSTALL_RNS; then
     # RNS stores data in a 'storage' subdirectory of its config directory.
     # When using system-wide config (/etc/reticulum/config), rnsd needs
     # the storage directory to exist with proper permissions.
-    # The 'ratchets' subdirectory is required by RNS Identity.persist_job()
-    # for key ratcheting (added in newer RNS versions).
+    # Subdirectories required by RNS:
+    #   ratchets/  - Identity.persist_job() key ratcheting
+    #   resources/ - Reticulum.__init__() resource storage
+    #   interfaces/ - Custom interface plugins (e.g. Meshtastic_Interface)
     echo "  Creating /etc/reticulum/ structure..."
     mkdir -p /etc/reticulum/storage/ratchets
+    mkdir -p /etc/reticulum/storage/resources
     mkdir -p /etc/reticulum/interfaces
     chmod 755 /etc/reticulum
     chmod 755 /etc/reticulum/storage
     chmod 755 /etc/reticulum/storage/ratchets
+    chmod 755 /etc/reticulum/storage/resources
     chmod 755 /etc/reticulum/interfaces
 
     # Create systemd service (deploy from template or create inline)

--- a/src/core/diagnostics/checks/rns.py
+++ b/src/core/diagnostics/checks/rns.py
@@ -148,10 +148,11 @@ def check_rns_storage_permissions() -> CheckResult:
             duration_ms=(time.time() - start) * 1000
         )
 
-    # All subdirectories RNS Transport needs to write to
+    # All subdirectories RNS needs to write to
     required_dirs = [
         (etc_storage, "storage/"),
         (etc_storage / 'ratchets', "storage/ratchets/"),
+        (etc_storage / 'resources', "storage/resources/"),
         (etc_storage / 'cache', "storage/cache/"),
         (etc_storage / 'cache' / 'announces', "storage/cache/announces/"),
     ]
@@ -172,7 +173,7 @@ def check_rns_storage_permissions() -> CheckResult:
             status=CheckStatus.FAIL,
             message="; ".join(issues),
             fix_hint=(
-                "sudo mkdir -p /etc/reticulum/storage/{ratchets,cache/announces} && "
+                "sudo mkdir -p /etc/reticulum/storage/{ratchets,resources,cache/announces} && "
                 "sudo chown -R $(whoami) /etc/reticulum/storage/"
             ),
             duration_ms=duration
@@ -182,7 +183,7 @@ def check_rns_storage_permissions() -> CheckResult:
         name="RNS storage permissions",
         category=CheckCategory.RNS,
         status=CheckStatus.PASS,
-        message="storage/, ratchets/, cache/announces/ directories OK",
+        message="storage/, ratchets/, resources/, cache/announces/ directories OK",
         duration_ms=duration
     )
 

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -806,21 +806,24 @@ class RNSMeshtasticBridge:
             logger.info("RNS not installed, will be handled in _connect_rns")
             return
 
-        # Ensure /etc/reticulum/storage/ratchets exists before RNS init.
-        # RNS Identity.persist_job() creates this in a background thread
-        # and crashes with PermissionError if it can't. Pre-creating it
-        # here (when running as root/sudo) prevents the crash.
+        # Ensure /etc/reticulum/storage subdirs exist before RNS init.
+        # RNS requires ratchets/ (Identity.persist_job), resources/
+        # (Reticulum.__init__), and cache/announces/ (Transport).
+        # Pre-creating them (when running as root/sudo) prevents crashes.
         if os.geteuid() == 0:
-            ratchets_missing = (
+            dirs_missing = (
                 ReticulumPaths.ETC_BASE.exists()
-                and not ReticulumPaths.ETC_RATCHETS.exists()
+                and (
+                    not ReticulumPaths.ETC_RATCHETS.exists()
+                    or not ReticulumPaths.ETC_RESOURCES.exists()
+                )
             )
             if not ReticulumPaths.ensure_system_dirs():
                 logger.warning("Could not create /etc/reticulum directories "
                              "(filesystem may be read-only)")
-            elif ratchets_missing:
+            elif dirs_missing:
                 # Dirs were just created — restart rnsd so it stops crashing
-                logger.info("Created missing RNS ratchets dir, restarting rnsd")
+                logger.info("Created missing RNS storage dirs, restarting rnsd")
                 try:
                     from utils.service_check import apply_config_and_restart
                     success, msg = apply_config_and_restart('rnsd')

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -266,9 +266,11 @@ class StartupChecker:
     def _heal_rns_storage_dirs(self):
         """Create missing RNS storage directories and restart rnsd if needed.
 
-        RNS Identity.persist_job() requires /etc/reticulum/storage/ratchets/.
-        If the directory is missing, we create it and restart rnsd so it
-        picks up the fix without requiring manual intervention.
+        RNS requires several subdirectories under /etc/reticulum/storage/:
+        - ratchets/ (Identity.persist_job key ratcheting)
+        - resources/ (Reticulum.__init__ resource storage)
+        - cache/announces/ (Transport announce caching)
+        If any are missing, we create them and restart rnsd.
         """
         try:
             from utils.paths import ReticulumPaths
@@ -276,11 +278,13 @@ class StartupChecker:
             return
 
         ratchets = ReticulumPaths.ETC_RATCHETS
+        resources = ReticulumPaths.ETC_RESOURCES
         announces = ReticulumPaths.ETC_ANNOUNCE_CACHE
         needs_restart = (
             ReticulumPaths.ETC_BASE.exists()
             and (
                 not ratchets.exists()
+                or not resources.exists()
                 or not announces.exists()
                 or self._has_permission_issues(announces)
             )

--- a/src/utils/knowledge_content.py
+++ b/src/utils/knowledge_content.py
@@ -1014,19 +1014,19 @@ Common Issues:
 
     kb._add_guide(TroubleshootingGuide(
         problem="rnsd_ratchets_permission",
-        description="rnsd crashes with PermissionError on /etc/reticulum/storage/ratchets",
+        description="rnsd crashes with PermissionError on /etc/reticulum/storage/ subdirectories (ratchets, resources, cache)",
         prerequisites=["rnsd installed", "Using system-wide config at /etc/reticulum/"],
         steps=[
             TroubleshootingStep(
-                instruction="Check if ratchets directory exists",
-                command="ls -la /etc/reticulum/storage/ratchets",
-                expected_result="Directory exists with write permissions",
-                if_fail="Directory missing — RNS Identity.persist_job() needs it for key ratcheting",
+                instruction="Check if required storage subdirectories exist",
+                command="ls -la /etc/reticulum/storage/{ratchets,resources,cache/announces}",
+                expected_result="All directories exist with write permissions",
+                if_fail="One or more directories missing — RNS needs ratchets/ (key ratcheting), resources/ (resource storage), cache/announces/ (transport)",
             ),
             TroubleshootingStep(
-                instruction="Create the ratchets directory with correct permissions",
-                command="sudo mkdir -p /etc/reticulum/storage/ratchets && sudo chmod 755 /etc/reticulum/storage/ratchets",
-                expected_result="Directory created successfully",
+                instruction="Create all required directories with correct permissions",
+                command="sudo mkdir -p /etc/reticulum/storage/{ratchets,resources,cache/announces} && sudo chmod 755 /etc/reticulum/storage/{ratchets,resources,cache/announces}",
+                expected_result="Directories created successfully",
                 if_fail="Check filesystem is not mounted read-only",
             ),
             TroubleshootingStep(

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -110,6 +110,7 @@ class ReticulumPaths:
     ETC_BASE = Path('/etc/reticulum')
     ETC_STORAGE = ETC_BASE / 'storage'
     ETC_RATCHETS = ETC_STORAGE / 'ratchets'
+    ETC_RESOURCES = ETC_STORAGE / 'resources'
     ETC_CACHE = ETC_STORAGE / 'cache'
     ETC_ANNOUNCE_CACHE = ETC_CACHE / 'announces'
     ETC_INTERFACES = ETC_BASE / 'interfaces'
@@ -123,9 +124,10 @@ class ReticulumPaths:
         must exist with proper permissions before rnsd can start.
 
         The 'ratchets' subdirectory is required by RNS Identity.persist_job()
-        for key ratcheting support. The 'cache/announces' subdirectory is
-        required by Transport jobs for announce caching. Without these,
-        rnsd crashes with PermissionError in background threads.
+        for key ratcheting support. The 'resources' subdirectory is required
+        by RNS Reticulum.__init__() for resource storage. The 'cache/announces'
+        subdirectory is required by Transport jobs for announce caching.
+        Without these, rnsd crashes with PermissionError.
 
         Also fixes file permissions inside storage/ — if files were created
         by a different user (e.g. root vs rnsd), Transport jobs fail with
@@ -148,6 +150,7 @@ class ReticulumPaths:
                 # files, ratchets, and announce entries.
                 cls.ETC_STORAGE.mkdir(mode=0o777, parents=True, exist_ok=True)
                 cls.ETC_RATCHETS.mkdir(mode=0o777, parents=True, exist_ok=True)
+                cls.ETC_RESOURCES.mkdir(mode=0o777, parents=True, exist_ok=True)
                 cls.ETC_CACHE.mkdir(mode=0o777, parents=True, exist_ok=True)
                 cls.ETC_ANNOUNCE_CACHE.mkdir(mode=0o777, parents=True, exist_ok=True)
                 cls.ETC_INTERFACES.mkdir(mode=0o755, parents=True, exist_ok=True)


### PR DESCRIPTION
RNS Reticulum.__init__() (line 302) requires a 'resources' subdirectory under storage/. When rnsd runs as non-root user with system-wide config at /etc/reticulum/, it crashes with PermissionError trying to create this directory. Same pattern as the ratchets fix from 2026-02-09.

Changes (6 files):
- paths.py: ETC_RESOURCES constant + ensure_system_dirs() creates it
- startup_checks.py: self-healing checks for resources/ at TUI launch
- rns_bridge.py: pre-init check includes resources/ before RNS init
- rns.py (diagnostics): storage permission check includes resources/
- install_noc.sh: mkdir + chmod for resources/ during install
- knowledge_content.py: troubleshooting guide covers all storage subdirs

https://claude.ai/code/session_01MDELg3em8TW7LAYjUs6EtB