### PR TITLE
fix: eliminate RNS config drift between rnsd and NomadNet

### DIFF
--- a/.claude/session_notes/2026-02-13_rns_config_regression_cont.md
+++ b/.claude/session_notes/2026-02-13_rns_config_regression_cont.md
@@ -1,55 +1,86 @@
-# Session: RNS Config Regression — Continuation
+# Session: RNS Config Regression — Root Cause Analysis & Fix
 **Date:** 2026-02-13
 **Branch:** `claude/fix-rns-config-regression-P7ikY`
 **Prior session:** `2026-02-13_rns_config_autofix_regression.md`
 
 ## Context
 
-Continuation of RNS config auto-fix regression work. Prior session made 4 fixes.
-This session reviewed remaining open items and fixed a service name bug.
+Continuation of RNS config auto-fix regression work. Prior session made 4 fixes
+but the underlying systemic issue persisted. This session traced the full
+progression from clean install to broken state and identified 4 design gaps
+that combine to create the recurring config/permission/auth failure.
+
+## Root Cause Analysis
+
+The recurring failure is caused by **4 gaps** that combine:
+
+### Gap 1: Auth token clearing is incomplete
+`_auto_fix_rns_shared_instance()` cleared tokens from `/etc/reticulum/storage`
+and `/root/.reticulum/storage` but NOT from `~/.reticulum/storage` (real user).
+After rnsd restart with new tokens, NomadNet (if it falls back to ~/.reticulum)
+has stale tokens → AuthenticationError.
+
+### Gap 2: Config path is not explicit
+NomadNet relied on RNS's default resolution (returning None from
+`_get_rns_config_for_user()`). Different user contexts may resolve to different
+paths. When `~/.reticulum/config` exists, NomadNet (running as real user) may
+use it instead of `/etc/reticulum/config` → config drift → auth mismatch.
+
+### Gap 3: `chmod -R 755` destroys world-writable
+The "fix permissions" option in `_check_rns_for_nomadnet()` ran
+`chmod -R 755 /etc/reticulum/`, removing S_IWOTH from storage. Next NomadNet
+launch detects storage isn't writable → falls back to ~/.reticulum → drift.
+
+### Gap 4: Storage file permissions not fixed before NomadNet launch
+`_fix_storage_file_permissions()` only ran during gateway bridge startup and
+auto-fix, NOT before NomadNet launch. Files created by rnsd (root, 0o644)
+are read-only to the real user.
 
 ## Issues Fixed This Session
 
-### 1. Entropy Diagnostic Suggests Wrong Service Name (rngd vs rng-tools-debian)
-**File:** `src/launcher_tui/rns_menu_mixin.py` — `_diagnose_rns_connectivity()`
-- Diagnostic suggested `sudo apt install rng-tools` and `sudo systemctl enable --now rngd`
-- On Debian/Pi OS Bookworm, the package is `rng-tools-debian` and service is `rng-tools-debian.service`
-- User got: `Failed to enable unit: Unit rngd.service does not exist`
-- **Fix:** Diagnostic now probes systemd for the actual service name before suggesting commands
-  - Checks `systemctl list-unit-files` for `rng-tools-debian`, `rngd`, `rng-tools` (in order)
-  - If service already installed, shows correct `enable --now` command
-  - If not installed, detects Debian (via `dpkg`) and suggests correct package name
+### 1. Entropy Diagnostic Wrong Service Name
+**File:** `src/launcher_tui/rns_menu_mixin.py`
+- Suggested `rng-tools`/`rngd` instead of `rng-tools-debian` for Debian/Pi OS
+- **Fix:** Probes systemd for actual service name before suggesting commands
 
-## Open Items Reviewed & Resolved
+### 2. Auth Token Clearing Now Covers All Locations
+**File:** `src/launcher_tui/rns_menu_mixin.py` — `_auto_fix_rns_shared_instance()`
+- Now clears `shared_instance_*` from ALL 4 locations:
+  - `/etc/reticulum/storage`
+  - `/root/.reticulum/storage`
+  - `~/.reticulum/storage` (real user)
+  - `~/.config/reticulum/storage` (real user XDG)
 
-### Entropy on Pi — RESOLVED
-- User installed `rng-tools-debian` (package auto-enabled the service via dpkg symlinks)
-- Diagnostic code now detects correct service name
-- No further action needed
+### 3. NomadNet Always Uses Explicit Config Path
+**File:** `src/launcher_tui/nomadnet_client_mixin.py` — `_get_rns_config_for_user()`
+- Never returns None — always returns explicit path
+- When `/etc/reticulum/config` exists → always uses it (auto-fixes permissions)
+- No fallback to `~/.reticulum` which caused config drift
+- NomadNet launched with `--rnsconfig /etc/reticulum` (same as rnsd)
 
-### RNS Config Location Consistency — RESOLVED (no change needed)
-- Config drift detection already runs automatically at critical points:
-  - Gateway bridge startup (`rns_bridge.py:849`)
-  - Connectivity diagnostics (`_diagnose_rns_connectivity` check #4)
-  - Gateway config validation (`config.py:648`)
-- Manual menu option available for user-triggered checks
-- Adding it to TUI menu entry would add latency for minimal benefit
-- Current architecture is appropriate
+### 4. Removed Destructive chmod -R 755
+**File:** `src/launcher_tui/nomadnet_client_mixin.py` — `_check_rns_for_nomadnet()`
+- Old code: `chmod -R 755 /etc/reticulum/` removed world-writable from storage
+- New code: `storage_dir.chmod(0o777)` + `_fix_storage_file_permissions()`
+- Never offers to fall back to `~/.reticulum` — always fixes system config
+- No more "continue with user config" option that created config drift
 
-### NomadNet Exit Code 1 — STILL OPEN (needs user testing)
-- Prior session fixed storage permissions (0o777) and writability checks
-- User needs to test NomadNet after pulling these fixes
-- If still fails, check:
-  - `cat /home/wh6gxz/.nomadnetwork/logfile` (last 20 lines)
-  - `sudo journalctl -u rnsd -n 30`
-  - Auth token stale? `sudo rm -f /etc/reticulum/storage/shared_instance_*`
+## Design Principle Established
+
+**NomadNet and rnsd MUST always use the SAME config directory.**
+- System config at `/etc/reticulum/config` is the convergence point
+- When it exists, ALWAYS pass `--rnsconfig /etc/reticulum` to NomadNet
+- Fix permissions rather than falling back to a different config dir
+- Clear auth tokens from ALL known locations when restarting rnsd
 
 ## Commits
 1. `fix: detect correct entropy service name for Debian/Pi OS`
+2. `fix: eliminate RNS config drift between rnsd and NomadNet`
 
 ## Tests
-- 4021 passed, 19 skipped (276s)
+- 4021 passed, 19 skipped (271s) — all clean
 
 ## Session Status
-- Clean — no entropy detected
-- Single focused fix with thorough review of prior open items
+- Clean — focused and systematic
+- Deep root cause analysis completed
+- 4 design gaps identified and fixed

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -58,70 +58,65 @@ class NomadNetClientMixin:
     def _get_rns_config_for_user(self) -> str:
         """Get RNS config directory path appropriate for the current user.
 
-        Detects the problematic case where /etc/reticulum/ exists (from a
-        previous root/sudo run) but is not writable by the current user.
-        In that case, returns the user's ~/.reticulum path.
+        Returns the EXPLICIT config dir that NomadNet should use via
+        --rnsconfig. This MUST match the config that rnsd is using to
+        prevent config drift (different identities, stale auth tokens).
 
-        IMPORTANT: MeshForge runs as root (sudo), but NomadNet launches as
-        the real user. We must check writability for the REAL USER, not root.
-        Root can always write — testing as root always passes, hiding the
-        problem from the user process.
+        Strategy:
+        1. If /etc/reticulum/config exists AND storage is writable → use it
+        2. If storage is NOT writable → FIX permissions (we run as root)
+        3. Never fall back to ~/.reticulum — that creates config drift
+
+        IMPORTANT: Always return an explicit path. Never return None to
+        let RNS use its own resolution, because user-context resolution
+        may pick ~/.reticulum instead of /etc/reticulum, causing auth
+        mismatches with rnsd.
 
         Returns:
-            Path string to pass to --rnsconfig, or None if default is fine.
+            Path string to pass to --rnsconfig.
         """
         import stat
 
         etc_rns = Path('/etc/reticulum')
-        user_home = get_real_user_home()
-        user_rns = user_home / '.reticulum'
+        etc_config = etc_rns / 'config'
 
-        # If /etc/reticulum exists, check if it's usable by the REAL user
-        if etc_rns.exists():
+        # If system config exists, always use it — fix permissions if needed
+        if etc_config.is_file():
             storage_dir = etc_rns / 'storage'
             try:
                 if storage_dir.exists():
-                    # Check directory permissions instead of doing a write test.
-                    # A write test as root always succeeds, but NomadNet runs
-                    # as the real user who may not have write access.
                     mode = storage_dir.stat().st_mode
-                    sudo_user = os.environ.get('SUDO_USER')
-
-                    if sudo_user and sudo_user != 'root':
-                        # Running via sudo — NomadNet will run as real user.
-                        # Check if storage is world-writable (others can write).
-                        if mode & stat.S_IWOTH:
-                            return None  # World-writable, real user can write
-                        else:
-                            logger.info(
-                                f"/etc/reticulum/storage not writable by {sudo_user} "
-                                f"(mode {oct(mode)}), using {user_rns}"
-                            )
-                            return str(user_rns)
-                    else:
-                        # Not running via sudo — direct write test is valid
-                        test_file = storage_dir / '.meshforge_write_test'
+                    if not (mode & stat.S_IWOTH):
+                        # Fix permissions — we're root (sudo), we can do this.
+                        # This prevents NomadNet from falling back to ~/.reticulum
+                        # which would cause config drift with rnsd.
+                        logger.info(
+                            f"/etc/reticulum/storage mode {oct(mode)} missing "
+                            f"world-writable bit, fixing to 0o777"
+                        )
+                        old_umask = os.umask(0)
                         try:
-                            test_file.touch()
-                            test_file.unlink()
-                            return None
-                        except (OSError, PermissionError):
-                            logger.info(f"/etc/reticulum/storage not writable, using {user_rns}")
-                            return str(user_rns)
+                            storage_dir.chmod(0o777)
+                        finally:
+                            os.umask(old_umask)
+                        # Also fix file permissions inside storage
+                        ReticulumPaths._fix_storage_file_permissions()
                 else:
-                    # storage dir doesn't exist - try to create it
+                    # Create storage dir with correct permissions
+                    old_umask = os.umask(0)
                     try:
-                        storage_dir.mkdir(parents=True, exist_ok=True)
-                        return None
-                    except (OSError, PermissionError):
-                        logger.info(f"Cannot create /etc/reticulum/storage, using {user_rns}")
-                        return str(user_rns)
-            except Exception as e:
-                logger.warning(f"Error checking /etc/reticulum: {e}, falling back to user config")
-                return str(user_rns)
+                        storage_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
+                    finally:
+                        os.umask(old_umask)
+            except (OSError, PermissionError) as e:
+                logger.warning(f"Could not fix /etc/reticulum/storage: {e}")
 
-        # /etc/reticulum doesn't exist - default resolution is fine
-        return None
+            return str(etc_rns)
+
+        # No system config — use default resolution
+        # (ReticulumPaths.get_config_dir will find XDG or ~/.reticulum)
+        config_dir = ReticulumPaths.get_config_dir()
+        return str(config_dir)
 
     # ------------------------------------------------------------------
     # Ownership fix for user directories
@@ -1053,65 +1048,37 @@ class NomadNetClientMixin:
                 logger.debug("RNS storage dir check failed: %s", e)
 
             if not can_write:
-                # /etc/reticulum exists but is not writable
-                # We'll use --rnsconfig to bypass it, but warn the user
+                # /etc/reticulum storage not writable — fix it immediately.
+                # We're running as root (sudo), so we can fix permissions.
+                # NEVER fall back to ~/.reticulum — that creates config drift
+                # (different identity/auth tokens than rnsd → auth failures).
                 target_user = sudo_user if sudo_user and sudo_user != 'root' else 'current user'
-                user_rns = get_real_user_home() / '.reticulum'
-
-                choice = self.dialog.menu(
-                    "/etc/reticulum Permission Issue",
-                    f"/etc/reticulum/ exists but is not writable by {target_user}.\n\n"
-                    f"This was likely created when RNS/rnsd ran as root.\n\n"
-                    f"NomadNet will use {user_rns} instead.",
-                    [
-                        ("continue", f"Continue (use {user_rns})"),
-                        ("fix", "Fix /etc/reticulum permissions (requires sudo)"),
-                        ("remove", "Remove /etc/reticulum (requires sudo)"),
-                        ("cancel", "Cancel"),
-                    ],
+                logger.info(
+                    f"/etc/reticulum/storage not writable by {target_user}, "
+                    "fixing permissions to 0o777"
                 )
-
-                if choice == "fix":
+                try:
+                    old_umask = os.umask(0)
                     try:
-                        if sudo_user and sudo_user != 'root':
-                            subprocess.run(
-                                ['chown', '-R', f'{sudo_user}:{sudo_user}', str(etc_rns)],
-                                capture_output=True, timeout=30
-                            )
-                        else:
-                            # Running as root already, just fix permissions
-                            subprocess.run(
-                                ['chmod', '-R', '755', str(etc_rns)],
-                                capture_output=True, timeout=30
-                            )
-                        self.dialog.msgbox(
-                            "Permissions Fixed",
-                            f"Fixed permissions on /etc/reticulum/.\n\n"
-                            "NomadNet should now work with system config.",
-                        )
-                    except Exception as e:
-                        self.dialog.msgbox("Fix Failed", f"Could not fix permissions: {e}")
-                        return False
-                elif choice == "remove":
-                    if self.dialog.yesno(
-                        "Confirm Removal",
-                        f"Remove /etc/reticulum/ directory?\n\n"
-                        f"RNS will use {user_rns} instead.\n\n"
-                        "Proceed?",
-                    ):
-                        try:
-                            shutil.rmtree(str(etc_rns))
-                            self.dialog.msgbox(
-                                "Removed",
-                                f"/etc/reticulum/ has been removed.\n\n"
-                                f"RNS will now use {user_rns}.",
-                            )
-                        except Exception as e:
-                            self.dialog.msgbox("Removal Failed", f"Could not remove: {e}")
-                            return False
-                elif choice == "cancel":
+                        storage_dir.chmod(0o777)
+                        # Also fix subdirectories and files
+                        ReticulumPaths._fix_storage_file_permissions()
+                    finally:
+                        os.umask(old_umask)
+                    self.dialog.msgbox(
+                        "Storage Permissions Fixed",
+                        f"/etc/reticulum/storage/ permissions have been fixed.\n\n"
+                        f"NomadNet will use the system config (same as rnsd).",
+                    )
+                except (OSError, PermissionError) as e:
+                    self.dialog.msgbox(
+                        "Permission Fix Failed",
+                        f"Could not fix /etc/reticulum/storage permissions:\n"
+                        f"  {e}\n\n"
+                        f"Try manually:\n"
+                        f"  sudo chmod 777 /etc/reticulum/storage"
+                    )
                     return False
-                # choice == "continue" falls through
 
         # Check if rnsd is running and get its user
         try:

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -814,12 +814,18 @@ class RNSMenuMixin(RNSSnifferMixin):
         except Exception as e:
             print(f"  Warning stopping rnsd: {e}")
 
-        # Clear stale shared_instance_* files that cause AuthenticationError
-        # These files contain auth tokens that become invalid after config changes
+        # Clear stale shared_instance_* files that cause AuthenticationError.
+        # These files contain auth tokens that become invalid after config changes.
+        # CRITICAL: Must clear from ALL locations — not just /etc and /root.
+        # If the real user has ~/.reticulum/storage/ with stale tokens, NomadNet
+        # (running as real user) will use those stale tokens → auth mismatch.
         print("  Clearing stale shared instance authentication files...")
+        user_home = get_real_user_home()
         storage_dirs = [
             Path('/etc/reticulum/storage'),
             Path('/root/.reticulum/storage'),
+            user_home / '.reticulum' / 'storage',
+            user_home / '.config' / 'reticulum' / 'storage',
         ]
         files_cleared = 0
         for storage_dir in storage_dirs:


### PR DESCRIPTION
Root cause of recurring RNS/NomadNet failures: 4 design gaps that combined to create config path divergence, stale auth tokens, and permission drift between rnsd and NomadNet.

Gap 1 - Auth token clearing was incomplete: auto-fix cleared tokens from /etc and /root but not from real user's ~/.reticulum/storage. After rnsd restart, NomadNet had stale tokens -> AuthenticationError. Fix: clear from all 4 known locations.

Gap 2 - Config path not explicit: _get_rns_config_for_user() returned None (let RNS resolve), but user-context resolution could pick ~/.reticulum instead of /etc/reticulum -> different identity/auth. Fix: always return explicit path, always pass --rnsconfig.

Gap 3 - chmod -R 755 destroyed world-writable: "fix permissions" option in _check_rns_for_nomadnet() removed S_IWOTH from storage. Next launch fell back to ~/.reticulum -> config drift. Fix: targeted chmod 777 on storage only, never fall back.

Gap 4 - Storage file permissions not fixed before NomadNet launch: _fix_storage_file_permissions() only ran during gateway/auto-fix. Fix: _get_rns_config_for_user() now auto-fixes when detecting drift.

https://claude.ai/code/session_01H81NMVDNh38yUejkoHgnQJ