### PR TITLE
refactor: consolidate except ImportError blocks with safe_import (35 …

### DIFF
--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -48,7 +48,27 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
+
+# Module-level safe imports for optional dependencies
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+_create_gateway_config_api, _HAS_CONFIG_API = safe_import(
+    'utils.config_api', 'create_gateway_config_api'
+)
+_SharedHealthState, _HAS_HEALTH_STATE = safe_import(
+    'utils.shared_health_state', 'SharedHealthState'
+)
+_create_gateway_health_probe, _HAS_HEALTH_PROBE = safe_import(
+    'utils.active_health_probe', 'create_gateway_health_probe'
+)
+_integrate_with_active_probe, _HAS_HEALTH_INTEGRATE = safe_import(
+    'utils.shared_health_state', 'integrate_with_active_probe'
+)
+_PrometheusExporter, _HAS_METRICS = safe_import(
+    'utils.metrics_export', 'PrometheusExporter'
+)
 
 
 # =============================================================================
@@ -108,10 +128,9 @@ class AgentConfig:
         # Set default data directory
         if not self.data_dir:
             # Use real user's home for sudo compatibility
-            try:
-                from utils.paths import get_real_user_home
-                home = get_real_user_home()
-            except ImportError:
+            if _HAS_PATHS:
+                home = _get_real_user_home()
+            else:
                 import os as _os
                 _sudo_user = _os.environ.get('SUDO_USER', '')
                 if _sudo_user and _sudo_user != 'root' and '/' not in _sudo_user and '..' not in _sudo_user:
@@ -324,23 +343,23 @@ class AgentDaemon:
 
     def _init_config_api(self) -> None:
         """Initialize Configuration API."""
+        if not _HAS_CONFIG_API:
+            logger.warning("Configuration API not available: module not found")
+            return
         try:
-            from utils.config_api import create_gateway_config_api
-            self._config_api = create_gateway_config_api()
+            self._config_api = _create_gateway_config_api()
             logger.info("Configuration API initialized")
-        except ImportError as e:
-            logger.warning(f"Configuration API not available: {e}")
         except Exception as e:
             logger.error(f"Failed to initialize Configuration API: {e}")
 
     def _init_health_state(self) -> None:
         """Initialize shared health state."""
+        if not _HAS_HEALTH_STATE:
+            logger.warning("Shared health state not available: module not found")
+            return
         try:
-            from utils.shared_health_state import SharedHealthState
-            self._health_state = SharedHealthState()
+            self._health_state = _SharedHealthState()
             logger.info("Shared health state initialized")
-        except ImportError as e:
-            logger.warning(f"Shared health state not available: {e}")
         except Exception as e:
             logger.error(f"Failed to initialize shared health state: {e}")
 

--- a/src/commands/gateway.py
+++ b/src/commands/gateway.py
@@ -12,8 +12,20 @@ import logging
 from typing import Optional, Dict, Any
 
 from .base import CommandResult
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# Optional dependencies — safe_import returns (*attrs, available_bool)
+RNSMeshtasticBridge, _HAS_BRIDGE = safe_import(
+    'gateway.rns_bridge', 'RNSMeshtasticBridge'
+)
+RNSOverMeshtasticConfig, _HAS_TRANSPORT_CONFIG = safe_import(
+    'gateway.config', 'RNSOverMeshtasticConfig'
+)
+create_rns_transport, RNSMeshtasticTransport, _HAS_TRANSPORT = safe_import(
+    'gateway.rns_transport', 'create_rns_transport', 'RNSMeshtasticTransport'
+)
 
 # Module-level bridge instance (singleton pattern)
 _bridge_instance = None
@@ -33,13 +45,12 @@ def _get_bridge():
     if _bridge_instance is not None:
         return _bridge_instance
 
-    try:
-        from gateway.rns_bridge import RNSMeshtasticBridge
-        _bridge_instance = RNSMeshtasticBridge()
-        return _bridge_instance
-    except ImportError as e:
-        logger.warning(f"Gateway bridge not available: {e}")
+    if not _HAS_BRIDGE:
+        logger.warning("Gateway bridge not available: gateway.rns_bridge not installed")
         return None
+
+    _bridge_instance = RNSMeshtasticBridge()
+    return _bridge_instance
 
 
 def get_status() -> CommandResult:
@@ -576,30 +587,33 @@ def check_prerequisites() -> CommandResult:
     # Note: Use BaseException to catch pyo3 PanicException (not an Exception subclass)
     # from RNS's cryptography library when cffi backend is missing
     try:
-        import RNS
-        checks['rns_package'] = True
-    except ImportError:
-        issues.append("RNS package not installed (pipx install rns)")
+        _, _HAS_RNS = safe_import('RNS')
+        if _HAS_RNS:
+            checks['rns_package'] = True
+        else:
+            issues.append("RNS package not installed (pipx install rns)")
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:
         issues.append(f"RNS package error: {e}")
 
     try:
-        import LXMF
-        checks['lxmf_package'] = True
-    except ImportError:
-        issues.append("LXMF package not installed (pip install lxmf)")
+        _, _HAS_LXMF = safe_import('LXMF')
+        if _HAS_LXMF:
+            checks['lxmf_package'] = True
+        else:
+            issues.append("LXMF package not installed (pip install lxmf)")
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:
         issues.append(f"LXMF package error: {e}")
 
     try:
-        import meshtastic
-        checks['meshtastic_package'] = True
-    except ImportError:
-        issues.append("meshtastic package not installed (pip install meshtastic)")
+        _, _HAS_MESHTASTIC = safe_import('meshtastic')
+        if _HAS_MESHTASTIC:
+            checks['meshtastic_package'] = True
+        else:
+            issues.append("meshtastic package not installed (pip install meshtastic)")
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:
@@ -621,11 +635,7 @@ def check_prerequisites() -> CommandResult:
 
 def is_available() -> bool:
     """Check if gateway functionality is available."""
-    try:
-        from gateway.rns_bridge import RNSMeshtasticBridge
-        return True
-    except ImportError:
-        return False
+    return _HAS_BRIDGE
 
 
 # ============================================================================
@@ -693,10 +703,13 @@ def start_transport(
             data=_transport_instance.get_status()
         )
 
-    try:
-        from gateway.config import RNSOverMeshtasticConfig
-        from gateway.rns_transport import create_rns_transport
+    if not _HAS_TRANSPORT_CONFIG or not _HAS_TRANSPORT:
+        return CommandResult.not_available(
+            "Transport module not available: gateway.rns_transport not installed",
+            fix_hint="Ensure gateway module is installed"
+        )
 
+    try:
         # Create configuration
         config = RNSOverMeshtasticConfig(
             enabled=True,
@@ -720,11 +733,6 @@ def start_transport(
             _transport_instance = None
             return CommandResult.fail("Failed to start transport")
 
-    except ImportError as e:
-        return CommandResult.not_available(
-            f"Transport module not available: {e}",
-            fix_hint="Ensure gateway module is installed"
-        )
     except Exception as e:
         return CommandResult.fail(f"Error starting transport: {e}")
 
@@ -927,8 +935,4 @@ def get_transport_presets() -> CommandResult:
 
 def is_transport_available() -> bool:
     """Check if transport functionality is available."""
-    try:
-        from gateway.rns_transport import RNSMeshtasticTransport
-        return True
-    except ImportError:
-        return False
+    return _HAS_TRANSPORT

--- a/src/commands/messaging.py
+++ b/src/commands/messaging.py
@@ -34,15 +34,28 @@ from dataclasses import dataclass, field
 from .base import CommandResult
 from utils.paths import get_real_user_home
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
 
-# Import event bus for TX event emission
-try:
-    from utils.event_bus import emit_message as _emit_message
-    _HAS_EVENT_BUS = True
-except ImportError:
-    _emit_message = None
-    _HAS_EVENT_BUS = False
+# Optional dependencies — module-level safe imports
+_emit_message, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_message')
+
+_RNSMeshtasticBridge, _HAS_GATEWAY_MODULE = safe_import(
+    'gateway', 'RNSMeshtasticBridge'
+)
+
+_cmd_gateway, _HAS_CMD_GATEWAY = safe_import('commands.gateway')
+
+_cmd_meshtastic, _HAS_CMD_MESHTASTIC = safe_import('commands.meshtastic')
+
+(_start_listener, _get_listener, _stop_listener,
+ _get_listener_status, _diagnose_pubsub,
+ _HAS_MSG_LISTENER) = safe_import(
+    'utils.message_listener',
+    'start_listener', 'get_listener', 'stop_listener',
+    'get_listener_status', 'diagnose_pubsub',
+)
 
 # Maximum message length before chunking
 MAX_MESSAGE_LENGTH = 160
@@ -203,13 +216,9 @@ def send_message(
     chunks = _chunk_message(content)
 
     try:
-        # Get bridge instance
-        try:
-            from gateway import RNSMeshtasticBridge
-            # Would get active bridge here
-            # bridge = get_active_bridge()
-        except ImportError:
-            pass
+        # Get bridge instance (if available)
+        # _HAS_GATEWAY_MODULE / _RNSMeshtasticBridge checked at module level
+        # bridge = get_active_bridge()  # Would get active bridge here
 
         # Store message
         conn = _init_db()
@@ -232,19 +241,19 @@ def send_message(
         if network == "meshtastic":
             # Try gateway first, then fall back to direct CLI
             gateway_available = False
-            try:
-                from commands import gateway
-                status = gateway.get_status()
-                if status.success and status.data.get('running') and status.data.get('meshtastic_connected'):
-                    gateway_available = True
-            except Exception:
-                pass
+            if _HAS_CMD_GATEWAY:
+                try:
+                    status = _cmd_gateway.get_status()
+                    if status.success and status.data.get('running') and status.data.get('meshtastic_connected'):
+                        gateway_available = True
+                except Exception:
+                    pass
 
             if gateway_available:
                 # Use gateway bridge
                 try:
                     for chunk in chunks:
-                        result = gateway.send_to_meshtastic(chunk, destination, channel)
+                        result = _cmd_gateway.send_to_meshtastic(chunk, destination, channel)
                         if not result.success:
                             send_error = result.message
                             break
@@ -258,60 +267,62 @@ def send_message(
 
             # Fallback to direct meshtastic CLI if gateway failed
             if not send_success:
-                try:
-                    from commands import meshtastic as mesh_cmd
-
-                    for chunk in chunks:
-                        # Use send_dm for direct messages, send_broadcast for channels
-                        if destination and destination != '!ffffffff':
-                            result = mesh_cmd.send_dm(
-                                text=chunk,
-                                dest=destination,
-                                ack=False,
-                                high_reliability=high_reliability
-                            )
+                if not _HAS_CMD_MESHTASTIC:
+                    if not send_error:
+                        send_error = "meshtastic module not available"
+                else:
+                    try:
+                        for chunk in chunks:
+                            # Use send_dm for direct messages, send_broadcast for channels
+                            if destination and destination != '!ffffffff':
+                                result = _cmd_meshtastic.send_dm(
+                                    text=chunk,
+                                    dest=destination,
+                                    ack=False,
+                                    high_reliability=high_reliability
+                                )
+                            else:
+                                result = _cmd_meshtastic.send_broadcast(
+                                    text=chunk,
+                                    channel_index=channel if channel > 0 else 1,
+                                    hop_limit=7 if high_reliability else 3
+                                )
+                            if not result.success:
+                                send_error = result.message
+                                break
                         else:
-                            result = mesh_cmd.send_broadcast(
-                                text=chunk,
-                                channel_index=channel if channel > 0 else 1,
-                                hop_limit=7 if high_reliability else 3
+                            send_success = True
+                            send_error = None  # Clear any previous error
+                    except Exception as e:
+                        if not send_error:  # Don't overwrite gateway error
+                            send_error = f"Direct send failed: {e}"
+                        logger.error(f"Failed to send via direct meshtastic: {e}")
+
+        elif network == "rns":
+            # RNS messages go through gateway only
+            if not _HAS_CMD_GATEWAY:
+                send_error = "Gateway module not available"
+            else:
+                try:
+                    # Validate destination is valid hex before attempting conversion
+                    if destination:
+                        clean_dest = destination.lstrip('!')
+                        if not all(c in '0123456789abcdefABCDEF' for c in clean_dest):
+                            return CommandResult.fail(
+                                f"Invalid RNS destination: {destination}\n"
+                                "Must be a hex hash (e.g. a1b2c3d4e5f6...)"
                             )
+                    for chunk in chunks:
+                        dest_bytes = bytes.fromhex(destination.lstrip('!')) if destination else None
+                        result = _cmd_gateway.send_to_rns(chunk, dest_bytes)
                         if not result.success:
                             send_error = result.message
                             break
                     else:
                         send_success = True
-                        send_error = None  # Clear any previous error
                 except Exception as e:
-                    if not send_error:  # Don't overwrite gateway error
-                        send_error = f"Direct send failed: {e}"
-                    logger.error(f"Failed to send via direct meshtastic: {e}")
-
-        elif network == "rns":
-            # RNS messages go through gateway only
-            try:
-                from commands import gateway
-                # Validate destination is valid hex before attempting conversion
-                if destination:
-                    clean_dest = destination.lstrip('!')
-                    if not all(c in '0123456789abcdefABCDEF' for c in clean_dest):
-                        return CommandResult.fail(
-                            f"Invalid RNS destination: {destination}\n"
-                            "Must be a hex hash (e.g. a1b2c3d4e5f6...)"
-                        )
-                for chunk in chunks:
-                    dest_bytes = bytes.fromhex(destination.lstrip('!')) if destination else None
-                    result = gateway.send_to_rns(chunk, dest_bytes)
-                    if not result.success:
-                        send_error = result.message
-                        break
-                else:
-                    send_success = True
-            except ImportError as e:
-                send_error = f"Gateway module not available: {e}"
-            except Exception as e:
-                send_error = f"RNS send failed: {e}"
-                logger.error(f"Failed to send via RNS: {e}")
+                    send_error = f"RNS send failed: {e}"
+                    logger.error(f"Failed to send via RNS: {e}")
 
         # Update delivery status
         if send_success:
@@ -657,13 +668,17 @@ def start_receiving(
             print(f"New message from {msg['from_id']}: {msg['content']}")
         result = messaging.start_receiving(callback=on_message)
     """
-    try:
-        from utils.message_listener import start_listener, get_listener
+    if not _HAS_MSG_LISTENER:
+        return CommandResult.fail(
+            "Message listener not available",
+            fix_hint="Ensure utils/message_listener.py exists"
+        )
 
-        success = start_listener(host=host)
+    try:
+        success = _start_listener(host=host)
 
         if callback:
-            listener = get_listener()
+            listener = _get_listener()
             listener.add_callback(callback)
 
         if success:
@@ -681,11 +696,6 @@ def start_receiving(
                 error="Could not connect to meshtastic"
             )
 
-    except ImportError as e:
-        return CommandResult.fail(
-            f"Message listener not available: {e}",
-            fix_hint="Ensure utils/message_listener.py exists"
-        )
     except Exception as e:
         logger.error(f"Failed to start receiving: {e}")
         return CommandResult.fail(f"Failed to start listener: {e}")
@@ -698,9 +708,11 @@ def stop_receiving() -> CommandResult:
     Returns:
         CommandResult with status
     """
+    if not _HAS_MSG_LISTENER:
+        return CommandResult.fail("Error stopping listener: module not available")
+
     try:
-        from utils.message_listener import stop_listener
-        stop_listener()
+        _stop_listener()
         return CommandResult.ok("Message listener stopped")
     except Exception as e:
         return CommandResult.fail(f"Error stopping listener: {e}")
@@ -713,18 +725,17 @@ def get_rx_status() -> CommandResult:
     Returns:
         CommandResult with listener state, message count, etc.
     """
-    try:
-        from utils.message_listener import get_listener_status
-        status = get_listener_status()
-        return CommandResult.ok(
-            f"RX status: {status['state']}",
-            data=status
-        )
-    except ImportError:
+    if not _HAS_MSG_LISTENER:
         return CommandResult.ok(
             "RX status: not initialized",
             data={'state': 'disconnected', 'error': 'Listener not available'}
         )
+
+    status = _get_listener_status()
+    return CommandResult.ok(
+        f"RX status: {status['state']}",
+        data=status
+    )
 
 
 # ============================================================================
@@ -745,24 +756,20 @@ def diagnose() -> CommandResult:
     Returns:
         CommandResult with diagnostic data and recommendations
     """
-    try:
-        from commands import meshtastic as mesh_cmd
-        return mesh_cmd.diagnose_messaging()
-    except ImportError:
-        # Fallback minimal diagnostics
-        diagnostics = {
-            'error': 'meshtastic module not available',
-            'rx_status': {},
-        }
+    if _HAS_CMD_MESHTASTIC:
+        return _cmd_meshtastic.diagnose_messaging()
 
-        try:
-            from utils.message_listener import get_listener_status, diagnose_pubsub
-            diagnostics['rx_status'] = get_listener_status()
-            diagnostics['pubsub'] = diagnose_pubsub()
-        except ImportError:
-            pass
+    # Fallback minimal diagnostics
+    diagnostics = {
+        'error': 'meshtastic module not available',
+        'rx_status': {},
+    }
 
-        return CommandResult.ok("Limited diagnostics", data=diagnostics)
+    if _HAS_MSG_LISTENER:
+        diagnostics['rx_status'] = _get_listener_status()
+        diagnostics['pubsub'] = _diagnose_pubsub()
+
+    return CommandResult.ok("Limited diagnostics", data=diagnostics)
 
 
 def get_routing_info() -> CommandResult:
@@ -772,54 +779,51 @@ def get_routing_info() -> CommandResult:
     Returns:
         CommandResult with hop_limit, device_role, and routing notes
     """
-    try:
-        from commands import meshtastic as mesh_cmd
-
-        info = {
-            'hop_limit': None,
-            'device_role': None,
-            'routing_behavior': None,
-            'recommendations': [],
-        }
-
-        # Get hop limit
-        hop_result = mesh_cmd.get_hop_limit()
-        if hop_result.success and hop_result.data:
-            info['hop_limit'] = hop_result.data.get('hop_limit')
-
-        # Get device role
-        role_result = mesh_cmd.get_device_role()
-        if role_result.success and role_result.data:
-            info['device_role'] = role_result.data.get('role')
-            info['role_description'] = role_result.data.get('description')
-
-        # Determine routing behavior
-        role = info['device_role']
-        hop = info['hop_limit']
-
-        if role == 'CLIENT_MUTE':
-            info['routing_behavior'] = 'Receive only - no rebroadcast'
-            info['recommendations'].append(
-                "Messages won't be relayed. Good for monitoring, bad for mesh health."
-            )
-        elif role in ('ROUTER', 'ROUTER_CLIENT'):
-            info['routing_behavior'] = 'Full router - always rebroadcasts with max hops'
-        elif role == 'REPEATER':
-            info['routing_behavior'] = 'Dedicated repeater - minimal processing'
-        else:
-            info['routing_behavior'] = f'Standard client with hop_limit={hop}'
-
-            if hop and hop < 3:
-                info['recommendations'].append(
-                    f"Low hop limit ({hop}) may cause messages to not reach distant nodes"
-                )
-
-        return CommandResult.ok(
-            f"Routing: {info['routing_behavior']}",
-            data=info
-        )
-
-    except ImportError:
+    if not _HAS_CMD_MESHTASTIC:
         return CommandResult.fail(
             "Cannot get routing info - meshtastic module not available"
         )
+
+    info = {
+        'hop_limit': None,
+        'device_role': None,
+        'routing_behavior': None,
+        'recommendations': [],
+    }
+
+    # Get hop limit
+    hop_result = _cmd_meshtastic.get_hop_limit()
+    if hop_result.success and hop_result.data:
+        info['hop_limit'] = hop_result.data.get('hop_limit')
+
+    # Get device role
+    role_result = _cmd_meshtastic.get_device_role()
+    if role_result.success and role_result.data:
+        info['device_role'] = role_result.data.get('role')
+        info['role_description'] = role_result.data.get('description')
+
+    # Determine routing behavior
+    role = info['device_role']
+    hop = info['hop_limit']
+
+    if role == 'CLIENT_MUTE':
+        info['routing_behavior'] = 'Receive only - no rebroadcast'
+        info['recommendations'].append(
+            "Messages won't be relayed. Good for monitoring, bad for mesh health."
+        )
+    elif role in ('ROUTER', 'ROUTER_CLIENT'):
+        info['routing_behavior'] = 'Full router - always rebroadcasts with max hops'
+    elif role == 'REPEATER':
+        info['routing_behavior'] = 'Dedicated repeater - minimal processing'
+    else:
+        info['routing_behavior'] = f'Standard client with hop_limit={hop}'
+
+        if hop and hop < 3:
+            info['recommendations'].append(
+                f"Low hop limit ({hop}) may cause messages to not reach distant nodes"
+            )
+
+    return CommandResult.ok(
+        f"Routing: {info['routing_behavior']}",
+        data=info
+    )

--- a/src/commands/propagation.py
+++ b/src/commands/propagation.py
@@ -32,12 +32,19 @@ from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 
 from .base import CommandResult
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
+# Module-level safe imports
+SettingsManager, _HAS_SETTINGS = safe_import('utils.common', 'SettingsManager')
+SpaceWeatherAPI, _HAS_SPACE_WEATHER = safe_import('utils.space_weather', 'SpaceWeatherAPI')
+get_pskreporter_subscriber, _HAS_PSKREPORTER = safe_import(
+    'monitoring.pskreporter_subscriber', 'get_pskreporter_subscriber'
+)
+
 # Settings persistence for source configuration
-try:
-    from utils.common import SettingsManager
+if _HAS_SETTINGS:
     _settings = SettingsManager("propagation", defaults={
         "sources": {
             "openhamclock": {"host": "localhost", "port": 3000, "enabled": False, "timeout": 10},
@@ -45,10 +52,8 @@ try:
             "pskreporter": {"enabled": False, "callsign": "", "bands": [], "modes": []},
         }
     })
-    _HAS_SETTINGS = True
-except ImportError:
+else:
     _settings = None
-    _HAS_SETTINGS = False
 
 
 class DataSource(Enum):
@@ -279,9 +284,7 @@ def get_space_weather() -> CommandResult:
         - band_conditions: Per-band HF condition assessment
         - source: Data source used
     """
-    try:
-        from utils.space_weather import SpaceWeatherAPI
-    except ImportError:
+    if not _HAS_SPACE_WEATHER:
         return CommandResult.fail(
             "Space weather module not available",
             error="utils.space_weather not found"
@@ -329,9 +332,7 @@ def get_band_conditions() -> CommandResult:
     Returns:
         CommandResult with per-band condition assessments
     """
-    try:
-        from utils.space_weather import SpaceWeatherAPI
-    except ImportError:
+    if not _HAS_SPACE_WEATHER:
         return CommandResult.fail(
             "Space weather module not available",
             error="utils.space_weather not found"
@@ -408,9 +409,7 @@ def get_propagation_summary() -> CommandResult:
     Returns:
         CommandResult with summary string and overall assessment
     """
-    try:
-        from utils.space_weather import SpaceWeatherAPI
-    except ImportError:
+    if not _HAS_SPACE_WEATHER:
         return CommandResult.fail("Space weather module not available")
 
     api = SpaceWeatherAPI(timeout=10)
@@ -553,8 +552,13 @@ def _test_pskreporter() -> CommandResult:
             data={'hint': 'Configure with: propagation.configure_source(DataSource.PSKREPORTER, enabled=True)'}
         )
 
+    if not _HAS_PSKREPORTER:
+        return CommandResult.fail(
+            "PSKReporter module not available",
+            data={'hint': 'pip install paho-mqtt'}
+        )
+
     try:
-        from monitoring.pskreporter_subscriber import get_pskreporter_subscriber
         sub = get_pskreporter_subscriber()
         if sub.is_connected():
             stats = sub.get_stats()
@@ -572,11 +576,6 @@ def _test_pskreporter() -> CommandResult:
                 "PSKReporter MQTT not connected",
                 data={'hint': 'Check network connectivity to mqtt.pskreporter.info'}
             )
-    except ImportError:
-        return CommandResult.fail(
-            "PSKReporter module not available",
-            data={'hint': 'pip install paho-mqtt'}
-        )
     except Exception as e:
         return CommandResult.fail(
             f"PSKReporter check failed: {e}",
@@ -690,13 +689,14 @@ def _fetch_pskreporter_data() -> Optional[Dict[str, Any]]:
     Returns:
         Dict with PSKReporter propagation data or None on failure
     """
+    if not _HAS_PSKREPORTER:
+        logger.debug("PSKReporter module not available")
+        return None
+
     try:
-        from monitoring.pskreporter_subscriber import get_pskreporter_subscriber
         sub = get_pskreporter_subscriber()
         if sub.is_connected():
             return sub.get_propagation_data()
-    except ImportError:
-        logger.debug("PSKReporter module not available")
     except Exception as e:
         logger.debug(f"PSKReporter data fetch failed: {e}")
     return None

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -18,16 +18,15 @@ from typing import Optional, Dict, Any, List, Tuple
 from dataclasses import dataclass, field
 
 from .base import CommandResult
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
 # Import centralized service checker (SINGLE SOURCE OF TRUTH)
-try:
-    from utils.service_check import check_service
-    HAS_SERVICE_CHECK = True
-except ImportError:
-    check_service = None
-    HAS_SERVICE_CHECK = False
+check_service, HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+
+# RNS module (optional — not installed on all systems)
+RNS, _HAS_RNS = safe_import('RNS')
 
 
 # ============================================================================
@@ -78,21 +77,20 @@ def create_identities() -> CommandResult:
 
     if rns_identity_path.exists():
         results['rns_identity_status'] = 'exists'
+    elif not _HAS_RNS:
+        results['rns_identity_status'] = 'error'
+        return CommandResult.fail(
+            "RNS module not installed — cannot create identity",
+            data=results
+        )
     else:
         try:
-            import RNS
             identity = RNS.Identity()
             config_dir.mkdir(parents=True, exist_ok=True)
             identity.to_file(str(rns_identity_path))
             results['rns_identity_status'] = 'created'
             results['created'].append('rns')
             logger.info(f"Created RNS identity at {rns_identity_path}")
-        except ImportError:
-            results['rns_identity_status'] = 'error'
-            return CommandResult.fail(
-                "RNS module not installed — cannot create identity",
-                data=results
-            )
         except Exception as e:
             results['rns_identity_status'] = 'error'
             return CommandResult.fail(
@@ -108,7 +106,6 @@ def create_identities() -> CommandResult:
         results['gateway_identity_status'] = 'exists'
     else:
         try:
-            import RNS
             identity = RNS.Identity()
             gw_identity_path.parent.mkdir(parents=True, exist_ok=True)
             identity.to_file(str(gw_identity_path))
@@ -811,18 +808,11 @@ def check_connectivity() -> CommandResult:
             connectivity['issues'].append("rnsd daemon not running")
 
     # Check RNS import
-    # Note: Use BaseException to catch pyo3 PanicException (not an Exception subclass)
-    # from RNS's cryptography library when cffi backend is missing
-    try:
-        import RNS
+    if not _HAS_RNS:
+        connectivity['issues'].append("RNS Python module not installed")
+    else:
         connectivity['can_import_rns'] = True
         connectivity['rns_version'] = RNS.__version__ if hasattr(RNS, '__version__') else 'unknown'
-    except ImportError:
-        connectivity['issues'].append("RNS Python module not installed")
-    except (SystemExit, KeyboardInterrupt, GeneratorExit):
-        raise
-    except BaseException as e:
-        connectivity['issues'].append(f"RNS import error: {e}")
 
     # Check config
     config_result = read_config()
@@ -891,9 +881,13 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
             error="Hash must be 32 hex characters"
         )
 
-    try:
-        import RNS
+    if not _HAS_RNS:
+        return CommandResult.not_available(
+            "RNS not installed",
+            fix_hint="pipx install rns"
+        )
 
+    try:
         dest_bytes = bytes.fromhex(destination_hash)
 
         # Check if path exists
@@ -935,11 +929,6 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
             }
         )
 
-    except ImportError:
-        return CommandResult.not_available(
-            "RNS not installed",
-            fix_hint="pipx install rns"
-        )
     except Exception as e:
         # Catch pyo3 PanicException and other RNS errors
         return CommandResult.fail(f"Path test failed: {e}")
@@ -964,9 +953,13 @@ def get_path_info(destination_hash: str) -> CommandResult:
             error="Hash must be 32 hex characters"
         )
 
-    try:
-        import RNS
+    if not _HAS_RNS:
+        return CommandResult.not_available(
+            "RNS not installed",
+            fix_hint="pipx install rns"
+        )
 
+    try:
         dest_bytes = bytes.fromhex(destination_hash)
         has_path = RNS.Transport.has_path(dest_bytes)
 
@@ -1027,11 +1020,6 @@ def get_path_info(destination_hash: str) -> CommandResult:
             data=info
         )
 
-    except ImportError:
-        return CommandResult.not_available(
-            "RNS not installed",
-            fix_hint="pipx install rns"
-        )
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:
@@ -1254,7 +1242,6 @@ def _init_rns_client():
     "Address already in use" errors when rnsd already owns the ports.
     See: .claude/foundations/persistent_issues.md Issue #12
     """
-    import RNS
     import tempfile
 
     client_config_dir = Path(tempfile.gettempdir()) / "meshforge_rns_client"
@@ -1315,9 +1302,13 @@ def list_known_destinations() -> CommandResult:
         except Exception:
             pass
 
-    try:
-        import RNS
+    if not _HAS_RNS:
+        return CommandResult.not_available(
+            "RNS not installed",
+            fix_hint="pipx install rns"
+        )
 
+    try:
         # Connect as client to avoid "Address already in use" when rnsd owns ports
         reticulum = _init_rns_client()
 
@@ -1396,11 +1387,6 @@ def list_known_destinations() -> CommandResult:
                 }
             )
 
-    except ImportError:
-        return CommandResult.not_available(
-            "RNS not installed",
-            fix_hint="pipx install rns"
-        )
     except (SystemExit, KeyboardInterrupt, GeneratorExit):
         raise
     except BaseException as e:
@@ -1423,8 +1409,13 @@ def discover_nodes(timeout: int = 30) -> CommandResult:
     Returns:
         CommandResult with discovered nodes
     """
+    if not _HAS_RNS:
+        return CommandResult.not_available(
+            "RNS not installed",
+            fix_hint="pipx install rns"
+        )
+
     try:
-        import RNS
         import time
 
         # Connect as client to avoid "Address already in use" when rnsd owns ports
@@ -1500,10 +1491,5 @@ def discover_nodes(timeout: int = 30) -> CommandResult:
                 }
             )
 
-    except ImportError:
-        return CommandResult.not_available(
-            "RNS not installed",
-            fix_hint="pipx install rns"
-        )
     except Exception as e:
         return CommandResult.fail(f"Discovery failed: {e}")

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -14,17 +14,19 @@ import subprocess
 import json
 from pathlib import Path
 
-# Import version
-try:
-    from __version__ import __version__
-except ImportError:
-    __version__ = "0.5.0-beta"
+from utils.safe_import import safe_import
 
-# Import centralized path utility for sudo compatibility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
+# Module-level safe imports
+_version_val, _HAS_VERSION = safe_import('__version__', '__version__')
+__version__ = _version_val if _HAS_VERSION else "0.5.0-beta"
+
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
+if _HAS_PATHS:
+    get_real_user_home = _get_real_user_home
+else:
     def get_real_user_home() -> Path:
+        """Fallback: resolve real user home under sudo."""
         sudo_user = os.environ.get('SUDO_USER', '')
         if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
             candidate = Path(f'/home/{sudo_user}')
@@ -35,21 +37,31 @@ except ImportError:
             return candidate
         return Path('/root')
 
-# Import NOC orchestrator for service management
-try:
-    from core.orchestrator import ServiceOrchestrator, ServiceState
-    HAS_ORCHESTRATOR = True
-except ImportError:
-    HAS_ORCHESTRATOR = False
+# NOC orchestrator for service management
+ServiceOrchestrator, ServiceState, _HAS_ORCHESTRATOR = safe_import(
+    'core.orchestrator', 'ServiceOrchestrator', 'ServiceState'
+)
 
-# Import startup health check
-try:
-    from utils.startup_health import run_health_check, print_health_summary
-    HAS_HEALTH_CHECK = True
-except ImportError:
-    HAS_HEALTH_CHECK = False
-    run_health_check = None
-    print_health_summary = None
+# Startup health check
+run_health_check, print_health_summary, _HAS_HEALTH_CHECK = safe_import(
+    'utils.startup_health', 'run_health_check', 'print_health_summary'
+)
+
+# Setup wizard
+SetupWizard, _HAS_SETUP_WIZARD = safe_import('setup_wizard', 'SetupWizard')
+
+# Gateway bridge modules
+RNSMeshtasticBridge, _HAS_BRIDGE = safe_import(
+    'gateway.rns_bridge', 'RNSMeshtasticBridge'
+)
+GatewayConfig, _HAS_GATEWAY_CONFIG = safe_import(
+    'gateway.config', 'GatewayConfig'
+)
+
+# Startup checker for --verify-install
+StartupChecker, _HAS_STARTUP_CHECKER = safe_import(
+    'launcher_tui.startup_checks', 'StartupChecker'
+)
 
 # Config file location
 CONFIG_DIR = get_real_user_home() / '.config' / 'meshforge'
@@ -110,12 +122,11 @@ def run_setup_wizard():
         response = 'n'
 
     if response != 'n':
-        try:
-            from setup_wizard import SetupWizard
+        if _HAS_SETUP_WIZARD:
             wizard = SetupWizard(interactive=True)
             wizard.run_interactive_setup()
             wizard.mark_setup_complete()
-        except ImportError:
+        else:
             try:
                 import importlib.util
                 spec = importlib.util.spec_from_file_location(
@@ -150,7 +161,7 @@ def print_banner():
 
 def show_startup_health():
     """Show startup health summary."""
-    if not HAS_HEALTH_CHECK:
+    if not _HAS_HEALTH_CHECK:
         return
 
     print(f"{Colors.CYAN}{'─' * 50}{Colors.NC}")
@@ -279,11 +290,11 @@ def launch_interface(choice):
 
 def launch_gateway_bridge(src_dir):
     """Launch the gateway bridge in headless mode"""
-    try:
-        sys.path.insert(0, str(src_dir))
-        from gateway.rns_bridge import RNSMeshtasticBridge
-        from gateway.config import GatewayConfig
+    if not _HAS_BRIDGE or not _HAS_GATEWAY_CONFIG:
+        print(f"{Colors.RED}Gateway module not available{Colors.NC}")
+        return
 
+    try:
         config = GatewayConfig.load()
         if not config.enabled:
             print(f"{Colors.YELLOW}Gateway bridge is disabled in config.{Colors.NC}")
@@ -320,15 +331,13 @@ def launch_gateway_bridge(src_dir):
         else:
             print(f"{Colors.RED}Failed to start bridge. Check logs for details.{Colors.NC}")
 
-    except ImportError as e:
-        print(f"{Colors.RED}Gateway module not available: {e}{Colors.NC}")
     except Exception as e:
         print(f"{Colors.RED}Error starting bridge: {e}{Colors.NC}")
 
 
 def start_noc_services():
     """Start NOC managed services (meshtasticd, rnsd) if in local mode."""
-    if not HAS_ORCHESTRATOR:
+    if not _HAS_ORCHESTRATOR:
         return True
 
     noc_config_path = Path('/etc/meshforge/noc.yaml')
@@ -390,43 +399,42 @@ def main():
         else:
             # Fallback: run Python-based verification using StartupChecker
             print(f"{Colors.CYAN}Running installation verification...{Colors.NC}\n")
-            try:
-                from launcher_tui.startup_checks import StartupChecker
-                checker = StartupChecker()
-                env = checker.check_all()
-
-                # Print results
-                print(f"{Colors.BOLD}Service Status:{Colors.NC}")
-                for name, info in env.services.items():
-                    if info.state.value == 'running':
-                        print(f"  {Colors.GREEN}[PASS]{Colors.NC} {name}")
-                    else:
-                        print(f"  {Colors.RED}[FAIL]{Colors.NC} {name}: {info.state.value}")
-
-                print(f"\n{Colors.BOLD}Hardware:{Colors.NC}")
-                if env.hardware.spi_devices:
-                    print(f"  {Colors.GREEN}[PASS]{Colors.NC} SPI: {', '.join(env.hardware.spi_devices)}")
-                if env.hardware.usb_serial_devices:
-                    for dev in env.hardware.usb_serial_devices:
-                        print(f"  {Colors.GREEN}[PASS]{Colors.NC} USB: {dev['path']} ({dev.get('name', 'Unknown')})")
-                if not env.hardware.spi_devices and not env.hardware.usb_serial_devices:
-                    print(f"  {Colors.YELLOW}[WARN]{Colors.NC} No radio hardware detected")
-
-                if env.conflicts:
-                    print(f"\n{Colors.BOLD}Conflicts:{Colors.NC}")
-                    for conflict in env.conflicts:
-                        print(f"  {Colors.RED}[FAIL]{Colors.NC} Port {conflict.port}: {conflict.actual_process} (PID {conflict.actual_pid})")
-
-                # Exit code based on state
-                if env.all_services_running and not env.conflicts:
-                    print(f"\n{Colors.GREEN}Verification passed.{Colors.NC}")
-                    sys.exit(0)
-                else:
-                    print(f"\n{Colors.YELLOW}Verification completed with issues.{Colors.NC}")
-                    sys.exit(2)
-            except ImportError as e:
-                print(f"{Colors.RED}Error: Could not load verification module: {e}{Colors.NC}")
+            if not _HAS_STARTUP_CHECKER:
+                print(f"{Colors.RED}Error: Could not load verification module{Colors.NC}")
                 sys.exit(1)
+
+            checker = StartupChecker()
+            env = checker.check_all()
+
+            # Print results
+            print(f"{Colors.BOLD}Service Status:{Colors.NC}")
+            for name, info in env.services.items():
+                if info.state.value == 'running':
+                    print(f"  {Colors.GREEN}[PASS]{Colors.NC} {name}")
+                else:
+                    print(f"  {Colors.RED}[FAIL]{Colors.NC} {name}: {info.state.value}")
+
+            print(f"\n{Colors.BOLD}Hardware:{Colors.NC}")
+            if env.hardware.spi_devices:
+                print(f"  {Colors.GREEN}[PASS]{Colors.NC} SPI: {', '.join(env.hardware.spi_devices)}")
+            if env.hardware.usb_serial_devices:
+                for dev in env.hardware.usb_serial_devices:
+                    print(f"  {Colors.GREEN}[PASS]{Colors.NC} USB: {dev['path']} ({dev.get('name', 'Unknown')})")
+            if not env.hardware.spi_devices and not env.hardware.usb_serial_devices:
+                print(f"  {Colors.YELLOW}[WARN]{Colors.NC} No radio hardware detected")
+
+            if env.conflicts:
+                print(f"\n{Colors.BOLD}Conflicts:{Colors.NC}")
+                for conflict in env.conflicts:
+                    print(f"  {Colors.RED}[FAIL]{Colors.NC} Port {conflict.port}: {conflict.actual_process} (PID {conflict.actual_pid})")
+
+            # Exit code based on state
+            if env.all_services_running and not env.conflicts:
+                print(f"\n{Colors.GREEN}Verification passed.{Colors.NC}")
+                sys.exit(0)
+            else:
+                print(f"\n{Colors.YELLOW}Verification completed with issues.{Colors.NC}")
+                sys.exit(2)
 
     # Check root
     if os.geteuid() != 0:

--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -19,6 +19,31 @@ import webbrowser
 from pathlib import Path
 from typing import Optional
 
+from utils.safe_import import safe_import
+
+# --- Optional dependencies (safe_import returns (*attrs, available_bool)) ---
+diagnose, Category, Severity, _HAS_DIAGNOSTICS = safe_import(
+    'utils.diagnostic_engine', 'diagnose', 'Category', 'Severity'
+)
+get_knowledge_base, _HAS_KNOWLEDGE = safe_import(
+    'utils.knowledge_base', 'get_knowledge_base'
+)
+ClaudeAssistant, _HAS_ASSISTANT = safe_import(
+    'utils.claude_assistant', 'ClaudeAssistant'
+)
+CoverageMapGenerator, MapNode, _HAS_COVERAGE_MAP = safe_import(
+    'utils.coverage_map', 'CoverageMapGenerator', 'MapNode'
+)
+MapDataCollector, get_all_ips, _HAS_MAP_SERVICE = safe_import(
+    'utils.map_data_service', 'MapDataCollector', 'get_all_ips'
+)
+TileCache, HAWAII_BOUNDS, _HAS_TILE_CACHE = safe_import(
+    'utils.tile_cache', 'TileCache', 'HAWAII_BOUNDS'
+)
+ReviewOrchestrator, ReviewScope, _HAS_AUTO_REVIEW = safe_import(
+    'utils.auto_review', 'ReviewOrchestrator', 'ReviewScope'
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -531,42 +556,48 @@ class AIToolsMixin:
         """Run diagnosis on a symptom."""
         self.dialog.infobox("Analyzing", f"Analyzing: {symptom[:40]}...")
 
-        try:
-            from utils.diagnostic_engine import diagnose, Category, Severity
+        if not _HAS_DIAGNOSTICS:
+            self.dialog.msgbox(
+                "Error",
+                "Diagnostic engine not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
 
+        try:
             # Run diagnosis
-            diagnosis = diagnose(
+            diagnosis_result = diagnose(
                 symptom,
                 category=Category.CONNECTIVITY,
                 severity=Severity.ERROR
             )
 
-            if diagnosis:
+            if diagnosis_result:
                 # Format diagnosis for display
                 result_lines = [
                     f"SYMPTOM: {symptom}",
                     "",
                     f"LIKELY CAUSE:",
-                    f"  {diagnosis.likely_cause}",
+                    f"  {diagnosis_result.likely_cause}",
                     "",
-                    f"CONFIDENCE: {diagnosis.confidence:.0%}",
+                    f"CONFIDENCE: {diagnosis_result.confidence:.0%}",
                     "",
                 ]
 
-                if diagnosis.evidence:
+                if diagnosis_result.evidence:
                     result_lines.append("EVIDENCE:")
-                    for ev in diagnosis.evidence[:3]:
+                    for ev in diagnosis_result.evidence[:3]:
                         result_lines.append(f"  - {ev}")
                     result_lines.append("")
 
-                if diagnosis.suggestions:
+                if diagnosis_result.suggestions:
                     result_lines.append("SUGGESTIONS:")
-                    for i, sug in enumerate(diagnosis.suggestions[:5], 1):
+                    for i, sug in enumerate(diagnosis_result.suggestions[:5], 1):
                         result_lines.append(f"  {i}. {sug}")
                     result_lines.append("")
 
-                if diagnosis.auto_recoverable:
-                    result_lines.append(f"AUTO-RECOVERY: {diagnosis.recovery_action}")
+                if diagnosis_result.auto_recoverable:
+                    result_lines.append(f"AUTO-RECOVERY: {diagnosis_result.recovery_action}")
 
                 self.dialog.msgbox(
                     "Diagnosis Result",
@@ -579,12 +610,6 @@ class AIToolsMixin:
                     "Try the Knowledge Base for general information,\n"
                     "or use Claude Assistant for detailed help."
                 )
-        except ImportError:
-            self.dialog.msgbox(
-                "Error",
-                "Diagnostic engine not available.\n\n"
-                "Ensure you're running from the src/ directory."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Diagnosis failed: {e}")
 
@@ -639,9 +664,15 @@ class AIToolsMixin:
         """Query the knowledge base."""
         self.dialog.infobox("Searching", f"Searching: {query[:40]}...")
 
-        try:
-            from utils.knowledge_base import get_knowledge_base
+        if not _HAS_KNOWLEDGE:
+            self.dialog.msgbox(
+                "Error",
+                "Knowledge base not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
 
+        try:
             kb = get_knowledge_base()
             results = kb.query(query)
 
@@ -668,12 +699,6 @@ class AIToolsMixin:
                     f"No knowledge base entries found for:\n{query}\n\n"
                     "Try different keywords or use Claude Assistant."
                 )
-        except ImportError:
-            self.dialog.msgbox(
-                "Error",
-                "Knowledge base not available.\n\n"
-                "Ensure you're running from the src/ directory."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Query failed: {e}")
 
@@ -705,9 +730,15 @@ class AIToolsMixin:
         """Ask the Claude assistant."""
         self.dialog.infobox("Thinking", f"Processing: {question[:40]}...")
 
-        try:
-            from utils.claude_assistant import ClaudeAssistant
+        if not _HAS_ASSISTANT:
+            self.dialog.msgbox(
+                "Error",
+                "Claude assistant not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
 
+        try:
             assistant = ClaudeAssistant()
             response = assistant.ask(question)
 
@@ -734,12 +765,6 @@ class AIToolsMixin:
                 "Claude Assistant",
                 "\n".join(result_lines)
             )
-        except ImportError:
-            self.dialog.msgbox(
-                "Error",
-                "Claude assistant not available.\n\n"
-                "Ensure you're running from the src/ directory."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Assistant failed: {e}")
 
@@ -765,8 +790,16 @@ class AIToolsMixin:
 
         self.dialog.infobox("Generating", "Creating coverage map...")
 
+        if not _HAS_COVERAGE_MAP:
+            self.dialog.msgbox(
+                "Error",
+                "Coverage map generator not available.\n\n"
+                "You may need to install folium:\n"
+                "pip3 install folium"
+            )
+            return
+
         try:
-            from utils.coverage_map import CoverageMapGenerator, MapNode
             from utils.paths import get_real_user_home
 
             generator = CoverageMapGenerator()
@@ -774,26 +807,24 @@ class AIToolsMixin:
             if choice == "all":
                 # Use MapDataCollector to get nodes from ALL sources
                 # (meshtasticd, MQTT, node_cache.json, RNS cache)
-                try:
-                    from utils.map_data_service import MapDataCollector
-                    collector = MapDataCollector()
-                    geojson = collector.collect()
-                    features = geojson.get('features', [])
-                    if features:
-                        generator.add_nodes_from_geojson(geojson)
-                        self.dialog.infobox(
-                            "Generating",
-                            f"Found {len(features)} nodes from all sources..."
-                        )
-                    else:
-                        self.dialog.msgbox(
-                            "No Nodes",
-                            "No nodes found from any source.\n\n"
-                            "Check meshtasticd, MQTT, or node cache."
-                        )
-                        return
-                except ImportError as e:
-                    self.dialog.msgbox("Error", f"MapDataCollector not available: {e}")
+                if not _HAS_MAP_SERVICE:
+                    self.dialog.msgbox("Error", "MapDataCollector not available.")
+                    return
+                collector = MapDataCollector()
+                geojson = collector.collect()
+                features = geojson.get('features', [])
+                if features:
+                    generator.add_nodes_from_geojson(geojson)
+                    self.dialog.infobox(
+                        "Generating",
+                        f"Found {len(features)} nodes from all sources..."
+                    )
+                else:
+                    self.dialog.msgbox(
+                        "No Nodes",
+                        "No nodes found from any source.\n\n"
+                        "Check meshtasticd, MQTT, or node cache."
+                    )
                     return
 
             elif choice == "live":
@@ -866,13 +897,6 @@ class AIToolsMixin:
             # Open browser in background
             self._open_in_browser(str(output_file))
 
-        except ImportError as e:
-            self.dialog.msgbox(
-                "Error",
-                f"Coverage map generator not available: {e}\n\n"
-                "You may need to install folium:\n"
-                "pip3 install folium"
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Map generation failed: {e}")
 
@@ -885,9 +909,10 @@ class AIToolsMixin:
         Returns:
             GeoJSON FeatureCollection filtered to the specified source.
         """
-        try:
-            from utils.map_data_service import MapDataCollector
+        if not _HAS_MAP_SERVICE:
+            return {"type": "FeatureCollection", "features": []}
 
+        try:
             collector = MapDataCollector()
             geojson = collector.collect()
 
@@ -905,8 +930,6 @@ class AIToolsMixin:
                     "count": len(filtered_features)
                 }
             }
-        except ImportError:
-            return {"type": "FeatureCollection", "features": []}
         except Exception as e:
             logger.debug("GeoJSON collection failed: %s", e)
             return {"type": "FeatureCollection", "features": []}
@@ -962,29 +985,36 @@ class AIToolsMixin:
         """Generate a node density heatmap and open in browser."""
         self.dialog.infobox("Generating", "Creating node density heatmap...")
 
+        if not _HAS_COVERAGE_MAP:
+            self.dialog.msgbox(
+                "Error",
+                "Coverage map generator not available.\n\n"
+                "You may need to install folium:\n"
+                "pip3 install folium"
+            )
+            return
+
+        if not _HAS_MAP_SERVICE:
+            self.dialog.msgbox("Error", "MapDataCollector not available.")
+            return
+
         try:
-            from utils.coverage_map import CoverageMapGenerator
             from utils.paths import get_real_user_home
 
             generator = CoverageMapGenerator()
 
             # Collect nodes from all sources
-            try:
-                from utils.map_data_service import MapDataCollector
-                collector = MapDataCollector()
-                geojson = collector.collect()
-                features = geojson.get('features', [])
-                if features:
-                    generator.add_nodes_from_geojson(geojson)
-                else:
-                    self.dialog.msgbox(
-                        "No Nodes",
-                        "No nodes found from any source.\n\n"
-                        "Check meshtasticd, MQTT, or node cache."
-                    )
-                    return
-            except ImportError as e:
-                self.dialog.msgbox("Error", f"MapDataCollector not available: {e}")
+            collector = MapDataCollector()
+            geojson = collector.collect()
+            features = geojson.get('features', [])
+            if features:
+                generator.add_nodes_from_geojson(geojson)
+            else:
+                self.dialog.msgbox(
+                    "No Nodes",
+                    "No nodes found from any source.\n\n"
+                    "Check meshtasticd, MQTT, or node cache."
+                )
                 return
 
             # Generate heatmap
@@ -1010,13 +1040,6 @@ class AIToolsMixin:
             )
             self._open_in_browser(result_path)
 
-        except ImportError as e:
-            self.dialog.msgbox(
-                "Error",
-                f"Coverage map generator not available: {e}\n\n"
-                "You may need to install folium:\n"
-                "pip3 install folium"
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Heatmap generation failed: {e}")
 
@@ -1056,8 +1079,11 @@ class AIToolsMixin:
 
     def _tile_cache_stats(self):
         """Display tile cache statistics."""
+        if not _HAS_TILE_CACHE:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+            return
+
         try:
-            from utils.tile_cache import TileCache
             cache = TileCache()
             stats = cache.get_stats()
 
@@ -1075,16 +1101,16 @@ class AIToolsMixin:
                 info.append("to cache tiles for offline map viewing.")
 
             self.dialog.msgbox("Tile Cache Stats", "\n".join(info))
-        except ImportError:
-            self.dialog.msgbox("Error", "Tile cache module not available.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to get cache stats: {e}")
 
     def _tile_cache_download(self):
         """Download tiles for a geographic region."""
-        try:
-            from utils.tile_cache import TileCache, HAWAII_BOUNDS
+        if not _HAS_TILE_CACHE:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+            return
 
+        try:
             # Get bounds from user
             region_choices = [
                 ("hawaii", "Hawaii              (18.5-22.5N, 160.5-154.5W)"),
@@ -1154,16 +1180,16 @@ class AIToolsMixin:
                     f"Failed: {result['failed']}"
                 )
 
-        except ImportError:
-            self.dialog.msgbox("Error", "Tile cache module not available.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Tile download failed: {e}")
 
     def _tile_cache_estimate(self):
         """Estimate download size for a region."""
-        try:
-            from utils.tile_cache import TileCache, HAWAII_BOUNDS
+        if not _HAS_TILE_CACHE:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+            return
 
+        try:
             coords = self.dialog.inputbox(
                 "Estimate Size",
                 "Enter bounds as: south,west,north,east\n"
@@ -1198,16 +1224,16 @@ class AIToolsMixin:
                     f"Within limit: {'Yes' if estimate['within_limit'] else 'No'}"
                 )
 
-        except ImportError:
-            self.dialog.msgbox("Error", "Tile cache module not available.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Estimation failed: {e}")
 
     def _tile_cache_clear(self):
         """Clear expired tiles from cache."""
-        try:
-            from utils.tile_cache import TileCache
+        if not _HAS_TILE_CACHE:
+            self.dialog.msgbox("Error", "Tile cache module not available.")
+            return
 
+        try:
             confirm = self.dialog.yesno(
                 "Clear Expired Tiles",
                 "Remove tiles older than 30 days?\n\n"
@@ -1228,8 +1254,6 @@ class AIToolsMixin:
                 f"Space freed: {freed_mb:.1f} MB"
             )
 
-        except ImportError:
-            self.dialog.msgbox("Error", "Tile cache module not available.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Cache clear failed: {e}")
 
@@ -1273,9 +1297,15 @@ class AIToolsMixin:
         """Execute an auto-review with the specified scope."""
         self.dialog.infobox("Reviewing", f"Running {scope_name.lower()} review...")
 
-        try:
-            from utils.auto_review import ReviewOrchestrator, ReviewScope
+        if not _HAS_AUTO_REVIEW:
+            self.dialog.msgbox(
+                "Error",
+                "Auto-review module not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
 
+        try:
             scope_map = {
                 "ALL": ReviewScope.ALL,
                 "SECURITY": ReviewScope.SECURITY,
@@ -1322,11 +1352,5 @@ class AIToolsMixin:
 
             self.dialog.msgbox("Review Results", "\n".join(lines))
 
-        except ImportError:
-            self.dialog.msgbox(
-                "Error",
-                "Auto-review module not available.\n\n"
-                "Ensure you're running from the src/ directory."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Review failed: {e}")

--- a/src/launcher_tui/amateur_radio_mixin.py
+++ b/src/launcher_tui/amateur_radio_mixin.py
@@ -12,6 +12,16 @@ Emergency Mode for EMCOMM operations.
 
 import subprocess
 from backend import clear_screen
+from utils.safe_import import safe_import
+
+# Module-level safe imports — replaces scattered try/except ImportError blocks
+CallsignManager, _HAS_CALLSIGN = safe_import('amateur.callsign', 'CallsignManager')
+Part97Reference, ComplianceChecker, _HAS_COMPLIANCE = safe_import(
+    'amateur.compliance', 'Part97Reference', 'ComplianceChecker'
+)
+ARESRACESTools, MessagePriority, _HAS_ARES = safe_import(
+    'amateur.ares_races', 'ARESRACESTools', 'MessagePriority'
+)
 
 
 class AmateurRadioMixin:
@@ -66,9 +76,7 @@ class AmateurRadioMixin:
         clear_screen()
         print(f"=== Callsign Lookup: {callsign} ===\n")
 
-        try:
-            from amateur.callsign import CallsignManager
-        except ImportError:
+        if not _HAS_CALLSIGN:
             print("  Callsign module not available.")
             print("  File: src/amateur/callsign.py")
             self._wait_for_enter()
@@ -113,9 +121,7 @@ class AmateurRadioMixin:
         clear_screen()
         print("=== Part 97 Band Plan (ISM/LoRa Relevant) ===\n")
 
-        try:
-            from amateur.compliance import Part97Reference
-        except ImportError:
+        if not _HAS_COMPLIANCE:
             # Show a basic reference even without the module
             print("  ISM Bands Used by Meshtastic:\n")
             print("  Band        Frequency       Power    Notes")
@@ -159,9 +165,7 @@ class AmateurRadioMixin:
         clear_screen()
         print("=== Compliance Check ===\n")
 
-        try:
-            from amateur.compliance import ComplianceChecker
-        except ImportError:
+        if not _HAS_COMPLIANCE:
             print("  Compliance module not available.")
             print("  File: src/amateur/compliance.py")
             self._wait_for_enter()
@@ -255,9 +259,7 @@ class AmateurRadioMixin:
         clear_screen()
         print("=== ICS-213 General Message Form ===\n")
 
-        try:
-            from amateur.ares_races import ARESRACESTools, MessagePriority
-        except ImportError:
+        if not _HAS_ARES:
             print("  ARES/RACES module not available.")
             print("  File: src/amateur/ares_races.py")
             self._wait_for_enter()
@@ -324,8 +326,7 @@ class AmateurRadioMixin:
         clear_screen()
         print("=== Net Control Operator Checklist ===\n")
 
-        try:
-            from amateur.ares_races import ARESRACESTools
+        if _HAS_ARES:
             tools = ARESRACESTools()
             checklist = tools.get_net_checklist()
 
@@ -334,7 +335,7 @@ class AmateurRadioMixin:
                 print(f"  {status} {i:2d}. {item.task}")
                 print(f"       {item.description}")
             print()
-        except ImportError:
+        else:
             # Fallback: show standard NCS checklist
             checklist = [
                 ("Pre-Net", "Verify radio/antenna, check propagation"),
@@ -357,25 +358,25 @@ class AmateurRadioMixin:
         clear_screen()
         print("=== ARES/RACES Net Status ===\n")
 
-        try:
-            from amateur.ares_races import ARESRACESTools
-            tools = ARESRACESTools()
-            status = tools.get_net_status()
-
-            if status:
-                print(f"  Net Active: {'Yes' if status.get('active') else 'No'}")
-                print(f"  NCS:        {status.get('ncs', 'Not set')}")
-                print(f"  Frequency:  {status.get('frequency', 'Not set')}")
-                print(f"  Check-ins:  {status.get('checkin_count', 0)}")
-                print(f"  Traffic:    {status.get('traffic_count', 0)} messages")
-            else:
-                print("  No active net session.")
-                print("  Use 'Net Checklist' to start operations.")
-        except ImportError:
+        if not _HAS_ARES:
             print("  ARES/RACES module not available.")
             print("  File: src/amateur/ares_races.py")
-        except Exception as e:
-            print(f"  Status unavailable: {e}")
+        else:
+            try:
+                tools = ARESRACESTools()
+                status = tools.get_net_status()
+
+                if status:
+                    print(f"  Net Active: {'Yes' if status.get('active') else 'No'}")
+                    print(f"  NCS:        {status.get('ncs', 'Not set')}")
+                    print(f"  Frequency:  {status.get('frequency', 'Not set')}")
+                    print(f"  Check-ins:  {status.get('checkin_count', 0)}")
+                    print(f"  Traffic:    {status.get('traffic_count', 0)} messages")
+                else:
+                    print("  No active net session.")
+                    print("  Use 'Net Checklist' to start operations.")
+            except Exception as e:
+                print(f"  Status unavailable: {e}")
 
         print()
         self._wait_for_enter()

--- a/src/launcher_tui/analytics_mixin.py
+++ b/src/launcher_tui/analytics_mixin.py
@@ -7,8 +7,13 @@ Extracted as a mixin to keep main.py under 1,500 lines.
 
 import logging
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+get_analytics_store, get_predictive_analyzer, get_coverage_analyzer, _HAS_ANALYTICS = safe_import(
+    'utils.analytics', 'get_analytics_store', 'get_predictive_analyzer', 'get_coverage_analyzer'
+)
 
 
 class AnalyticsMixin:
@@ -53,9 +58,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Link Budget Trends ===\n")
 
-        try:
-            from utils.analytics import get_analytics_store
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Analytics module not available.")
             print("  File: src/utils/analytics.py")
             self._wait_for_enter()
@@ -92,9 +95,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Network Health History ===\n")
 
-        try:
-            from utils.analytics import get_analytics_store
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Analytics module not available.")
             self._wait_for_enter()
             return
@@ -128,9 +129,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Network Forecast (24h) ===\n")
 
-        try:
-            from utils.analytics import get_predictive_analyzer
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Predictive analytics module not available.")
             self._wait_for_enter()
             return
@@ -184,9 +183,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Predictive Alerts ===\n")
 
-        try:
-            from utils.analytics import get_predictive_analyzer
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Predictive analytics module not available.")
             self._wait_for_enter()
             return
@@ -227,9 +224,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Coverage Statistics ===\n")
 
-        try:
-            from utils.analytics import get_coverage_analyzer
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Coverage analyzer module not available.")
             self._wait_for_enter()
             return
@@ -268,9 +263,7 @@ class AnalyticsMixin:
         clear_screen()
         print("=== Cleanup Analytics Data ===\n")
 
-        try:
-            from utils.analytics import get_analytics_store
-        except ImportError:
+        if not _HAS_ANALYTICS:
             print("  Analytics module not available.")
             self._wait_for_enter()
             return

--- a/src/launcher_tui/aredn_mixin.py
+++ b/src/launcher_tui/aredn_mixin.py
@@ -7,8 +7,14 @@ Extracted from main.py to reduce file size per CLAUDE.md guidelines.
 import logging
 import subprocess
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# AREDN utilities - optional dependency
+get_aredn_node, AREDNClient, AREDNScanner, _HAS_AREDN = safe_import(
+    'utils.aredn', 'get_aredn_node', 'AREDNClient', 'AREDNScanner'
+)
 
 
 class AREDNMixin:
@@ -72,9 +78,13 @@ class AREDNMixin:
         clear_screen()
         print("=== AREDN Node Status ===\n")
 
-        try:
-            from utils.aredn import get_aredn_node
+        if not _HAS_AREDN:
+            print("AREDN utilities not available.")
+            print("Check: src/utils/aredn.py")
+            self._wait_for_enter()
+            return
 
+        try:
             node_ip = self._aredn_get_node_ip()
             if not node_ip:
                 print("No AREDN node found on local network.")
@@ -103,9 +113,6 @@ class AREDNMixin:
                 print(f"Connected to {node_ip} but couldn't parse node info.")
                 print(f"Check: http://{node_ip}:8080/cgi-bin/sysinfo.json")
 
-        except ImportError:
-            print("AREDN utilities not available.")
-            print("Check: src/utils/aredn.py")
         except Exception as e:
             print(f"Error: {e}")
 
@@ -116,9 +123,12 @@ class AREDNMixin:
         clear_screen()
         print("=== AREDN Neighbors ===\n")
 
-        try:
-            from utils.aredn import AREDNClient
+        if not _HAS_AREDN:
+            print("AREDN utilities not available.")
+            self._wait_for_enter()
+            return
 
+        try:
             node_ip = self._aredn_get_node_ip()
             if not node_ip:
                 print("No AREDN node found. Is it connected?")
@@ -139,8 +149,6 @@ class AREDNMixin:
                 print("No neighbors found.")
                 print("Check that your AREDN node has active RF links.")
 
-        except ImportError:
-            print("AREDN utilities not available.")
         except Exception as e:
             print(f"Error: {e}")
 
@@ -151,9 +159,12 @@ class AREDNMixin:
         clear_screen()
         print("=== AREDN Services ===\n")
 
-        try:
-            from utils.aredn import AREDNClient
+        if not _HAS_AREDN:
+            print("AREDN utilities not available.")
+            self._wait_for_enter()
+            return
 
+        try:
             node_ip = self._aredn_get_node_ip()
             if not node_ip:
                 print("No AREDN node found.")
@@ -179,8 +190,6 @@ class AREDNMixin:
             else:
                 print("Could not retrieve services.")
 
-        except ImportError:
-            print("AREDN utilities not available.")
         except Exception as e:
             print(f"Error: {e}")
 
@@ -212,9 +221,12 @@ class AREDNMixin:
         print("=== AREDN Network Scan ===\n")
         print("Scanning 10.0.0.0/24 for AREDN nodes...\n")
 
-        try:
-            from utils.aredn import AREDNScanner
+        if not _HAS_AREDN:
+            print("AREDN utilities not available.")
+            self._wait_for_enter()
+            return
 
+        try:
             scanner = AREDNScanner()
             nodes = scanner.scan_subnet("10.0.0.0/24")
 
@@ -227,8 +239,6 @@ class AREDNMixin:
                 print("\nYour network may use a different subnet.")
                 print("Check your AREDN node's IP configuration.")
 
-        except ImportError:
-            print("AREDN utilities not available.")
         except Exception as e:
             print(f"Error: {e}")
 
@@ -254,9 +264,12 @@ class AREDNMixin:
 
         print(f"Connecting to AREDN node at {node_ip}...\n")
 
-        try:
-            from utils.aredn import get_aredn_node
+        if not _HAS_AREDN:
+            print("AREDN utilities not available.")
+            self._wait_for_enter()
+            return
 
+        try:
             node = get_aredn_node(node_ip)
             if not node:
                 print("Could not retrieve node information.")
@@ -286,8 +299,7 @@ class AREDNMixin:
             for link in node.links[:5]:  # Check first 5 to avoid long waits
                 if link.ip:
                     try:
-                        from utils.aredn import get_aredn_node as get_neighbor
-                        neighbor = get_neighbor(link.ip)
+                        neighbor = get_aredn_node(link.ip)
                         if neighbor and neighbor.has_location():
                             neighbors_with_loc += 1
                             print(f"    ✓ {neighbor.hostname} has location")
@@ -318,8 +330,6 @@ class AREDNMixin:
             except OSError as e:
                 logger.debug("AREDN map server check failed: %s", e)
 
-        except ImportError as e:
-            print(f"AREDN utilities not available: {e}")
         except Exception as e:
             print(f"Error: {e}")
 

--- a/src/launcher_tui/classifier_mixin.py
+++ b/src/launcher_tui/classifier_mixin.py
@@ -7,8 +7,13 @@ Extracted as a mixin to keep main.py under 1,500 lines.
 
 import logging
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+create_routing_system, create_notification_system, _HAS_CLASSIFIER = safe_import(
+    'utils.classifier', 'create_routing_system', 'create_notification_system'
+)
 
 
 class ClassifierMixin:
@@ -49,9 +54,7 @@ class ClassifierMixin:
         clear_screen()
         print("=== Routing Classification Stats ===\n")
 
-        try:
-            from utils.classifier import create_routing_system
-        except ImportError:
+        if not _HAS_CLASSIFIER:
             print("  Classifier module not available.")
             print("  File: src/utils/classifier.py")
             self._wait_for_enter()
@@ -87,9 +90,7 @@ class ClassifierMixin:
         clear_screen()
         print("=== Notification Classification Stats ===\n")
 
-        try:
-            from utils.classifier import create_notification_system
-        except ImportError:
+        if not _HAS_CLASSIFIER:
             print("  Classifier module not available.")
             self._wait_for_enter()
             return
@@ -131,9 +132,7 @@ class ClassifierMixin:
         clear_screen()
         print("=== Recent Classification Decisions ===\n")
 
-        try:
-            from utils.classifier import create_routing_system
-        except ImportError:
+        if not _HAS_CLASSIFIER:
             print("  Classifier module not available.")
             self._wait_for_enter()
             return
@@ -168,9 +167,7 @@ class ClassifierMixin:
         clear_screen()
         print("=== Bounced Items (Low Confidence) ===\n")
 
-        try:
-            from utils.classifier import create_routing_system
-        except ImportError:
+        if not _HAS_CLASSIFIER:
             print("  Classifier module not available.")
             self._wait_for_enter()
             return

--- a/src/launcher_tui/dashboard_mixin.py
+++ b/src/launcher_tui/dashboard_mixin.py
@@ -8,8 +8,22 @@ Provides the display methods used by the Dashboard submenu.
 import logging
 import subprocess
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# --- Module-level safe imports (replaces try/except ImportError blocks) ---
+ServiceRunState, _HAS_STARTUP_CHECKS = safe_import('startup_checks', 'ServiceRunState')
+get_http_client, reset_http_client, _HAS_MESHTASTIC_HTTP = safe_import(
+    'utils.meshtastic_http', 'get_http_client', 'reset_http_client'
+)
+MapDataCollector, _HAS_MAP_COLLECTOR = safe_import('utils.map_data_collector', 'MapDataCollector')
+generate_report, generate_and_save, _HAS_REPORT_GEN = safe_import(
+    'utils.report_generator', 'generate_report', 'generate_and_save'
+)
+get_health_scorer, _HAS_HEALTH_SCORE = safe_import('utils.health_score', 'get_health_scorer')
+EASAlertsPlugin, _HAS_EAS = safe_import('plugins.eas_alerts', 'EASAlertsPlugin')
+pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
 
 
 class DashboardMixin:
@@ -44,13 +58,7 @@ class DashboardMixin:
         clear_screen()
         print("=== Service Status ===\n")
 
-        # Import here to avoid circular imports at module level
-        try:
-            from startup_checks import ServiceRunState
-        except ImportError:
-            ServiceRunState = None
-
-        if self._env_state and ServiceRunState:
+        if self._env_state and _HAS_STARTUP_CHECKS:
             for name, info in self._env_state.services.items():
                 if info.state == ServiceRunState.RUNNING:
                     print(f"  \033[0;32m●\033[0m {name:<18} running")
@@ -83,18 +91,18 @@ class DashboardMixin:
         print("=== Node Counts ===\n")
 
         # Meshtastic nodes via HTTP API
-        try:
-            from utils.meshtastic_http import get_http_client
-            client = get_http_client()
-            if client.is_available:
-                nodes = client.get_nodes()
-                print(f"  Meshtastic nodes: {len(nodes)}")
-            else:
-                print("  Meshtastic: HTTP API unavailable")
-        except ImportError:
+        if not _HAS_MESHTASTIC_HTTP:
             print("  Meshtastic: meshtastic_http module not available")
-        except Exception as e:
-            print(f"  Meshtastic: unavailable ({e})")
+        else:
+            try:
+                client = get_http_client()
+                if client.is_available:
+                    nodes = client.get_nodes()
+                    print(f"  Meshtastic nodes: {len(nodes)}")
+                else:
+                    print("  Meshtastic: HTTP API unavailable")
+            except Exception as e:
+                print(f"  Meshtastic: unavailable ({e})")
 
         # RNS destinations
         try:
@@ -166,73 +174,73 @@ class DashboardMixin:
 
         # Test 3: meshtasticd HTTP API
         print("[3/6] Testing meshtasticd HTTP API...")
-        try:
-            from utils.meshtastic_http import get_http_client, reset_http_client
-            # Reset singleton so we get a fresh probe (not stale cached state)
-            reset_http_client()
-            client = get_http_client()
-            if client.is_available:
-                nodes = client.get_nodes()
-                results.append(("meshtasticd HTTP", "OK",
-                               f"{len(nodes)} nodes via {client._base_url}"))
-                print(f"      \033[0;32mOK\033[0m - {len(nodes)} nodes at {client._base_url}")
-            else:
-                # Provide actionable fix guidance
-                hint = self._check_webserver_config()
-                detail = f"Not reachable (tried ports 9443,443,80,4403). {hint}"
-                results.append(("meshtasticd HTTP", "FAIL", detail))
-                print(f"      \033[0;31mFAIL\033[0m - HTTP API not reachable")
-                print(f"      \033[2m{hint}\033[0m")
-        except ImportError:
+        if not _HAS_MESHTASTIC_HTTP:
             results.append(("meshtasticd HTTP", "SKIP", "meshtastic_http module not available"))
             print("      \033[0;33mSKIP\033[0m - Module not available")
-        except Exception as e:
-            err_msg = str(e)[:50]
-            results.append(("meshtasticd HTTP", "FAIL", err_msg))
-            print(f"      \033[0;31mFAIL\033[0m - {err_msg}")
+        else:
+            try:
+                # Reset singleton so we get a fresh probe (not stale cached state)
+                reset_http_client()
+                client = get_http_client()
+                if client.is_available:
+                    nodes = client.get_nodes()
+                    results.append(("meshtasticd HTTP", "OK",
+                                   f"{len(nodes)} nodes via {client._base_url}"))
+                    print(f"      \033[0;32mOK\033[0m - {len(nodes)} nodes at {client._base_url}")
+                else:
+                    # Provide actionable fix guidance
+                    hint = self._check_webserver_config()
+                    detail = f"Not reachable (tried ports 9443,443,80,4403). {hint}"
+                    results.append(("meshtasticd HTTP", "FAIL", detail))
+                    print(f"      \033[0;31mFAIL\033[0m - HTTP API not reachable")
+                    print(f"      \033[2m{hint}\033[0m")
+            except Exception as e:
+                err_msg = str(e)[:50]
+                results.append(("meshtasticd HTTP", "FAIL", err_msg))
+                print(f"      \033[0;31mFAIL\033[0m - {err_msg}")
 
         # Test 4: pubsub availability
         print("[4/6] Testing pubsub (for live capture)...")
-        try:
-            from pubsub import pub
-            listeners = pub.getDefaultTopicMgr().getTopic('meshtastic.receive', okIfNone=True)
-            if listeners:
-                count = len(list(listeners.getListeners()))
-                results.append(("pubsub", "OK", f"{count} listener(s) on meshtastic.receive"))
-                print(f"      \033[0;32mOK\033[0m - {count} listener(s) registered")
-            else:
-                results.append(("pubsub", "WARN", "Topic exists but no listeners"))
-                print("      \033[0;33mWARN\033[0m - No listeners registered")
-        except ImportError:
+        if not _HAS_PUBSUB:
             results.append(("pubsub", "SKIP", "pubsub module not installed"))
             print("      \033[0;33mSKIP\033[0m - Module not installed")
-        except Exception as e:
-            results.append(("pubsub", "WARN", str(e)[:50]))
-            print(f"      \033[0;33mWARN\033[0m - {e}")
+        else:
+            try:
+                listeners = pub.getDefaultTopicMgr().getTopic('meshtastic.receive', okIfNone=True)
+                if listeners:
+                    count = len(list(listeners.getListeners()))
+                    results.append(("pubsub", "OK", f"{count} listener(s) on meshtastic.receive"))
+                    print(f"      \033[0;32mOK\033[0m - {count} listener(s) registered")
+                else:
+                    results.append(("pubsub", "WARN", "Topic exists but no listeners"))
+                    print("      \033[0;33mWARN\033[0m - No listeners registered")
+            except Exception as e:
+                results.append(("pubsub", "WARN", str(e)[:50]))
+                print(f"      \033[0;33mWARN\033[0m - {e}")
 
         # Test 5: MapDataCollector
         print("[5/6] Testing MapDataCollector...")
-        try:
-            from utils.map_data_collector import MapDataCollector
-            collector = MapDataCollector(enable_history=False)
-            geojson = collector.collect(max_age_seconds=30)
-            props = geojson.get('properties', {})
-            total = props.get('total_nodes', 0)
-            with_gps = props.get('nodes_with_position', 0)
-            sources = props.get('sources', {})
-            active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
-            if total > 0:
-                results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
-                print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")
-            else:
-                results.append(("MapDataCollector", "WARN", "0 nodes returned"))
-                print("      \033[0;33mWARN\033[0m - 0 nodes (check meshtasticd connection)")
-        except ImportError:
+        if not _HAS_MAP_COLLECTOR:
             results.append(("MapDataCollector", "SKIP", "Module not available"))
             print("      \033[0;33mSKIP\033[0m - Module not available")
-        except Exception as e:
-            results.append(("MapDataCollector", "FAIL", str(e)[:50]))
-            print(f"      \033[0;31mFAIL\033[0m - {e}")
+        else:
+            try:
+                collector = MapDataCollector(enable_history=False)
+                geojson = collector.collect(max_age_seconds=30)
+                props = geojson.get('properties', {})
+                total = props.get('total_nodes', 0)
+                with_gps = props.get('nodes_with_position', 0)
+                sources = props.get('sources', {})
+                active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
+                if total > 0:
+                    results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
+                    print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")
+                else:
+                    results.append(("MapDataCollector", "WARN", "0 nodes returned"))
+                    print("      \033[0;33mWARN\033[0m - 0 nodes (check meshtasticd connection)")
+            except Exception as e:
+                results.append(("MapDataCollector", "FAIL", str(e)[:50]))
+                print(f"      \033[0;31mFAIL\033[0m - {e}")
 
         # Test 6: RNS path table
         print("[6/6] Testing RNS path table...")
@@ -315,9 +323,7 @@ class DashboardMixin:
         print("=== Generating Network Status Report ===\n")
         print("Collecting data from all subsystems...\n")
 
-        try:
-            from utils.report_generator import generate_report
-        except ImportError:
+        if not _HAS_REPORT_GEN:
             print("  Report generator module not available.")
             print("  File: src/utils/report_generator.py")
             self._wait_for_enter()
@@ -335,9 +341,7 @@ class DashboardMixin:
         _sp.run(['clear'], check=False, timeout=5)
         print("=== Generating & Saving Report ===\n")
 
-        try:
-            from utils.report_generator import generate_and_save
-        except ImportError:
+        if not _HAS_REPORT_GEN:
             print("  Report generator module not available.")
             print("  File: src/utils/report_generator.py")
             self._wait_for_enter()
@@ -353,9 +357,7 @@ class DashboardMixin:
         _sp.run(['clear'], check=False, timeout=5)
         print("=== Network Health Score ===\n")
 
-        try:
-            from utils.health_score import get_health_scorer
-        except ImportError:
+        if not _HAS_HEALTH_SCORE:
             print("  Health score module not available.")
             print("  File: src/utils/health_score.py")
             self._wait_for_enter()
@@ -435,24 +437,22 @@ class DashboardMixin:
 
         # EAS / Weather alerts
         print()
-        try:
-            from plugins.eas_alerts import EASAlertsPlugin
-            plugin = EASAlertsPlugin()
-            eas_alerts = plugin.get_weather_alerts()
-            if eas_alerts:
-                print(f"WEATHER ALERTS ({len(eas_alerts)}):")
-                for alert in eas_alerts[:5]:
-                    severity = getattr(alert, 'severity', 'Unknown')
-                    headline = getattr(alert, 'headline', str(alert))
-                    if len(headline) > 65:
-                        headline = headline[:62] + "..."
-                    print(f"  \033[0;31m!\033[0m [{severity}] {headline}")
-            else:
-                print("  Weather: No active alerts")
-        except ImportError:
-            pass  # EAS plugin not installed, skip silently
-        except Exception as e:
-            logger.debug("EAS alert check failed: %s", e)
+        if _HAS_EAS:
+            try:
+                plugin = EASAlertsPlugin()
+                eas_alerts = plugin.get_weather_alerts()
+                if eas_alerts:
+                    print(f"WEATHER ALERTS ({len(eas_alerts)}):")
+                    for alert in eas_alerts[:5]:
+                        severity = getattr(alert, 'severity', 'Unknown')
+                        headline = getattr(alert, 'headline', str(alert))
+                        if len(headline) > 65:
+                            headline = headline[:62] + "..."
+                        print(f"  \033[0;31m!\033[0m [{severity}] {headline}")
+                else:
+                    print("  Weather: No active alerts")
+            except Exception as e:
+                logger.debug("EAS alert check failed: %s", e)
 
         print()
         self._wait_for_enter()

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -23,10 +23,11 @@ from typing import Optional, List, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
+from utils.safe_import import safe_import
+
 # Import path utilities
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
+get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+if not _HAS_PATHS:
     def get_real_user_home() -> Path:
         sudo_user = os.environ.get('SUDO_USER', '')
         if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
@@ -39,24 +40,15 @@ except ImportError:
         return Path('/root')
 
 # Import service check
-try:
-    from utils.service_check import check_service, apply_config_and_restart
-    _HAS_APPLY_RESTART = True
-except ImportError:
-    check_service = None
-    _HAS_APPLY_RESTART = False
+check_service, apply_config_and_restart, _HAS_APPLY_RESTART = safe_import(
+    'utils.service_check', 'check_service', 'apply_config_and_restart'
+)
 
 # Import device scanner
-try:
-    from utils.device_scanner import DeviceScanner
-except ImportError:
-    DeviceScanner = None
+DeviceScanner, _HAS_DEVICE_SCANNER = safe_import('utils.device_scanner', 'DeviceScanner')
 
 # Import startup checker for hardware detection
-try:
-    from startup_checks import StartupChecker
-except ImportError:
-    StartupChecker = None
+StartupChecker, _HAS_STARTUP_CHECKER = safe_import('startup_checks', 'StartupChecker')
 
 
 # =========================================================================

--- a/src/launcher_tui/messaging_mixin.py
+++ b/src/launcher_tui/messaging_mixin.py
@@ -7,8 +7,22 @@ Extracted as a mixin to keep main.py under 1,500 lines.
 
 import logging
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# --- Optional dependencies (module-level) ---
+event_bus, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'event_bus')
+
+(send_message, get_messages, get_conversations, get_stats,
+ start_receiving, stop_receiving, get_rx_status,
+ diagnose, get_routing_info, clear_messages,
+ _HAS_MESSAGING) = safe_import(
+    'commands.messaging',
+    'send_message', 'get_messages', 'get_conversations', 'get_stats',
+    'start_receiving', 'stop_receiving', 'get_rx_status',
+    'diagnose', 'get_routing_info', 'clear_messages',
+)
 
 
 class MessagingMixin:
@@ -62,9 +76,7 @@ class MessagingMixin:
         """
         import threading
 
-        try:
-            from utils.event_bus import event_bus
-        except ImportError:
+        if not _HAS_EVENT_BUS:
             self.dialog.msgbox("Unavailable", "Event bus module not available.\nFile: src/utils/event_bus.py")
             return
 
@@ -116,9 +128,7 @@ class MessagingMixin:
 
     def _messaging_send(self):
         """Send a message via mesh network."""
-        try:
-            from commands.messaging import send_message
-        except ImportError:
+        if not _HAS_MESSAGING:
             self.dialog.msgbox("Unavailable", "Messaging module not available.\nFile: src/commands/messaging.py")
             return
 
@@ -183,9 +193,7 @@ class MessagingMixin:
         clear_screen()
         print("=== Recent Messages ===\n")
 
-        try:
-            from commands.messaging import get_messages
-        except ImportError:
+        if not _HAS_MESSAGING:
             print("  Messaging module not available.")
             self._wait_for_enter()
             return
@@ -226,9 +234,7 @@ class MessagingMixin:
         clear_screen()
         print("=== Conversations ===\n")
 
-        try:
-            from commands.messaging import get_conversations
-        except ImportError:
+        if not _HAS_MESSAGING:
             print("  Messaging module not available.")
             self._wait_for_enter()
             return
@@ -264,9 +270,7 @@ class MessagingMixin:
         clear_screen()
         print("=== Messaging Statistics ===\n")
 
-        try:
-            from commands.messaging import get_stats
-        except ImportError:
+        if not _HAS_MESSAGING:
             print("  Messaging module not available.")
             self._wait_for_enter()
             return
@@ -296,9 +300,7 @@ class MessagingMixin:
 
     def _messaging_rx_control(self):
         """Start or stop the message RX listener."""
-        try:
-            from commands.messaging import start_receiving, stop_receiving, get_rx_status
-        except ImportError:
+        if not _HAS_MESSAGING:
             self.dialog.msgbox("Unavailable", "Messaging module not available.")
             return
 
@@ -331,9 +333,7 @@ class MessagingMixin:
         clear_screen()
         print("=== Messaging Diagnostics ===\n")
 
-        try:
-            from commands.messaging import diagnose
-        except ImportError:
+        if not _HAS_MESSAGING:
             print("  Messaging module not available.")
             self._wait_for_enter()
             return
@@ -364,9 +364,7 @@ class MessagingMixin:
         clear_screen()
         print("=== Messaging Routing Info ===\n")
 
-        try:
-            from commands.messaging import get_routing_info
-        except ImportError:
+        if not _HAS_MESSAGING:
             print("  Messaging module not available.")
             self._wait_for_enter()
             return
@@ -388,9 +386,7 @@ class MessagingMixin:
 
     def _messaging_cleanup(self):
         """Purge old messages."""
-        try:
-            from commands.messaging import clear_messages
-        except ImportError:
+        if not _HAS_MESSAGING:
             self.dialog.msgbox("Unavailable", "Messaging module not available.")
             return
 

--- a/src/launcher_tui/metrics_mixin.py
+++ b/src/launcher_tui/metrics_mixin.py
@@ -13,8 +13,18 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# Module-level safe imports
+get_metrics_history, MetricType, _HAS_METRICS_HISTORY = safe_import(
+    'utils.metrics_history', 'get_metrics_history', 'MetricType'
+)
+get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+start_metrics_server, _HAS_METRICS_EXPORT = safe_import(
+    'utils.metrics_export', 'start_metrics_server'
+)
 
 
 class MetricsMixin:
@@ -62,11 +72,9 @@ class MetricsMixin:
 
     def _get_metrics_history(self):
         """Get the MetricsHistory instance."""
-        try:
-            from utils.metrics_history import get_metrics_history
-            return get_metrics_history()
-        except ImportError:
+        if not _HAS_METRICS_HISTORY:
             return None
+        return get_metrics_history()
 
     def _metrics_stats(self):
         """Show metrics storage statistics."""
@@ -113,9 +121,7 @@ class MetricsMixin:
             self.dialog.msgbox("Unavailable", "Metrics history module not loaded.")
             return
 
-        try:
-            from utils.metrics_history import MetricType
-        except ImportError:
+        if not _HAS_METRICS_HISTORY:
             self.dialog.msgbox("Error", "MetricType not available")
             return
 
@@ -283,9 +289,7 @@ class MetricsMixin:
             self.dialog.msgbox("Unavailable", "Metrics history module not loaded.")
             return
 
-        try:
-            from utils.metrics_history import MetricType
-        except ImportError:
+        if not _HAS_METRICS_HISTORY:
             return
 
         # Get edge info from user
@@ -423,11 +427,9 @@ class MetricsMixin:
             return
 
         # Default export path
-        try:
-            from utils.paths import get_real_user_home
+        if _HAS_PATHS:
             export_dir = get_real_user_home() / ".cache" / "meshforge"
-        except ImportError:
-            from pathlib import Path
+        else:
             import os
             sudo_user = os.environ.get('SUDO_USER', '')
             if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
@@ -510,9 +512,7 @@ class MetricsMixin:
 
     def _prometheus_start(self):
         """Start Prometheus server in background thread."""
-        try:
-            from utils.metrics_export import start_metrics_server
-        except ImportError:
+        if not _HAS_METRICS_EXPORT:
             self.dialog.msgbox("Error", "Prometheus exporter module not available.")
             return
 

--- a/src/launcher_tui/mqtt_mixin.py
+++ b/src/launcher_tui/mqtt_mixin.py
@@ -34,9 +34,9 @@ MQTTWebSocketBridge, is_bridge_available, _HAS_WS_BRIDGE_MOD = safe_import(
 )
 _HAS_WS_BRIDGE = is_bridge_available() if _HAS_WS_BRIDGE_MOD and is_bridge_available else False
 
-# Try to import TelemetryPoller for auto-start
-get_telemetry_poller, _HAS_TELEMETRY_POLLER = safe_import(
-    'utils.telemetry_poller', 'get_telemetry_poller'
+# Try to import TelemetryPoller for auto-start and telemetry requests
+TelemetryPoller, get_telemetry_poller, _HAS_TELEMETRY_POLLER = safe_import(
+    'utils.telemetry_poller', 'TelemetryPoller', 'get_telemetry_poller'
 )
 
 
@@ -1121,19 +1121,13 @@ class MQTTMixin:
         mesh congestion. This menu allows requesting telemetry from specific
         nodes or identifying silent nodes that haven't reported recently.
         """
-        try:
-            from utils.telemetry_poller import TelemetryPoller, get_telemetry_poller
-            _HAS_POLLER = True
-        except ImportError:
-            _HAS_POLLER = False
-
         choices = [
             ("single", "Request from Node    Enter node ID manually"),
             ("silent", "Find Silent Nodes    Nodes with stale telemetry"),
             ("batch", "Poll Silent Nodes    Request from all silent"),
         ]
 
-        if _HAS_POLLER:
+        if _HAS_TELEMETRY_POLLER:
             poller = get_telemetry_poller()
             stats = poller.get_stats()
             choices.append(("stats", f"Poller Statistics    {stats.get('total_requests', 0)} requests"))

--- a/src/launcher_tui/node_health_mixin.py
+++ b/src/launcher_tui/node_health_mixin.py
@@ -13,8 +13,24 @@ import logging
 import subprocess
 import time
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# --- Optional dependencies (module-level safe_import) ---
+probe_tcp, DEFAULT_SERVICES, _HAS_LATENCY = safe_import(
+    'utils.latency_monitor', 'probe_tcp', 'DEFAULT_SERVICES'
+)
+MaintenancePredictor, _HAS_PREDICTOR = safe_import(
+    'utils.predictive_maintenance', 'MaintenancePredictor'
+)
+SignalTrend, SignalTrendingManager, _HAS_SIGNAL = safe_import(
+    'utils.signal_trending', 'SignalTrend', 'SignalTrendingManager'
+)
+get_http_client, _HAS_HTTP = safe_import(
+    'utils.meshtastic_http', 'get_http_client'
+)
+meshtastic_tcp, _HAS_MESHTASTIC_TCP = safe_import('meshtastic.tcp_interface')
 
 
 class NodeHealthMixin:
@@ -54,9 +70,7 @@ class NodeHealthMixin:
         print("=== Service Latency Probe ===\n")
         print("Probing services (2s timeout each)...\n")
 
-        try:
-            from utils.latency_monitor import probe_tcp, DEFAULT_SERVICES
-        except ImportError:
+        if not _HAS_LATENCY:
             print("  Latency monitor module not available.")
             print("  File: src/utils/latency_monitor.py")
             self._wait_for_enter()
@@ -109,9 +123,7 @@ class NodeHealthMixin:
         clear_screen()
         print("=== Battery Forecast & Maintenance ===\n")
 
-        try:
-            from utils.predictive_maintenance import MaintenancePredictor
-        except ImportError:
+        if not _HAS_PREDICTOR:
             print("  Predictive maintenance module not available.")
             print("  File: src/utils/predictive_maintenance.py")
             self._wait_for_enter()
@@ -215,62 +227,62 @@ class NodeHealthMixin:
         nodes = {}
 
         # Primary: meshtasticd HTTP API (no TCP lock, no Python lib needed)
-        try:
-            from utils.meshtastic_http import get_http_client
-            client = get_http_client()
-            if client.is_available:
-                report = client.get_report()
-                http_nodes = client.get_nodes()
-                # Device report has battery for the local node
-                if report and report.has_battery:
-                    nodes['local'] = {
-                        'battery_level': report.battery_percent,
-                        'voltage': report.battery_voltage_mv / 1000.0 if report.battery_voltage_mv else None,
-                        'short_name': 'Local',
-                        'long_name': 'Local Device',
-                    }
-                # Node list has per-node data
-                for node in http_nodes:
-                    # HTTP API doesn't expose per-node battery yet,
-                    # but we get the node list for signal/position data
-                    nodes[node.node_id] = {
-                        'battery_level': None,
-                        'voltage': None,
-                        'short_name': node.short_name or node.node_id[:8],
-                        'long_name': node.long_name or '',
-                        'snr': node.snr,
-                    }
-                if nodes:
-                    return nodes
-        except ImportError:
+        if _HAS_HTTP:
+            try:
+                client = get_http_client()
+                if client.is_available:
+                    report = client.get_report()
+                    http_nodes = client.get_nodes()
+                    # Device report has battery for the local node
+                    if report and report.has_battery:
+                        nodes['local'] = {
+                            'battery_level': report.battery_percent,
+                            'voltage': report.battery_voltage_mv / 1000.0 if report.battery_voltage_mv else None,
+                            'short_name': 'Local',
+                            'long_name': 'Local Device',
+                        }
+                    # Node list has per-node data
+                    for node in http_nodes:
+                        # HTTP API doesn't expose per-node battery yet,
+                        # but we get the node list for signal/position data
+                        nodes[node.node_id] = {
+                            'battery_level': None,
+                            'voltage': None,
+                            'short_name': node.short_name or node.node_id[:8],
+                            'long_name': node.long_name or '',
+                            'snr': node.snr,
+                        }
+                    if nodes:
+                        return nodes
+            except Exception as e:
+                logger.debug(f"HTTP API telemetry query failed: {e}")
+        else:
             logger.debug("meshtastic_http module not available")
-        except Exception as e:
-            logger.debug(f"HTTP API telemetry query failed: {e}")
 
         # Fallback: meshtastic TCP API (legacy, needs meshtastic Python lib)
-        try:
-            import meshtastic.tcp_interface
-            iface = meshtastic.tcp_interface.TCPInterface(
-                hostname='localhost', connectNow=True
-            )
-            if iface.nodes:
-                for node_id, node in iface.nodes.items():
-                    device_metrics = node.get('deviceMetrics', {})
-                    user = node.get('user', {})
-                    if device_metrics:
-                        nodes[node_id] = {
-                            'battery_level': device_metrics.get('batteryLevel'),
-                            'voltage': device_metrics.get('voltage'),
-                            'short_name': user.get('shortName', node_id[:8]),
-                            'long_name': user.get('longName', ''),
-                        }
-            iface.close()
-        except ImportError:
+        if _HAS_MESHTASTIC_TCP:
+            try:
+                iface = meshtastic_tcp.TCPInterface(
+                    hostname='localhost', connectNow=True
+                )
+                if iface.nodes:
+                    for node_id, node in iface.nodes.items():
+                        device_metrics = node.get('deviceMetrics', {})
+                        user = node.get('user', {})
+                        if device_metrics:
+                            nodes[node_id] = {
+                                'battery_level': device_metrics.get('batteryLevel'),
+                                'voltage': device_metrics.get('voltage'),
+                                'short_name': user.get('shortName', node_id[:8]),
+                                'long_name': user.get('longName', ''),
+                            }
+                iface.close()
+            except (ConnectionRefusedError, OSError, TimeoutError) as e:
+                logger.debug(f"meshtasticd not reachable for telemetry: {e}")
+            except Exception as e:
+                logger.warning(f"Unexpected error querying meshtastic telemetry: {e}")
+        else:
             logger.debug("meshtastic module not installed, skipping TCP telemetry")
-        except (ConnectionRefusedError, OSError, TimeoutError) as e:
-            logger.debug(f"meshtasticd not reachable for telemetry: {e}")
-        except Exception as e:
-            logger.warning(f"Unexpected error querying meshtastic telemetry: {e}")
 
         return nodes
 
@@ -279,9 +291,7 @@ class NodeHealthMixin:
         clear_screen()
         print("=== Signal Trending Analysis ===\n")
 
-        try:
-            from utils.signal_trending import SignalTrend, SignalTrendingManager
-        except ImportError:
+        if not _HAS_SIGNAL:
             print("  Signal trending module not available.")
             print("  File: src/utils/signal_trending.py")
             self._wait_for_enter()
@@ -377,50 +387,50 @@ class NodeHealthMixin:
         nodes = {}
 
         # Primary: meshtasticd HTTP API
-        try:
-            from utils.meshtastic_http import get_http_client
-            client = get_http_client()
-            if client.is_available:
-                for node in client.get_nodes():
-                    if node.snr:
-                        nodes[node.node_id] = {
-                            'snr': node.snr,
-                            'rssi': None,  # HTTP /json/nodes doesn't expose RSSI
-                            'short_name': node.short_name or node.node_id[:8],
-                            'hops_away': None,
-                        }
-                if nodes:
-                    return nodes
-        except ImportError:
+        if _HAS_HTTP:
+            try:
+                client = get_http_client()
+                if client.is_available:
+                    for node in client.get_nodes():
+                        if node.snr:
+                            nodes[node.node_id] = {
+                                'snr': node.snr,
+                                'rssi': None,  # HTTP /json/nodes doesn't expose RSSI
+                                'short_name': node.short_name or node.node_id[:8],
+                                'hops_away': None,
+                            }
+                    if nodes:
+                        return nodes
+            except Exception as e:
+                logger.debug(f"HTTP API signal query failed: {e}")
+        else:
             logger.debug("meshtastic_http module not available")
-        except Exception as e:
-            logger.debug(f"HTTP API signal query failed: {e}")
 
         # Fallback: meshtastic TCP API (legacy)
-        try:
-            import meshtastic.tcp_interface
-            iface = meshtastic.tcp_interface.TCPInterface(
-                hostname='localhost', connectNow=True
-            )
-            if iface.nodes:
-                for node_id, node in iface.nodes.items():
-                    user = node.get('user', {})
-                    snr = node.get('snr')
-                    rssi = node.get('rssi')
-                    hops = node.get('hopsAway')
-                    if snr is not None or rssi is not None:
-                        nodes[node_id] = {
-                            'snr': snr,
-                            'rssi': rssi,
-                            'short_name': user.get('shortName', node_id[:8]),
-                            'hops_away': hops,
-                        }
-            iface.close()
-        except ImportError:
+        if _HAS_MESHTASTIC_TCP:
+            try:
+                iface = meshtastic_tcp.TCPInterface(
+                    hostname='localhost', connectNow=True
+                )
+                if iface.nodes:
+                    for node_id, node in iface.nodes.items():
+                        user = node.get('user', {})
+                        snr = node.get('snr')
+                        rssi = node.get('rssi')
+                        hops = node.get('hopsAway')
+                        if snr is not None or rssi is not None:
+                            nodes[node_id] = {
+                                'snr': snr,
+                                'rssi': rssi,
+                                'short_name': user.get('shortName', node_id[:8]),
+                                'hops_away': hops,
+                            }
+                iface.close()
+            except (ConnectionRefusedError, OSError, TimeoutError) as e:
+                logger.debug(f"meshtasticd not reachable for signal data: {e}")
+            except Exception as e:
+                logger.warning(f"Unexpected error querying meshtastic signal data: {e}")
+        else:
             logger.debug("meshtastic module not installed, skipping signal data")
-        except (ConnectionRefusedError, OSError, TimeoutError) as e:
-            logger.debug(f"meshtasticd not reachable for signal data: {e}")
-        except Exception as e:
-            logger.warning(f"Unexpected error querying meshtastic signal data: {e}")
 
         return nodes

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -26,16 +26,21 @@ from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
+from utils.safe_import import safe_import
+
 # Import centralized service checking
-try:
-    from utils.service_check import (
-        check_systemd_service,
-        check_process_running,
-        check_port as _check_port,
-    )
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
+check_systemd_service, check_process_running, _check_port, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port'
+)
+
+# Optional modules for quick actions
+generate_report, _HAS_REPORT_GENERATOR = safe_import('utils.report_generator', 'generate_report')
+NodeInventory, _HAS_NODE_INVENTORY = safe_import('utils.node_inventory', 'NodeInventory')
+GPSManager, _HAS_GPS_INTEGRATION = safe_import('utils.gps_integration', 'GPSManager')
+get_diagnostic_engine, _HAS_DIAGNOSTIC_ENGINE = safe_import(
+    'utils.diagnostic_engine', 'get_diagnostic_engine'
+)
+ChannelMonitor, _HAS_CHANNEL_SCAN = safe_import('utils.channel_scan', 'ChannelMonitor')
 
 
 # Quick action definitions: (tag, description, method_name)
@@ -297,26 +302,26 @@ class QuickActionsMixin:
         clear_screen()
         print("Generating status report...\n")
 
-        try:
-            from utils.report_generator import generate_report
-            report = generate_report()
-            # Print report, paginated
-            lines = report.split('\n')
-            for i, line in enumerate(lines):
-                print(line)
-                # Pause every 40 lines
-                if (i + 1) % 40 == 0 and i + 1 < len(lines):
-                    try:
-                        resp = input("\n--- More (Enter=continue, q=quit) ---\n")
-                    except (KeyboardInterrupt, EOFError):
-                        print()
-                        break
-                    if resp.strip().lower() == 'q':
-                        break
-        except ImportError:
+        if not _HAS_REPORT_GENERATOR:
             print("Error: Report generator module not available.")
-        except Exception as e:
-            print(f"Error generating report: {e}")
+        else:
+            try:
+                report = generate_report()
+                # Print report, paginated
+                lines = report.split('\n')
+                for i, line in enumerate(lines):
+                    print(line)
+                    # Pause every 40 lines
+                    if (i + 1) % 40 == 0 and i + 1 < len(lines):
+                        try:
+                            resp = input("\n--- More (Enter=continue, q=quit) ---\n")
+                        except (KeyboardInterrupt, EOFError):
+                            print()
+                            break
+                        if resp.strip().lower() == 'q':
+                            break
+            except Exception as e:
+                print(f"Error generating report: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -326,49 +331,49 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Node Inventory ===\n")
 
-        try:
-            from utils.node_inventory import NodeInventory
-            from utils.paths import get_real_user_home
-
-            path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
-            inv = NodeInventory(path=path)
-
-            stats = inv.get_stats()
-            print(f"  Total nodes:    {stats['total']}")
-            print(f"  Online:         {stats['online']}")
-            print(f"  Offline:        {stats['offline']}")
-            print(f"  Stale (>7d):    {stats['stale']}")
-            print(f"  With position:  {stats['with_position']}")
-
-            if stats['total'] > 0:
-                # Show node list (non-stale only)
-                nodes = [n for n in inv.get_all_nodes() if not n.is_stale]
-                if nodes:
-                    print(f"\n  {'ID':<12} {'Name':<20} {'Status':<8} {'SNR':>5}  {'Hardware'}")
-                    print(f"  {'-'*12} {'-'*20} {'-'*8} {'-'*5}  {'-'*12}")
-                    for node in nodes[:25]:  # Cap at 25 for readability
-                        name = node.display_name[:20]
-                        nid = node.node_id[:12]
-                        status = node.status
-                        snr = f"{node.last_snr:.1f}" if node.last_snr is not None else "  -"
-                        hw = node.hardware[:12] if node.hardware else "-"
-                        print(f"  {nid:<12} {name:<20} {status:<8} {snr:>5}  {hw}")
-                    if len(nodes) > 25:
-                        print(f"\n  ... and {len(nodes) - 25} more nodes")
-
-                # Role breakdown
-                if stats['roles']:
-                    roles_str = ", ".join(f"{r}: {c}" for r, c in stats['roles'].items())
-                    print(f"\n  Roles: {roles_str}")
-            else:
-                print("\n  No nodes tracked yet.")
-                print("  Nodes are added when received via MQTT or meshtastic CLI.")
-
-        except ImportError:
+        if not _HAS_NODE_INVENTORY:
             print("Error: Node inventory module not available.")
-        except Exception as e:
-            logger.debug(f"Node inventory quick action failed: {e}")
-            print(f"Error: {e}")
+        else:
+            try:
+                from utils.paths import get_real_user_home
+
+                path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+                inv = NodeInventory(path=path)
+
+                stats = inv.get_stats()
+                print(f"  Total nodes:    {stats['total']}")
+                print(f"  Online:         {stats['online']}")
+                print(f"  Offline:        {stats['offline']}")
+                print(f"  Stale (>7d):    {stats['stale']}")
+                print(f"  With position:  {stats['with_position']}")
+
+                if stats['total'] > 0:
+                    # Show node list (non-stale only)
+                    nodes = [n for n in inv.get_all_nodes() if not n.is_stale]
+                    if nodes:
+                        print(f"\n  {'ID':<12} {'Name':<20} {'Status':<8} {'SNR':>5}  {'Hardware'}")
+                        print(f"  {'-'*12} {'-'*20} {'-'*8} {'-'*5}  {'-'*12}")
+                        for node in nodes[:25]:  # Cap at 25 for readability
+                            name = node.display_name[:20]
+                            nid = node.node_id[:12]
+                            status = node.status
+                            snr = f"{node.last_snr:.1f}" if node.last_snr is not None else "  -"
+                            hw = node.hardware[:12] if node.hardware else "-"
+                            print(f"  {nid:<12} {name:<20} {status:<8} {snr:>5}  {hw}")
+                        if len(nodes) > 25:
+                            print(f"\n  ... and {len(nodes) - 25} more nodes")
+
+                    # Role breakdown
+                    if stats['roles']:
+                        roles_str = ", ".join(f"{r}: {c}" for r, c in stats['roles'].items())
+                        print(f"\n  Roles: {roles_str}")
+                else:
+                    print("\n  No nodes tracked yet.")
+                    print("  Nodes are added when received via MQTT or meshtastic CLI.")
+
+            except Exception as e:
+                logger.debug(f"Node inventory quick action failed: {e}")
+                print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -378,48 +383,48 @@ class QuickActionsMixin:
         clear_screen()
         print("=== GPS Position ===\n")
 
-        try:
-            from utils.gps_integration import GPSManager
-            from utils.paths import get_real_user_home
-
-            config_path = get_real_user_home() / ".config" / "meshforge" / "operator_position.json"
-            gps = GPSManager(config_path=config_path)
-
-            # Try to get nodes for distance calculation
-            nodes = []
-            try:
-                from utils.node_inventory import NodeInventory
-                inv_path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
-                inv = NodeInventory(path=inv_path)
-                for node in inv.get_all_nodes():
-                    if node.has_position:
-                        nodes.append({
-                            'id': node.node_id,
-                            'name': node.display_name,
-                            'lat': node.lat,
-                            'lon': node.lon,
-                        })
-            except Exception as e:
-                logger.debug("Node inventory for GPS report unavailable: %s", e)
-
-            # Display position report
-            report = gps.format_position_report(nodes=nodes if nodes else None)
-            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
-
-            # Show gpsd status
-            print()
-            if gps.gpsd_available:
-                print("  gpsd: connected")
-            else:
-                print("  gpsd: not available")
-                if not gps.has_position:
-                    print("  Tip: Set position manually in Tools > GPS")
-
-        except ImportError:
+        if not _HAS_GPS_INTEGRATION:
             print("Error: GPS integration module not available.")
-        except Exception as e:
-            logger.debug(f"GPS quick action failed: {e}")
-            print(f"Error: {e}")
+        else:
+            try:
+                from utils.paths import get_real_user_home
+
+                config_path = get_real_user_home() / ".config" / "meshforge" / "operator_position.json"
+                gps = GPSManager(config_path=config_path)
+
+                # Try to get nodes for distance calculation
+                nodes = []
+                try:
+                    from utils.node_inventory import NodeInventory as _NodeInv
+                    inv_path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+                    inv = _NodeInv(path=inv_path)
+                    for node in inv.get_all_nodes():
+                        if node.has_position:
+                            nodes.append({
+                                'id': node.node_id,
+                                'name': node.display_name,
+                                'lat': node.lat,
+                                'lon': node.lon,
+                            })
+                except Exception as e:
+                    logger.debug("Node inventory for GPS report unavailable: %s", e)
+
+                # Display position report
+                report = gps.format_position_report(nodes=nodes if nodes else None)
+                print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+
+                # Show gpsd status
+                print()
+                if gps.gpsd_available:
+                    print("  gpsd: connected")
+                else:
+                    print("  gpsd: not available")
+                    if not gps.has_position:
+                        print("  Tip: Set position manually in Tools > GPS")
+
+            except Exception as e:
+                logger.debug(f"GPS quick action failed: {e}")
+                print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -429,31 +434,31 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Diagnostic Health Check ===\n")
 
-        try:
-            from utils.diagnostic_engine import get_diagnostic_engine
-            engine = get_diagnostic_engine()
-            summary = engine.get_health_summary()
-
-            print(f"  Overall Health:    {summary['overall_health']}")
-            print(f"  Symptoms (1h):     {summary['symptoms_last_hour']}")
-            print(f"  Total Diagnoses:   {summary['stats'].get('diagnoses_made', 0)}")
-            print(f"  Auto-Recoveries:   {summary['stats'].get('auto_recoveries', 0)}")
-            print(f"  Rules Loaded:      {summary['stats'].get('rules_loaded', 0)}")
-
-            # Recent issues
-            recent = engine.get_recent_diagnoses(limit=5)
-            if recent:
-                print(f"\n  Recent Issues ({len(recent)}):")
-                for d in recent[-5:]:
-                    cat = d.symptom.category.value
-                    print(f"    [{cat}] {d.likely_cause[:60]}")
-            else:
-                print("\n  No recent issues detected.")
-
-        except ImportError:
+        if not _HAS_DIAGNOSTIC_ENGINE:
             print("Error: Diagnostic engine not available.")
-        except Exception as e:
-            print(f"Error: {e}")
+        else:
+            try:
+                engine = get_diagnostic_engine()
+                summary = engine.get_health_summary()
+
+                print(f"  Overall Health:    {summary['overall_health']}")
+                print(f"  Symptoms (1h):     {summary['symptoms_last_hour']}")
+                print(f"  Total Diagnoses:   {summary['stats'].get('diagnoses_made', 0)}")
+                print(f"  Auto-Recoveries:   {summary['stats'].get('auto_recoveries', 0)}")
+                print(f"  Rules Loaded:      {summary['stats'].get('rules_loaded', 0)}")
+
+                # Recent issues
+                recent = engine.get_recent_diagnoses(limit=5)
+                if recent:
+                    print(f"\n  Recent Issues ({len(recent)}):")
+                    for d in recent[-5:]:
+                        cat = d.symptom.category.value
+                        print(f"    [{cat}] {d.likely_cause[:60]}")
+                else:
+                    print("\n  No recent issues detected.")
+
+            except Exception as e:
+                print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -463,27 +468,26 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Channel Activity ===\n")
 
-        try:
-            from utils.channel_scan import ChannelMonitor
-
-            monitor = ChannelMonitor()
-
-            # Try to query device for channel config
-            channels = monitor.query_device_channels()
-            if not channels:
-                print("  (Could not query device channels)")
-                print("  Showing activity from MQTT monitoring only.")
-                print()
-
-            # Display activity report
-            report = monitor.get_activity_report()
-            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
-
-        except ImportError:
+        if not _HAS_CHANNEL_SCAN:
             print("Error: Channel scan module not available.")
-        except Exception as e:
-            logger.debug(f"Channel scan quick action failed: {e}")
-            print(f"Error: {e}")
+        else:
+            try:
+                monitor = ChannelMonitor()
+
+                # Try to query device for channel config
+                channels = monitor.query_device_channels()
+                if not channels:
+                    print("  (Could not query device channels)")
+                    print("  Showing activity from MQTT monitoring only.")
+                    print()
+
+                # Display activity report
+                report = monitor.get_activity_report()
+                print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+
+            except Exception as e:
+                logger.debug(f"Channel scan quick action failed: {e}")
+                print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/rf_awareness_mixin.py
+++ b/src/launcher_tui/rf_awareness_mixin.py
@@ -15,8 +15,14 @@ import time
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# RF Awareness module — optional dependency (requires numpy, optionally SoapySDR)
+RFAwareness, LoRaBand, _HAS_RF_AWARENESS = safe_import(
+    'utils.rf_awareness', 'RFAwareness', 'LoRaBand'
+)
 
 
 class RFAwarenessMixin:
@@ -60,13 +66,11 @@ class RFAwarenessMixin:
 
     def _get_rf_awareness(self):
         """Get or create RFAwareness instance."""
-        try:
-            from utils.rf_awareness import RFAwareness
-            if not hasattr(self, '_rf_awareness') or self._rf_awareness is None:
-                self._rf_awareness = RFAwareness()
-            return self._rf_awareness
-        except ImportError:
+        if not _HAS_RF_AWARENESS:
             return None
+        if not hasattr(self, '_rf_awareness') or self._rf_awareness is None:
+            self._rf_awareness = RFAwareness()
+        return self._rf_awareness
 
     def _rf_status(self):
         """Show SDR status and manage connection."""
@@ -165,8 +169,7 @@ class RFAwarenessMixin:
                 return
 
         # Select band
-        try:
-            from utils.rf_awareness import LoRaBand
+        if _HAS_RF_AWARENESS:
             band_choices = [
                 ("US_915", "US 915 MHz (902-928 MHz)"),
                 ("EU_868", "EU 868 MHz (863-870 MHz)"),
@@ -175,7 +178,7 @@ class RFAwarenessMixin:
                 ("custom", "Custom Frequency"),
                 ("back", "Back"),
             ]
-        except ImportError:
+        else:
             band_choices = [("custom", "Custom Frequency"), ("back", "Back")]
 
         band_choice = self.dialog.menu(
@@ -240,12 +243,11 @@ class RFAwarenessMixin:
                 self.dialog.msgbox("Error", "Failed to connect to SDR")
                 return
 
-        try:
-            from utils.rf_awareness import LoRaBand
-            band = LoRaBand.US_915
-        except ImportError:
+        if not _HAS_RF_AWARENESS:
             self.dialog.msgbox("Error", "LoRaBand not available")
             return
+
+        band = LoRaBand.US_915
 
         # Show waterfall in terminal (exit TUI temporarily)
         clear_screen()
@@ -318,11 +320,7 @@ class RFAwarenessMixin:
             self.dialog.msgbox("Error", "Invalid duration (1-300 seconds)")
             return
 
-        try:
-            from utils.rf_awareness import LoRaBand
-            band = LoRaBand.US_915
-        except ImportError:
-            band = None
+        band = LoRaBand.US_915 if _HAS_RF_AWARENESS else None
 
         self.dialog.infobox(
             "Measuring...",
@@ -386,9 +384,7 @@ class RFAwarenessMixin:
                 self.dialog.msgbox("Error", "Failed to connect to SDR")
                 return
 
-        try:
-            from utils.rf_awareness import LoRaBand
-        except ImportError:
+        if not _HAS_RF_AWARENESS:
             self.dialog.msgbox("Error", "Module not available")
             return
 
@@ -471,12 +467,11 @@ class RFAwarenessMixin:
                 self.dialog.msgbox("Error", "Failed to connect to SDR")
                 return
 
-        try:
-            from utils.rf_awareness import LoRaBand
-            band = LoRaBand.US_915
-        except ImportError:
+        if not _HAS_RF_AWARENESS:
             self.dialog.msgbox("Error", "Module not available")
             return
+
+        band = LoRaBand.US_915
 
         self.dialog.infobox(
             "Scanning...",

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -17,18 +17,29 @@ logger = logging.getLogger(__name__)
 
 from rns_sniffer_mixin import RNSSnifferMixin
 
-# Import centralized service checking
-try:
-    from utils.service_check import check_process_running
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
-
 # Import centralized path utility - SINGLE SOURCE OF TRUTH for all paths
 # See: utils/paths.py (ReticulumPaths, get_real_user_home)
 # NO FALLBACK: stale fallback copies caused config divergence bugs (Issue #25+)
 from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
+
+# --- Optional dependency imports via safe_import ---
+from utils.safe_import import safe_import
+
+check_process_running, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running'
+)
+
+get_identity_path, create_identities, list_known_destinations, \
+    check_connectivity, get_status, _HAS_RNS_COMMANDS = safe_import(
+    'commands.rns',
+    'get_identity_path', 'create_identities', 'list_known_destinations',
+    'check_connectivity', 'get_status',
+)
+
+detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
+    'utils.config_drift', 'detect_rnsd_config_drift'
+)
 
 
 class RNSMenuMixin(RNSSnifferMixin):
@@ -150,10 +161,9 @@ class RNSMenuMixin(RNSSnifferMixin):
             # Check identity status for menu hints
             config_dir = ReticulumPaths.get_config_dir()
             rnsd_exists = (config_dir / 'identity').exists()
-            try:
-                from commands.rns import get_identity_path
+            if _HAS_RNS_COMMANDS:
                 gw_exists = get_identity_path().exists()
-            except ImportError:
+            else:
                 gw_exists = False
 
             choices = [
@@ -195,7 +205,7 @@ class RNSMenuMixin(RNSSnifferMixin):
                         print(f"rnsd identity: {rnsd_identity}")
                         print("  Not found — use 'Create identities' to generate.\n")
 
-                    try:
+                    if _HAS_RNS_COMMANDS:
                         gw_id = get_identity_path()
                         print(f"\nMeshForge gateway identity: {gw_id}")
                         if gw_id.exists():
@@ -205,8 +215,6 @@ class RNSMenuMixin(RNSSnifferMixin):
                             )
                         else:
                             print("  Not created — use 'Create identities' to generate.")
-                    except ImportError:
-                        pass
                     self._wait_for_enter()
 
                 elif choice == "path":
@@ -225,8 +233,7 @@ class RNSMenuMixin(RNSSnifferMixin):
                     else:
                         print("  Not found (created on first rnsd start)")
 
-                    try:
-                        from commands.rns import get_identity_path
+                    if _HAS_RNS_COMMANDS:
                         gw_id = get_identity_path()
                         print(f"\nMeshForge gateway:  {gw_id}")
                         if gw_id.exists():
@@ -234,8 +241,6 @@ class RNSMenuMixin(RNSSnifferMixin):
                             print(f"  Size: {stat.st_size} bytes")
                         else:
                             print("  Not created yet")
-                    except ImportError:
-                        pass
                     self._wait_for_enter()
 
                 elif choice == "recall":
@@ -271,8 +276,13 @@ class RNSMenuMixin(RNSSnifferMixin):
         clear_screen()
         print("=== Create RNS Identities ===\n")
 
+        if not _HAS_RNS_COMMANDS:
+            print("ERROR: RNS module not installed.")
+            print("  Install: pip install rns")
+            self._wait_for_enter()
+            return
+
         try:
-            from commands.rns import create_identities, get_identity_path
             config_dir = ReticulumPaths.get_config_dir()
 
             # Show current state
@@ -300,9 +310,6 @@ class RNSMenuMixin(RNSSnifferMixin):
                     print("  All identities already existed.")
             else:
                 print(f"ERROR: {result.message}")
-        except ImportError:
-            print("ERROR: RNS module not installed.")
-            print("  Install: pip install rns")
         except Exception as e:
             print(f"ERROR: {type(e).__name__}: {e}")
         self._wait_for_enter()
@@ -312,8 +319,11 @@ class RNSMenuMixin(RNSSnifferMixin):
         clear_screen()
         print("=== Known RNS Destinations ===\n")
 
-        try:
-            from commands.rns import list_known_destinations
+        if not _HAS_RNS_COMMANDS:
+            # Fallback: use rnstatus which also shows some destination info
+            print("Commands module not available, falling back to rnstatus...\n")
+            self._run_rns_tool(['rnstatus', '-a'], 'rnstatus')
+        else:
             result = list_known_destinations()
 
             if result.success:
@@ -340,10 +350,6 @@ class RNSMenuMixin(RNSSnifferMixin):
                 fix_hint = (result.data or {}).get('fix_hint', '')
                 if fix_hint:
                     print(f"Fix: {fix_hint}")
-        except ImportError:
-            # Fallback: use rnstatus which also shows some destination info
-            print("Commands module not available, falling back to rnstatus...\n")
-            self._run_rns_tool(['rnstatus', '-a'], 'rnstatus')
 
         self._wait_for_enter()
 
@@ -538,9 +544,7 @@ class RNSMenuMixin(RNSSnifferMixin):
         clear_screen()
         print("=== RNS Diagnostics ===\n")
 
-        try:
-            from commands.rns import check_connectivity, get_status
-        except ImportError:
+        if not _HAS_RNS_COMMANDS:
             print("RNS commands module not available.")
             print("Run from MeshForge root: sudo python3 src/launcher_tui/main.py")
             self._wait_for_enter()
@@ -658,7 +662,6 @@ class RNSMenuMixin(RNSSnifferMixin):
                 "  • Gateway identity: used by MeshForge bridge"
             ):
                 try:
-                    from commands.rns import create_identities
                     result = create_identities()
                     if result.success:
                         print(f"  ✓ {result.message}")
@@ -689,9 +692,7 @@ class RNSMenuMixin(RNSSnifferMixin):
         print("=== RNS Config Drift Check ===\n")
         print("Comparing gateway config path vs rnsd actual path...\n")
 
-        try:
-            from utils.config_drift import detect_rnsd_config_drift
-        except ImportError:
+        if not _HAS_CONFIG_DRIFT:
             print("  Config drift module not available.")
             print("  File: src/utils/config_drift.py")
             self._wait_for_enter()

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -12,29 +12,23 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
 # Import centralized service checking
-try:
-    from utils.service_check import (
-        check_systemd_service,
-        check_process_running,
-        check_service,
-        apply_config_and_restart,
-        enable_service,
-        ServiceState,
-    )
-    _HAS_SERVICE_CHECK = True
-    _HAS_APPLY_RESTART = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
-    _HAS_APPLY_RESTART = False
+(check_systemd_service, check_process_running, check_service,
+ apply_config_and_restart, enable_service, ServiceState,
+ _HAS_SERVICE_CHECK) = safe_import(
+    'utils.service_check',
+    'check_systemd_service', 'check_process_running', 'check_service',
+    'apply_config_and_restart', 'enable_service', 'ServiceState',
+)
+_HAS_APPLY_RESTART = _HAS_SERVICE_CHECK
 
 # Import centralized path utility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
+get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+if not _HAS_PATHS:
     def get_real_user_home() -> Path:
         sudo_user = os.environ.get('SUDO_USER', '')
         if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
@@ -43,6 +37,22 @@ except ImportError:
         if logname and logname != 'root' and '/' not in logname and '..' not in logname:
             return Path(f'/home/{logname}')
         return Path('/root')
+
+# Import port lockdown helpers
+(lock_port_external, unlock_port_external,
+ check_port_locked, persist_iptables,
+ _HAS_PORT_LOCKDOWN) = safe_import(
+    'utils.service_check',
+    'lock_port_external', 'unlock_port_external',
+    'check_port_locked', 'persist_iptables',
+)
+
+# Import RNS identity helpers
+get_identity_path, _HAS_RNS_IDENTITY = safe_import('commands.rns', 'get_identity_path')
+create_identities, _HAS_RNS_CREATE = safe_import('commands.rns', 'create_identities')
+
+# Import propagation module
+propagation_mod, _HAS_PROPAGATION = safe_import('commands.propagation')
 
 
 class ServiceMenuMixin:
@@ -152,13 +162,10 @@ class ServiceMenuMixin:
             pass
 
         # 3. Check gateway identity exists
-        try:
-            from commands.rns import get_identity_path
+        if _HAS_RNS_IDENTITY:
             gw_id = get_identity_path()
             if not gw_id.exists():
                 issues.append("Gateway identity not created yet")
-        except ImportError:
-            pass
 
         if not issues:
             return True
@@ -224,8 +231,7 @@ class ServiceMenuMixin:
                 print("  Bridge may fail to connect.\n")
 
         # Create gateway identity if missing
-        try:
-            from commands.rns import create_identities, get_identity_path
+        if _HAS_RNS_IDENTITY and _HAS_RNS_CREATE:
             gw_id = get_identity_path()
             if not gw_id.exists():
                 print("[3] Creating gateway identity...")
@@ -234,8 +240,6 @@ class ServiceMenuMixin:
                     print(f"  {result.message}\n")
                 else:
                     print(f"  Warning: {result.message}\n")
-        except ImportError:
-            pass
 
         # Restart NomadNet as client (if we stopped it)
         if nomadnet_conflict:
@@ -568,12 +572,7 @@ class ServiceMenuMixin:
 
     def _manage_port_lockdown(self):
         """Lock/unlock external access to meshtasticd port 9443."""
-        try:
-            from utils.service_check import (
-                lock_port_external, unlock_port_external,
-                check_port_locked, persist_iptables,
-            )
-        except ImportError:
+        if not _HAS_PORT_LOCKDOWN:
             self.dialog.msgbox(
                 "Unavailable",
                 "Port lockdown requires utils.service_check module."
@@ -1281,16 +1280,13 @@ WantedBy=multi-user.target
                 )
                 if result.returncode == 0:
                     print("\033[0;32m✓\033[0m OpenHamClock started on port 3000")
-                    print("\nAuto-configuring MeshForge...")
-                    try:
-                        from commands import propagation
-                        propagation.configure_source(
-                            propagation.DataSource.OPENHAMCLOCK,
+                    if _HAS_PROPAGATION:
+                        print("\nAuto-configuring MeshForge...")
+                        propagation_mod.configure_source(
+                            propagation_mod.DataSource.OPENHAMCLOCK,
                             host="localhost", port=3000
                         )
                         print("\033[0;32m✓\033[0m MeshForge configured for OpenHamClock")
-                    except ImportError:
-                        pass
                 else:
                     print(f"\033[0;31mError:\033[0m {result.stderr}")
 

--- a/src/launcher_tui/settings_menu_mixin.py
+++ b/src/launcher_tui/settings_menu_mixin.py
@@ -4,6 +4,13 @@ Settings Menu Mixin - Application settings handlers.
 Extracted from main.py to reduce file size per CLAUDE.md guidelines.
 """
 
+from utils.safe_import import safe_import
+
+MapDataCollector, _HAS_MAP_DATA_COLLECTOR = safe_import(
+    'utils.map_data_collector', 'MapDataCollector'
+)
+_propagation, _HAS_PROPAGATION = safe_import('commands.propagation')
+
 
 class SettingsMenuMixin:
     """Mixin providing application settings functionality."""
@@ -77,12 +84,10 @@ class SettingsMenuMixin:
 
     def _save_meshtasticd_connection(self, host: str, port: int):
         """Save meshtasticd connection settings for MapDataCollector."""
-        try:
-            from utils.map_data_collector import MapDataCollector
-            collector = MapDataCollector()
-            collector.set_meshtasticd_connection(host, port)
-        except ImportError:
-            pass  # MapDataCollector not available
+        if not _HAS_MAP_DATA_COLLECTOR:
+            return  # MapDataCollector not available
+        collector = MapDataCollector()
+        collector.set_meshtasticd_connection(host, port)
 
     def _configure_propagation_sources(self):
         """Configure propagation data sources.
@@ -124,46 +129,44 @@ class SettingsMenuMixin:
 
     def _test_noaa_source(self):
         """Test NOAA SWPC connectivity and show current data."""
-        try:
-            from commands import propagation
-            result = propagation.check_source(propagation.DataSource.NOAA)
-            if result.success:
-                # Also get current conditions
-                wx = propagation.get_space_weather()
-                if wx.success:
-                    d = wx.data
-                    lines = [
-                        "NOAA SWPC - Connected",
-                        "",
-                        f"Solar Flux (SFI): {d.get('solar_flux', 'N/A')}",
-                        f"Kp Index: {d.get('k_index', 'N/A')}",
-                        f"A Index: {d.get('a_index', 'N/A')}",
-                        f"X-ray: {d.get('xray_flux', 'N/A')}",
-                        f"Geomagnetic: {d.get('geomag_storm', 'N/A')}",
-                        "",
-                        "Band Conditions:",
-                    ]
-                    for band, cond in d.get('band_conditions', {}).items():
-                        lines.append(f"  {band}: {cond}")
-                    self.dialog.msgbox("NOAA Space Weather", "\n".join(lines))
-                else:
-                    self.dialog.msgbox("NOAA SWPC", "Connected but no data available.")
-            else:
-                self.dialog.msgbox("Error", f"Cannot reach NOAA SWPC:\n{result.message}")
-        except ImportError:
+        if not _HAS_PROPAGATION:
             self.dialog.msgbox("Error", "Propagation module not available.")
+            return
+
+        result = _propagation.check_source(_propagation.DataSource.NOAA)
+        if result.success:
+            # Also get current conditions
+            wx = _propagation.get_space_weather()
+            if wx.success:
+                d = wx.data
+                lines = [
+                    "NOAA SWPC - Connected",
+                    "",
+                    f"Solar Flux (SFI): {d.get('solar_flux', 'N/A')}",
+                    f"Kp Index: {d.get('k_index', 'N/A')}",
+                    f"A Index: {d.get('a_index', 'N/A')}",
+                    f"X-ray: {d.get('xray_flux', 'N/A')}",
+                    f"Geomagnetic: {d.get('geomag_storm', 'N/A')}",
+                    "",
+                    "Band Conditions:",
+                ]
+                for band, cond in d.get('band_conditions', {}).items():
+                    lines.append(f"  {band}: {cond}")
+                self.dialog.msgbox("NOAA Space Weather", "\n".join(lines))
+            else:
+                self.dialog.msgbox("NOAA SWPC", "Connected but no data available.")
+        else:
+            self.dialog.msgbox("Error", f"Cannot reach NOAA SWPC:\n{result.message}")
 
     def _configure_pskreporter(self):
         """Configure PSKReporter MQTT as propagation data source."""
-        try:
-            from commands import propagation
-        except ImportError:
+        if not _HAS_PROPAGATION:
             self.dialog.msgbox("Error", "Propagation module not available.")
             return
 
         while True:
             # Get current config
-            pskr_cfg = propagation._sources.get(propagation.DataSource.PSKREPORTER)
+            pskr_cfg = _propagation._sources.get(_propagation.DataSource.PSKREPORTER)
             current_call = pskr_cfg.callsign if pskr_cfg else ""
             current_bands = ", ".join(pskr_cfg.bands) if pskr_cfg and pskr_cfg.bands else "all"
             is_enabled = pskr_cfg.enabled if pskr_cfg else False
@@ -191,8 +194,8 @@ class SettingsMenuMixin:
 
             if choice == "enable":
                 new_state = not is_enabled
-                result = propagation.configure_source(
-                    propagation.DataSource.PSKREPORTER,
+                result = _propagation.configure_source(
+                    _propagation.DataSource.PSKREPORTER,
                     enabled=new_state,
                     callsign=current_call,
                     bands=pskr_cfg.bands if pskr_cfg else [],
@@ -214,8 +217,8 @@ class SettingsMenuMixin:
                     current_call,
                 )
                 if call is not None:
-                    propagation.configure_source(
-                        propagation.DataSource.PSKREPORTER,
+                    _propagation.configure_source(
+                        _propagation.DataSource.PSKREPORTER,
                         enabled=is_enabled,
                         callsign=call.strip(),
                         bands=pskr_cfg.bands if pskr_cfg else [],
@@ -232,8 +235,8 @@ class SettingsMenuMixin:
                 )
                 if bands_input is not None:
                     bands = [b.strip() for b in bands_input.split(",") if b.strip()]
-                    propagation.configure_source(
-                        propagation.DataSource.PSKREPORTER,
+                    _propagation.configure_source(
+                        _propagation.DataSource.PSKREPORTER,
                         enabled=is_enabled,
                         callsign=current_call,
                         bands=bands,
@@ -241,7 +244,7 @@ class SettingsMenuMixin:
                     )
 
             elif choice == "test":
-                result = propagation.check_source(propagation.DataSource.PSKREPORTER)
+                result = _propagation.check_source(_propagation.DataSource.PSKREPORTER)
                 if result.success:
                     self.dialog.msgbox(
                         "PSKReporter Connected",
@@ -286,34 +289,34 @@ class SettingsMenuMixin:
             self.dialog.msgbox("Error", "Invalid port number (1-65535).")
             return
 
-        try:
-            from commands import propagation
-            result = propagation.configure_source(
-                propagation.DataSource.OPENHAMCLOCK,
-                host=host,
-                port=int(port),
-            )
-            if result.success:
-                # Test connectivity
-                test = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
-                if test.success:
-                    self.dialog.msgbox(
-                        "OpenHamClock Connected",
-                        f"API: {host}:{port}\n\nOpenHamClock is now active as\n"
-                        "an enhanced data source."
-                    )
-                else:
-                    self.dialog.msgbox(
-                        "OpenHamClock Configured",
-                        f"Saved: {host}:{port}\n\n"
-                        f"Connection test failed:\n{test.message}\n\n"
-                        "Make sure OpenHamClock is running\n"
-                        "(docker compose up)"
-                    )
-            else:
-                self.dialog.msgbox("Error", result.message)
-        except ImportError:
+        if not _HAS_PROPAGATION:
             self.dialog.msgbox("Error", "Propagation module not available.")
+            return
+
+        result = _propagation.configure_source(
+            _propagation.DataSource.OPENHAMCLOCK,
+            host=host,
+            port=int(port),
+        )
+        if result.success:
+            # Test connectivity
+            test = _propagation.check_source(_propagation.DataSource.OPENHAMCLOCK)
+            if test.success:
+                self.dialog.msgbox(
+                    "OpenHamClock Connected",
+                    f"API: {host}:{port}\n\nOpenHamClock is now active as\n"
+                    "an enhanced data source."
+                )
+            else:
+                self.dialog.msgbox(
+                    "OpenHamClock Configured",
+                    f"Saved: {host}:{port}\n\n"
+                    f"Connection test failed:\n{test.message}\n\n"
+                    "Make sure OpenHamClock is running\n"
+                    "(docker compose up)"
+                )
+        else:
+            self.dialog.msgbox("Error", result.message)
 
     def _configure_hamclock_legacy(self):
         """Configure legacy HamClock as optional data source."""
@@ -344,49 +347,49 @@ class SettingsMenuMixin:
             self.dialog.msgbox("Error", "Invalid port number (1-65535).")
             return
 
-        try:
-            from commands import propagation
-            result = propagation.configure_source(
-                propagation.DataSource.HAMCLOCK,
-                host=host,
-                port=int(port),
-            )
-            if result.success:
-                test = propagation.check_source(propagation.DataSource.HAMCLOCK)
-                if test.success:
-                    self.dialog.msgbox(
-                        "HamClock Connected",
-                        f"API: {host}:{port}\n\nHamClock is now active as\n"
-                        "an enhanced data source.\n\n"
-                        "NOTE: Consider migrating to OpenHamClock\n"
-                        "(original HamClock sunsets June 2026)"
-                    )
-                else:
-                    self.dialog.msgbox(
-                        "HamClock Configured",
-                        f"Saved: {host}:{port}\n\n"
-                        f"Connection test failed:\n{test.message}\n\n"
-                        "Make sure HamClock is running."
-                    )
-            else:
-                self.dialog.msgbox("Error", result.message)
-        except ImportError:
+        if not _HAS_PROPAGATION:
             self.dialog.msgbox("Error", "Propagation module not available.")
+            return
+
+        result = _propagation.configure_source(
+            _propagation.DataSource.HAMCLOCK,
+            host=host,
+            port=int(port),
+        )
+        if result.success:
+            test = _propagation.check_source(_propagation.DataSource.HAMCLOCK)
+            if test.success:
+                self.dialog.msgbox(
+                    "HamClock Connected",
+                    f"API: {host}:{port}\n\nHamClock is now active as\n"
+                    "an enhanced data source.\n\n"
+                    "NOTE: Consider migrating to OpenHamClock\n"
+                    "(original HamClock sunsets June 2026)"
+                )
+            else:
+                self.dialog.msgbox(
+                    "HamClock Configured",
+                    f"Saved: {host}:{port}\n\n"
+                    f"Connection test failed:\n{test.message}\n\n"
+                    "Make sure HamClock is running."
+                )
+        else:
+            self.dialog.msgbox("Error", result.message)
 
     def _test_all_sources(self):
         """Test all configured propagation data sources."""
         lines = ["Propagation Source Status", "=" * 35, ""]
 
-        try:
-            from commands import propagation
-
+        if not _HAS_PROPAGATION:
+            lines.append("Propagation module not available.")
+        else:
             # NOAA (always)
-            noaa = propagation.check_source(propagation.DataSource.NOAA)
+            noaa = _propagation.check_source(_propagation.DataSource.NOAA)
             status = "Connected" if noaa.success else "Unreachable"
             lines.append(f"NOAA SWPC (primary): {status}")
 
             # PSKReporter
-            pskr = propagation.check_source(propagation.DataSource.PSKREPORTER)
+            pskr = _propagation.check_source(_propagation.DataSource.PSKREPORTER)
             if pskr.success:
                 spots = pskr.data.get('spots_received', 0)
                 lines.append(f"PSKReporter MQTT: Connected ({spots} spots)")
@@ -394,21 +397,21 @@ class SettingsMenuMixin:
                 lines.append(f"PSKReporter MQTT: Not configured")
 
             # OpenHamClock
-            ohc = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
+            ohc = _propagation.check_source(_propagation.DataSource.OPENHAMCLOCK)
             if ohc.success:
                 lines.append(f"OpenHamClock: Connected")
             else:
                 lines.append(f"OpenHamClock: Not configured")
 
             # HamClock
-            hc = propagation.check_source(propagation.DataSource.HAMCLOCK)
+            hc = _propagation.check_source(_propagation.DataSource.HAMCLOCK)
             if hc.success:
                 lines.append(f"HamClock (legacy): Connected")
             else:
                 lines.append(f"HamClock (legacy): Not configured")
 
             # Current data
-            wx = propagation.get_space_weather()
+            wx = _propagation.get_space_weather()
             if wx.success:
                 d = wx.data
                 lines.append("")
@@ -421,8 +424,5 @@ class SettingsMenuMixin:
                 if kp is not None:
                     lines.append(f"  Kp: {kp}")
                 lines.append(f"  {d.get('geomag_storm', '')}")
-
-        except ImportError:
-            lines.append("Propagation module not available.")
 
         self.dialog.msgbox("Source Status", "\n".join(lines))

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -17,8 +17,20 @@ import webbrowser
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# Module-level safe imports
+_get_network_topology, _HAS_NETWORK_TOPOLOGY = safe_import(
+    'gateway.network_topology', 'get_network_topology'
+)
+_get_node_tracker_func, _HAS_NODE_TRACKER = safe_import(
+    'gateway.node_tracker', 'get_node_tracker'
+)
+_TopologyVisualizer, _HAS_TOPOLOGY_VISUALIZER = safe_import(
+    'utils.topology_visualizer', 'TopologyVisualizer'
+)
 
 
 class TopologyMixin:
@@ -64,19 +76,15 @@ class TopologyMixin:
 
     def _get_topology(self):
         """Get the network topology instance."""
-        try:
-            from gateway.network_topology import get_network_topology
-            return get_network_topology()
-        except ImportError:
+        if not _HAS_NETWORK_TOPOLOGY:
             return None
+        return _get_network_topology()
 
     def _get_node_tracker(self):
         """Get the node tracker instance if available."""
-        try:
-            from gateway.node_tracker import get_node_tracker
-            return get_node_tracker()
-        except ImportError:
+        if not _HAS_NODE_TRACKER:
             return None
+        return _get_node_tracker_func()
 
     def _show_topology_stats(self):
         """Display topology statistics."""
@@ -631,34 +639,39 @@ class TopologyMixin:
 
     def _show_ascii_topology(self):
         """Show ASCII representation of topology."""
-        try:
-            from utils.topology_visualizer import TopologyVisualizer
+        if not _HAS_TOPOLOGY_VISUALIZER:
+            self.dialog.msgbox(
+                "Module Not Found",
+                "Topology visualizer module not available."
+            )
+            return
 
+        try:
             topology = self._get_topology()
             if topology is None:
                 self.dialog.msgbox("Unavailable", "Topology module not loaded.")
                 return
 
-            visualizer = TopologyVisualizer.from_topology(topology)
+            visualizer = _TopologyVisualizer.from_topology(topology)
             ascii_output = visualizer.generate_ascii(max_width=70)
 
             self.dialog.msgbox("Network Topology (ASCII)", ascii_output)
 
-        except ImportError:
-            self.dialog.msgbox(
-                "Module Not Found",
-                "Topology visualizer module not available."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to generate ASCII view:\n{e}")
 
     def _open_topology_browser(self):
         """Generate and open topology visualization in browser."""
+        if not _HAS_TOPOLOGY_VISUALIZER:
+            self.dialog.msgbox(
+                "Module Not Found",
+                "Topology visualizer module not available."
+            )
+            return
+
         self.dialog.infobox("Generating...", "Creating topology visualization...")
 
         try:
-            from utils.topology_visualizer import TopologyVisualizer
-
             topology = self._get_topology()
             tracker = self._get_node_tracker()
 
@@ -668,9 +681,9 @@ class TopologyMixin:
 
             # Generate visualization - start with topology data
             if topology:
-                visualizer = TopologyVisualizer.from_topology(topology)
+                visualizer = _TopologyVisualizer.from_topology(topology)
             else:
-                visualizer = TopologyVisualizer()
+                visualizer = _TopologyVisualizer()
                 visualizer.add_node("local", name="Local Node", node_type="local", network="rns")
 
             # Enrich with node tracker data (has richer Meshtastic node info)
@@ -808,11 +821,6 @@ class TopologyMixin:
                 f"you can open this file manually."
             )
 
-        except ImportError:
-            self.dialog.msgbox(
-                "Module Not Found",
-                "Topology visualizer module not available."
-            )
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to generate visualization:\n{e}")
 
@@ -843,11 +851,13 @@ class TopologyMixin:
         if not export_format or export_format == "back":
             return
 
-        try:
-            from utils.topology_visualizer import TopologyVisualizer
+        if not _HAS_TOPOLOGY_VISUALIZER:
+            self.dialog.msgbox("Error", "Topology visualizer module not available.")
+            return
 
+        try:
             # Create visualizer from topology
-            visualizer = TopologyVisualizer.from_topology(topology)
+            visualizer = _TopologyVisualizer.from_topology(topology)
 
             if export_format == "geojson":
                 output_path, count = visualizer.export_geojson()
@@ -902,7 +912,5 @@ class TopologyMixin:
                     f"File: {output_path}"
                 )
 
-        except ImportError:
-            self.dialog.msgbox("Error", "Topology visualizer module not available.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Export failed:\n{e}")

--- a/src/launcher_tui/webhooks_mixin.py
+++ b/src/launcher_tui/webhooks_mixin.py
@@ -7,8 +7,14 @@ Extracted as a mixin to keep main.py under 1,500 lines.
 
 import logging
 from backend import clear_screen
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# Module-level safe imports
+get_webhook_manager, WebhookEndpoint, EventType, _HAS_WEBHOOKS = safe_import(
+    'utils.webhooks', 'get_webhook_manager', 'WebhookEndpoint', 'EventType'
+)
 
 
 class WebhooksMixin:
@@ -53,9 +59,7 @@ class WebhooksMixin:
         clear_screen()
         print("=== Webhook Endpoints ===\n")
 
-        try:
-            from utils.webhooks import get_webhook_manager
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             print("  Webhooks module not available.")
             print("  File: src/utils/webhooks.py")
             self._wait_for_enter()
@@ -89,9 +93,7 @@ class WebhooksMixin:
 
     def _webhooks_add(self):
         """Add a new webhook endpoint via dialog."""
-        try:
-            from utils.webhooks import get_webhook_manager, WebhookEndpoint
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             self.dialog.msgbox("Unavailable", "Webhooks module not available.")
             return
 
@@ -119,9 +121,7 @@ class WebhooksMixin:
 
     def _webhooks_remove(self):
         """Remove a webhook endpoint."""
-        try:
-            from utils.webhooks import get_webhook_manager
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             self.dialog.msgbox("Unavailable", "Webhooks module not available.")
             return
 
@@ -158,9 +158,7 @@ class WebhooksMixin:
 
     def _webhooks_toggle(self):
         """Toggle a webhook endpoint on/off."""
-        try:
-            from utils.webhooks import get_webhook_manager
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             self.dialog.msgbox("Unavailable", "Webhooks module not available.")
             return
 
@@ -198,9 +196,7 @@ class WebhooksMixin:
         clear_screen()
         print("=== Test Webhook Delivery ===\n")
 
-        try:
-            from utils.webhooks import get_webhook_manager, EventType
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             print("  Webhooks module not available.")
             self._wait_for_enter()
             return
@@ -236,9 +232,7 @@ class WebhooksMixin:
         clear_screen()
         print("=== Supported Webhook Event Types ===\n")
 
-        try:
-            from utils.webhooks import EventType
-        except ImportError:
+        if not _HAS_WEBHOOKS:
             print("  Webhooks module not available.")
             self._wait_for_enter()
             return

--- a/src/monitoring/rns_sniffer.py
+++ b/src/monitoring/rns_sniffer.py
@@ -25,7 +25,18 @@ from pathlib import Path
 from queue import Queue, Empty, Full
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
+
+# Module-level safe imports
+RNS, _HAS_RNS = safe_import('RNS')
+(MeshPacket, PacketProtocol, PacketDirection, PacketTree,
+ PacketField, FieldType, _HAS_TRAFFIC_INSPECTOR) = safe_import(
+    'monitoring.traffic_inspector',
+    'MeshPacket', 'PacketProtocol', 'PacketDirection', 'PacketTree',
+    'PacketField', 'FieldType'
+)
 
 
 # =============================================================================
@@ -335,9 +346,11 @@ class RNSSniffer:
         if self._hooks_installed:
             return True
 
-        try:
-            import RNS
+        if not _HAS_RNS:
+            logger.debug("RNS not available for hooking")
+            return False
 
+        try:
             # Hook into Transport's packet handling
             # RNS.Transport processes all incoming/outgoing packets
 
@@ -375,9 +388,6 @@ class RNSSniffer:
             logger.debug("RNS hooks installed for packet capture")
             return True
 
-        except ImportError:
-            logger.debug("RNS not available for hooking")
-            return False
         except Exception as e:
             logger.debug(f"Failed to install RNS hooks: {e}")
             return False

--- a/src/standalone.py
+++ b/src/standalone.py
@@ -29,11 +29,29 @@ SRC_DIR = Path(__file__).parent
 if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
-# Version
-try:
-    from __version__ import __version__
-except ImportError:
-    __version__ = "0.5.0-beta"
+from utils.safe_import import safe_import
+
+# ── Module-level safe imports ─────────────────────────────────────────────────
+_version_mod, _HAS_VERSION = safe_import('__version__', '__version__')
+__version__ = _version_mod if _HAS_VERSION else "0.5.0-beta"
+
+_rich_mod, _HAS_RICH = safe_import('rich')
+_meshtastic_mod, _HAS_MESHTASTIC = safe_import('meshtastic')
+_serial_list_ports, _HAS_SERIAL = safe_import('serial.tools.list_ports')
+
+(
+    haversine_distance, fresnel_radius,
+    free_space_path_loss, earth_bulge,
+    link_budget, detailed_link_budget,
+    is_fast_available, CABLE_LOSS_DB_PER_M,
+    _HAS_RF_UTILS,
+) = safe_import(
+    'utils.rf',
+    'haversine_distance', 'fresnel_radius',
+    'free_space_path_loss', 'earth_bulge',
+    'link_budget', 'detailed_link_budget',
+    'is_fast_available', 'CABLE_LOSS_DB_PER_M',
+)
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -55,22 +73,14 @@ class DependencyStatus:
         self.messages['python'] = f"Python {sys.version_info.major}.{sys.version_info.minor}"
 
         # Rich - for pretty output
-        try:
-            import rich
-            self.available['rich'] = True
-            self.messages['rich'] = "Rich console available"
-        except ImportError:
-            self.available['rich'] = False
-            self.messages['rich'] = "pip install rich"
+        self.available['rich'] = _HAS_RICH
+        self.messages['rich'] = "Rich console available" if _HAS_RICH else "pip install rich"
 
         # Meshtastic - for device communication
-        try:
-            import meshtastic
-            self.available['meshtastic'] = True
-            self.messages['meshtastic'] = "Meshtastic library available"
-        except ImportError:
-            self.available['meshtastic'] = False
-            self.messages['meshtastic'] = "pip install meshtastic"
+        self.available['meshtastic'] = _HAS_MESHTASTIC
+        self.messages['meshtastic'] = (
+            "Meshtastic library available" if _HAS_MESHTASTIC else "pip install meshtastic"
+        )
 
         # Check root
         self.available['root'] = os.geteuid() == 0
@@ -100,21 +110,19 @@ class StandaloneTools:
         """RF Calculator - Pure Python, no dependencies"""
         print("\n═══ RF Calculator ═══\n")
 
-        try:
-            from utils.rf import (
-                haversine_distance, fresnel_radius,
-                free_space_path_loss, earth_bulge,
-                link_budget, detailed_link_budget,
-                is_fast_available, CABLE_LOSS_DB_PER_M
-            )
+        if _HAS_RF_UTILS:
             _has_detailed = True
+            _haversine = haversine_distance
+            _fspl_fn = free_space_path_loss
+            _fresnel = fresnel_radius
+            _bulge = earth_bulge
             fast_mode = " (Cython optimized)" if is_fast_available() else ""
             print(f"RF calculations ready{fast_mode}\n")
-        except ImportError:
+        else:
             # Inline implementation if utils not available
             import math
 
-            def haversine_distance(lat1, lon1, lat2, lon2):
+            def _haversine(lat1, lon1, lat2, lon2):
                 R = 6371000
                 lat1_rad, lat2_rad = math.radians(lat1), math.radians(lat2)
                 delta_lat = math.radians(lat2 - lat1)
@@ -123,13 +131,13 @@ class StandaloneTools:
                      math.cos(lat1_rad) * math.cos(lat2_rad) * math.sin(delta_lon / 2) ** 2)
                 return R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
 
-            def free_space_path_loss(distance_m, freq_mhz):
+            def _fspl_fn(distance_m, freq_mhz):
                 return 20 * math.log10(distance_m) + 20 * math.log10(freq_mhz) - 27.55
 
-            def fresnel_radius(distance_km, freq_ghz):
+            def _fresnel(distance_km, freq_ghz):
                 return 17.3 * math.sqrt(distance_km / (4 * freq_ghz))
 
-            def earth_bulge(distance_m):
+            def _bulge(distance_m):
                 return (distance_m ** 2) / (8 * 6371000 * (4/3))
 
             _has_detailed = False
@@ -158,7 +166,7 @@ class StandaloneTools:
                     lon1 = float(input("  Lon1: "))
                     lat2 = float(input("  Lat2: "))
                     lon2 = float(input("  Lon2: "))
-                    dist = haversine_distance(lat1, lon1, lat2, lon2)
+                    dist = _haversine(lat1, lon1, lat2, lon2)
                     print(f"\n  Distance: {dist/1000:.2f} km ({dist:.0f} m)\n")
                 except ValueError:
                     print("Invalid input\n")
@@ -168,7 +176,7 @@ class StandaloneTools:
                     print("\nEnter distance and frequency:")
                     dist = float(input("  Distance (km): ")) * 1000
                     freq = float(input("  Frequency (MHz): "))
-                    fspl = free_space_path_loss(dist, freq)
+                    fspl = _fspl_fn(dist, freq)
                     print(f"\n  FSPL: {fspl:.2f} dB\n")
                 except ValueError:
                     print("Invalid input\n")
@@ -178,7 +186,7 @@ class StandaloneTools:
                     print("\nEnter distance and frequency:")
                     dist = float(input("  Distance (km): "))
                     freq = float(input("  Frequency (GHz): "))
-                    radius = fresnel_radius(dist, freq)
+                    radius = _fresnel(dist, freq)
                     print(f"\n  Fresnel radius: {radius:.2f} m\n")
                 except ValueError:
                     print("Invalid input\n")
@@ -186,7 +194,7 @@ class StandaloneTools:
             elif choice == "4":
                 try:
                     dist = float(input("\n  Distance (km): ")) * 1000
-                    bulge = earth_bulge(dist)
+                    bulge = _bulge(dist)
                     print(f"\n  Earth bulge: {bulge:.2f} m\n")
                 except ValueError:
                     print("Invalid input\n")
@@ -231,7 +239,7 @@ class StandaloneTools:
                         rx_gain = float(input("  RX Antenna Gain (dBi): "))
                         dist = float(input("  Distance (km): ")) * 1000
                         freq = float(input("  Frequency (MHz): "))
-                        fspl = free_space_path_loss(dist, freq)
+                        fspl = _fspl_fn(dist, freq)
                         rx_power = tx_power + tx_gain + rx_gain - fspl
                         print(f"\n  FSPL: {fspl:.2f} dB")
                         print(f"  RX Power: {rx_power:.2f} dBm\n")
@@ -440,15 +448,14 @@ class StandaloneTools:
                 print(f"  {dev}")
 
             # Try to get more info if pyserial available
-            try:
-                import serial.tools.list_ports
+            if _HAS_SERIAL:
                 print("\nDetailed port info:")
-                for port in serial.tools.list_ports.comports():
+                for port in _serial_list_ports.comports():
                     print(f"  {port.device}")
                     print(f"    Description: {port.description}")
                     print(f"    VID:PID: {port.vid}:{port.pid}" if port.vid else "")
                     print()
-            except ImportError:
+            else:
                 print("\n  (Install pyserial for detailed info)")
         else:
             print("No serial devices found")

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -16,15 +16,24 @@ from typing import List, Dict, Optional
 
 # Import centralized path utility
 from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
 
-# Try to use centralized service checker
-try:
-    from utils.service_check import (
-        check_service, check_systemd_service, check_process_with_pid, ServiceState
+# Optional dependencies — module-level safe imports
+check_service, check_systemd_service, check_process_with_pid, ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_systemd_service',
+    'check_process_with_pid', 'ServiceState'
+)
+detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
+    'utils.config_drift', 'detect_rnsd_config_drift'
+)
+_meshtastic_mod, _HAS_MESHTASTIC = safe_import('meshtastic')
+MeshChatService, MeshChatServiceState, _HAS_MESHCHAT = safe_import(
+    'plugins.meshchat', 'MeshChatService', 'ServiceState'
+)
+if not _HAS_MESHCHAT:
+    MeshChatService, MeshChatServiceState, _HAS_MESHCHAT = safe_import(
+        'src.plugins.meshchat', 'MeshChatService', 'ServiceState'
     )
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
 
 
 class CheckStatus(Enum):
@@ -291,16 +300,13 @@ class GatewayDiagnostic:
             has_meshtastic = 'meshtastic' in content.lower()
 
             # Check for config drift between gateway and rnsd
-            try:
-                from utils.config_drift import detect_rnsd_config_drift
+            if _HAS_CONFIG_DRIFT:
                 drift = detect_rnsd_config_drift()
                 if drift.drifted:
                     issues.append(
                         f"Config drift: gateway uses {drift.gateway_config_dir} "
                         f"but rnsd uses {drift.rnsd_config_dir}"
                     )
-            except ImportError:
-                pass
 
             if issues:
                 return CheckResult(
@@ -368,17 +374,14 @@ class GatewayDiagnostic:
 
     def check_meshtastic_installed(self) -> CheckResult:
         """Check if meshtastic library is installed."""
-        # Try direct import first (same Python environment)
-        try:
-            import meshtastic
-            version = getattr(meshtastic, '__version__', 'unknown')
+        # Check module-level safe import result
+        if _HAS_MESHTASTIC:
+            version = getattr(_meshtastic_mod, '__version__', 'unknown')
             return CheckResult(
                 name="Meshtastic Library",
                 status=CheckStatus.PASS,
                 message=f"meshtastic {version} installed"
             )
-        except ImportError:
-            pass
 
         # Fallback: try subprocess with sys.executable
         try:
@@ -540,44 +543,7 @@ class GatewayDiagnostic:
 
     def check_meshchat(self) -> CheckResult:
         """Check if MeshChat service is available (optional)."""
-        try:
-            # Try relative import first, then absolute
-            try:
-                from plugins.meshchat import MeshChatService, ServiceState
-            except ImportError:
-                from src.plugins.meshchat import MeshChatService, ServiceState
-            service = MeshChatService()
-            status = service.check_status(blocking=True)
-
-            if status.available:
-                version_str = f" v{status.version}" if status.version else ""
-                return CheckResult(
-                    name="MeshChat (Optional)",
-                    status=CheckStatus.PASS,
-                    message=f"Running{version_str} on port {service.port}",
-                    details=f"PID: {status.pid}" if status.pid else None
-                )
-            elif status.state == ServiceState.STOPPED:
-                return CheckResult(
-                    name="MeshChat (Optional)",
-                    status=CheckStatus.SKIP,
-                    message="Installed but not running",
-                    fix_hint=status.fix_hint
-                )
-            elif status.state == ServiceState.STARTING:
-                return CheckResult(
-                    name="MeshChat (Optional)",
-                    status=CheckStatus.WARN,
-                    message="Starting (port not ready yet)"
-                )
-            else:
-                return CheckResult(
-                    name="MeshChat (Optional)",
-                    status=CheckStatus.SKIP,
-                    message="Not installed (optional LXMF messaging)",
-                    fix_hint="Install from: https://github.com/liamcottle/reticulum-meshchat"
-                )
-        except ImportError:
+        if not _HAS_MESHCHAT:
             # MeshChat plugin not available - check port directly
             if self.check_tcp_port('localhost', 8000):
                 return CheckResult(
@@ -590,6 +556,39 @@ class GatewayDiagnostic:
                 status=CheckStatus.SKIP,
                 message="Not installed (optional)"
             )
+
+        try:
+            service = MeshChatService()
+            status = service.check_status(blocking=True)
+
+            if status.available:
+                version_str = f" v{status.version}" if status.version else ""
+                return CheckResult(
+                    name="MeshChat (Optional)",
+                    status=CheckStatus.PASS,
+                    message=f"Running{version_str} on port {service.port}",
+                    details=f"PID: {status.pid}" if status.pid else None
+                )
+            elif status.state == MeshChatServiceState.STOPPED:
+                return CheckResult(
+                    name="MeshChat (Optional)",
+                    status=CheckStatus.SKIP,
+                    message="Installed but not running",
+                    fix_hint=status.fix_hint
+                )
+            elif status.state == MeshChatServiceState.STARTING:
+                return CheckResult(
+                    name="MeshChat (Optional)",
+                    status=CheckStatus.WARN,
+                    message="Starting (port not ready yet)"
+                )
+            else:
+                return CheckResult(
+                    name="MeshChat (Optional)",
+                    status=CheckStatus.SKIP,
+                    message="Not installed (optional LXMF messaging)",
+                    fix_hint="Install from: https://github.com/liamcottle/reticulum-meshchat"
+                )
         except Exception as e:
             return CheckResult(
                 name="MeshChat (Optional)",

--- a/src/utils/influxdb_exporter.py
+++ b/src/utils/influxdb_exporter.py
@@ -42,7 +42,16 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Union
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
+
+# Optional dependencies — module-level safe_import
+_version_mod, _HAS_VERSION = safe_import('__version__')
+_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+_MapDataCollector, _HAS_MAP_DATA = safe_import('utils.map_data_collector', 'MapDataCollector')
+_PersistentMessageQueue, _HAS_MESSAGE_QUEUE = safe_import('gateway.message_queue', 'PersistentMessageQueue')
+_get_local_subscriber, _HAS_MQTT = safe_import('monitoring.mqtt_subscriber', 'get_local_subscriber')
 
 
 class InfluxDBExporter:
@@ -306,11 +315,7 @@ class InfluxDBExporter:
         success = True
 
         # Version info
-        try:
-            from __version__ import __version__
-            version = __version__
-        except ImportError:
-            version = "unknown"
+        version = _version_mod.__version__ if _HAS_VERSION else "unknown"
 
         self.write_point(
             "meshforge_info",
@@ -320,11 +325,10 @@ class InfluxDBExporter:
         )
 
         # Service health
-        try:
-            from utils.service_check import check_service
+        if _HAS_SERVICE_CHECK:
             for service in ["meshtasticd", "rnsd", "mosquitto"]:
                 try:
-                    status = check_service(service)
+                    status = _check_service(service)
                     self.write_point(
                         "meshforge_service_healthy",
                         {
@@ -335,153 +339,148 @@ class InfluxDBExporter:
                     )
                 except Exception:
                     pass
-        except ImportError:
-            pass
 
         # Node counts
-        try:
-            from utils.map_data_collector import MapDataCollector
-            collector = MapDataCollector(enable_history=False)
-            geojson = collector.collect(max_age_seconds=60)
-            props = geojson.get("properties", {})
+        if _HAS_MAP_DATA:
+            try:
+                collector = _MapDataCollector(enable_history=False)
+                geojson = collector.collect(max_age_seconds=60)
+                props = geojson.get("properties", {})
 
-            self.write_point(
-                "meshforge_nodes",
-                {
-                    "total": props.get("total_nodes", 0),
-                    "with_gps": props.get("nodes_with_position", 0),
-                },
-                {},
-                timestamp
-            )
-
-            # Per-node metrics
-            for feature in geojson.get("features", []):
-                node_props = feature.get("properties", {})
-                node_id = node_props.get("id", "")
-                if not node_id:
-                    continue
-
-                fields = {}
-                if node_props.get("snr") is not None:
-                    fields["snr"] = float(node_props["snr"])
-                if node_props.get("rssi") is not None:
-                    fields["rssi"] = int(node_props["rssi"])
-                if node_props.get("battery") is not None:
-                    fields["battery"] = int(node_props["battery"])
-
-                if fields:
-                    self.write_point(
-                        "meshforge_node",
-                        fields,
-                        {"node_id": node_id, "name": node_props.get("name", "")},
-                        timestamp
-                    )
-
-        except ImportError:
-            logger.debug("MapDataCollector not available for InfluxDB export")
-        except Exception as e:
-            logger.debug(f"Error collecting node metrics: {e}")
-
-        # Message queue stats
-        try:
-            from gateway.message_queue import PersistentMessageQueue
-            queue = PersistentMessageQueue()
-            stats = queue.get_stats()
-
-            self.write_point(
-                "meshforge_messages",
-                {
-                    "pending": stats.get("pending", 0),
-                    "delivered": stats.get("delivered", 0),
-                    "failed": stats.get("failed", 0),
-                    "retried": stats.get("retried", 0),
-                },
-                {},
-                timestamp
-            )
-        except ImportError:
-            pass
-        except Exception as e:
-            logger.debug(f"Error collecting message metrics: {e}")
-
-        # Environment sensor metrics from MQTT subscriber
-        try:
-            from monitoring.mqtt_subscriber import get_local_subscriber
-            subscriber = get_local_subscriber()
-            if subscriber.is_connected():
-                # MQTT stats
-                mqtt_stats = subscriber.get_stats()
                 self.write_point(
-                    "meshforge_mqtt",
+                    "meshforge_nodes",
                     {
-                        "nodes_total": mqtt_stats.get("node_count", 0),
-                        "nodes_online": mqtt_stats.get("online_count", 0),
-                        "mesh_size_24h": mqtt_stats.get("mesh_size_24h", 0),
-                        "messages": mqtt_stats.get("message_count", 0),
+                        "total": props.get("total_nodes", 0),
+                        "with_gps": props.get("nodes_with_position", 0),
                     },
                     {},
                     timestamp
                 )
 
-                # Environment sensors per node
-                for node in subscriber.get_nodes_with_environment_metrics():
-                    fields = {}
-                    if node.temperature is not None:
-                        fields["temperature"] = float(node.temperature)
-                    if node.humidity is not None:
-                        fields["humidity"] = float(node.humidity)
-                    if node.pressure is not None:
-                        fields["pressure"] = float(node.pressure)
-                    if node.gas_resistance is not None:
-                        fields["gas_resistance"] = float(node.gas_resistance)
-                    if fields:
-                        self.write_point(
-                            "meshforge_environment",
-                            fields,
-                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
-                            timestamp
-                        )
+                # Per-node metrics
+                for feature in geojson.get("features", []):
+                    node_props = feature.get("properties", {})
+                    node_id = node_props.get("id", "")
+                    if not node_id:
+                        continue
 
-                # Air quality sensors per node
-                for node in subscriber.get_nodes_with_air_quality():
                     fields = {}
-                    if node.pm25_standard is not None:
-                        fields["pm25"] = int(node.pm25_standard)
-                    if node.pm10_standard is not None:
-                        fields["pm10"] = int(node.pm10_standard)
-                    if node.co2 is not None:
-                        fields["co2"] = int(node.co2)
-                    if node.iaq is not None:
-                        fields["iaq"] = int(node.iaq)
-                    if fields:
-                        self.write_point(
-                            "meshforge_air_quality",
-                            fields,
-                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
-                            timestamp
-                        )
+                    if node_props.get("snr") is not None:
+                        fields["snr"] = float(node_props["snr"])
+                    if node_props.get("rssi") is not None:
+                        fields["rssi"] = int(node_props["rssi"])
+                    if node_props.get("battery") is not None:
+                        fields["battery"] = int(node_props["battery"])
 
-                # Health metrics per node
-                for node in subscriber.get_nodes():
-                    fields = {}
-                    if node.heart_bpm is not None:
-                        fields["heart_bpm"] = int(node.heart_bpm)
-                    if node.spo2 is not None:
-                        fields["spo2"] = int(node.spo2)
-                    if node.body_temperature is not None:
-                        fields["body_temperature"] = float(node.body_temperature)
                     if fields:
                         self.write_point(
-                            "meshforge_health",
+                            "meshforge_node",
                             fields,
-                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                            {"node_id": node_id, "name": node_props.get("name", "")},
                             timestamp
                         )
-        except ImportError:
+            except Exception as e:
+                logger.debug(f"Error collecting node metrics: {e}")
+        else:
+            logger.debug("MapDataCollector not available for InfluxDB export")
+
+        # Message queue stats
+        if _HAS_MESSAGE_QUEUE:
+            try:
+                queue = _PersistentMessageQueue()
+                stats = queue.get_stats()
+
+                self.write_point(
+                    "meshforge_messages",
+                    {
+                        "pending": stats.get("pending", 0),
+                        "delivered": stats.get("delivered", 0),
+                        "failed": stats.get("failed", 0),
+                        "retried": stats.get("retried", 0),
+                    },
+                    {},
+                    timestamp
+                )
+            except Exception as e:
+                logger.debug(f"Error collecting message metrics: {e}")
+
+        # Environment sensor metrics from MQTT subscriber
+        if _HAS_MQTT:
+            try:
+                subscriber = _get_local_subscriber()
+                if subscriber.is_connected():
+                    # MQTT stats
+                    mqtt_stats = subscriber.get_stats()
+                    self.write_point(
+                        "meshforge_mqtt",
+                        {
+                            "nodes_total": mqtt_stats.get("node_count", 0),
+                            "nodes_online": mqtt_stats.get("online_count", 0),
+                            "mesh_size_24h": mqtt_stats.get("mesh_size_24h", 0),
+                            "messages": mqtt_stats.get("message_count", 0),
+                        },
+                        {},
+                        timestamp
+                    )
+
+                    # Environment sensors per node
+                    for node in subscriber.get_nodes_with_environment_metrics():
+                        fields = {}
+                        if node.temperature is not None:
+                            fields["temperature"] = float(node.temperature)
+                        if node.humidity is not None:
+                            fields["humidity"] = float(node.humidity)
+                        if node.pressure is not None:
+                            fields["pressure"] = float(node.pressure)
+                        if node.gas_resistance is not None:
+                            fields["gas_resistance"] = float(node.gas_resistance)
+                        if fields:
+                            self.write_point(
+                                "meshforge_environment",
+                                fields,
+                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                                timestamp
+                            )
+
+                    # Air quality sensors per node
+                    for node in subscriber.get_nodes_with_air_quality():
+                        fields = {}
+                        if node.pm25_standard is not None:
+                            fields["pm25"] = int(node.pm25_standard)
+                        if node.pm10_standard is not None:
+                            fields["pm10"] = int(node.pm10_standard)
+                        if node.co2 is not None:
+                            fields["co2"] = int(node.co2)
+                        if node.iaq is not None:
+                            fields["iaq"] = int(node.iaq)
+                        if fields:
+                            self.write_point(
+                                "meshforge_air_quality",
+                                fields,
+                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                                timestamp
+                            )
+
+                    # Health metrics per node
+                    for node in subscriber.get_nodes():
+                        fields = {}
+                        if node.heart_bpm is not None:
+                            fields["heart_bpm"] = int(node.heart_bpm)
+                        if node.spo2 is not None:
+                            fields["spo2"] = int(node.spo2)
+                        if node.body_temperature is not None:
+                            fields["body_temperature"] = float(node.body_temperature)
+                        if fields:
+                            self.write_point(
+                                "meshforge_health",
+                                fields,
+                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                                timestamp
+                            )
+            except Exception as e:
+                logger.debug(f"Error collecting MQTT/environment metrics: {e}")
+        else:
             logger.debug("MQTT subscriber not available for InfluxDB export")
-        except Exception as e:
-            logger.debug(f"Error collecting MQTT/environment metrics: {e}")
 
         # Flush remaining batch
         if not self._flush_batch():
@@ -548,22 +547,17 @@ class InfluxDBExporter:
         timestamp = self._get_timestamp()
 
         # Build same metrics as write_metrics but return as string
-        try:
-            from __version__ import __version__
-            version = __version__
-        except ImportError:
-            version = "unknown"
+        version = _version_mod.__version__ if _HAS_VERSION else "unknown"
 
         lines.append(self._format_line_protocol(
             "meshforge_info", {"value": 1}, {"version": version}, timestamp
         ))
 
         # Service health
-        try:
-            from utils.service_check import check_service
+        if _HAS_SERVICE_CHECK:
             for service in ["meshtasticd", "rnsd", "mosquitto"]:
                 try:
-                    status = check_service(service)
+                    status = _check_service(service)
                     lines.append(self._format_line_protocol(
                         "meshforge_service_healthy",
                         {"healthy": 1 if status.available else 0},
@@ -572,27 +566,25 @@ class InfluxDBExporter:
                     ))
                 except Exception:
                     pass
-        except ImportError:
-            pass
 
         # Node counts
-        try:
-            from utils.map_data_collector import MapDataCollector
-            collector = MapDataCollector(enable_history=False)
-            geojson = collector.collect(max_age_seconds=60)
-            props = geojson.get("properties", {})
+        if _HAS_MAP_DATA:
+            try:
+                collector = _MapDataCollector(enable_history=False)
+                geojson = collector.collect(max_age_seconds=60)
+                props = geojson.get("properties", {})
 
-            lines.append(self._format_line_protocol(
-                "meshforge_nodes",
-                {
-                    "total": props.get("total_nodes", 0),
-                    "with_gps": props.get("nodes_with_position", 0),
-                },
-                {},
-                timestamp
-            ))
-        except Exception:
-            pass
+                lines.append(self._format_line_protocol(
+                    "meshforge_nodes",
+                    {
+                        "total": props.get("total_nodes", 0),
+                        "with_gps": props.get("nodes_with_position", 0),
+                    },
+                    {},
+                    timestamp
+                ))
+            except Exception:
+                pass
 
         return "\n".join(lines)
 

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -26,6 +26,24 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+# --- Optional dependency imports via safe_import ---
+from utils.safe_import import safe_import
+
+get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+SettingsManager, _HAS_SETTINGS = safe_import('utils.common', 'SettingsManager')
+_get_node_tracker, _HAS_NODE_TRACKER = safe_import('gateway.node_tracker', 'get_node_tracker')
+_get_http_client, _HAS_MESHTASTIC_HTTP = safe_import('utils.meshtastic_http', 'get_http_client')
+(_get_connection_manager, _safe_close_interface, _ConnectionMode,
+ _reset_connection_manager, _HAS_MESHTASTIC_CONN) = safe_import(
+    'utils.meshtastic_connection',
+    'get_connection_manager', 'safe_close_interface',
+    'ConnectionMode', 'reset_connection_manager',
+)
+_get_local_subscriber, _HAS_MQTT = safe_import('monitoring.mqtt_subscriber', 'get_local_subscriber')
+_AREDNScanner, _AREDNClient, _HAS_AREDN = safe_import('utils.aredn', 'AREDNScanner', 'AREDNClient')
+_RNS, _HAS_RNS = safe_import('RNS')
+_msgpack, _HAS_MSGPACK = safe_import('msgpack')
+
 
 class MapDataCollector:
     """Collects node data from all available sources into unified GeoJSON.
@@ -53,12 +71,10 @@ class MapDataCollector:
     def __init__(self, cache_dir: Optional[Path] = None, enable_history: bool = True):
         if cache_dir:
             self._cache_dir = cache_dir
+        elif _HAS_PATHS:
+            self._cache_dir = get_real_user_home() / ".local" / "share" / "meshforge"
         else:
-            try:
-                from utils.paths import get_real_user_home
-                self._cache_dir = get_real_user_home() / ".local" / "share" / "meshforge"
-            except ImportError:
-                self._cache_dir = Path("/tmp/meshforge")
+            self._cache_dir = Path("/tmp/meshforge")
 
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._cache_file = self._cache_dir / "map_nodes.geojson"
@@ -66,8 +82,7 @@ class MapDataCollector:
         self._cached_geojson: Optional[Dict] = None
 
         # User-configurable cache age settings
-        try:
-            from utils.common import SettingsManager
+        if _HAS_SETTINGS:
             self._settings = SettingsManager(
                 "map_settings",
                 defaults={
@@ -79,7 +94,7 @@ class MapDataCollector:
                     "aredn_node_ips": [],  # e.g. ["10.54.25.1", "10.1.0.1"]
                 }
             )
-        except ImportError:
+        else:
             self._settings = None
 
         # Track nodes without GPS for reporting
@@ -349,14 +364,12 @@ class MapDataCollector:
         Returns:
             List of GeoJSON features for nodes with valid positions.
         """
-        try:
-            from gateway.node_tracker import get_node_tracker
-        except ImportError:
+        if not _HAS_NODE_TRACKER:
             logger.debug("UnifiedNodeTracker not available")
             return []
 
         try:
-            tracker = get_node_tracker()
+            tracker = _get_node_tracker()
             geojson = tracker.to_geojson()
             features = geojson.get("features", [])
 
@@ -434,13 +447,11 @@ class MapDataCollector:
         needing the TCP connection lock. This is the preferred collection
         method because it doesn't conflict with the gateway bridge.
         """
-        try:
-            from utils.meshtastic_http import get_http_client
-        except ImportError:
+        if not _HAS_MESHTASTIC_HTTP:
             return []
 
         try:
-            client = get_http_client(host=host)
+            client = _get_http_client(host=host)
             if not client.is_available:
                 logger.debug("meshtasticd HTTP API not available")
                 return []
@@ -513,9 +524,7 @@ class MapDataCollector:
         Returns list of GeoJSON features for nodes with valid positions.
         Also populates self._nodes_without_position for nodes lacking GPS.
         """
-        try:
-            from utils.meshtastic_connection import get_connection_manager
-        except ImportError:
+        if not _HAS_MESHTASTIC_CONN:
             logger.debug("meshtastic_connection module not available")
             return []
 
@@ -523,7 +532,7 @@ class MapDataCollector:
         no_position_nodes = []
         host = self.get_meshtasticd_host()
         port = self.get_meshtasticd_port()
-        manager = get_connection_manager(host=host, port=port)
+        manager = _get_connection_manager(host=host, port=port)
 
         # Don't block if someone else holds the connection
         if not manager.acquire_lock(timeout=5.0):
@@ -561,8 +570,7 @@ class MapDataCollector:
                         f"{len(no_position_nodes)} without GPS (total: {total_nodes})"
                     )
             finally:
-                from utils.meshtastic_connection import safe_close_interface
-                safe_close_interface(interface)
+                _safe_close_interface(interface)
 
         except Exception as e:
             logger.debug(f"TCP interface collection error: {e}")
@@ -579,12 +587,7 @@ class MapDataCollector:
 
         Returns list of GeoJSON features for nodes with valid positions.
         """
-        try:
-            from utils.meshtastic_connection import (
-                get_connection_manager, safe_close_interface, ConnectionMode,
-                reset_connection_manager
-            )
-        except ImportError:
+        if not _HAS_MESHTASTIC_CONN:
             logger.debug("meshtastic_connection module not available")
             return []
 
@@ -600,8 +603,8 @@ class MapDataCollector:
 
         # Reset manager to ensure we get SERIAL mode
         # (in case a previous TCP connection left it in TCP mode)
-        reset_connection_manager()
-        manager = get_connection_manager(mode=ConnectionMode.SERIAL)
+        _reset_connection_manager()
+        manager = _get_connection_manager(mode=_ConnectionMode.SERIAL)
 
         # Don't block if someone else holds the connection
         if not manager.acquire_lock(timeout=5.0):
@@ -642,7 +645,7 @@ class MapDataCollector:
                         f"{len(no_position_nodes)} without GPS (total: {total_nodes})"
                     )
             finally:
-                safe_close_interface(interface)
+                _safe_close_interface(interface)
 
         except Exception as e:
             logger.debug(f"Direct radio collection error: {e}")
@@ -875,19 +878,17 @@ class MapDataCollector:
         then falls back to cached GeoJSON file.
         """
         # Try live subscriber first (has real-time sensor data)
-        try:
-            from monitoring.mqtt_subscriber import get_local_subscriber
-            subscriber = get_local_subscriber()
-            if subscriber.is_connected():
-                geojson = subscriber.get_geojson()
-                features = geojson.get("features", [])
-                if features:
-                    logger.debug(f"MQTT live: {len(features)} nodes with position")
-                    return features
-        except ImportError:
-            pass
-        except Exception as e:
-            logger.debug(f"MQTT live collection error: {e}")
+        if _HAS_MQTT:
+            try:
+                subscriber = _get_local_subscriber()
+                if subscriber.is_connected():
+                    geojson = subscriber.get_geojson()
+                    features = geojson.get("features", [])
+                    if features:
+                        logger.debug(f"MQTT live: {len(features)} nodes with position")
+                        return features
+            except Exception as e:
+                logger.debug(f"MQTT live collection error: {e}")
 
         # Fallback: cached MQTT node file
         try:
@@ -909,12 +910,10 @@ class MapDataCollector:
         features = []
 
         # Check node_cache.json
-        try:
-            from utils.paths import get_real_user_home
+        if _HAS_PATHS:
             cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
-        except ImportError:
-            import os as _os
-            sudo_user = _os.environ.get('SUDO_USER', '')
+        else:
+            sudo_user = os.environ.get('SUDO_USER', '')
             # Path traversal protection (security)
             if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
                 cache_path = Path(f'/home/{sudo_user}/.config/meshforge/node_cache.json')
@@ -1007,9 +1006,7 @@ class MapDataCollector:
         """
         features = []
 
-        try:
-            from utils.aredn import AREDNScanner, AREDNClient
-        except ImportError:
+        if not _HAS_AREDN:
             logger.debug("AREDN module not available")
             return []
 
@@ -1021,7 +1018,7 @@ class MapDataCollector:
 
         try:
             # Get the local node info (may have location)
-            client = AREDNClient(local_node_ip, timeout=5)
+            client = _AREDNClient(local_node_ip, timeout=5)
             local_node = client.get_node_info()
 
             if local_node:
@@ -1033,7 +1030,7 @@ class MapDataCollector:
                 for link in local_node.links:
                     if link.ip:
                         try:
-                            neighbor_client = AREDNClient(link.ip, timeout=3)
+                            neighbor_client = _AREDNClient(link.ip, timeout=3)
                             neighbor_node = neighbor_client.get_node_info()
                             if neighbor_node:
                                 neighbor_feature = self._aredn_node_to_feature(neighbor_node)
@@ -1166,9 +1163,7 @@ class MapDataCollector:
         except OSError:
             return []
 
-        try:
-            import RNS
-        except ImportError:
+        if not _HAS_RNS:
             logger.debug("RNS module not available for direct query")
             return []
 
@@ -1190,11 +1185,11 @@ class MapDataCollector:
                 "  shared_instance_port = 37428\n"
                 "  instance_control_port = 37429\n"
             )
-            reticulum = RNS.Reticulum(configdir=str(client_config_dir))
+            reticulum = _RNS.Reticulum(configdir=str(client_config_dir))
 
             # Check for known destinations in path table
-            if hasattr(RNS.Transport, 'path_table') and RNS.Transport.path_table:
-                for dest_hash, path_data in RNS.Transport.path_table.items():
+            if hasattr(_RNS.Transport, 'path_table') and _RNS.Transport.path_table:
+                for dest_hash, path_data in _RNS.Transport.path_table.items():
                     try:
                         if isinstance(dest_hash, bytes) and len(dest_hash) == 16:
                             hash_hex = dest_hash.hex()
@@ -1235,7 +1230,7 @@ class MapDataCollector:
                 logger.debug(f"RNS direct: {len(features)} nodes with position")
             else:
                 # Log how many RNS destinations we found (even without position)
-                path_count = len(RNS.Transport.path_table) if hasattr(RNS.Transport, 'path_table') and RNS.Transport.path_table else 0
+                path_count = len(_RNS.Transport.path_table) if hasattr(_RNS.Transport, 'path_table') and _RNS.Transport.path_table else 0
                 if path_count:
                     logger.debug(
                         f"RNS: {path_count} destinations in path table, "
@@ -1277,10 +1272,9 @@ class MapDataCollector:
                 logger.debug(f"RNS position cache load error: {e}")
 
         # Source 2: Node tracker cache (RNS entries)
-        try:
-            from utils.paths import get_real_user_home
+        if _HAS_PATHS:
             cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
-        except ImportError:
+        else:
             cache_path = Path("/tmp/meshforge/node_cache.json")
 
         if cache_path.exists():
@@ -1308,14 +1302,16 @@ class MapDataCollector:
     def _load_nomadnet_peers(self) -> List[Dict]:
         """Load known peers from NomadNet cache if available."""
         peers = []
+        if not _HAS_PATHS or not _HAS_MSGPACK:
+            if not _HAS_MSGPACK:
+                logger.debug("msgpack not available for NomadNet peer reading")
+            return peers
         try:
-            from utils.paths import get_real_user_home
             nomadnet_dir = get_real_user_home() / '.nomadnetwork'
             peer_file = nomadnet_dir / 'storage' / 'peers'
             if peer_file.exists():
                 with open(peer_file, 'rb') as f:
-                    import msgpack
-                    data = msgpack.unpack(f, raw=False)
+                    data = _msgpack.unpack(f, raw=False)
                     if isinstance(data, dict):
                         for peer_hash, peer_data in data.items():
                             if isinstance(peer_data, dict):
@@ -1325,8 +1321,6 @@ class MapDataCollector:
                                     'lat': peer_data.get('latitude'),
                                     'lon': peer_data.get('longitude'),
                                 })
-        except ImportError:
-            logger.debug("msgpack not available for NomadNet peer reading")
         except FileNotFoundError:
             pass
         except Exception as e:

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -50,6 +50,26 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+# ── Optional dependency imports via safe_import ──────────────────────
+from utils.safe_import import safe_import
+
+_get_connection_manager, _ConnectionMode, _HAS_MESHTASTIC_CONN = safe_import(
+    'utils.meshtastic_connection', 'get_connection_manager', 'ConnectionMode'
+)
+_SRTMProvider, _LOSAnalyzer, _HAS_TERRAIN = safe_import(
+    'utils.terrain', 'SRTMProvider', 'LOSAnalyzer'
+)
+_MessageQueue, _HAS_MSG_QUEUE = safe_import(
+    'gateway.message_queue', 'MessageQueue'
+)
+_messaging_mod, _HAS_MESSAGING = safe_import('commands.messaging')
+_get_listener_status, _HAS_MSG_LISTENER = safe_import(
+    'utils.message_listener', 'get_listener_status'
+)
+_get_websocket_server, _is_websocket_available, _HAS_WS_SERVER = safe_import(
+    'utils.websocket_server', 'get_websocket_server', 'is_websocket_available'
+)
+
 # Default path where meshtasticd installs its web client files.
 # MeshForge serves these directly from disk instead of proxying HTML.
 MESHTASTICD_WEB_DIR = '/usr/share/meshtasticd/web'
@@ -354,9 +374,7 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
 
     def _get_radio_status_summary(self) -> Dict[str, Any]:
         """Get a summary of radio connection status for the status endpoint."""
-        try:
-            from utils.meshtastic_connection import get_connection_manager, ConnectionMode
-        except ImportError:
+        if not _HAS_MESHTASTIC_CONN:
             return {"available": False, "error": "meshtastic library not installed"}
 
         # Check TCP port (meshtasticd)
@@ -459,19 +477,18 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             radius_km = min(radius_km, 50)
 
             # Get coverage prediction from terrain analyzer
+            if not _HAS_TERRAIN:
+                self._serve_json({"error": "terrain module not available"})
+                return
             try:
-                from utils.terrain import SRTMProvider, LOSAnalyzer
-                provider = SRTMProvider()
-                analyzer = LOSAnalyzer(provider)
+                provider = _SRTMProvider()
+                analyzer = _LOSAnalyzer(provider)
                 coverage = analyzer.coverage_grid(
                     lat, lon, alt,
                     radius_km=radius_km,
                     freq_mhz=freq_mhz,
                     resolution=resolution
                 )
-            except ImportError:
-                self._serve_json({"error": "terrain module not available"})
-                return
             except Exception as e:
                 logger.error(f"Coverage calculation failed: {e}")
                 self._serve_json({"error": f"calculation failed: {str(e)}"})
@@ -599,14 +616,13 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             freq_mhz = float(params.get('freq_mhz', ['906'])[0])
 
             # Calculate LOS
-            try:
-                from utils.terrain import SRTMProvider, LOSAnalyzer
-                provider = SRTMProvider()
-                analyzer = LOSAnalyzer(provider)
-                result = analyzer.analyze(lat1, lon1, alt1, lat2, lon2, alt2, freq_mhz)
-            except ImportError:
+            if not _HAS_TERRAIN:
                 self._serve_json({"error": "terrain module not available"})
                 return
+            try:
+                provider = _SRTMProvider()
+                analyzer = _LOSAnalyzer(provider)
+                result = analyzer.analyze(lat1, lon1, alt1, lat2, lon2, alt2, freq_mhz)
             except Exception as e:
                 logger.error(f"LOS calculation failed: {e}")
                 self._serve_json({"error": f"calculation failed: {str(e)}"})
@@ -650,26 +666,26 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
         messages = []
 
         # Try to load from SQLite message queue
-        try:
-            from gateway.message_queue import MessageQueue
-            queue = MessageQueue()
-            pending = queue.get_pending_messages(limit=50)
-            for msg in pending:
-                messages.append({
-                    "id": msg.get("id"),
-                    "source": msg.get("source_id"),
-                    "source_name": msg.get("source_name", ""),
-                    "target": msg.get("target_id"),
-                    "target_name": msg.get("target_name", ""),
-                    "network": msg.get("target_network", "meshtastic"),
-                    "status": msg.get("status", "pending"),
-                    "created_at": msg.get("created_at", ""),
-                    "message_type": msg.get("message_type", "text")
-                })
-        except ImportError:
+        if not _HAS_MSG_QUEUE:
             logger.debug("MessageQueue not available")
-        except Exception as e:
-            logger.debug(f"Message queue error: {e}")
+        else:
+            try:
+                queue = _MessageQueue()
+                pending = queue.get_pending_messages(limit=50)
+                for msg in pending:
+                    messages.append({
+                        "id": msg.get("id"),
+                        "source": msg.get("source_id"),
+                        "source_name": msg.get("source_name", ""),
+                        "target": msg.get("target_id"),
+                        "target_name": msg.get("target_name", ""),
+                        "network": msg.get("target_network", "meshtastic"),
+                        "status": msg.get("status", "pending"),
+                        "created_at": msg.get("created_at", ""),
+                        "message_type": msg.get("message_type", "text")
+                    })
+            except Exception as e:
+                logger.debug(f"Message queue error: {e}")
 
         # Also check for cached queue file
         if not messages:
@@ -710,32 +726,32 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
 
         messages = []
 
-        try:
-            from commands import messaging
-            result = messaging.get_messages(limit=limit, network=network)
-
-            if result.success and result.data:
-                all_messages = result.data.get('messages', [])
-
-                # Filter by timestamp if 'since' is provided
-                if since:
-                    try:
-                        since_dt = datetime.fromisoformat(since.replace('Z', '+00:00'))
-                        all_messages = [
-                            m for m in all_messages
-                            if m.get('timestamp') and
-                            datetime.fromisoformat(m['timestamp']) > since_dt
-                        ]
-                    except (ValueError, TypeError):
-                        pass  # Invalid timestamp, skip filtering
-
-                # Filter to show only received messages (from_id != 'local')
-                messages = [m for m in all_messages if m.get('from_id') != 'local']
-
-        except ImportError:
+        if not _HAS_MESSAGING:
             logger.debug("Messaging module not available")
-        except Exception as e:
-            logger.debug(f"Error getting received messages: {e}")
+        else:
+            try:
+                result = _messaging_mod.get_messages(limit=limit, network=network)
+
+                if result.success and result.data:
+                    all_messages = result.data.get('messages', [])
+
+                    # Filter by timestamp if 'since' is provided
+                    if since:
+                        try:
+                            since_dt = datetime.fromisoformat(since.replace('Z', '+00:00'))
+                            all_messages = [
+                                m for m in all_messages
+                                if m.get('timestamp') and
+                                datetime.fromisoformat(m['timestamp']) > since_dt
+                            ]
+                        except (ValueError, TypeError):
+                            pass  # Invalid timestamp, skip filtering
+
+                    # Filter to show only received messages (from_id != 'local')
+                    messages = [m for m in all_messages if m.get('from_id') != 'local']
+
+            except Exception as e:
+                logger.debug(f"Error getting received messages: {e}")
 
         self._serve_json({
             "messages": messages,
@@ -757,13 +773,13 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             "error": None,
         }
 
-        try:
-            from utils.message_listener import get_listener_status
-            status = get_listener_status()
-        except ImportError:
+        if not _HAS_MSG_LISTENER:
             status["error"] = "MessageListener not available"
-        except Exception as e:
-            status["error"] = str(e)
+        else:
+            try:
+                status = _get_listener_status()
+            except Exception as e:
+                status["error"] = str(e)
 
         self._serve_json(status)
 
@@ -780,35 +796,32 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             "messages_broadcast": 0,
         }
 
-        try:
-            from utils.websocket_server import (
-                get_websocket_server, is_websocket_available
-            )
-
-            if not is_websocket_available():
-                status["error"] = "websockets library not installed"
-                self._serve_json(status)
-                return
-
-            ws_server = get_websocket_server()
-            if ws_server._running:
-                stats = ws_server.stats
-                status["available"] = True
-                status["port"] = ws_server.port
-                # Build WebSocket URL based on request host
-                host = self.headers.get('Host', 'localhost:5000')
-                hostname = host.split(':')[0]
-                status["url"] = f"ws://{hostname}:{ws_server.port}/"
-                status["connected_clients"] = stats.connected_clients
-                status["messages_broadcast"] = stats.messages_broadcast
-                status["total_connections"] = stats.total_connections
-                if stats.started_at:
-                    status["started_at"] = stats.started_at.isoformat()
-
-        except ImportError:
+        if not _HAS_WS_SERVER:
             status["error"] = "WebSocket server not available"
-        except Exception as e:
-            status["error"] = str(e)
+        else:
+            try:
+                if not _is_websocket_available():
+                    status["error"] = "websockets library not installed"
+                    self._serve_json(status)
+                    return
+
+                ws_server = _get_websocket_server()
+                if ws_server._running:
+                    stats = ws_server.stats
+                    status["available"] = True
+                    status["port"] = ws_server.port
+                    # Build WebSocket URL based on request host
+                    host = self.headers.get('Host', 'localhost:5000')
+                    hostname = host.split(':')[0]
+                    status["url"] = f"ws://{hostname}:{ws_server.port}/"
+                    status["connected_clients"] = stats.connected_clients
+                    status["messages_broadcast"] = stats.messages_broadcast
+                    status["total_connections"] = stats.total_connections
+                    if stats.started_at:
+                        status["started_at"] = stats.started_at.isoformat()
+
+            except Exception as e:
+                status["error"] = str(e)
 
         self._serve_json(status)
 
@@ -1346,13 +1359,9 @@ Webserver:
 
     def _get_radio_connection(self):
         """Get or create radio connection manager."""
-        try:
-            from utils.meshtastic_connection import (
-                get_connection_manager, ConnectionMode
-            )
-            return get_connection_manager(mode=ConnectionMode.AUTO)
-        except ImportError:
+        if not _HAS_MESHTASTIC_CONN:
             return None
+        return _get_connection_manager(mode=_ConnectionMode.AUTO)
 
     def _serve_radio_info(self):
         """Serve radio device information."""

--- a/src/utils/message_listener.py
+++ b/src/utils/message_listener.py
@@ -31,6 +31,21 @@ from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
+# --- Optional dependencies (safe_import) ---
+from utils.safe_import import safe_import
+
+create_local_subscriber, _HAS_MQTT_SUBSCRIBER = safe_import(
+    'monitoring.mqtt_subscriber', 'create_local_subscriber'
+)
+pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
+get_connection_manager, _HAS_MESH_CONN = safe_import(
+    'utils.meshtastic_connection', 'get_connection_manager'
+)
+get_node_tracker, Telemetry, AirQualityMetrics, Position, _HAS_NODE_TRACKER = safe_import(
+    'gateway.node_tracker', 'get_node_tracker', 'Telemetry', 'AirQualityMetrics', 'Position'
+)
+meshtastic_mod, _HAS_MESHTASTIC = safe_import('meshtastic')
+
 # Connection states
 DISCONNECTED = "disconnected"
 CONNECTING = "connecting"
@@ -187,11 +202,11 @@ class MessageListener:
         else:
             # TCP mode cleanup
             # Unsubscribe from pubsub
-            try:
-                from pubsub import pub
-                pub.unsubscribe(self._on_receive, "meshtastic.receive")
-            except Exception as e:
-                logger.debug(f"Cleanup: pubsub unsubscribe: {e}")
+            if _HAS_PUBSUB:
+                try:
+                    pub.unsubscribe(self._on_receive, "meshtastic.receive")
+                except Exception as e:
+                    logger.debug(f"Cleanup: pubsub unsubscribe: {e}")
 
             # Only close interface if we own it (not borrowing from gateway)
             if self._interface and self._owns_connection:
@@ -219,12 +234,10 @@ class MessageListener:
 
     def _run_mqtt_mode(self):
         """Run listener in MQTT mode - subscribe to local MQTT broker."""
-        try:
-            from monitoring.mqtt_subscriber import create_local_subscriber
-        except ImportError as e:
+        if not _HAS_MQTT_SUBSCRIBER:
             self._status.state = ERROR
-            self._status.error = f"MQTT module not available: {e}"
-            logger.error(f"Cannot start MQTT listener: {e}")
+            self._status.error = "MQTT module not available: monitoring.mqtt_subscriber"
+            logger.error("Cannot start MQTT listener: monitoring.mqtt_subscriber not available")
             return
 
         try:
@@ -282,14 +295,17 @@ class MessageListener:
     def _run_tcp_mode(self):
         """Run listener in TCP mode - direct meshtasticd connection."""
         try:
-            # Import dependencies
-            try:
-                from pubsub import pub
-                from utils.meshtastic_connection import get_connection_manager
-            except ImportError as e:
+            # Check dependencies
+            if not _HAS_PUBSUB or not _HAS_MESH_CONN:
+                missing = []
+                if not _HAS_PUBSUB:
+                    missing.append('pubsub')
+                if not _HAS_MESH_CONN:
+                    missing.append('utils.meshtastic_connection')
+                dep_str = ', '.join(missing)
                 self._status.state = ERROR
-                self._status.error = f"Missing dependency: {e}"
-                logger.error(f"Cannot start listener: {e}")
+                self._status.error = f"Missing dependency: {dep_str}"
+                logger.error(f"Cannot start listener: {dep_str}")
                 return
 
             # Check if another component (like gateway) already has a connection
@@ -506,8 +522,7 @@ class MessageListener:
                     )
 
                     # Update node tracker if available
-                    try:
-                        from gateway.node_tracker import get_node_tracker, Telemetry
+                    if _HAS_NODE_TRACKER:
                         tracker = get_node_tracker()
                         node = tracker.get_node(from_id)
                         if node:
@@ -517,8 +532,6 @@ class MessageListener:
                             node.telemetry.humidity = humidity
                             node.telemetry.barometric_pressure = pressure
                             tracker.add_node(node)
-                    except ImportError:
-                        pass
 
             # Air quality metrics (PMSA003I, SCD4X, etc.)
             aq_metrics = telemetry.get('airQualityMetrics', {})
@@ -535,10 +548,7 @@ class MessageListener:
                     )
 
                     # Update node tracker
-                    try:
-                        from gateway.node_tracker import (
-                            get_node_tracker, AirQualityMetrics
-                        )
+                    if _HAS_NODE_TRACKER:
                         tracker = get_node_tracker()
                         node = tracker.get_node(from_id)
                         if node and node.telemetry:
@@ -549,8 +559,6 @@ class MessageListener:
                                 iaq=iaq,
                             )
                             tracker.add_node(node)
-                    except ImportError:
-                        pass
 
             # Device metrics (battery, voltage, channel utilization)
             device_metrics = telemetry.get('deviceMetrics', {})
@@ -566,8 +574,7 @@ class MessageListener:
                         f"Voltage={voltage}V, ChUtil={ch_util}%"
                     )
 
-                    try:
-                        from gateway.node_tracker import get_node_tracker, Telemetry
+                    if _HAS_NODE_TRACKER:
                         tracker = get_node_tracker()
                         node = tracker.get_node(from_id)
                         if node:
@@ -578,8 +585,6 @@ class MessageListener:
                             node.telemetry.channel_utilization = ch_util
                             node.telemetry.air_util_tx = air_util
                             tracker.add_node(node)
-                    except ImportError:
-                        pass
 
         except Exception as e:
             logger.debug(f"Error processing telemetry: {e}")
@@ -596,8 +601,7 @@ class MessageListener:
                 logger.debug(f"POSITION [{from_id}]: {lat:.4f}, {lon:.4f}, alt={alt}m")
 
                 # Update node tracker
-                try:
-                    from gateway.node_tracker import get_node_tracker, Position
+                if _HAS_NODE_TRACKER:
                     tracker = get_node_tracker()
                     node = tracker.get_node(from_id)
                     if node:
@@ -607,8 +611,6 @@ class MessageListener:
                             altitude=alt or 0,
                         )
                         tracker.add_node(node)
-                except ImportError:
-                    pass
 
         except Exception as e:
             logger.debug(f"Error processing position: {e}")
@@ -768,8 +770,7 @@ def diagnose_pubsub() -> dict:
     }
 
     # Check pubsub
-    try:
-        from pubsub import pub
+    if _HAS_PUBSUB:
         result['pubsub_available'] = True
 
         # Get current subscriptions for meshtastic topics
@@ -794,17 +795,15 @@ def diagnose_pubsub() -> dict:
                 })
         except Exception as e:
             result['errors'].append(f"Could not inspect topics: {e}")
-
-    except ImportError as e:
-        result['errors'].append(f"pubsub not available: {e}")
+    else:
+        result['errors'].append("pubsub not available: pubsub")
 
     # Check meshtastic
-    try:
-        import meshtastic
+    if _HAS_MESHTASTIC:
         result['meshtastic_available'] = True
-        result['meshtastic_version'] = getattr(meshtastic, '__version__', 'unknown')
-    except ImportError as e:
-        result['errors'].append(f"meshtastic not available: {e}")
+        result['meshtastic_version'] = getattr(meshtastic_mod, '__version__', 'unknown')
+    else:
+        result['errors'].append("meshtastic not available: meshtastic")
 
     # Check if meshtasticd is reachable
     try:

--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -33,35 +33,29 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-# Import centralized path utility for sudo compatibility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
-    # Fallback for when running tests from project root
-    try:
-        from src.utils.paths import get_real_user_home
-    except ImportError:
-        # Ultimate fallback - handle sudo case
-        def get_real_user_home():
-            sudo_user = os.environ.get('SUDO_USER', '')
-            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-                return Path(f'/home/{sudo_user}')
-            logname = os.environ.get('LOGNAME', '')
-            if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-                return Path(f'/home/{logname}')
-            return Path('/root')
+# Safe import utility for consolidated ImportError handling
+from utils.safe_import import safe_import
 
+# Import centralized path utility for sudo compatibility
+get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+if not _HAS_PATHS:
+    # Ultimate fallback - handle sudo case
+    def get_real_user_home():
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f'/home/{sudo_user}')
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f'/home/{logname}')
+        return Path('/root')
 
 # Import centralized service checking
-try:
-    from utils.service_check import check_process_running
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    try:
-        from src.utils.service_check import check_process_running
-        _HAS_SERVICE_CHECK = True
-    except ImportError:
-        _HAS_SERVICE_CHECK = False
+check_process_running, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running'
+)
+
+# Import RNS module for health checks
+_RNS, _HAS_RNS = safe_import('RNS')
 
 # Diagnostic data directory
 DIAG_DIR = get_real_user_home() / ".config" / "meshforge" / "diagnostics"
@@ -465,11 +459,7 @@ class NetworkDiagnostics:
                 rnsd_running = result.returncode == 0
 
             # Check if RNS module is available
-            try:
-                import RNS
-                rns_installed = True
-            except ImportError:
-                rns_installed = False
+            rns_installed = _HAS_RNS
 
             if rnsd_running:
                 self.update_health(

--- a/src/utils/prometheus_exporter.py
+++ b/src/utils/prometheus_exporter.py
@@ -44,6 +44,40 @@ from utils.metrics_common import (
     format_metric_line,
     _format_metric_line,
 )
+from utils.safe_import import safe_import
+
+# --- Optional dependency imports (consolidated via safe_import) ---
+_meshforge_version, _HAS_VERSION = safe_import('__version__', '__version__')
+SharedHealthState, _HAS_HEALTH_STATE = safe_import(
+    'utils.shared_health_state', 'SharedHealthState'
+)
+get_health_scorer, _HAS_HEALTH_SCORER = safe_import(
+    'utils.health_score', 'get_health_scorer'
+)
+PersistentMessageQueue, _HAS_MESSAGE_QUEUE = safe_import(
+    'gateway.message_queue', 'PersistentMessageQueue'
+)
+MapDataCollector, _HAS_MAP_COLLECTOR = safe_import(
+    'utils.map_data_collector', 'MapDataCollector'
+)
+get_metrics_history, MetricType, _HAS_METRICS_HISTORY = safe_import(
+    'utils.metrics_history', 'get_metrics_history', 'MetricType'
+)
+check_service, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service'
+)
+TCPMonitor, TCPState, _HAS_TCP_MONITOR = safe_import(
+    'monitoring.tcp_monitor', 'TCPMonitor', 'TCPState'
+)
+get_rns_sniffer, _HAS_RNS_SNIFFER = safe_import(
+    'monitoring.rns_sniffer', 'get_rns_sniffer'
+)
+get_local_subscriber, _HAS_MQTT_SUBSCRIBER = safe_import(
+    'monitoring.mqtt_subscriber', 'get_local_subscriber'
+)
+get_topology_snapshot_store, _HAS_TOPOLOGY_SNAPSHOT = safe_import(
+    'utils.topology_snapshot', 'get_topology_snapshot_store'
+)
 
 logger = logging.getLogger(__name__)
 
@@ -116,15 +150,12 @@ class PrometheusExporter:
         lines = []
 
         # Version info
-        try:
-            from __version__ import __version__
-        except ImportError:
-            __version__ = "unknown"
+        version = _meshforge_version if _HAS_VERSION else "unknown"
 
         defn = METRICS["meshforge_info"]
         lines.append(f"# HELP {defn.name} {defn.help_text}")
         lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-        lines.append(_format_metric_line(defn.name, 1, {"version": __version__}))
+        lines.append(_format_metric_line(defn.name, 1, {"version": version}))
 
         # Uptime
         defn = METRICS["meshforge_uptime_seconds"]
@@ -145,68 +176,64 @@ class PrometheusExporter:
         """Collect service health metrics from SharedHealthState."""
         lines = []
 
-        try:
-            from utils.shared_health_state import SharedHealthState
-            state = SharedHealthState()
-            services = state.get_all_services()
-            state.close()
+        if _HAS_HEALTH_STATE:
+            try:
+                state = SharedHealthState()
+                services = state.get_all_services()
+                state.close()
 
-            if not services:
-                return lines
+                if not services:
+                    return lines
 
-            # Service healthy gauge
-            defn = METRICS["meshforge_service_healthy"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            for svc in services:
-                healthy = 1 if svc.state.value == "healthy" else 0
-                lines.append(_format_metric_line(defn.name, healthy, {"service": svc.service}))
+                # Service healthy gauge
+                defn = METRICS["meshforge_service_healthy"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                for svc in services:
+                    healthy = 1 if svc.state.value == "healthy" else 0
+                    lines.append(_format_metric_line(defn.name, healthy, {"service": svc.service}))
 
-            # Uptime percentage
-            defn = METRICS["meshforge_service_uptime_percent"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            for svc in services:
-                lines.append(_format_metric_line(defn.name, svc.uptime_pct, {"service": svc.service}))
+                # Uptime percentage
+                defn = METRICS["meshforge_service_uptime_percent"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                for svc in services:
+                    lines.append(_format_metric_line(defn.name, svc.uptime_pct, {"service": svc.service}))
 
-            # Latency
-            defn = METRICS["meshforge_service_latency_ms"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            for svc in services:
-                lines.append(_format_metric_line(defn.name, svc.latency_ms, {"service": svc.service}))
+                # Latency
+                defn = METRICS["meshforge_service_latency_ms"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                for svc in services:
+                    lines.append(_format_metric_line(defn.name, svc.latency_ms, {"service": svc.service}))
 
-            # Consecutive failures
-            defn = METRICS["meshforge_service_consecutive_fails"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            for svc in services:
-                lines.append(_format_metric_line(defn.name, svc.consecutive_fails, {"service": svc.service}))
+                # Consecutive failures
+                defn = METRICS["meshforge_service_consecutive_fails"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                for svc in services:
+                    lines.append(_format_metric_line(defn.name, svc.consecutive_fails, {"service": svc.service}))
 
-        except ImportError:
-            logger.debug("SharedHealthState not available")
-        except Exception as e:
-            logger.debug(f"Error collecting health metrics: {e}")
+            except Exception as e:
+                logger.debug(f"Error collecting health metrics: {e}")
 
         # Health scores from HealthScorer (uses shared singleton)
-        try:
-            from utils.health_score import get_health_scorer
-            scorer = get_health_scorer()
-            snapshot = scorer.get_snapshot()
+        if _HAS_HEALTH_SCORER:
+            try:
+                scorer = get_health_scorer()
+                snapshot = scorer.get_snapshot()
 
-            defn = METRICS["meshforge_health_score"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            lines.append(_format_metric_line(defn.name, snapshot.overall_score, {"category": "overall"}))
-            lines.append(_format_metric_line(defn.name, snapshot.connectivity_score, {"category": "connectivity"}))
-            lines.append(_format_metric_line(defn.name, snapshot.performance_score, {"category": "performance"}))
-            lines.append(_format_metric_line(defn.name, snapshot.reliability_score, {"category": "reliability"}))
-            lines.append(_format_metric_line(defn.name, snapshot.freshness_score, {"category": "freshness"}))
+                defn = METRICS["meshforge_health_score"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                lines.append(_format_metric_line(defn.name, snapshot.overall_score, {"category": "overall"}))
+                lines.append(_format_metric_line(defn.name, snapshot.connectivity_score, {"category": "connectivity"}))
+                lines.append(_format_metric_line(defn.name, snapshot.performance_score, {"category": "performance"}))
+                lines.append(_format_metric_line(defn.name, snapshot.reliability_score, {"category": "reliability"}))
+                lines.append(_format_metric_line(defn.name, snapshot.freshness_score, {"category": "freshness"}))
 
-        except ImportError:
-            logger.debug("HealthScorer not available")
-        except Exception as e:
-            logger.debug(f"Error collecting health scores: {e}")
+            except Exception as e:
+                logger.debug(f"Error collecting health scores: {e}")
 
         return lines
 
@@ -214,51 +241,49 @@ class PrometheusExporter:
         """Collect message queue metrics from PersistentMessageQueue."""
         lines = []
 
-        try:
-            from gateway.message_queue import PersistentMessageQueue
-            queue = PersistentMessageQueue()
-            stats = queue.get_stats()
+        if _HAS_MESSAGE_QUEUE:
+            try:
+                queue = PersistentMessageQueue()
+                stats = queue.get_stats()
 
-            # Queue depth by status
-            defn = METRICS["meshforge_message_queue_depth"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            lines.append(_format_metric_line(defn.name, stats.get("pending", 0), {"status": "pending"}))
-            lines.append(_format_metric_line(defn.name, stats.get("in_progress", 0), {"status": "in_progress"}))
+                # Queue depth by status
+                defn = METRICS["meshforge_message_queue_depth"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                lines.append(_format_metric_line(defn.name, stats.get("pending", 0), {"status": "pending"}))
+                lines.append(_format_metric_line(defn.name, stats.get("in_progress", 0), {"status": "in_progress"}))
 
-            # Total messages
-            defn = METRICS["meshforge_messages_total"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            lines.append(_format_metric_line(
-                defn.name, stats.get("enqueued", 0),
-                {"direction": "incoming", "status": "enqueued"}
-            ))
-            lines.append(_format_metric_line(
-                defn.name, stats.get("delivered", 0),
-                {"direction": "outgoing", "status": "delivered"}
-            ))
-            lines.append(_format_metric_line(
-                defn.name, stats.get("failed", 0),
-                {"direction": "outgoing", "status": "failed"}
-            ))
+                # Total messages
+                defn = METRICS["meshforge_messages_total"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                lines.append(_format_metric_line(
+                    defn.name, stats.get("enqueued", 0),
+                    {"direction": "incoming", "status": "enqueued"}
+                ))
+                lines.append(_format_metric_line(
+                    defn.name, stats.get("delivered", 0),
+                    {"direction": "outgoing", "status": "delivered"}
+                ))
+                lines.append(_format_metric_line(
+                    defn.name, stats.get("failed", 0),
+                    {"direction": "outgoing", "status": "failed"}
+                ))
 
-            # Retries
-            defn = METRICS["meshforge_message_retries_total"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            lines.append(_format_metric_line(defn.name, stats.get("retried", 0)))
+                # Retries
+                defn = METRICS["meshforge_message_retries_total"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                lines.append(_format_metric_line(defn.name, stats.get("retried", 0)))
 
-            # Dead letters
-            defn = METRICS["meshforge_dead_letter_count"]
-            lines.append(f"# HELP {defn.name} {defn.help_text}")
-            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-            lines.append(_format_metric_line(defn.name, stats.get("dead_letter", 0)))
+                # Dead letters
+                defn = METRICS["meshforge_dead_letter_count"]
+                lines.append(f"# HELP {defn.name} {defn.help_text}")
+                lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                lines.append(_format_metric_line(defn.name, stats.get("dead_letter", 0)))
 
-        except ImportError:
-            logger.debug("PersistentMessageQueue not available")
-        except Exception as e:
-            logger.debug(f"Error collecting message metrics: {e}")
+            except Exception as e:
+                logger.debug(f"Error collecting message metrics: {e}")
 
         return lines
 
@@ -269,28 +294,23 @@ class PrometheusExporter:
         nodes_with_gps = 0
 
         # Primary source: MapDataCollector (has actual node data)
-        try:
-            from utils.map_data_collector import MapDataCollector
-            collector = MapDataCollector(enable_history=False)
-            geojson = collector.collect(max_age_seconds=60)
-            props = geojson.get("properties", {})
-            node_count = props.get("total_nodes", 0)
-            nodes_with_gps = props.get("nodes_with_position", 0)
-            logger.debug(f"MapDataCollector: {node_count} total, {nodes_with_gps} with GPS")
-        except ImportError:
-            logger.debug("MapDataCollector not available")
-        except Exception as e:
-            logger.debug(f"Error collecting from MapDataCollector: {e}")
+        if _HAS_MAP_COLLECTOR:
+            try:
+                collector = MapDataCollector(enable_history=False)
+                geojson = collector.collect(max_age_seconds=60)
+                props = geojson.get("properties", {})
+                node_count = props.get("total_nodes", 0)
+                nodes_with_gps = props.get("nodes_with_position", 0)
+                logger.debug(f"MapDataCollector: {node_count} total, {nodes_with_gps} with GPS")
+            except Exception as e:
+                logger.debug(f"Error collecting from MapDataCollector: {e}")
 
         # Fallback to MetricsHistory if MapDataCollector returned 0
-        if node_count == 0:
+        if node_count == 0 and _HAS_METRICS_HISTORY:
             try:
-                from utils.metrics_history import get_metrics_history, MetricType
                 history = get_metrics_history()
                 stats = history.get_statistics()
                 node_count = stats.get("unique_nodes", 0)
-            except ImportError:
-                logger.debug("MetricsHistory not available")
             except Exception as e:
                 logger.debug(f"Error collecting from MetricsHistory: {e}")
 
@@ -303,47 +323,45 @@ class PrometheusExporter:
             lines.append(_format_metric_line(defn.name, nodes_with_gps, {"state": "with_gps"}))
 
         # Per-node SNR/RSSI metrics from MetricsHistory
-        try:
-            from utils.metrics_history import get_metrics_history, MetricType
-            history = get_metrics_history()
+        if _HAS_METRICS_HISTORY:
+            try:
+                history = get_metrics_history()
 
-            # SNR metrics
-            snr_added = False
-            for point in history.get_recent(metric_type=MetricType.SNR, hours=1, limit=100):
-                if point.node_id:
-                    if not snr_added:
-                        defn = METRICS["meshforge_node_snr"]
-                        lines.append(f"# HELP {defn.name} {defn.help_text}")
-                        lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-                        snr_added = True
-                    lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
+                # SNR metrics
+                snr_added = False
+                for point in history.get_recent(metric_type=MetricType.SNR, hours=1, limit=100):
+                    if point.node_id:
+                        if not snr_added:
+                            defn = METRICS["meshforge_node_snr"]
+                            lines.append(f"# HELP {defn.name} {defn.help_text}")
+                            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                            snr_added = True
+                        lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
 
-            # RSSI metrics
-            rssi_added = False
-            for point in history.get_recent(metric_type=MetricType.RSSI, hours=1, limit=100):
-                if point.node_id:
-                    if not rssi_added:
-                        defn = METRICS["meshforge_node_rssi"]
-                        lines.append(f"# HELP {defn.name} {defn.help_text}")
-                        lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-                        rssi_added = True
-                    lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
+                # RSSI metrics
+                rssi_added = False
+                for point in history.get_recent(metric_type=MetricType.RSSI, hours=1, limit=100):
+                    if point.node_id:
+                        if not rssi_added:
+                            defn = METRICS["meshforge_node_rssi"]
+                            lines.append(f"# HELP {defn.name} {defn.help_text}")
+                            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                            rssi_added = True
+                        lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
 
-            # Battery metrics
-            battery_added = False
-            for point in history.get_recent(metric_type=MetricType.BATTERY, hours=1, limit=100):
-                if point.node_id:
-                    if not battery_added:
-                        defn = METRICS["meshforge_node_battery_percent"]
-                        lines.append(f"# HELP {defn.name} {defn.help_text}")
-                        lines.append(f"# TYPE {defn.name} {defn.metric_type}")
-                        battery_added = True
-                    lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
+                # Battery metrics
+                battery_added = False
+                for point in history.get_recent(metric_type=MetricType.BATTERY, hours=1, limit=100):
+                    if point.node_id:
+                        if not battery_added:
+                            defn = METRICS["meshforge_node_battery_percent"]
+                            lines.append(f"# HELP {defn.name} {defn.help_text}")
+                            lines.append(f"# TYPE {defn.name} {defn.metric_type}")
+                            battery_added = True
+                        lines.append(_format_metric_line(defn.name, point.value, {"node_id": point.node_id}))
 
-        except ImportError:
-            pass
-        except Exception as e:
-            logger.debug(f"Error collecting SNR/RSSI/battery metrics: {e}")
+            except Exception as e:
+                logger.debug(f"Error collecting SNR/RSSI/battery metrics: {e}")
 
         return lines
 
@@ -355,12 +373,14 @@ class PrometheusExporter:
         rns_connected = 0
 
         # Check meshtasticd service status
-        try:
-            from utils.service_check import check_service
-            mesh_status = check_service("meshtasticd")
-            if mesh_status.available:
-                meshtastic_connected = 1
-        except ImportError:
+        if _HAS_SERVICE_CHECK:
+            try:
+                mesh_status = check_service("meshtasticd")
+                if mesh_status.available:
+                    meshtastic_connected = 1
+            except Exception as e:
+                logger.debug(f"Error checking meshtasticd: {e}")
+        else:
             # Fallback: check if port 4403 is listening
             try:
                 import socket
@@ -372,16 +392,16 @@ class PrometheusExporter:
                     meshtastic_connected = 1
             except Exception:
                 pass
-        except Exception as e:
-            logger.debug(f"Error checking meshtasticd: {e}")
 
         # Check rnsd service status
-        try:
-            from utils.service_check import check_service
-            rns_status = check_service("rnsd")
-            if rns_status.available:
-                rns_connected = 1
-        except ImportError:
+        if _HAS_SERVICE_CHECK:
+            try:
+                rns_status = check_service("rnsd")
+                if rns_status.available:
+                    rns_connected = 1
+            except Exception as e:
+                logger.debug(f"Error checking rnsd: {e}")
+        else:
             # Fallback: check if UDP port 37428 is in use (rnsd default)
             try:
                 import subprocess
@@ -395,8 +415,6 @@ class PrometheusExporter:
                     rns_connected = 1
             except Exception:
                 pass
-        except Exception as e:
-            logger.debug(f"Error checking rnsd: {e}")
 
         defn = METRICS["meshforge_gateway_connections"]
         lines.append(f"# HELP {defn.name} {defn.help_text}")
@@ -410,9 +428,7 @@ class PrometheusExporter:
         """Collect TCP connection metrics."""
         lines = []
 
-        try:
-            from monitoring.tcp_monitor import TCPMonitor, TCPState
-        except ImportError:
+        if not _HAS_TCP_MONITOR:
             logger.debug("TCP monitor not available for metrics collection")
             return lines
 
@@ -474,9 +490,7 @@ class PrometheusExporter:
         """Collect RNS sniffer metrics for Wireshark-grade visibility."""
         lines = []
 
-        try:
-            from monitoring.rns_sniffer import get_rns_sniffer
-        except ImportError:
+        if not _HAS_RNS_SNIFFER:
             logger.debug("RNS sniffer not available for metrics collection")
             return lines
 
@@ -556,9 +570,7 @@ class PrometheusExporter:
         """
         lines = []
 
-        try:
-            from monitoring.mqtt_subscriber import get_local_subscriber
-        except ImportError:
+        if not _HAS_MQTT_SUBSCRIBER:
             logger.debug("MQTT subscriber not available for environment metrics")
             return lines
 
@@ -692,9 +704,7 @@ class PrometheusExporter:
         """
         lines = []
 
-        try:
-            from monitoring.mqtt_subscriber import get_local_subscriber
-        except ImportError:
+        if not _HAS_MQTT_SUBSCRIBER:
             logger.debug("MQTT subscriber not available for metrics")
             return lines
 
@@ -746,9 +756,7 @@ class PrometheusExporter:
         """
         lines = []
 
-        try:
-            from utils.topology_snapshot import get_topology_snapshot_store
-        except ImportError:
+        if not _HAS_TOPOLOGY_SNAPSHOT:
             logger.debug("Topology snapshot store not available")
             return lines
 
@@ -1202,43 +1210,51 @@ Grafana Setup (Option 2 - Infinity plugin):
             metrics = {}
 
             # Get node counts from MapDataCollector
-            try:
-                from utils.map_data_collector import MapDataCollector
-                collector = MapDataCollector(enable_history=False)
-                geojson = collector.collect(max_age_seconds=60)
-                props = geojson.get('properties', {})
-                metrics['nodes_total'] = props.get('total_nodes', 0)
-                metrics['nodes_with_gps'] = props.get('nodes_with_position', 0)
-                metrics['sources'] = props.get('sources', {})
-            except Exception as e:
-                logger.debug(f"MapDataCollector error: {e}")
+            if _HAS_MAP_COLLECTOR:
+                try:
+                    collector = MapDataCollector(enable_history=False)
+                    geojson = collector.collect(max_age_seconds=60)
+                    props = geojson.get('properties', {})
+                    metrics['nodes_total'] = props.get('total_nodes', 0)
+                    metrics['nodes_with_gps'] = props.get('nodes_with_position', 0)
+                    metrics['sources'] = props.get('sources', {})
+                except Exception as e:
+                    logger.debug(f"MapDataCollector error: {e}")
+                    metrics['nodes_total'] = 0
+                    metrics['nodes_with_gps'] = 0
+            else:
                 metrics['nodes_total'] = 0
                 metrics['nodes_with_gps'] = 0
 
             # Get service status
-            try:
-                from utils.service_check import check_service
-                mesh_status = check_service("meshtasticd")
-                rns_status = check_service("rnsd")
-                metrics['meshtasticd_running'] = 1 if mesh_status.available else 0
-                metrics['rnsd_running'] = 1 if rns_status.available else 0
-            except Exception:
+            if _HAS_SERVICE_CHECK:
+                try:
+                    mesh_status = check_service("meshtasticd")
+                    rns_status = check_service("rnsd")
+                    metrics['meshtasticd_running'] = 1 if mesh_status.available else 0
+                    metrics['rnsd_running'] = 1 if rns_status.available else 0
+                except Exception:
+                    metrics['meshtasticd_running'] = 0
+                    metrics['rnsd_running'] = 0
+            else:
                 metrics['meshtasticd_running'] = 0
                 metrics['rnsd_running'] = 0
 
             # MQTT stats
-            try:
-                from monitoring.mqtt_subscriber import get_local_subscriber
-                subscriber = get_local_subscriber()
-                mqtt_stats = subscriber.get_stats()
-                metrics['mqtt_connected'] = 1 if subscriber.is_connected() else 0
-                metrics['mqtt_nodes'] = mqtt_stats.get('node_count', 0)
-                metrics['mqtt_online'] = mqtt_stats.get('online_count', 0)
-                metrics['mqtt_mesh_size_24h'] = mqtt_stats.get('mesh_size_24h', 0)
-                metrics['mqtt_nodes_with_env'] = mqtt_stats.get('nodes_with_env_metrics', 0)
-                metrics['mqtt_nodes_with_aq'] = mqtt_stats.get('nodes_with_aq_metrics', 0)
-                metrics['mesh_health_status'] = mqtt_stats.get('mesh_health_status', 'unknown')
-            except Exception:
+            if _HAS_MQTT_SUBSCRIBER:
+                try:
+                    subscriber = get_local_subscriber()
+                    mqtt_stats = subscriber.get_stats()
+                    metrics['mqtt_connected'] = 1 if subscriber.is_connected() else 0
+                    metrics['mqtt_nodes'] = mqtt_stats.get('node_count', 0)
+                    metrics['mqtt_online'] = mqtt_stats.get('online_count', 0)
+                    metrics['mqtt_mesh_size_24h'] = mqtt_stats.get('mesh_size_24h', 0)
+                    metrics['mqtt_nodes_with_env'] = mqtt_stats.get('nodes_with_env_metrics', 0)
+                    metrics['mqtt_nodes_with_aq'] = mqtt_stats.get('nodes_with_aq_metrics', 0)
+                    metrics['mesh_health_status'] = mqtt_stats.get('mesh_health_status', 'unknown')
+                except Exception:
+                    metrics['mqtt_connected'] = 0
+            else:
                 metrics['mqtt_connected'] = 0
 
             # Uptime
@@ -1267,38 +1283,38 @@ Grafana Setup (Option 2 - Infinity plugin):
         try:
             nodes = []
 
-            try:
-                from utils.map_data_collector import MapDataCollector
-                collector = MapDataCollector(enable_history=False)
-                geojson = collector.collect(max_age_seconds=60)
+            if _HAS_MAP_COLLECTOR:
+                try:
+                    collector = MapDataCollector(enable_history=False)
+                    geojson = collector.collect(max_age_seconds=60)
 
-                for feature in geojson.get('features', []):
-                    props = feature.get('properties', {})
-                    coords = feature.get('geometry', {}).get('coordinates', [0, 0])
-                    node_data = {
-                        'id': props.get('id', ''),
-                        'name': props.get('name', ''),
-                        'lat': coords[1] if len(coords) > 1 else 0,
-                        'lon': coords[0] if len(coords) > 0 else 0,
-                        'snr': props.get('snr'),
-                        'rssi': props.get('rssi'),
-                        'battery': props.get('battery'),
-                        'last_heard': props.get('last_heard'),
-                        'online': props.get('online', False),
-                        'hardware': props.get('hardware', ''),
-                        'role': props.get('role', ''),
-                        # Environment sensors
-                        'temperature': props.get('temperature'),
-                        'humidity': props.get('humidity'),
-                        'pressure': props.get('pressure'),
-                        # Air quality
-                        'pm25': props.get('pm25'),
-                        'co2': props.get('co2'),
-                        'iaq': props.get('iaq'),
-                    }
-                    nodes.append(node_data)
-            except Exception as e:
-                logger.debug(f"Node collection error: {e}")
+                    for feature in geojson.get('features', []):
+                        props = feature.get('properties', {})
+                        coords = feature.get('geometry', {}).get('coordinates', [0, 0])
+                        node_data = {
+                            'id': props.get('id', ''),
+                            'name': props.get('name', ''),
+                            'lat': coords[1] if len(coords) > 1 else 0,
+                            'lon': coords[0] if len(coords) > 0 else 0,
+                            'snr': props.get('snr'),
+                            'rssi': props.get('rssi'),
+                            'battery': props.get('battery'),
+                            'last_heard': props.get('last_heard'),
+                            'online': props.get('online', False),
+                            'hardware': props.get('hardware', ''),
+                            'role': props.get('role', ''),
+                            # Environment sensors
+                            'temperature': props.get('temperature'),
+                            'humidity': props.get('humidity'),
+                            'pressure': props.get('pressure'),
+                            # Air quality
+                            'pm25': props.get('pm25'),
+                            'co2': props.get('co2'),
+                            'iaq': props.get('iaq'),
+                        }
+                        nodes.append(node_data)
+                except Exception as e:
+                    logger.debug(f"Node collection error: {e}")
 
             result = {
                 'timestamp': datetime.now().isoformat(),
@@ -1323,13 +1339,10 @@ Grafana Setup (Option 2 - Infinity plugin):
         """Serve system status as JSON."""
         import json
 
-        try:
-            from __version__ import __version__
-        except ImportError:
-            __version__ = "unknown"
+        version = _meshforge_version if _HAS_VERSION else "unknown"
 
         status = {
-            'version': __version__,
+            'version': version,
             'timestamp': datetime.now().isoformat(),
             'services': {},
         }

--- a/src/utils/report_generator.py
+++ b/src/utils/report_generator.py
@@ -28,7 +28,29 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional dependency imports (consolidated via safe_import)
+# ---------------------------------------------------------------------------
+HealthScorer, format_health_display, get_health_scorer, _HAS_HEALTH_SCORE = safe_import(
+    'utils.health_score', 'HealthScorer', 'format_health_display', 'get_health_scorer'
+)
+SignalTrendingManager, _HAS_SIGNAL_TRENDING = safe_import(
+    'utils.signal_trending', 'SignalTrendingManager'
+)
+MaintenancePredictor, _HAS_PREDICTIVE_MAINTENANCE = safe_import(
+    'utils.predictive_maintenance', 'MaintenancePredictor'
+)
+get_diagnostic_engine, Category, _HAS_DIAGNOSTIC_ENGINE = safe_import(
+    'utils.diagnostic_engine', 'get_diagnostic_engine', 'Category'
+)
+PresetAnalyzer, _HAS_PRESET_IMPACT = safe_import(
+    'utils.preset_impact', 'PresetAnalyzer'
+)
+__version__, _HAS_VERSION = safe_import('__version__', '__version__')
 
 
 @dataclass
@@ -119,32 +141,32 @@ class ReportGenerator:
         """Add network health scoring section."""
         lines = []
 
-        try:
-            from utils.health_score import HealthScorer, format_health_display
-            scorer = _get_health_scorer()
-            if scorer is None:
-                lines.append("*Health scorer not initialized — no node data available.*")
-            else:
-                snapshot = scorer.get_snapshot()
-                lines.append(f"**Overall Score: {snapshot.overall_score:.0f}/100** "
-                             f"({snapshot.status})")
-                lines.append("")
-                lines.append("| Category | Score | Status |")
-                lines.append("|----------|-------|--------|")
-                for cat, score in snapshot.category_scores.items():
-                    status = _score_status(score)
-                    lines.append(f"| {cat.title()} | {score:.0f} | {status} |")
-                lines.append("")
-                lines.append(f"- Nodes reporting: {snapshot.node_count}")
-                lines.append(f"- Services tracked: {snapshot.service_count}")
+        if _HAS_HEALTH_SCORE:
+            try:
+                scorer = _get_health_scorer()
+                if scorer is None:
+                    lines.append("*Health scorer not initialized — no node data available.*")
+                else:
+                    snapshot = scorer.get_snapshot()
+                    lines.append(f"**Overall Score: {snapshot.overall_score:.0f}/100** "
+                                 f"({snapshot.status})")
+                    lines.append("")
+                    lines.append("| Category | Score | Status |")
+                    lines.append("|----------|-------|--------|")
+                    for cat, score in snapshot.category_scores.items():
+                        status = _score_status(score)
+                        lines.append(f"| {cat.title()} | {score:.0f} | {status} |")
+                    lines.append("")
+                    lines.append(f"- Nodes reporting: {snapshot.node_count}")
+                    lines.append(f"- Services tracked: {snapshot.service_count}")
 
-                trend = scorer.get_trend()
-                if trend != 'stable':
-                    lines.append(f"- Trend: **{trend}**")
-        except ImportError:
+                    trend = scorer.get_trend()
+                    if trend != 'stable':
+                        lines.append(f"- Trend: **{trend}**")
+            except Exception as e:
+                lines.append(f"*Error collecting health data: {e}*")
+        else:
             lines.append("*Health score module not available.*")
-        except Exception as e:
-            lines.append(f"*Error collecting health data: {e}*")
 
         self._sections.append(ReportSection(
             heading="Network Health",
@@ -157,37 +179,37 @@ class ReportGenerator:
         """Add signal trending section."""
         lines = []
 
-        try:
-            from utils.signal_trending import SignalTrendingManager
-            manager = _get_signal_manager()
-            if manager is None:
-                lines.append("*Signal trending not initialized — no signal data available.*")
-            else:
-                nodes = manager.get_tracked_nodes()
-                if not nodes:
-                    lines.append("*No nodes currently tracked.*")
+        if _HAS_SIGNAL_TRENDING:
+            try:
+                manager = _get_signal_manager()
+                if manager is None:
+                    lines.append("*Signal trending not initialized — no signal data available.*")
                 else:
-                    lines.append(f"Tracking {len(nodes)} node(s).\n")
-                    lines.append("| Node | Current SNR | Current RSSI | Trend | Samples |")
-                    lines.append("|------|-------------|--------------|-------|---------|")
+                    nodes = manager.get_tracked_nodes()
+                    if not nodes:
+                        lines.append("*No nodes currently tracked.*")
+                    else:
+                        lines.append(f"Tracking {len(nodes)} node(s).\n")
+                        lines.append("| Node | Current SNR | Current RSSI | Trend | Samples |")
+                        lines.append("|------|-------------|--------------|-------|---------|")
 
-                    for node_id in sorted(nodes)[:self.config.max_signal_nodes]:
-                        report = manager.get_report(node_id)
-                        if report:
-                            snr_str = f"{report.current_snr:.1f} dB" if report.current_snr else "N/A"
-                            rssi_str = f"{report.current_rssi:.0f} dBm" if report.current_rssi else "N/A"
-                            trend = report.trend if hasattr(report, 'trend') else "—"
-                            samples = report.sample_count if hasattr(report, 'sample_count') else "—"
-                            lines.append(f"| {node_id} | {snr_str} | {rssi_str} | {trend} | {samples} |")
+                        for node_id in sorted(nodes)[:self.config.max_signal_nodes]:
+                            report = manager.get_report(node_id)
+                            if report:
+                                snr_str = f"{report.current_snr:.1f} dB" if report.current_snr else "N/A"
+                                rssi_str = f"{report.current_rssi:.0f} dBm" if report.current_rssi else "N/A"
+                                trend = report.trend if hasattr(report, 'trend') else "—"
+                                samples = report.sample_count if hasattr(report, 'sample_count') else "—"
+                                lines.append(f"| {node_id} | {snr_str} | {rssi_str} | {trend} | {samples} |")
 
-                    # Check for degrading nodes
-                    degrading = manager.get_degrading_nodes()
-                    if degrading:
-                        lines.append(f"\n**Warning:** {len(degrading)} node(s) showing signal degradation.")
-        except ImportError:
+                        # Check for degrading nodes
+                        degrading = manager.get_degrading_nodes()
+                        if degrading:
+                            lines.append(f"\n**Warning:** {len(degrading)} node(s) showing signal degradation.")
+            except Exception as e:
+                lines.append(f"*Error collecting signal data: {e}*")
+        else:
             lines.append("*Signal trending module not available.*")
-        except Exception as e:
-            lines.append(f"*Error collecting signal data: {e}*")
 
         self._sections.append(ReportSection(
             heading="Signal Quality",
@@ -200,60 +222,60 @@ class ReportGenerator:
         """Add predictive maintenance section."""
         lines = []
 
-        try:
-            from utils.predictive_maintenance import MaintenancePredictor
-            predictor = _get_maintenance_predictor()
-            if predictor is None:
-                lines.append("*Maintenance predictor not initialized — no telemetry data.*")
-            else:
-                node_ids = predictor.get_node_ids()
-                if not node_ids:
-                    lines.append("*No nodes tracked for maintenance.*")
+        if _HAS_PREDICTIVE_MAINTENANCE:
+            try:
+                predictor = _get_maintenance_predictor()
+                if predictor is None:
+                    lines.append("*Maintenance predictor not initialized — no telemetry data.*")
                 else:
-                    # Battery forecasts
-                    forecasts = predictor.get_all_forecasts()
-                    battery_nodes = [f for f in forecasts.values()
-                                     if f.trend != 'insufficient_data']
-                    if battery_nodes:
-                        lines.append("### Battery Status\n")
-                        lines.append("| Node | Level | Drain Rate | Hours to Critical | Trend |")
-                        lines.append("|------|-------|------------|-------------------|-------|")
-                        for f in sorted(battery_nodes, key=lambda x: x.current_pct):
-                            rate = f"{f.drain_rate_pct_per_hour:.2f}%/h" if f.trend == 'draining' else "—"
-                            critical = f"{f.hours_to_critical:.0f}h" if f.hours_to_critical else "—"
-                            lines.append(f"| {f.node_id} | {f.current_pct:.0f}% | {rate} | "
-                                         f"{critical} | {f.trend} |")
+                    node_ids = predictor.get_node_ids()
+                    if not node_ids:
+                        lines.append("*No nodes tracked for maintenance.*")
+                    else:
+                        # Battery forecasts
+                        forecasts = predictor.get_all_forecasts()
+                        battery_nodes = [f for f in forecasts.values()
+                                         if f.trend != 'insufficient_data']
+                        if battery_nodes:
+                            lines.append("### Battery Status\n")
+                            lines.append("| Node | Level | Drain Rate | Hours to Critical | Trend |")
+                            lines.append("|------|-------|------------|-------------------|-------|")
+                            for f in sorted(battery_nodes, key=lambda x: x.current_pct):
+                                rate = f"{f.drain_rate_pct_per_hour:.2f}%/h" if f.trend == 'draining' else "—"
+                                critical = f"{f.hours_to_critical:.0f}h" if f.hours_to_critical else "—"
+                                lines.append(f"| {f.node_id} | {f.current_pct:.0f}% | {rate} | "
+                                             f"{critical} | {f.trend} |")
 
-                    # Dropout patterns
-                    patterns = predictor.get_all_patterns()
-                    problem_nodes = [p for p in patterns.values()
-                                     if p.prediction in ('intermittent', 'failing')]
-                    if problem_nodes:
-                        lines.append("\n### Node Reliability Issues\n")
-                        lines.append("| Node | Uptime | Dropouts/Day | Pattern | Reliability |")
-                        lines.append("|------|--------|--------------|---------|-------------|")
-                        for p in sorted(problem_nodes, key=lambda x: x.reliability_score):
-                            lines.append(f"| {p.node_id} | {p.uptime_pct:.0f}% | "
-                                         f"{p.dropouts_per_day:.1f} | {p.prediction} | "
-                                         f"{p.reliability_score:.0f}/100 |")
+                        # Dropout patterns
+                        patterns = predictor.get_all_patterns()
+                        problem_nodes = [p for p in patterns.values()
+                                         if p.prediction in ('intermittent', 'failing')]
+                        if problem_nodes:
+                            lines.append("\n### Node Reliability Issues\n")
+                            lines.append("| Node | Uptime | Dropouts/Day | Pattern | Reliability |")
+                            lines.append("|------|--------|--------------|---------|-------------|")
+                            for p in sorted(problem_nodes, key=lambda x: x.reliability_score):
+                                lines.append(f"| {p.node_id} | {p.uptime_pct:.0f}% | "
+                                             f"{p.dropouts_per_day:.1f} | {p.prediction} | "
+                                             f"{p.reliability_score:.0f}/100 |")
 
-                    # Recommendations
-                    recs = predictor.get_maintenance_recommendations()
-                    if recs:
-                        lines.append("\n### Maintenance Actions\n")
-                        for rec in recs[:10]:
-                            icon = {'urgent': '!!!', 'soon': '!!',
-                                    'scheduled': '!', 'monitor': '?'}.get(rec.priority, '')
-                            lines.append(f"- **[{rec.priority.upper()}]** {rec.node_id}: "
-                                         f"{rec.action}")
-                            lines.append(f"  - Reason: {rec.reason}")
+                        # Recommendations
+                        recs = predictor.get_maintenance_recommendations()
+                        if recs:
+                            lines.append("\n### Maintenance Actions\n")
+                            for rec in recs[:10]:
+                                icon = {'urgent': '!!!', 'soon': '!!',
+                                        'scheduled': '!', 'monitor': '?'}.get(rec.priority, '')
+                                lines.append(f"- **[{rec.priority.upper()}]** {rec.node_id}: "
+                                             f"{rec.action}")
+                                lines.append(f"  - Reason: {rec.reason}")
 
-                    if not battery_nodes and not problem_nodes and not recs:
-                        lines.append("All tracked nodes are healthy. No maintenance needed.")
-        except ImportError:
+                        if not battery_nodes and not problem_nodes and not recs:
+                            lines.append("All tracked nodes are healthy. No maintenance needed.")
+            except Exception as e:
+                lines.append(f"*Error collecting maintenance data: {e}*")
+        else:
             lines.append("*Predictive maintenance module not available.*")
-        except Exception as e:
-            lines.append(f"*Error collecting maintenance data: {e}*")
 
         self._sections.append(ReportSection(
             heading="Predictive Maintenance",
@@ -266,40 +288,40 @@ class ReportGenerator:
         """Add diagnostic history section."""
         lines = []
 
-        try:
-            from utils.diagnostic_engine import get_diagnostic_engine, Category
-            engine = get_diagnostic_engine()
+        if _HAS_DIAGNOSTIC_ENGINE:
+            try:
+                engine = get_diagnostic_engine()
 
-            # Health summary
-            summary = engine.get_health_summary()
-            lines.append(f"**System Health:** {summary.get('overall_health', 'unknown')}")
-            lines.append(f"- Symptoms last hour: {summary.get('symptoms_last_hour', 0)}")
-            lines.append(f"- Total diagnosed: {summary['stats'].get('diagnoses_made', 0)}")
-            lines.append(f"- Auto-recoveries: {summary['stats'].get('auto_recoveries', 0)}")
+                # Health summary
+                summary = engine.get_health_summary()
+                lines.append(f"**System Health:** {summary.get('overall_health', 'unknown')}")
+                lines.append(f"- Symptoms last hour: {summary.get('symptoms_last_hour', 0)}")
+                lines.append(f"- Total diagnosed: {summary['stats'].get('diagnoses_made', 0)}")
+                lines.append(f"- Auto-recoveries: {summary['stats'].get('auto_recoveries', 0)}")
 
-            # Recent diagnoses
-            recent = engine.get_recent_diagnoses(limit=self.config.max_diagnostic_entries)
-            if recent:
-                lines.append(f"\n### Recent Diagnoses ({len(recent)})\n")
-                lines.append("| Time | Category | Cause | Confidence |")
-                lines.append("|------|----------|-------|------------|")
-                for d in recent[-10:]:
-                    ts = d.symptom.timestamp.strftime('%H:%M:%S') if hasattr(d.symptom.timestamp, 'strftime') else '—'
-                    cat = d.symptom.category.value
-                    cause = d.likely_cause[:50]
-                    lines.append(f"| {ts} | {cat} | {cause} | {d.confidence:.0%} |")
+                # Recent diagnoses
+                recent = engine.get_recent_diagnoses(limit=self.config.max_diagnostic_entries)
+                if recent:
+                    lines.append(f"\n### Recent Diagnoses ({len(recent)})\n")
+                    lines.append("| Time | Category | Cause | Confidence |")
+                    lines.append("|------|----------|-------|------------|")
+                    for d in recent[-10:]:
+                        ts = d.symptom.timestamp.strftime('%H:%M:%S') if hasattr(d.symptom.timestamp, 'strftime') else '—'
+                        cat = d.symptom.category.value
+                        cause = d.likely_cause[:50]
+                        lines.append(f"| {ts} | {cat} | {cause} | {d.confidence:.0%} |")
 
-            # Recurring issues
-            recurring = engine.get_recurring_issues(threshold=2, hours=24)
-            if recurring:
-                lines.append("\n### Recurring Issues\n")
-                for issue in recurring[:5]:
-                    lines.append(f"- **{issue['likely_cause']}** "
-                                 f"({issue['count']}x in {issue['category']})")
-        except ImportError:
+                # Recurring issues
+                recurring = engine.get_recurring_issues(threshold=2, hours=24)
+                if recurring:
+                    lines.append("\n### Recurring Issues\n")
+                    for issue in recurring[:5]:
+                        lines.append(f"- **{issue['likely_cause']}** "
+                                     f"({issue['count']}x in {issue['category']})")
+            except Exception as e:
+                lines.append(f"*Error collecting diagnostic data: {e}*")
+        else:
             lines.append("*Diagnostic engine not available.*")
-        except Exception as e:
-            lines.append(f"*Error collecting diagnostic data: {e}*")
 
         self._sections.append(ReportSection(
             heading="Diagnostics",
@@ -312,29 +334,28 @@ class ReportGenerator:
         """Add RF analysis section."""
         lines = []
 
-        try:
-            from utils.preset_impact import PresetAnalyzer
-            analyzer = PresetAnalyzer()
+        if _HAS_PRESET_IMPACT:
+            try:
+                analyzer = PresetAnalyzer()
 
-            # Current preset analysis
-            lines.append("### LoRa Preset Summary\n")
-            lines.append("| Preset | Max Range (LOS) | Sensitivity | Throughput |")
-            lines.append("|--------|-----------------|-------------|------------|")
+                # Current preset analysis
+                lines.append("### LoRa Preset Summary\n")
+                lines.append("| Preset | Max Range (LOS) | Sensitivity | Throughput |")
+                lines.append("|--------|-----------------|-------------|------------|")
 
-            key_presets = ['SHORT_FAST', 'MEDIUM_FAST', 'LONG_FAST', 'LONG_SLOW']
-            for preset in key_presets:
-                try:
-                    impact = analyzer.analyze_preset(preset)
-                    lines.append(f"| {preset} | {impact.max_range_los_km:.1f} km | "
-                                 f"{impact.sensitivity_dbm:.1f} dBm | "
-                                 f"{impact.throughput_bps:.0f} bps |")
-                except Exception as e:
-                    logger.debug(f"Preset {preset} analysis failed: {e}")
-
-        except ImportError:
+                key_presets = ['SHORT_FAST', 'MEDIUM_FAST', 'LONG_FAST', 'LONG_SLOW']
+                for preset in key_presets:
+                    try:
+                        impact = analyzer.analyze_preset(preset)
+                        lines.append(f"| {preset} | {impact.max_range_los_km:.1f} km | "
+                                     f"{impact.sensitivity_dbm:.1f} dBm | "
+                                     f"{impact.throughput_bps:.0f} bps |")
+                    except Exception as e:
+                        logger.debug(f"Preset {preset} analysis failed: {e}")
+            except Exception as e:
+                lines.append(f"*Error in RF analysis: {e}*")
+        else:
             lines.append("*RF analysis module not available.*")
-        except Exception as e:
-            lines.append(f"*Error in RF analysis: {e}*")
 
         self._sections.append(ReportSection(
             heading="RF Analysis",
@@ -350,7 +371,6 @@ class ReportGenerator:
 
         # Gather recommendations from all subsystems
         try:
-            from utils.health_score import HealthScorer
             scorer = _get_health_scorer()
             if scorer:
                 snapshot = scorer.get_snapshot()
@@ -369,7 +389,6 @@ class ReportGenerator:
             logger.debug(f"Error collecting health recommendations: {e}")
 
         try:
-            from utils.predictive_maintenance import MaintenancePredictor
             predictor = _get_maintenance_predictor()
             if predictor:
                 for rec in predictor.get_maintenance_recommendations()[:5]:
@@ -400,10 +419,9 @@ class ReportGenerator:
         """Add report metadata."""
         lines = []
 
-        try:
-            from __version__ import __version__
+        if _HAS_VERSION:
             lines.append(f"- MeshForge Version: {__version__}")
-        except ImportError:
+        else:
             lines.append("- MeshForge Version: unknown")
 
         lines.append(f"- Report Generated: {datetime.now().isoformat()}")
@@ -500,34 +518,28 @@ _maintenance_predictor = None
 
 def _get_health_scorer():
     """Get shared health scorer instance if available."""
-    try:
-        from utils.health_score import get_health_scorer
-        return get_health_scorer()
-    except ImportError:
+    if not _HAS_HEALTH_SCORE:
         return None
+    return get_health_scorer()
 
 
 def _get_signal_manager():
     """Get signal trending manager if available."""
     global _signal_manager
+    if not _HAS_SIGNAL_TRENDING:
+        return None
     if _signal_manager is None:
-        try:
-            from utils.signal_trending import SignalTrendingManager
-            _signal_manager = SignalTrendingManager()
-        except ImportError:
-            return None
+        _signal_manager = SignalTrendingManager()
     return _signal_manager
 
 
 def _get_maintenance_predictor():
     """Get maintenance predictor if available."""
     global _maintenance_predictor
+    if not _HAS_PREDICTIVE_MAINTENANCE:
+        return None
     if _maintenance_predictor is None:
-        try:
-            from utils.predictive_maintenance import MaintenancePredictor
-            _maintenance_predictor = MaintenancePredictor()
-        except ImportError:
-            return None
+        _maintenance_predictor = MaintenancePredictor()
     return _maintenance_predictor
 
 

--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -14,20 +14,18 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Callable, List, Tuple, Dict, Any
 
-try:
-    import distro
-except ImportError:
-    distro = None  # Handle Windows where distro isn't available
-
 # Import centralized path utility for sudo compatibility
 from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
 
-# Try to use centralized service checker
-try:
-    from utils.service_check import check_service, check_systemd_service, ServiceState
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
+# Module-level safe imports
+distro, _HAS_DISTRO = safe_import('distro')
+check_service, check_systemd_service, ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState'
+)
+_psutil, _HAS_PSUTIL = safe_import('psutil')
+_serial_list_ports, _HAS_SERIAL = safe_import('serial.tools.list_ports')
+GLib, _HAS_GLIB = safe_import('gi.repository', 'GLib')
 
 
 def check_root() -> bool:
@@ -253,10 +251,9 @@ def run_admin_command_async(
     def do_run():
         success, stdout, stderr = run_admin_command(cmd, use_gui, timeout)
         # Use GLib.idle_add if available (GTK apps)
-        try:
-            from gi.repository import GLib
+        if _HAS_GLIB:
             GLib.idle_add(callback, success, stdout, stderr)
-        except ImportError:
+        else:
             callback(success, stdout, stderr)
 
     thread = threading.Thread(target=do_run, daemon=True)
@@ -297,7 +294,7 @@ def get_system_info():
     info = {}
 
     # OS information (handle Windows where distro isn't available)
-    if distro:
+    if _HAS_DISTRO:
         info['os'] = distro.name() or 'Unknown Linux'
         info['os_version'] = distro.version() or 'Unknown'
         info['os_codename'] = distro.codename() or ''
@@ -594,19 +591,17 @@ def check_package_installed(package_name: str) -> bool:
 
 def get_available_memory():
     """Get available system memory in MB"""
-    try:
-        import psutil
-        mem = psutil.virtual_memory()
+    if _HAS_PSUTIL:
+        mem = _psutil.virtual_memory()
         return mem.available // (1024 * 1024)
-    except ImportError:
-        # Fallback to reading /proc/meminfo
-        try:
-            with open('/proc/meminfo', 'r') as f:
-                for line in f:
-                    if 'MemAvailable' in line:
-                        return int(line.split()[1]) // 1024
-        except Exception:
-            return 0
+    # Fallback to reading /proc/meminfo
+    try:
+        with open('/proc/meminfo', 'r') as f:
+            for line in f:
+                if 'MemAvailable' in line:
+                    return int(line.split()[1]) // 1024
+    except Exception:
+        return 0
 
 
 def get_disk_space(path: str = '/') -> int:
@@ -615,20 +610,18 @@ def get_disk_space(path: str = '/') -> int:
     Args:
         path: Filesystem path to check (validated, no shell chars)
     """
-    try:
-        import psutil
-        disk = psutil.disk_usage(path)
+    if _HAS_PSUTIL:
+        disk = _psutil.disk_usage(path)
         return disk.free // (1024 * 1024)
-    except ImportError:
-        # Fallback to df command - use list form for security
-        result = run_command(['df', '-m', path])
-        if result['success']:
-            lines = result['stdout'].strip().split('\n')
-            if len(lines) > 1:
-                parts = lines[1].split()
-                if len(parts) >= 4:
-                    return int(parts[3])
-        return 0
+    # Fallback to df command - use list form for security
+    result = run_command(['df', '-m', path])
+    if result['success']:
+        lines = result['stdout'].strip().split('\n')
+        if len(lines) > 1:
+            parts = lines[1].split()
+            if len(parts) >= 4:
+                return int(parts[3])
+    return 0
 
 
 # =============================================================================
@@ -649,12 +642,9 @@ def get_serial_ports() -> List[str]:
     ports = []
 
     # Try pyserial first (most reliable, cross-platform)
-    try:
-        import serial.tools.list_ports
-        ports = [p.device for p in serial.tools.list_ports.comports()]
+    if _HAS_SERIAL:
+        ports = [p.device for p in _serial_list_ports.comports()]
         return sorted(ports)
-    except ImportError:
-        pass
 
     # Fallback for Linux/macOS without pyserial
     if platform.system() == 'Linux':

--- a/tests/test_map_data_service.py
+++ b/tests/test_map_data_service.py
@@ -503,7 +503,7 @@ class TestMeshtasticdCollection:
         mock_manager.acquire_lock.return_value = True
         mock_manager._create_interface.return_value = mock_interface
 
-        with patch('utils.meshtastic_connection.get_connection_manager', return_value=mock_manager):
+        with patch('utils.map_data_collector._get_connection_manager', return_value=mock_manager):
             features = collector._collect_via_tcp_interface()
 
         # Should get 2 nodes (one has no position)
@@ -519,7 +519,7 @@ class TestMeshtasticdCollection:
         mock_manager = MagicMock()
         mock_manager.acquire_lock.return_value = False  # Lock held by someone else
 
-        with patch('utils.meshtastic_connection.get_connection_manager', return_value=mock_manager):
+        with patch('utils.map_data_collector._get_connection_manager', return_value=mock_manager):
             features = collector._collect_via_tcp_interface()
 
         assert features == []

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -824,7 +824,7 @@ class TestEnvironmentCollector:
         mock_subscriber.get_nodes_with_air_quality.return_value = [mock_node]
         mock_subscriber.get_nodes.return_value = [mock_node]
 
-        with patch('monitoring.mqtt_subscriber.get_local_subscriber', return_value=mock_subscriber):
+        with patch('utils.prometheus_exporter.get_local_subscriber', return_value=mock_subscriber):
             exporter = PrometheusExporter()
             lines = exporter._collect_environment_metrics()
 
@@ -846,7 +846,7 @@ class TestEnvironmentCollector:
         mock_subscriber = MagicMock()
         mock_subscriber.is_connected.return_value = False
 
-        with patch('monitoring.mqtt_subscriber.get_local_subscriber', return_value=mock_subscriber):
+        with patch('utils.prometheus_exporter.get_local_subscriber', return_value=mock_subscriber):
             exporter = PrometheusExporter()
             lines = exporter._collect_environment_metrics()
             assert lines == []
@@ -873,7 +873,7 @@ class TestMQTTCollector:
             "mesh_size_24h": 45,
         }
 
-        with patch('monitoring.mqtt_subscriber.get_local_subscriber', return_value=mock_subscriber):
+        with patch('utils.prometheus_exporter.get_local_subscriber', return_value=mock_subscriber):
             exporter = PrometheusExporter()
             lines = exporter._collect_mqtt_metrics()
 
@@ -900,7 +900,7 @@ class TestTopologyCollector:
         mock_store = MagicMock()
         mock_store.get_snapshots.return_value = [mock_snapshot]
 
-        with patch('utils.topology_snapshot.get_topology_snapshot_store', return_value=mock_store):
+        with patch('utils.prometheus_exporter.get_topology_snapshot_store', return_value=mock_store):
             exporter = PrometheusExporter()
             lines = exporter._collect_topology_metrics()
 
@@ -914,7 +914,7 @@ class TestTopologyCollector:
         mock_store = MagicMock()
         mock_store.get_snapshots.return_value = []
 
-        with patch('utils.topology_snapshot.get_topology_snapshot_store', return_value=mock_store):
+        with patch('utils.prometheus_exporter.get_topology_snapshot_store', return_value=mock_store):
             exporter = PrometheusExporter()
             lines = exporter._collect_topology_metrics()
 

--- a/tests/test_rns_identities.py
+++ b/tests/test_rns_identities.py
@@ -36,6 +36,8 @@ class TestCreateIdentities:
         mock_rns.Identity.return_value = mock_identity
 
         with patch.dict(sys.modules, {'RNS': mock_rns}), \
+             patch('commands.rns.RNS', mock_rns), \
+             patch('commands.rns._HAS_RNS', True), \
              patch('commands.rns.ReticulumPaths.get_config_dir', return_value=rns_config_dir), \
              patch('commands.rns.get_identity_path', return_value=gw_path):
             from commands.rns import create_identities
@@ -83,6 +85,8 @@ class TestCreateIdentities:
         mock_rns.Identity.return_value = mock_identity
 
         with patch.dict(sys.modules, {'RNS': mock_rns}), \
+             patch('commands.rns.RNS', mock_rns), \
+             patch('commands.rns._HAS_RNS', True), \
              patch('commands.rns.ReticulumPaths.get_config_dir', return_value=rns_config_dir), \
              patch('commands.rns.get_identity_path', return_value=gw_path):
             from commands.rns import create_identities
@@ -140,6 +144,8 @@ class TestConnectivityWarnings:
         mock_rns.__version__ = '1.1.3'
 
         with patch.dict(sys.modules, {'RNS': mock_rns}), \
+             patch('commands.rns.RNS', mock_rns), \
+             patch('commands.rns._HAS_RNS', True), \
              patch('commands.rns.get_status', return_value=mock_status), \
              patch('commands.rns.read_config', return_value=mock_config), \
              patch('commands.rns.validate_config', return_value=(True, [])), \
@@ -182,6 +188,8 @@ class TestConnectivityWarnings:
         mock_rns.__version__ = '1.1.3'
 
         with patch.dict(sys.modules, {'RNS': mock_rns}), \
+             patch('commands.rns.RNS', mock_rns), \
+             patch('commands.rns._HAS_RNS', True), \
              patch('commands.rns.get_status', return_value=mock_status), \
              patch('commands.rns.read_config', return_value=mock_config), \
              patch('commands.rns.validate_config', return_value=(True, [])), \


### PR DESCRIPTION
…files, ~190 blocks)

Phase 1.2 of import consolidation — migrates the highest-impact files (8+ blocks down to 4+ blocks per file) to use the safe_import utility established in Phase 1.1.

Migrated files across src/commands/, src/launcher_tui/, src/utils/, src/monitoring/, src/agent/, and src/launcher.py. Updated 3 test files to patch module-level references instead of source-module paths.

4071 passed, 19 skipped, 0 failures.

https://claude.ai/code/session_016H8FMmGEXrrhe5k76KYZgS