### PR TITLE
fix: force-close TCP socket to prevent CLOSE-WAIT zombies blocking re…

### DIFF
--- a/src/utils/meshtastic_connection.py
+++ b/src/utils/meshtastic_connection.py
@@ -148,6 +148,12 @@ def safe_close_interface(interface) -> None:
 
     The meshtastic library can raise BrokenPipeError or ConnectionResetError
     when trying to send the disconnect message if the connection is already gone.
+
+    CRITICAL: After interface.close(), we must also force-close the underlying
+    TCP socket. The meshtastic library's close() tries to send a disconnect
+    message — if the pipe is broken, it catches the error but may NOT close
+    the raw socket. This leaves meshtasticd with a CLOSE-WAIT zombie connection
+    that blocks all new TCP clients (meshtasticd only allows one).
     """
     global _last_global_close_time
 
@@ -164,8 +170,38 @@ def safe_close_interface(interface) -> None:
         # Log other errors but don't raise
         logger.warning(f"Unexpected error during interface cleanup: {e}")
     finally:
+        # Force-close the underlying TCP socket to prevent CLOSE-WAIT zombies.
+        # meshtasticd only allows ONE TCP client — a lingering CLOSE-WAIT socket
+        # blocks reconnection indefinitely until meshtasticd is restarted.
+        _force_close_socket(interface)
         # Always update global close time
         _last_global_close_time = time.time()
+
+
+def _force_close_socket(interface) -> None:
+    """
+    Force-close the underlying TCP socket on a meshtastic interface.
+
+    The meshtastic library's TCPInterface stores the socket as _socket
+    (inherited from StreamInterface). If interface.close() failed to
+    properly tear down the TCP connection, this sends RST to the peer
+    so meshtasticd immediately frees the client slot.
+    """
+    raw_socket = getattr(interface, '_socket', None)
+    if raw_socket is None:
+        return
+
+    try:
+        # shutdown() sends RST if there's pending data, ensuring
+        # meshtasticd sees the connection as fully closed
+        raw_socket.shutdown(socket.SHUT_RDWR)
+    except OSError:
+        pass  # Already closed or not connected
+
+    try:
+        raw_socket.close()
+    except OSError:
+        pass  # Already closed
 
 
 class MeshtasticConnectionManager:

--- a/tests/test_meshtastic_connection.py
+++ b/tests/test_meshtastic_connection.py
@@ -58,6 +58,59 @@ class TestSafeCloseInterface:
         # Should not raise
         safe_close_interface(mock_interface)
 
+    def test_safe_close_force_closes_tcp_socket(self):
+        """safe_close_interface force-closes the underlying TCP socket to prevent CLOSE-WAIT"""
+        from utils.meshtastic_connection import safe_close_interface
+
+        mock_socket = MagicMock()
+        mock_interface = MagicMock()
+        mock_interface._socket = mock_socket
+
+        safe_close_interface(mock_interface)
+
+        # Underlying socket should be shut down and closed
+        mock_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+        mock_socket.close.assert_called_once()
+
+    def test_safe_close_force_closes_socket_on_broken_pipe(self):
+        """Socket is force-closed even when interface.close() raises BrokenPipeError"""
+        from utils.meshtastic_connection import safe_close_interface
+
+        mock_socket = MagicMock()
+        mock_interface = MagicMock()
+        mock_interface._socket = mock_socket
+        mock_interface.close.side_effect = BrokenPipeError("Broken pipe")
+
+        safe_close_interface(mock_interface)
+
+        # Socket should still be force-closed even though interface.close() failed
+        mock_socket.shutdown.assert_called_once_with(socket.SHUT_RDWR)
+        mock_socket.close.assert_called_once()
+
+    def test_safe_close_handles_no_socket_attr(self):
+        """safe_close_interface works when interface has no _socket attribute"""
+        from utils.meshtastic_connection import safe_close_interface
+
+        mock_interface = MagicMock(spec=[])  # No attributes
+        mock_interface.close = MagicMock()
+
+        # Should not raise
+        safe_close_interface(mock_interface)
+
+    def test_safe_close_handles_socket_already_closed(self):
+        """Force-close handles socket that's already closed"""
+        from utils.meshtastic_connection import safe_close_interface
+
+        mock_socket = MagicMock()
+        mock_socket.shutdown.side_effect = OSError("Transport endpoint is not connected")
+        mock_interface = MagicMock()
+        mock_interface._socket = mock_socket
+
+        # Should not raise - OSError from shutdown is expected
+        safe_close_interface(mock_interface)
+        # close() should still be called even if shutdown fails
+        mock_socket.close.assert_called_once()
+
 
 class TestMeshtasticConnectionManager:
     """Tests for the connection manager"""


### PR DESCRIPTION
…connect

When the gateway bridge loses its TCP connection to meshtasticd, the meshtastic library's close() may fail to properly tear down the socket (BrokenPipeError during disconnect message send). This leaves meshtasticd with a CLOSE-WAIT zombie connection - since meshtasticd only allows ONE TCP client, the gateway can never reconnect until meshtasticd is restarted.

Fix: safe_close_interface() now explicitly calls shutdown(SHUT_RDWR) and close() on the underlying _socket, ensuring meshtasticd gets a proper RST and immediately frees the client slot for reconnection.

https://claude.ai/code/session_01MDELg3em8TW7LAYjUs6EtB