### PR TITLE
fix: clear scrollback buffer to prevent TUI screen roll

### DIFF
--- a/src/launcher_tui/backend.py
+++ b/src/launcher_tui/backend.py
@@ -17,12 +17,17 @@ logger = logging.getLogger(__name__)
 
 
 def clear_screen() -> None:
-    """Clear the terminal using ANSI escape codes.
+    """Clear the terminal including scrollback buffer.
 
-    Much faster than subprocess.run(['clear']) — no subprocess spawn,
-    no visible flash between clear and redraw.
+    Uses three ANSI sequences:
+    - \\033[H     Move cursor to home position (top-left)
+    - \\033[2J    Clear the visible viewport
+    - \\033[3J    Clear the scrollback buffer
+
+    The scrollback clear (\\033[3J) prevents "screen roll" where old
+    print() output bleeds through when whiptail/dialog redraws.
     """
-    sys.stdout.write('\033[H\033[2J')
+    sys.stdout.write('\033[H\033[2J\033[3J')
     sys.stdout.flush()
 
 

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -168,11 +168,19 @@ class MeshForgeLauncher(
 
     @staticmethod
     def _wait_for_enter(msg: str = "\nPress Enter to continue...") -> None:
-        """Wait for user to press Enter, handling Ctrl+C gracefully."""
+        """Wait for user to press Enter, handling Ctrl+C gracefully.
+
+        Clears the screen (including scrollback) after input so that
+        print() output doesn't bleed through when whiptail/dialog redraws.
+        """
         try:
             input(msg)
         except (KeyboardInterrupt, EOFError):
-            print()  # Clean newline after ^C
+            pass  # Clean exit on ^C
+        # Clear screen + scrollback before returning to dialog menu.
+        # Without this, old print output stays in scrollback and causes
+        # "screen roll" — visible flash of terminal text behind the dialog.
+        clear_screen()
 
     def _get_meshtastic_cli(self) -> str:
         """Find the meshtastic CLI binary path, with caching."""


### PR DESCRIPTION
When making menu selections, old print() output in the terminal scrollback would bleed through as whiptail/dialog redraws — visible as a flash of terminal text behind the dialog ("screen roll").

Two changes:
1. clear_screen() now includes \033[3J to clear the scrollback buffer, not just the visible viewport (\033[2J)
2. _wait_for_enter() calls clear_screen() after input, so print output is wiped before control returns to the dialog menu loop

https://claude.ai/code/session_01MDELg3em8TW7LAYjUs6EtB