### PR TITLE
fix: HealthSnapshot missing category_scores and meshforge self-detection

### DIFF
--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -91,6 +91,25 @@ class QuickActionsMixin:
         services = ['meshtasticd', 'rnsd', 'mosquitto', 'meshforge']
         warnings = []
         for svc in services:
+            # MeshForge TUI IS MeshForge — if we're running, it's running.
+            if svc == 'meshforge':
+                is_systemd = False
+                try:
+                    if _HAS_SERVICE_CHECK:
+                        is_running, _ = check_systemd_service(svc)
+                        is_systemd = is_running
+                    else:
+                        result = subprocess.run(
+                            ['systemctl', 'is-active', svc],
+                            capture_output=True, text=True, timeout=5
+                        )
+                        is_systemd = result.stdout.strip() == 'active'
+                except Exception:
+                    pass
+                mode = "service" if is_systemd else "interactive"
+                print(f"  * {svc:<18} running ({mode})")
+                continue
+
             try:
                 if _HAS_SERVICE_CHECK:
                     is_running, is_enabled = check_systemd_service(svc)

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -468,6 +468,30 @@ class ServiceMenuMixin:
         use_direct_rnsd = not self._has_systemd_unit('rnsd')
 
         for svc in ['meshtasticd', 'rnsd', 'meshforge']:
+            # MeshForge TUI IS MeshForge — if we're executing this code, it's running.
+            # systemctl only knows about the systemd unit, not interactive sessions.
+            if svc == 'meshforge':
+                # Check systemd first, fall back to interactive detection
+                is_systemd = False
+                try:
+                    if _HAS_SERVICE_CHECK:
+                        svc_status = check_service(svc)
+                        is_systemd = svc_status.available
+                    else:
+                        result = subprocess.run(
+                            ['systemctl', 'is-active', svc],
+                            capture_output=True, text=True, timeout=5
+                        )
+                        is_systemd = result.stdout.strip() == 'active'
+                except Exception:
+                    pass
+
+                if is_systemd:
+                    print(f"  \033[0;32m●\033[0m {svc:<18} running (service)")
+                else:
+                    print(f"  \033[0;32m●\033[0m {svc:<18} running (interactive)")
+                continue
+
             # Special handling for rnsd without systemd unit
             if svc == 'rnsd' and use_direct_rnsd:
                 if self._is_rnsd_running():

--- a/src/utils/health_score.py
+++ b/src/utils/health_score.py
@@ -138,22 +138,34 @@ class HealthSnapshot:
     freshness_score: float
     status: str  # 'healthy', 'fair', 'degraded', 'critical'
     timestamp: float = 0.0
+    node_count: int = 0
+    service_count: int = 0
     details: Dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
         if self.timestamp == 0.0:
             self.timestamp = time.time()
 
+    @property
+    def category_scores(self) -> Dict[str, float]:
+        """Per-category score breakdown as a dict."""
+        return {
+            'connectivity': self.connectivity_score,
+            'performance': self.performance_score,
+            'reliability': self.reliability_score,
+            'freshness': self.freshness_score,
+        }
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             'overall_score': round(self.overall_score, 1),
             'status': self.status,
             'categories': {
-                'connectivity': round(self.connectivity_score, 1),
-                'performance': round(self.performance_score, 1),
-                'reliability': round(self.reliability_score, 1),
-                'freshness': round(self.freshness_score, 1),
+                cat: round(score, 1)
+                for cat, score in self.category_scores.items()
             },
+            'node_count': self.node_count,
+            'service_count': self.service_count,
             'timestamp': self.timestamp,
             'details': self.details,
         }
@@ -550,6 +562,8 @@ class HealthScorer:
                 reliability_score=rel_score,
                 freshness_score=fresh_score,
                 status=score_to_status(overall),
+                node_count=len(self._nodes),
+                service_count=len(self._services),
                 details={
                     'connectivity': conn_details,
                     'performance': perf_details,


### PR DESCRIPTION
Two bugs fixed:

1. HealthSnapshot.category_scores AttributeError - The dataclass had individual score fields (connectivity_score, etc.) but no category_scores property. Three callers (report_generator, dashboard_mixin) expected a dict. Added category_scores property + node_count/service_count fields.

2. MeshForge TUI showing itself as "stopped" - service_menu_mixin and quick_actions_mixin checked meshforge via systemctl, which only knows about the systemd unit. When running interactively (sudo python3), systemctl says "inactive". Since the TUI IS MeshForge, it now shows "running (interactive)" vs "running (service)" based on launch mode.

https://claude.ai/code/session_01MDELg3em8TW7LAYjUs6EtB