### PR TITLE
fix: clear screen before every dialog invocation to prevent buffer bleed

### DIFF
--- a/src/launcher_tui/backend.py
+++ b/src/launcher_tui/backend.py
@@ -90,6 +90,12 @@ class DialogBackend:
             # Build command as list args (safe, no shell needed)
             cmd_parts = [self.backend] + [str(a) for a in full_args]
 
+            # Clear screen before launching dialog so whiptail saves a clean
+            # main buffer. Without this, whiptail saves whatever print() output
+            # was on the main buffer and restores it on exit — causing the
+            # "screen roll" where old text bleeds through between dialogs.
+            clear_screen()
+
             # Run with stderr redirected to file to capture selection
             # whiptail/dialog opens /dev/tty directly for ncurses display
             with open(tmp_path, 'w') as stderr_file:


### PR DESCRIPTION
The previous fix (clearing scrollback in clear_screen) wasn't enough. Whiptail saves the main buffer state when it opens and restores it on exit. If print() output was on the main buffer when whiptail saved it, that dirty buffer gets restored every time whiptail closes — causing the screen roll bleed-through.

Fix: clear_screen() now runs in _run() right before launching whiptail/dialog, ensuring it always saves a clean main buffer. Combined with the scrollback clear and _wait_for_enter() cleanup, all three transition points are now handled:
  1. Before dialog opens (saves clean buffer) ← this commit
  2. Scrollback cleared during print screens (previous commit)
  3. After _wait_for_enter() returns (previous commit)

https://claude.ai/code/session_01MDELg3em8TW7LAYjUs6EtB