### PR TITLE
feat: wire event bus for real-time RX message propagation (Issue #17 …

### DIFF
--- a/src/gateway/mqtt_bridge_handler.py
+++ b/src/gateway/mqtt_bridge_handler.py
@@ -386,6 +386,26 @@ class MQTTBridgeHandler:
             except Exception as e:
                 logger.error(f"Message callback error: {e}")
 
+        # Emit to event bus for TUI live feed (Issue #17 Phase 3)
+        try:
+            from utils.event_bus import emit_message
+            emit_message(
+                direction='rx',
+                content=text,
+                node_id=sender,
+                channel=channel,
+                network='meshtastic',
+                raw_data={
+                    'to_id': to_id,
+                    'is_broadcast': is_broadcast,
+                    'mqtt_topic': topic,
+                    'msg_id': data.get('id'),
+                    'timestamp': data.get('timestamp'),
+                }
+            )
+        except Exception as e:
+            logger.debug(f"Event bus emit failed: {e}")
+
     def _update_node_from_mqtt(self, data: dict) -> None:
         """Update node tracker from MQTT message data."""
         try:

--- a/src/launcher_tui/messaging_mixin.py
+++ b/src/launcher_tui/messaging_mixin.py
@@ -19,6 +19,7 @@ class MessagingMixin:
         while True:
             choices = [
                 ("send", "Send Message        Send to node or broadcast"),
+                ("live", "Live Feed           Real-time message stream"),
                 ("messages", "View Messages       Recent message history"),
                 ("convos", "Conversations       Message threads by node"),
                 ("stats", "Statistics          Message counts & rates"),
@@ -40,6 +41,7 @@ class MessagingMixin:
 
             dispatch = {
                 "send": ("Send Message", self._messaging_send),
+                "live": ("Live Feed", self._messaging_live_feed),
                 "messages": ("View Messages", self._messaging_view),
                 "convos": ("Conversations", self._messaging_conversations),
                 "stats": ("Statistics", self._messaging_stats),
@@ -51,6 +53,66 @@ class MessagingMixin:
             entry = dispatch.get(choice)
             if entry:
                 self._safe_call(*entry)
+
+    def _messaging_live_feed(self):
+        """Live message feed — event-bus-driven real-time RX display.
+
+        Subscribes to the event bus and displays messages as they arrive.
+        Press Enter to stop and return to menu.
+        """
+        import threading
+
+        try:
+            from utils.event_bus import event_bus
+        except ImportError:
+            self.dialog.msgbox("Unavailable", "Event bus module not available.\nFile: src/utils/event_bus.py")
+            return
+
+        clear_screen()
+        print("=== Live Message Feed ===")
+        print("  Listening for mesh messages via event bus...")
+        print("  Press Enter to stop.\n")
+        print(f"  {'Time':<10} {'Dir':<4} {'From':<14} {'Ch':<4} {'Net':<6} Message")
+        print(f"  {'-'*65}")
+
+        msg_count = [0]  # Mutable counter for closure
+
+        def _on_message(event):
+            """Print incoming message event to terminal."""
+            direction = getattr(event, 'direction', '?')
+            arrow = '<-' if direction == 'rx' else '->'
+            ts = getattr(event, 'timestamp', None)
+            time_str = ts.strftime("%H:%M:%S") if ts else "??:??:??"
+            node = getattr(event, 'node_name', '') or getattr(event, 'node_id', '') or '?'
+            if len(node) > 12:
+                node = node[:12]
+            channel = getattr(event, 'channel', 0)
+            network = getattr(event, 'network', '?')
+            content = getattr(event, 'content', '')
+            if len(content) > 35:
+                content = content[:32] + "..."
+
+            print(f"  {time_str:<10} {arrow:<4} {node:<14} {channel:<4} {network:<6} {content}")
+            msg_count[0] += 1
+
+        # Subscribe
+        event_bus.subscribe('message', _on_message)
+
+        # Clear unread count in status bar
+        if hasattr(self, 'status_bar'):
+            self.status_bar.clear_unread()
+
+        try:
+            # Block until user presses Enter
+            input()
+        except (EOFError, KeyboardInterrupt):
+            pass
+        finally:
+            event_bus.unsubscribe('message', _on_message)
+
+        print(f"\n  Stopped. {msg_count[0]} messages received during session.")
+        print()
+        self._wait_for_enter()
 
     def _messaging_send(self):
         """Send a message via mesh network."""
@@ -114,6 +176,10 @@ class MessagingMixin:
 
     def _messaging_view(self):
         """View recent messages."""
+        # Clear unread count when viewing
+        if hasattr(self, 'status_bar'):
+            self.status_bar.clear_unread()
+
         clear_screen()
         print("=== Recent Messages ===\n")
 

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -94,6 +94,8 @@ class StatusBar:
             self._startup_checker = StartupChecker()
         # Event-driven status updates from ActiveHealthProbe
         self._event_subscribed = False
+        # Unread message counter (Issue #17 Phase 3)
+        self._unread_messages = 0
         self._subscribe_to_events()
 
     def get_status_line(self) -> str:
@@ -125,6 +127,10 @@ class StatusBar:
         if self._bridge_running is not None:
             bridge_label = self._format_bridge_status()
             parts.append(bridge_label)
+
+        # Unread message count (Issue #17 Phase 3)
+        if self._unread_messages > 0:
+            parts.append(f"msg:{self._unread_messages}")
 
         # Space weather (compact format: SFI:125 K:2)
         if self._space_weather:
@@ -314,8 +320,9 @@ class StatusBar:
         try:
             from utils.event_bus import event_bus
             event_bus.subscribe('service', self._on_service_event)
+            event_bus.subscribe('message', self._on_message_event)
             self._event_subscribed = True
-            logger.debug("StatusBar subscribed to EventBus service events")
+            logger.debug("StatusBar subscribed to EventBus service+message events")
         except ImportError:
             logger.debug("EventBus not available — StatusBar will poll only")
 
@@ -349,6 +356,21 @@ class StatusBar:
                 f"StatusBar updated {service_name} via event: "
                 f"{'running' if available else 'stopped'}"
             )
+
+    def _on_message_event(self, event) -> None:
+        """Handle a MessageEvent from the EventBus.
+
+        Increments the unread message counter shown in the status bar.
+        Counter is reset when the user views messages.
+        """
+        direction = getattr(event, 'direction', '')
+        if direction == 'rx':
+            self._unread_messages += 1
+            logger.debug(f"StatusBar unread count: {self._unread_messages}")
+
+    def clear_unread(self) -> None:
+        """Reset unread message counter (called when user views messages)."""
+        self._unread_messages = 0
 
     # =========================================================================
     # Enhanced Status Methods (v0.4.8)

--- a/src/utils/message_listener.py
+++ b/src/utils/message_listener.py
@@ -121,6 +121,28 @@ class MessageListener:
             if callback in self._callbacks:
                 self._callbacks.remove(callback)
 
+    def _emit_message_event(self, msg_data: dict) -> None:
+        """Emit a message event to the event bus for TUI live feed."""
+        try:
+            from utils.event_bus import emit_message
+            emit_message(
+                direction='rx',
+                content=msg_data.get('content', ''),
+                node_id=msg_data.get('from_id', ''),
+                channel=msg_data.get('channel', 0),
+                network='meshtastic',
+                raw_data={
+                    'to_id': msg_data.get('to_id'),
+                    'is_broadcast': msg_data.get('is_broadcast', False),
+                    'snr': msg_data.get('snr'),
+                    'rssi': msg_data.get('rssi'),
+                    'hops_away': msg_data.get('hops_away'),
+                    'via_mqtt': msg_data.get('via_mqtt', False),
+                }
+            )
+        except Exception as e:
+            logger.debug(f"Event bus emit failed: {e}")
+
     def get_status(self) -> ListenerStatus:
         """Get current listener status."""
         return self._status
@@ -462,6 +484,9 @@ class MessageListener:
                 except Exception as e:
                     logger.error(f"Callback error: {e}")
 
+        # Emit to event bus for TUI live feed (Issue #17 Phase 3)
+        self._emit_message_event(msg_data)
+
     def _handle_telemetry(self, packet, decoded, from_id):
         """Handle TELEMETRY_APP packets - sensor data."""
         try:
@@ -643,6 +668,9 @@ class MessageListener:
                         callback(msg_data)
                     except Exception as e:
                         logger.error(f"Callback error: {e}")
+
+            # Emit to event bus for TUI live feed (Issue #17 Phase 3)
+            self._emit_message_event(msg_data)
 
         except Exception as e:
             logger.error(f"Error processing MQTT message: {e}")

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -335,3 +335,150 @@ class TestGlobalEventBus:
             assert len(received) == 1
         finally:
             event_bus.unsubscribe('singleton_test', callback)
+
+
+class TestStatusBarMessageEvents:
+    """Tests for StatusBar event bus integration (Issue #17 Phase 3)."""
+
+    def test_status_bar_message_counter(self):
+        """Test that StatusBar counts unread RX messages."""
+        from src.launcher_tui.status_bar import StatusBar
+
+        bar = StatusBar(version="0.5.4")
+        bar._unread_messages = 0
+
+        # Simulate RX message event
+        rx_event = MessageEvent(
+            direction='rx',
+            content='Hello mesh',
+            node_id='!abc123',
+        )
+        bar._on_message_event(rx_event)
+        assert bar._unread_messages == 1
+
+        bar._on_message_event(rx_event)
+        assert bar._unread_messages == 2
+
+    def test_status_bar_ignores_tx(self):
+        """Test that StatusBar ignores TX messages for unread count."""
+        from src.launcher_tui.status_bar import StatusBar
+
+        bar = StatusBar(version="0.5.4")
+        bar._unread_messages = 0
+
+        tx_event = MessageEvent(
+            direction='tx',
+            content='Outgoing',
+            node_id='!abc123',
+        )
+        bar._on_message_event(tx_event)
+        assert bar._unread_messages == 0
+
+    def test_status_bar_clear_unread(self):
+        """Test clearing unread message counter."""
+        from src.launcher_tui.status_bar import StatusBar
+
+        bar = StatusBar(version="0.5.4")
+        bar._unread_messages = 5
+        bar.clear_unread()
+        assert bar._unread_messages == 0
+
+    def test_status_bar_shows_msg_count(self):
+        """Test that unread count appears in status line."""
+        from src.launcher_tui.status_bar import StatusBar
+
+        bar = StatusBar(version="0.5.4")
+        bar._unread_messages = 3
+        line = bar.get_status_line()
+        assert 'msg:3' in line
+
+    def test_status_bar_hides_zero_count(self):
+        """Test that zero unread count is not shown."""
+        from src.launcher_tui.status_bar import StatusBar
+
+        bar = StatusBar(version="0.5.4")
+        bar._unread_messages = 0
+        line = bar.get_status_line()
+        assert 'msg:' not in line
+
+
+class TestMessageListenerEventBus:
+    """Tests for MessageListener event bus integration (Issue #17 Phase 3)."""
+
+    def test_emit_message_event_helper(self):
+        """Test that _emit_message_event calls emit_message with correct args."""
+        from src.utils.message_listener import MessageListener
+
+        listener = MessageListener()
+
+        msg_data = {
+            'from_id': '!abc123',
+            'content': 'Test message',
+            'channel': 0,
+            'is_broadcast': False,
+            'snr': 10.5,
+            'rssi': -90,
+            'hops_away': 1,
+            'to_id': '!def456',
+            'via_mqtt': False,
+        }
+
+        with patch('utils.event_bus.emit_message') as mock_emit:
+            listener._emit_message_event(msg_data)
+            mock_emit.assert_called_once()
+            call_kwargs = mock_emit.call_args
+            # Check positional/keyword args
+            assert call_kwargs.kwargs.get('direction') == 'rx' or call_kwargs[1].get('direction') == 'rx'
+            assert call_kwargs.kwargs.get('content') == 'Test message' or call_kwargs[1].get('content') == 'Test message'
+            assert call_kwargs.kwargs.get('node_id') == '!abc123' or call_kwargs[1].get('node_id') == '!abc123'
+
+    def test_emit_message_event_includes_raw_data(self):
+        """Test that raw_data includes signal quality info."""
+        from src.utils.message_listener import MessageListener
+
+        listener = MessageListener()
+
+        msg_data = {
+            'from_id': '!abc123',
+            'content': 'Signal test',
+            'channel': 2,
+            'is_broadcast': True,
+            'snr': 8.0,
+            'rssi': -95,
+            'hops_away': 3,
+            'to_id': None,
+            'via_mqtt': True,
+        }
+
+        with patch('utils.event_bus.emit_message') as mock_emit:
+            listener._emit_message_event(msg_data)
+            mock_emit.assert_called_once()
+            call_kwargs = mock_emit.call_args
+            raw = call_kwargs.kwargs.get('raw_data') or call_kwargs[1].get('raw_data')
+            assert raw['snr'] == 8.0
+            assert raw['rssi'] == -95
+            assert raw['hops_away'] == 3
+            assert raw['via_mqtt'] is True
+            assert raw['is_broadcast'] is True
+
+    def test_emit_message_event_handles_import_error(self):
+        """Test that _emit_message_event fails silently if event bus unavailable."""
+        from src.utils.message_listener import MessageListener
+
+        listener = MessageListener()
+
+        msg_data = {
+            'from_id': '!abc123',
+            'content': 'Test',
+            'channel': 0,
+            'is_broadcast': False,
+            'snr': None,
+            'rssi': None,
+            'hops_away': None,
+            'to_id': None,
+            'via_mqtt': False,
+        }
+
+        # Should not raise even if import fails
+        with patch('builtins.__import__', side_effect=ImportError("no event bus")):
+            listener._emit_message_event(msg_data)  # Should not raise


### PR DESCRIPTION
…Phase 3)

Publishers: MQTT bridge handler and message listener now emit message events to the event bus when RX messages arrive, joining the existing rns_bridge.py publisher.

Subscribers: Status bar shows unread message count (msg:N). Messaging mixin adds Live Feed view for real-time event-bus-driven message display.

Tests: 8 new tests covering status bar message counting, listener event emission, and error handling. 28/28 passing.

https://claude.ai/code/session_01AS2aXSvLHzuuTjDyW6s8xs