### PR TITLE
feat: Phase 2 circuit breakers — independent subsystem lifecycle

### DIFF
--- a/.claude/session_notes/2026-02-13_phase2_circuit_breakers.md
+++ b/.claude/session_notes/2026-02-13_phase2_circuit_breakers.md
@@ -1,0 +1,96 @@
+# Session Notes: Phase 2 — Circuit Breakers (Cascading Failure Isolation)
+**Date**: 2026-02-13
+**Branch**: `claude/autonomous-task-execution-AgP6X`
+**Version**: v0.5.4-beta
+**Tests**: 4046 passed (+25 new), 19 skipped, 0 failed
+
+## What Was Done
+
+### Phase 2: Circuit Breakers — Independent Subsystem Lifecycle
+
+The bridge now treats Meshtastic and RNS as independent subsystems with their own
+lifecycle states. When one side goes down, the other continues operating and messages
+are queued for later delivery instead of being dropped.
+
+### Changes
+
+#### 1. `SubsystemState` enum (`bridge_health.py`)
+- Added `SubsystemState(Enum)`: HEALTHY, DEGRADED, DISCONNECTED, DISABLED
+- Added subsystem tracking to `BridgeHealthMonitor`:
+  - `set_subsystem_state()` / `get_subsystem_state()` / `get_subsystem_states()`
+  - `record_message_queued_degraded()` — tracks messages queued during degraded state
+  - `get_bridge_status_detailed()` — full status including subsystem states
+- Subsystem states now included in `get_summary()` output
+
+#### 2. Gateway CLI extraction (`gateway_cli.py` — NEW)
+- Extracted 115 lines of module-level CLI helpers from `rns_bridge.py`
+- `start_gateway_headless()`, `stop_gateway_headless()`, `get_gateway_stats()`, `is_gateway_running()`
+- Re-exported from `rns_bridge.py` for backward compatibility
+- `rns_bridge.py`: 1,499 → 1,485 lines (under 1,500 threshold)
+
+#### 3. Subsystem state tracking in bridge (`rns_bridge.py`)
+- `_update_subsystem_state()` — sets state + emits EventBus event
+- `_sync_subsystem_states()` — called each bridge loop iteration, derives state from connection status
+- `_rns_loop()` — now sets RNS subsystem to DISABLED on permanent failure, DISCONNECTED on transient
+- `_bridge_loop()` — checks destination subsystem state before processing messages:
+  - Destination DISCONNECTED/DISABLED → queue to persistent storage (SQLite)
+  - Destination HEALTHY → process normally
+  - Periodic drain of persistent queue when subsystems recover
+- `get_status()` — now includes `subsystems` and `bridge_status` fields
+
+#### 4. Status bar subsystem display (`status_bar.py`)
+- `_format_bridge_status()` — shows:
+  - `bridge:*` when both healthy
+  - `bridge:DEGRADED(rns)` or `bridge:DEGRADED(mesh)` when one side down
+  - `bridge:OFFLINE` when both down
+- `set_subsystem_states()` — setter for external state updates
+- EventBus integration: `bridge_meshtastic` / `bridge_rns` events update status bar
+
+### Tests Added (25 new)
+- 14 `TestSubsystemState` tests in `test_bridge_health.py`
+  - Enum values, initial state, set/get, thread safety, summary integration
+- 10 `TestSubsystemStatusDisplay` tests in `test_status_bar.py`
+  - All display states (healthy, degraded, offline, disabled), event integration
+- 1 backward-compatibility re-export test in `test_rns_bridge.py`
+- Updated `test_bridge_integration.py` roundtrip test for subsystem state awareness
+
+### File Size Audit
+- `rns_bridge.py`: 1,485 lines (✅ under 1,500)
+- `bridge_health.py`: ~740 lines (✅ well under)
+- `gateway_cli.py`: 130 lines (NEW, extracted)
+- `status_bar.py`: ~440 lines (✅)
+
+## Architecture
+
+```
+Bridge Loop (every 0.1s):
+  1. _sync_subsystem_states()     — observe connection status
+  2. mesh→rns queue:
+     - RNS HEALTHY → process normally
+     - RNS DOWN → requeue to SQLite persistent queue
+  3. rns→mesh queue:
+     - Mesh HEALTHY → process normally
+     - Mesh DOWN → requeue to SQLite persistent queue
+  4. Every 30s: drain persistent queue + check delivery timeouts
+```
+
+EventBus flow:
+```
+rns_bridge._update_subsystem_state()
+  → emit_service_status("bridge_rns", available, message)
+  → StatusBar._on_service_event()
+  → _subsystem_states["rns"] = "disconnected"
+  → _format_bridge_status() → "bridge:DEGRADED(rns)"
+```
+
+## Next: Phase 3 (from reliability plan)
+
+Priority candidates:
+1. **Auto-fix verification**: Health loop acts on auto_fix=True (currently defanged)
+2. **Persistent queue drain telemetry**: Log/metric when queued messages are drained
+3. **Circuit breaker per-destination**: Use existing CircuitBreakerRegistry in bridge loop
+4. **Error rate → DEGRADED state**: Set subsystem to DEGRADED when error rate crosses threshold
+
+## Session Entropy
+
+None observed — clean session, all changes are incremental and well-tested.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ src/
 │   └── base.py        # CommandResult base class
 ├── gateway/           # RNS-Meshtastic bridge
 │   ├── rns_bridge.py  # Main gateway bridge
+│   ├── gateway_cli.py # Headless CLI helpers (extracted)
 │   └── message_queue.py # Persistent message queue (SQLite)
 ├── monitoring/        # Network monitoring
 │   └── mqtt_subscriber.py # Nodeless MQTT monitoring
@@ -204,8 +205,8 @@ directly from `utils.service_check` — no try/except compatibility shims needed
 
 Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md` Issue #6):
 
-**File size audit (2026-02-12):**
-- ✅ `rns_bridge.py` (1,495 lines) - MessageRouter extracted to message_routing.py
+**File size audit (2026-02-13):**
+- ✅ `rns_bridge.py` (1,485 lines) - MessageRouter + gateway_cli.py extracted
 - ⚠️ `knowledge_content.py` (1,824 lines) - Content file by design, acceptable
 - ✅ `map_data_collector.py` (1,509 lines) - Borderline, monitor
 - ✅ `launcher_tui/main.py` (1,488 lines) - 30 mixins, dead code removed
@@ -216,7 +217,7 @@ Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md
 
 **Refactoring history:**
 - `launcher_tui/main.py` (was 2,822 → 1,336 → 1,799 → 1,433 → 1,488)
-- `rns_bridge.py` (was 1,991 → 1,614 → 1,694 → 1,495, MeshtasticHandler + MessageRouter extracted)
+- `rns_bridge.py` (was 1,991 → 1,614 → 1,694 → 1,495 → 1,485, MeshtasticHandler + MessageRouter + gateway_cli extracted)
 - `node_tracker.py` (was 1,808 → 930, node_models.py extracted)
 - `rns_menu_mixin.py` (was 1,524 → 1,210, rns_sniffer_mixin.py extracted)
 - `metrics_export.py` (was 1,762 → 96, split to common/prometheus/influxdb)

--- a/src/gateway/bridge_health.py
+++ b/src/gateway/bridge_health.py
@@ -34,6 +34,21 @@ from typing import Any, Dict, List, Optional
 logger = logging.getLogger(__name__)
 
 
+class SubsystemState(Enum):
+    """Independent state for each bridge subsystem (Phase 2: Circuit Breakers).
+
+    Each side of the bridge (Meshtastic, RNS) has its own lifecycle:
+    - HEALTHY: Connected and operational
+    - DEGRADED: Connected but experiencing issues (high error rate)
+    - DISCONNECTED: Not connected, will retry automatically
+    - DISABLED: Intentionally turned off by user or config
+    """
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    DISCONNECTED = "disconnected"
+    DISABLED = "disabled"
+
+
 class BridgeStatus(Enum):
     """Bridge operational status.
 
@@ -181,6 +196,14 @@ class BridgeHealthMonitor:
             "rns": 0.0,
         }
 
+        # Subsystem states (Phase 2: Circuit Breakers)
+        self._subsystem_states: Dict[str, SubsystemState] = {
+            "meshtastic": SubsystemState.DISCONNECTED,
+            "rns": SubsystemState.DISCONNECTED,
+        }
+        # Messages queued during degraded state
+        self._messages_queued_degraded: int = 0
+
     def record_connection_event(self, service: str, event: str,
                                 detail: str = "") -> None:
         """Record a connection state change.
@@ -210,6 +233,71 @@ class BridgeHealthMonitor:
                     self._uptime_seconds[service] += now - connected_at
                 self._connected[service] = False
                 self._last_disconnected[service] = now
+
+    # =========================================================================
+    # Subsystem State Management (Phase 2: Circuit Breakers)
+    # =========================================================================
+
+    def set_subsystem_state(self, subsystem: str, state: SubsystemState) -> Optional[SubsystemState]:
+        """Set the state of a subsystem, returning the previous state.
+
+        Args:
+            subsystem: "meshtastic" or "rns"
+            state: New SubsystemState value
+
+        Returns:
+            Previous SubsystemState, or None if subsystem unknown.
+        """
+        with self._lock:
+            if subsystem not in self._subsystem_states:
+                return None
+            old_state = self._subsystem_states[subsystem]
+            if old_state != state:
+                self._subsystem_states[subsystem] = state
+                logger.info(f"Subsystem {subsystem}: {old_state.value} → {state.value}")
+            return old_state
+
+    def get_subsystem_state(self, subsystem: str) -> SubsystemState:
+        """Get the current state of a subsystem.
+
+        Args:
+            subsystem: "meshtastic" or "rns"
+
+        Returns:
+            Current SubsystemState (defaults to DISCONNECTED).
+        """
+        with self._lock:
+            return self._subsystem_states.get(subsystem, SubsystemState.DISCONNECTED)
+
+    def get_subsystem_states(self) -> Dict[str, str]:
+        """Get all subsystem states as a dict of name→value strings."""
+        with self._lock:
+            return {k: v.value for k, v in self._subsystem_states.items()}
+
+    def record_message_queued_degraded(self) -> None:
+        """Record that a message was queued because the destination subsystem is down."""
+        with self._lock:
+            self._messages_queued_degraded += 1
+
+    def get_degraded_queue_count(self) -> int:
+        """Get count of messages queued during degraded state."""
+        with self._lock:
+            return self._messages_queued_degraded
+
+    def get_bridge_status_detailed(self) -> Dict[str, Any]:
+        """Get detailed bridge status including subsystem states.
+
+        Returns:
+            Dict with bridge_status, subsystem states, and degraded reason.
+        """
+        status = self.get_bridge_status()
+        reason = self.get_degraded_reason()
+        return {
+            "bridge_status": status.value,
+            "subsystems": self.get_subsystem_states(),
+            "degraded_reason": reason,
+            "messages_queued_degraded": self._messages_queued_degraded,
+        }
 
     def record_message_sent(self, direction: str) -> None:
         """Record a successfully bridged message.
@@ -347,6 +435,8 @@ class BridgeHealthMonitor:
                     "rate_per_min": self.get_message_rate(),
                 },
                 "errors": self.get_error_rate(),
+                "subsystems": self.get_subsystem_states(),
+                "messages_queued_degraded": self._messages_queued_degraded,
             }
 
     def is_healthy(self) -> bool:

--- a/src/gateway/gateway_cli.py
+++ b/src/gateway/gateway_cli.py
@@ -1,0 +1,138 @@
+"""
+Gateway CLI helpers — headless operation of the RNS-Meshtastic bridge.
+
+Extracted from rns_bridge.py to keep that file under the 1,500 line threshold.
+These functions manage a module-level singleton bridge for CLI/headless use.
+
+Usage:
+    from gateway.gateway_cli import start_gateway_headless, stop_gateway_headless
+
+    start_gateway_headless()
+    stats = get_gateway_stats()
+    stop_gateway_headless()
+"""
+
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+_active_bridge = None
+
+
+def start_gateway_headless() -> bool:
+    """
+    Start the gateway bridge in headless mode (for CLI use).
+
+    Returns True if started successfully, False otherwise.
+    """
+    global _active_bridge
+
+    if _active_bridge is not None and _active_bridge._running:
+        logger.warning("Gateway bridge is already running")
+        print("Gateway bridge is already running")
+        return True
+
+    try:
+        from .rns_bridge import RNSMeshtasticBridge
+
+        _active_bridge = RNSMeshtasticBridge()
+        success = _active_bridge.start()
+
+        if success:
+            print("Gateway bridge started successfully")
+            mesh_ok = _active_bridge._mesh_handler.is_connected if _active_bridge._mesh_handler else False
+            print(f"  Meshtastic: {'Connected' if mesh_ok else 'Disconnected'}")
+            print(f"  RNS: {'Connected' if _active_bridge._connected_rns else 'Disconnected'}")
+        else:
+            print("Gateway bridge failed to start - check logs")
+
+        return success
+    except Exception as e:
+        logger.error(f"Failed to start gateway: {e}")
+        print(f"Failed to start gateway: {e}")
+        return False
+
+
+def stop_gateway_headless() -> bool:
+    """
+    Stop the gateway bridge (for CLI use).
+
+    Returns True if stopped successfully.
+    """
+    global _active_bridge
+
+    if _active_bridge is None:
+        print("No active gateway bridge to stop")
+        return True
+
+    try:
+        _active_bridge.stop()
+        _active_bridge = None
+        print("Gateway bridge stopped")
+        return True
+    except Exception as e:
+        logger.error(f"Error stopping gateway: {e}")
+        print(f"Error stopping gateway: {e}")
+        return False
+
+
+def get_gateway_stats() -> dict:
+    """
+    Get current gateway statistics (for CLI use).
+
+    Returns dict with bridge status and statistics.
+    """
+    global _active_bridge
+
+    if _active_bridge is None:
+        return {
+            'running': False,
+            'status': 'Not started',
+            'meshtastic_connected': False,
+            'rns_connected': False,
+            'messages_mesh_to_rns': 0,
+            'messages_rns_to_mesh': 0,
+            'errors': 0,
+            'bounced': 0,
+        }
+
+    try:
+        status = _active_bridge.get_status()
+        stats = status.get('statistics', {})
+        result = {
+            'running': _active_bridge._running,
+            'status': 'Running' if _active_bridge._running else 'Stopped',
+            'meshtastic_connected': _active_bridge._mesh_handler.is_connected if _active_bridge._mesh_handler else False,
+            'rns_connected': _active_bridge._connected_rns,
+            'messages_mesh_to_rns': stats.get('messages_mesh_to_rns', 0),
+            'messages_rns_to_mesh': stats.get('messages_rns_to_mesh', 0),
+            'errors': stats.get('errors', 0),
+            'bounced': stats.get('bounced', 0),
+            'uptime_seconds': status.get('uptime_seconds'),
+        }
+        # Include health metrics if available
+        if hasattr(_active_bridge, 'health'):
+            result['health'] = _active_bridge.health.get_summary()
+        # Include delivery confirmation stats
+        if hasattr(_active_bridge, 'delivery_tracker'):
+            result['delivery'] = _active_bridge.delivery_tracker.get_stats()
+        return result
+    except Exception as e:
+        logger.error(f"Error getting gateway stats: {e}")
+        return {
+            'running': False,
+            'status': f'Error: {e}',
+            'meshtastic_connected': False,
+            'rns_connected': False,
+            'messages_mesh_to_rns': 0,
+            'messages_rns_to_mesh': 0,
+            'errors': 0,
+            'bounced': 0,
+        }
+
+
+def is_gateway_running() -> bool:
+    """Check if gateway bridge is currently running."""
+    global _active_bridge
+    return _active_bridge is not None and _active_bridge._running

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -18,7 +18,7 @@ from .node_tracker import UnifiedNodeTracker, UnifiedNode
 from .reconnect import ReconnectStrategy
 from .bridge_health import (
     BridgeHealthMonitor, DeliveryTracker, classify_error,
-    BridgeStatus, MessageOrigin
+    BridgeStatus, SubsystemState, MessageOrigin
 )
 # MQTT bridge handler (zero-interference, recommended)
 try:
@@ -286,6 +286,42 @@ class RNSMeshtasticBridge:
         """Get current bridge operational status."""
         return self.health.get_bridge_status()
 
+    # =========================================================================
+    # Subsystem State Management (Phase 2: Circuit Breakers)
+    # =========================================================================
+
+    def _update_subsystem_state(self, subsystem: str, state: SubsystemState) -> None:
+        """Update a subsystem's state and emit an event if it changed.
+
+        Args:
+            subsystem: "meshtastic" or "rns"
+            state: New SubsystemState value
+        """
+        old_state = self.health.set_subsystem_state(subsystem, state)
+        if old_state != state:
+            # Emit event for StatusBar and other listeners
+            if HAS_EVENT_BUS:
+                try:
+                    from utils.event_bus import emit_service_status
+                    emit_service_status(
+                        f"bridge_{subsystem}",
+                        available=(state == SubsystemState.HEALTHY),
+                        message=f"{subsystem}: {state.value}",
+                    )
+                except Exception as e:
+                    logger.debug(f"Failed to emit subsystem state event: {e}")
+
+    def get_subsystem_state(self, subsystem: str) -> SubsystemState:
+        """Get the current state of a bridge subsystem.
+
+        Args:
+            subsystem: "meshtastic" or "rns"
+
+        Returns:
+            Current SubsystemState.
+        """
+        return self.health.get_subsystem_state(subsystem)
+
     @property
     def is_fully_healthy(self) -> bool:
         """Check if bridge is fully operational (both networks up)."""
@@ -446,7 +482,7 @@ class RNSMeshtasticBridge:
         self._notify_status("stopped")
 
     def get_status(self) -> dict:
-        """Get current bridge status"""
+        """Get current bridge status including subsystem states."""
         uptime = None
         if self.stats['start_time']:
             uptime = (datetime.now() - self.stats['start_time']).total_seconds()
@@ -461,6 +497,8 @@ class RNSMeshtasticBridge:
             'uptime_seconds': uptime,
             'statistics': self.stats.copy(),
             'node_stats': self.node_tracker.get_stats(),
+            'subsystems': self.health.get_subsystem_states(),
+            'bridge_status': self.bridge_status.value,
         }
 
     def send_to_meshtastic(self, message: str, destination: str = None, channel: int = 0) -> bool:
@@ -703,12 +741,14 @@ class RNSMeshtasticBridge:
 
         Uses ReconnectStrategy for exponential backoff with jitter.
         Respects permanent failure flag for non-retriable errors.
+        Manages the RNS subsystem state independently of Meshtastic.
         """
         _logged_permanent_failure = False
         while self._running:
             try:
                 # Don't retry if RNS init failed permanently (e.g., library not installed)
                 if self._rns_init_failed_permanently:
+                    self._update_subsystem_state("rns", SubsystemState.DISABLED)
                     if not _logged_permanent_failure:
                         logger.warning("RNS initialization failed permanently - "
                                       "bridge will not attempt reconnection. "
@@ -718,6 +758,7 @@ class RNSMeshtasticBridge:
                     continue
 
                 if not self._connected_rns:
+                    self._update_subsystem_state("rns", SubsystemState.DISCONNECTED)
                     if not self._rns_reconnect.should_retry():
                         logger.warning("RNS reconnection: max attempts reached, resetting")
                         self._rns_reconnect.reset()
@@ -732,6 +773,7 @@ class RNSMeshtasticBridge:
                     if self._connected_rns:
                         self._rns_reconnect.record_success()
                         self.health.record_connection_event("rns", "connected")
+                        self._update_subsystem_state("rns", SubsystemState.HEALTHY)
                         logger.info("RNS connection established")
                     else:
                         self._rns_reconnect.record_failure()
@@ -751,26 +793,53 @@ class RNSMeshtasticBridge:
                 if category == "permanent":
                     logger.error("RNS permanent error detected, stopping retries")
                     self._rns_init_failed_permanently = True
+                    self._update_subsystem_state("rns", SubsystemState.DISABLED)
                 else:
+                    self._update_subsystem_state("rns", SubsystemState.DISCONNECTED)
                     self._rns_reconnect.record_failure()
                     self._rns_reconnect.wait(self._stop_event)
 
     def _bridge_loop(self):
-        """Main loop for message bridging"""
+        """Main loop for message bridging.
+
+        Phase 2 (Circuit Breakers): Each subsystem operates independently.
+        When a destination is down, messages are queued to the persistent
+        queue instead of being dropped. The bridge drains queued messages
+        when the destination comes back up.
+        """
         loop_count = 0
         while self._running:
             try:
+                # Sync subsystem states from connection status
+                self._sync_subsystem_states()
+
                 # Process Meshtastic → RNS queue
                 try:
                     msg = self._mesh_to_rns_queue.get(timeout=0.1)
-                    self._process_mesh_to_rns(msg)
+                    rns_state = self.health.get_subsystem_state("rns")
+                    if rns_state in (SubsystemState.DISCONNECTED, SubsystemState.DISABLED):
+                        # RNS is down — queue for later delivery
+                        requeued = self._requeue_failed_message(msg, "rns")
+                        if requeued:
+                            self.health.record_message_queued_degraded()
+                            logger.debug("Mesh→RNS: RNS subsystem down, message queued")
+                    else:
+                        self._process_mesh_to_rns(msg)
                 except Empty:
                     pass
 
                 # Process RNS → Meshtastic queue
                 try:
                     msg = self._rns_to_mesh_queue.get(timeout=0.1)
-                    self._process_rns_to_mesh(msg)
+                    mesh_state = self.health.get_subsystem_state("meshtastic")
+                    if mesh_state in (SubsystemState.DISCONNECTED, SubsystemState.DISABLED):
+                        # Meshtastic is down — queue for later delivery
+                        requeued = self._requeue_failed_message(msg, "meshtastic")
+                        if requeued:
+                            self.health.record_message_queued_degraded()
+                            logger.debug("RNS→Mesh: Meshtastic subsystem down, message queued")
+                    else:
+                        self._process_rns_to_mesh(msg)
                 except Empty:
                     pass
 
@@ -778,10 +847,49 @@ class RNSMeshtasticBridge:
                 loop_count += 1
                 if loop_count % 150 == 0:
                     self.delivery_tracker.check_timeouts()
+                    # Drain persistent queue when subsystems are back
+                    self._drain_persistent_queue()
 
             except Exception as e:
                 logger.error(f"Bridge loop error: {e}")
                 self._stop_event.wait(1)
+
+    def _sync_subsystem_states(self) -> None:
+        """Synchronize subsystem states from connection status.
+
+        Called each bridge loop iteration. Both handlers manage their own
+        reconnection, so we observe connection states and update accordingly.
+        The RNS subsystem state is also updated in _rns_loop, but we sync
+        here too so the bridge loop has accurate state even when _rns_loop
+        is not running (e.g., in tests).
+        """
+        # Meshtastic
+        if not self._mesh_handler:
+            self._update_subsystem_state("meshtastic", SubsystemState.DISABLED)
+        elif self._mesh_handler.is_connected:
+            self._update_subsystem_state("meshtastic", SubsystemState.HEALTHY)
+        else:
+            self._update_subsystem_state("meshtastic", SubsystemState.DISCONNECTED)
+
+        # RNS (also managed by _rns_loop, but kept in sync here)
+        if self._rns_init_failed_permanently:
+            self._update_subsystem_state("rns", SubsystemState.DISABLED)
+        elif self._connected_rns:
+            self._update_subsystem_state("rns", SubsystemState.HEALTHY)
+        # Note: don't overwrite DISCONNECTED here — _rns_loop handles transitions
+
+    def _drain_persistent_queue(self) -> None:
+        """Process pending messages from the persistent queue.
+
+        Called periodically from _bridge_loop when subsystems are healthy.
+        Only drains messages destined for currently-connected subsystems.
+        """
+        if not self._persistent_queue:
+            return
+        try:
+            self._persistent_queue.process_once(batch_size=5)
+        except Exception as e:
+            logger.debug(f"Persistent queue drain error: {e}")
 
     def _init_rns_main_thread(self):
         """Pre-initialize RNS from the main thread.
@@ -1378,121 +1486,10 @@ class RNSMeshtasticBridge:
 
 
 # === Module-level helper functions for CLI/headless operation ===
-
-_active_bridge: Optional[RNSMeshtasticBridge] = None
-
-
-def start_gateway_headless() -> bool:
-    """
-    Start the gateway bridge in headless mode (for CLI use).
-
-    Returns True if started successfully, False otherwise.
-    """
-    global _active_bridge
-
-    if _active_bridge is not None and _active_bridge._running:
-        logger.warning("Gateway bridge is already running")
-        print("Gateway bridge is already running")
-        return True
-
-    try:
-        _active_bridge = RNSMeshtasticBridge()
-        success = _active_bridge.start()
-
-        if success:
-            print("Gateway bridge started successfully")
-            mesh_ok = _active_bridge._mesh_handler.is_connected if _active_bridge._mesh_handler else False
-            print(f"  Meshtastic: {'Connected' if mesh_ok else 'Disconnected'}")
-            print(f"  RNS: {'Connected' if _active_bridge._connected_rns else 'Disconnected'}")
-        else:
-            print("Gateway bridge failed to start - check logs")
-
-        return success
-    except Exception as e:
-        logger.error(f"Failed to start gateway: {e}")
-        print(f"Failed to start gateway: {e}")
-        return False
-
-
-def stop_gateway_headless() -> bool:
-    """
-    Stop the gateway bridge (for CLI use).
-
-    Returns True if stopped successfully.
-    """
-    global _active_bridge
-
-    if _active_bridge is None:
-        print("No active gateway bridge to stop")
-        return True
-
-    try:
-        _active_bridge.stop()
-        _active_bridge = None
-        print("Gateway bridge stopped")
-        return True
-    except Exception as e:
-        logger.error(f"Error stopping gateway: {e}")
-        print(f"Error stopping gateway: {e}")
-        return False
-
-
-def get_gateway_stats() -> dict:
-    """
-    Get current gateway statistics (for CLI use).
-
-    Returns dict with bridge status and statistics.
-    """
-    global _active_bridge
-
-    if _active_bridge is None:
-        return {
-            'running': False,
-            'status': 'Not started',
-            'meshtastic_connected': False,
-            'rns_connected': False,
-            'messages_mesh_to_rns': 0,
-            'messages_rns_to_mesh': 0,
-            'errors': 0,
-            'bounced': 0,
-        }
-
-    try:
-        status = _active_bridge.get_status()
-        stats = status.get('statistics', {})
-        result = {
-            'running': _active_bridge._running,
-            'status': 'Running' if _active_bridge._running else 'Stopped',
-            'meshtastic_connected': _active_bridge._mesh_handler.is_connected if _active_bridge._mesh_handler else False,
-            'rns_connected': _active_bridge._connected_rns,
-            'messages_mesh_to_rns': stats.get('messages_mesh_to_rns', 0),
-            'messages_rns_to_mesh': stats.get('messages_rns_to_mesh', 0),
-            'errors': stats.get('errors', 0),
-            'bounced': stats.get('bounced', 0),
-            'uptime_seconds': status.get('uptime_seconds'),
-        }
-        # Include health metrics if available
-        if hasattr(_active_bridge, 'health'):
-            result['health'] = _active_bridge.health.get_summary()
-        # Include delivery confirmation stats
-        if hasattr(_active_bridge, 'delivery_tracker'):
-            result['delivery'] = _active_bridge.delivery_tracker.get_stats()
-        return result
-    except Exception as e:
-        logger.error(f"Error getting gateway stats: {e}")
-        return {
-            'running': False,
-            'status': f'Error: {e}',
-            'meshtastic_connected': False,
-            'rns_connected': False,
-            'messages_mesh_to_rns': 0,
-            'messages_rns_to_mesh': 0,
-            'errors': 0,
-            'bounced': 0,
-        }
-
-
-def is_gateway_running() -> bool:
-    """Check if gateway bridge is currently running."""
-    global _active_bridge
-    return _active_bridge is not None and _active_bridge._running
+# Extracted to gateway_cli.py; re-exported here for backward compatibility.
+from .gateway_cli import (  # noqa: F401, E402
+    start_gateway_headless,
+    stop_gateway_headless,
+    get_gateway_stats,
+    is_gateway_running,
+)

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -82,6 +82,8 @@ class StatusBar:
         self._cache_time: float = 0.0
         self._node_count: Optional[int] = None
         self._bridge_running: Optional[bool] = None
+        # Subsystem states (Phase 2: Circuit Breakers)
+        self._subsystem_states: Dict[str, str] = {}  # e.g. {"meshtastic": "healthy"}
         # Space weather (separate cache with longer TTL)
         self._space_weather: Optional[str] = None
         self._space_weather_time: float = 0.0
@@ -119,10 +121,10 @@ class StatusBar:
         if self._node_count is not None:
             parts.append(f"nodes:{self._node_count}")
 
-        # Bridge status
+        # Bridge status with subsystem detail
         if self._bridge_running is not None:
-            bridge_sym = SYM_RUNNING if self._bridge_running else SYM_STOPPED
-            parts.append(f"bridge:{bridge_sym}")
+            bridge_label = self._format_bridge_status()
+            parts.append(bridge_label)
 
         # Space weather (compact format: SFI:125 K:2)
         if self._space_weather:
@@ -228,6 +230,50 @@ class StatusBar:
             logger.debug(f"Space weather fetch failed: {e}")
             self._space_weather = None
 
+    def _format_bridge_status(self) -> str:
+        """Format bridge status with subsystem detail.
+
+        Returns compact status like:
+        - bridge:* (both healthy)
+        - bridge:DEGRADED(rns) (one side down)
+        - bridge:- (bridge not running)
+        """
+        if not self._bridge_running:
+            return f"bridge:{SYM_STOPPED}"
+
+        if not self._subsystem_states:
+            return f"bridge:{SYM_RUNNING}"
+
+        mesh_state = self._subsystem_states.get("meshtastic", "disconnected")
+        rns_state = self._subsystem_states.get("rns", "disconnected")
+
+        mesh_ok = mesh_state == "healthy"
+        rns_ok = rns_state == "healthy"
+
+        if mesh_ok and rns_ok:
+            return f"bridge:{SYM_RUNNING}"
+
+        # Build degraded indicator showing which side(s) are down
+        down = []
+        if not mesh_ok:
+            down.append("mesh")
+        if not rns_ok:
+            down.append("rns")
+
+        if len(down) == 2:
+            return "bridge:OFFLINE"
+
+        return f"bridge:DEGRADED({down[0]})"
+
+    def set_subsystem_states(self, states: Dict[str, str]) -> None:
+        """Update subsystem states from bridge health data.
+
+        Args:
+            states: Dict of subsystem name → state value string.
+                   e.g. {"meshtastic": "healthy", "rns": "disconnected"}
+        """
+        self._subsystem_states = states
+
     def set_node_count(self, count: int) -> None:
         """Update the displayed node count.
 
@@ -278,10 +324,24 @@ class StatusBar:
 
         Updates the cache immediately so the next dialog render shows
         the new state without waiting for the TTL-based refresh.
+        Also handles bridge subsystem state events (bridge_meshtastic,
+        bridge_rns) emitted by the Phase 2 circuit breaker code.
         """
         service_name = getattr(event, 'service_name', None)
         if not service_name:
             return
+
+        # Handle bridge subsystem state updates (Phase 2)
+        if service_name.startswith('bridge_'):
+            subsystem = service_name.removeprefix('bridge_')
+            message = getattr(event, 'message', '')
+            # Extract state from message like "meshtastic: healthy"
+            if ':' in message:
+                state_str = message.split(':', 1)[1].strip()
+                self._subsystem_states[subsystem] = state_str
+                logger.debug(f"StatusBar subsystem {subsystem}: {state_str}")
+            return
+
         available = getattr(event, 'available', None)
         if available is not None:
             self._cache[service_name] = SYM_RUNNING if available else SYM_STOPPED

--- a/tests/test_bridge_health.py
+++ b/tests/test_bridge_health.py
@@ -1,4 +1,4 @@
-"""Tests for BridgeHealthMonitor and error classification."""
+"""Tests for BridgeHealthMonitor, error classification, and SubsystemState."""
 
 import sys
 import os
@@ -18,6 +18,8 @@ from gateway.bridge_health import (
     classify_error,
     ConnectionEvent,
     ErrorEvent,
+    SubsystemState,
+    BridgeStatus,
 )
 
 
@@ -426,3 +428,144 @@ class TestDeliveryTracker:
         # History should be capped
         with tracker._lock:
             assert len(tracker._history) <= tracker.MAX_HISTORY
+
+
+# ---------------------------------------------------------------------------
+# SubsystemState (Phase 2: Circuit Breakers)
+# ---------------------------------------------------------------------------
+
+class TestSubsystemState:
+    """Test SubsystemState enum and BridgeHealthMonitor subsystem tracking."""
+
+    def test_enum_values(self):
+        """SubsystemState has correct values."""
+        assert SubsystemState.HEALTHY.value == "healthy"
+        assert SubsystemState.DEGRADED.value == "degraded"
+        assert SubsystemState.DISCONNECTED.value == "disconnected"
+        assert SubsystemState.DISABLED.value == "disabled"
+
+    def test_initial_state_is_disconnected(self):
+        """Subsystems start in DISCONNECTED state."""
+        health = BridgeHealthMonitor()
+        assert health.get_subsystem_state("meshtastic") == SubsystemState.DISCONNECTED
+        assert health.get_subsystem_state("rns") == SubsystemState.DISCONNECTED
+
+    def test_set_subsystem_state(self):
+        """Setting state returns previous state."""
+        health = BridgeHealthMonitor()
+        old = health.set_subsystem_state("rns", SubsystemState.HEALTHY)
+        assert old == SubsystemState.DISCONNECTED
+        assert health.get_subsystem_state("rns") == SubsystemState.HEALTHY
+
+    def test_set_subsystem_state_same_value(self):
+        """Setting same state is a no-op but returns same value."""
+        health = BridgeHealthMonitor()
+        health.set_subsystem_state("rns", SubsystemState.HEALTHY)
+        old = health.set_subsystem_state("rns", SubsystemState.HEALTHY)
+        assert old == SubsystemState.HEALTHY
+
+    def test_unknown_subsystem_returns_disconnected(self):
+        """Unknown subsystem defaults to DISCONNECTED."""
+        health = BridgeHealthMonitor()
+        assert health.get_subsystem_state("unknown") == SubsystemState.DISCONNECTED
+
+    def test_set_unknown_subsystem_returns_none(self):
+        """Setting unknown subsystem returns None."""
+        health = BridgeHealthMonitor()
+        result = health.set_subsystem_state("unknown", SubsystemState.HEALTHY)
+        assert result is None
+
+    def test_get_subsystem_states_dict(self):
+        """get_subsystem_states returns string-valued dict."""
+        health = BridgeHealthMonitor()
+        health.set_subsystem_state("meshtastic", SubsystemState.HEALTHY)
+        health.set_subsystem_state("rns", SubsystemState.DISCONNECTED)
+        states = health.get_subsystem_states()
+        assert states == {"meshtastic": "healthy", "rns": "disconnected"}
+
+    def test_subsystem_states_in_summary(self):
+        """get_summary includes subsystem states."""
+        health = BridgeHealthMonitor()
+        health.set_subsystem_state("meshtastic", SubsystemState.HEALTHY)
+        health.set_subsystem_state("rns", SubsystemState.DEGRADED)
+        summary = health.get_summary()
+        assert "subsystems" in summary
+        assert summary["subsystems"]["meshtastic"] == "healthy"
+        assert summary["subsystems"]["rns"] == "degraded"
+
+    def test_record_message_queued_degraded(self):
+        """Track messages queued during degraded state."""
+        health = BridgeHealthMonitor()
+        assert health.get_degraded_queue_count() == 0
+        health.record_message_queued_degraded()
+        health.record_message_queued_degraded()
+        assert health.get_degraded_queue_count() == 2
+
+    def test_messages_queued_degraded_in_summary(self):
+        """Summary includes queued-during-degraded count."""
+        health = BridgeHealthMonitor()
+        health.record_message_queued_degraded()
+        summary = health.get_summary()
+        assert summary["messages_queued_degraded"] == 1
+
+    def test_get_bridge_status_detailed(self):
+        """Detailed status includes subsystem states and degraded reason."""
+        health = BridgeHealthMonitor()
+        health.record_connection_event("meshtastic", "connected")
+        health.set_subsystem_state("meshtastic", SubsystemState.HEALTHY)
+        detailed = health.get_bridge_status_detailed()
+        assert "bridge_status" in detailed
+        assert "subsystems" in detailed
+        assert "degraded_reason" in detailed
+        assert detailed["subsystems"]["meshtastic"] == "healthy"
+
+    def test_independent_subsystem_lifecycle(self):
+        """Each subsystem transitions independently."""
+        health = BridgeHealthMonitor()
+        # Mesh comes up
+        health.set_subsystem_state("meshtastic", SubsystemState.HEALTHY)
+        # RNS still down
+        assert health.get_subsystem_state("rns") == SubsystemState.DISCONNECTED
+        # RNS comes up
+        health.set_subsystem_state("rns", SubsystemState.HEALTHY)
+        assert health.get_subsystem_state("meshtastic") == SubsystemState.HEALTHY
+        assert health.get_subsystem_state("rns") == SubsystemState.HEALTHY
+        # Mesh goes down
+        health.set_subsystem_state("meshtastic", SubsystemState.DISCONNECTED)
+        assert health.get_subsystem_state("rns") == SubsystemState.HEALTHY
+        assert health.get_subsystem_state("meshtastic") == SubsystemState.DISCONNECTED
+
+    def test_disabled_state(self):
+        """DISABLED state for permanently failed subsystems."""
+        health = BridgeHealthMonitor()
+        health.set_subsystem_state("rns", SubsystemState.DISABLED)
+        assert health.get_subsystem_state("rns") == SubsystemState.DISABLED
+        states = health.get_subsystem_states()
+        assert states["rns"] == "disabled"
+
+    def test_thread_safety(self):
+        """Concurrent state updates don't corrupt data."""
+        health = BridgeHealthMonitor()
+        states = [SubsystemState.HEALTHY, SubsystemState.DISCONNECTED,
+                  SubsystemState.DEGRADED, SubsystemState.DISABLED]
+        errors = []
+
+        def toggle(subsystem, iterations):
+            try:
+                for i in range(iterations):
+                    health.set_subsystem_state(subsystem, states[i % len(states)])
+                    health.get_subsystem_state(subsystem)
+                    health.get_subsystem_states()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=toggle, args=("meshtastic", 100)),
+            threading.Thread(target=toggle, args=("rns", 100)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert len(errors) == 0

--- a/tests/test_bridge_integration.py
+++ b/tests/test_bridge_integration.py
@@ -308,6 +308,8 @@ class TestRoundTrip:
     def test_roundtrip_with_bridge_loop_thread(self, bridge):
         """Test round trip using the bridge_loop thread for queue processing."""
         bridge._connected_rns = True
+        # Set handler as connected so subsystem state syncs to HEALTHY
+        bridge._mesh_handler._connected = True
 
         # Mock both send methods to succeed
         with patch.object(bridge, 'send_to_rns', return_value=True),              patch.object(bridge, 'send_to_meshtastic', return_value=True) as mock_mesh_send:

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -1188,53 +1188,53 @@ class TestRNSConnectionFlow:
 # ---------------------------------------------------------------------------
 
 class TestHeadlessHelpers:
-    """Tests for module-level helper functions."""
+    """Tests for module-level helper functions (extracted to gateway_cli.py)."""
 
     def test_is_gateway_running_no_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
-            mod._active_bridge = None
-            assert mod.is_gateway_running() is False
+            cli._active_bridge = None
+            assert cli.is_gateway_running() is False
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_is_gateway_running_with_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
             mock_bridge = MagicMock()
             mock_bridge._running = True
-            mod._active_bridge = mock_bridge
-            assert mod.is_gateway_running() is True
+            cli._active_bridge = mock_bridge
+            assert cli.is_gateway_running() is True
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_is_gateway_running_stopped_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
             mock_bridge = MagicMock()
             mock_bridge._running = False
-            mod._active_bridge = mock_bridge
-            assert mod.is_gateway_running() is False
+            cli._active_bridge = mock_bridge
+            assert cli.is_gateway_running() is False
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_get_gateway_stats_no_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
-            mod._active_bridge = None
-            stats = mod.get_gateway_stats()
+            cli._active_bridge = None
+            stats = cli.get_gateway_stats()
             assert stats['running'] is False
             assert stats['status'] == 'Not started'
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_get_gateway_stats_with_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
             mock_bridge = MagicMock()
             mock_bridge._running = True
@@ -1251,47 +1251,55 @@ class TestHeadlessHelpers:
             }
             mock_bridge.health.get_summary.return_value = {"status": "ok"}
             mock_bridge.delivery_tracker.get_stats.return_value = {"delivered": 2}
-            mod._active_bridge = mock_bridge
+            cli._active_bridge = mock_bridge
 
-            stats = mod.get_gateway_stats()
+            stats = cli.get_gateway_stats()
             assert stats['running'] is True
             assert stats['messages_mesh_to_rns'] == 3
             assert stats['health'] == {"status": "ok"}
             assert stats['delivery'] == {"delivered": 2}
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_stop_gateway_headless_no_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
-            mod._active_bridge = None
-            assert mod.stop_gateway_headless() is True
+            cli._active_bridge = None
+            assert cli.stop_gateway_headless() is True
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_stop_gateway_headless_with_bridge(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
             mock_bridge = MagicMock()
-            mod._active_bridge = mock_bridge
-            assert mod.stop_gateway_headless() is True
+            cli._active_bridge = mock_bridge
+            assert cli.stop_gateway_headless() is True
             mock_bridge.stop.assert_called_once()
-            assert mod._active_bridge is None
+            assert cli._active_bridge is None
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
 
     def test_stop_gateway_headless_error(self):
-        import gateway.rns_bridge as mod
-        original = mod._active_bridge
+        import gateway.gateway_cli as cli
+        original = cli._active_bridge
         try:
             mock_bridge = MagicMock()
             mock_bridge.stop.side_effect = RuntimeError("stop fail")
-            mod._active_bridge = mock_bridge
-            assert mod.stop_gateway_headless() is False
+            cli._active_bridge = mock_bridge
+            assert cli.stop_gateway_headless() is False
         finally:
-            mod._active_bridge = original
+            cli._active_bridge = original
+
+    def test_reexport_from_rns_bridge(self):
+        """Verify backward-compatible re-export from rns_bridge."""
+        import gateway.rns_bridge as mod
+        assert hasattr(mod, 'start_gateway_headless')
+        assert hasattr(mod, 'stop_gateway_headless')
+        assert hasattr(mod, 'get_gateway_stats')
+        assert hasattr(mod, 'is_gateway_running')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -456,3 +456,94 @@ class TestStatusBarEdgeCases:
                 for _ in range(100):
                     line = bar.get_status_line()
                     assert isinstance(line, str)
+
+
+class TestSubsystemStatusDisplay:
+    """Test bridge status with subsystem states (Phase 2)."""
+
+    def test_bridge_healthy_both_subsystems(self):
+        """Both subsystems healthy shows running symbol."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "healthy", "rns": "healthy"})
+        result = bar._format_bridge_status()
+        assert result == "bridge:*"
+
+    def test_bridge_degraded_rns_down(self):
+        """RNS subsystem down shows DEGRADED(rns)."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "healthy", "rns": "disconnected"})
+        result = bar._format_bridge_status()
+        assert result == "bridge:DEGRADED(rns)"
+
+    def test_bridge_degraded_mesh_down(self):
+        """Meshtastic subsystem down shows DEGRADED(mesh)."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "disconnected", "rns": "healthy"})
+        result = bar._format_bridge_status()
+        assert result == "bridge:DEGRADED(mesh)"
+
+    def test_bridge_offline_both_down(self):
+        """Both subsystems down shows OFFLINE."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "disconnected", "rns": "disconnected"})
+        result = bar._format_bridge_status()
+        assert result == "bridge:OFFLINE"
+
+    def test_bridge_not_running(self):
+        """Bridge not running shows stopped symbol."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = False
+        result = bar._format_bridge_status()
+        assert result == "bridge:-"
+
+    def test_bridge_running_no_subsystem_data(self):
+        """Bridge running but no subsystem data shows running symbol."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        result = bar._format_bridge_status()
+        assert result == "bridge:*"
+
+    def test_disabled_subsystem_treated_as_down(self):
+        """DISABLED subsystem treated as not healthy."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "healthy", "rns": "disabled"})
+        result = bar._format_bridge_status()
+        assert result == "bridge:DEGRADED(rns)"
+
+    def test_subsystem_states_in_status_line(self):
+        """Subsystem state appears in full status line."""
+        bar = StatusBar(version="1.0")
+        bar._bridge_running = True
+        bar.set_subsystem_states({"meshtastic": "healthy", "rns": "disconnected"})
+        with patch.object(bar, '_refresh_if_stale'):
+            line = bar.get_status_line()
+            assert "DEGRADED(rns)" in line
+
+    def test_event_updates_subsystem_state(self):
+        """ServiceEvent with bridge_ prefix updates subsystem state."""
+        bar = StatusBar(version="1.0")
+
+        class FakeEvent:
+            service_name = "bridge_rns"
+            available = False
+            message = "rns: disconnected"
+
+        bar._on_service_event(FakeEvent())
+        assert bar._subsystem_states.get("rns") == "disconnected"
+
+    def test_event_healthy_subsystem(self):
+        """ServiceEvent for healthy bridge subsystem."""
+        bar = StatusBar(version="1.0")
+
+        class FakeEvent:
+            service_name = "bridge_meshtastic"
+            available = True
+            message = "meshtastic: healthy"
+
+        bar._on_service_event(FakeEvent())
+        assert bar._subsystem_states.get("meshtastic") == "healthy"


### PR DESCRIPTION
Bridge now treats Meshtastic and RNS as independent subsystems with their own lifecycle states (HEALTHY/DEGRADED/DISCONNECTED/DISABLED). When one side goes down, the other continues operating and messages are queued to persistent SQLite storage for later delivery.

Key changes:
- SubsystemState enum in bridge_health.py with per-subsystem tracking
- Bridge loop checks destination subsystem state before processing messages
- Degraded-mode message queueing via persistent queue (message_queue.py)
- Status bar shows bridge:DEGRADED(rns) or bridge:DEGRADED(mesh) when partial
- Extracted gateway_cli.py (115 lines) to keep rns_bridge.py under 1,500 lines
- EventBus integration for real-time subsystem state propagation to status bar

Tests: 4046 passed (+25 new), 19 skipped, 0 failed

https://claude.ai/code/session_01Gomn7hvnJjuvDS1dN2sWgL