### PR TITLE
refactor: consolidate except ImportError blocks with safe_import (bat…

### DIFF
--- a/src/agent/commands.py
+++ b/src/agent/commands.py
@@ -25,6 +25,11 @@ from enum import Enum
 from functools import wraps
 from typing import Any, Callable, Dict, List, Optional, Set, Type
 
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_version_mod, _HAS_VERSION = safe_import('__version__', '__version__')
+
 logger = logging.getLogger(__name__)
 
 
@@ -740,11 +745,7 @@ class CommandHandler:
         """Get system information."""
         try:
             # Get version
-            try:
-                from __version__ import __version__
-                version = __version__
-            except ImportError:
-                version = "unknown"
+            version = _version_mod if _HAS_VERSION else "unknown"
 
             return CommandResult.success({
                 "meshforge_version": version,

--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -21,13 +21,19 @@ if str(_src_dir) not in sys.path:
     sys.path.insert(0, str(_src_dir))
 
 from utils.paths import get_real_user_home, ReticulumPaths
+from utils.safe_import import safe_import
 
-# Import centralized service checker
-try:
-    from utils.service_check import check_service, check_port, ServiceState
-    SERVICE_CHECK_AVAILABLE = True
-except ImportError:
-    SERVICE_CHECK_AVAILABLE = False
+# Module-level safe imports
+_check_service, _check_port, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_port', 'ServiceState'
+)
+SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
+
+_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+
+_GatewayDiagnostic, _HAS_GATEWAY_DIAG = safe_import(
+    'utils.gateway_diagnostic', 'GatewayDiagnostic'
+)
 
 
 def print_header(title: str):
@@ -61,7 +67,7 @@ def check_services():
     for svc in services:
         if SERVICE_CHECK_AVAILABLE:
             # Use centralized service checker
-            status = check_service(svc)
+            status = _check_service(svc)
             is_active = status.available
             detail = status.state.value
             if not is_active and status.fix_hint:
@@ -177,11 +183,8 @@ def check_cli():
     """Check meshtastic CLI availability."""
     print_header("MESHTASTIC CLI")
 
-    try:
-        # Use centralized CLI finder
-        sys.path.insert(0, str(Path(__file__).parent.parent))
-        from utils.cli import find_meshtastic_cli
-        cli_path = find_meshtastic_cli()
+    if _HAS_CLI:
+        cli_path = _find_meshtastic_cli()
 
         if cli_path:
             print_status("meshtastic CLI", True, cli_path)
@@ -200,8 +203,7 @@ def check_cli():
         else:
             print_status("meshtastic CLI", False, "not found")
             print("    Install with: pipx install meshtastic")
-
-    except ImportError:
+    else:
         # Fallback
         cli_path = shutil.which('meshtastic')
         if cli_path:
@@ -464,7 +466,7 @@ def check_sdr():
     if openwebrx:
         try:
             if SERVICE_CHECK_AVAILABLE:
-                svc_status = check_service('openwebrx')
+                svc_status = _check_service('openwebrx')
                 print_status("OpenWebRX", svc_status.available, svc_status.state.value)
             else:
                 result = subprocess.run(['systemctl', 'is-active', 'openwebrx'],
@@ -533,17 +535,17 @@ def check_ham_callsign():
 
 def run_gateway_wizard():
     """Run the AI-like gateway diagnostic wizard."""
-    try:
-        # Add parent directory to path for imports
-        sys.path.insert(0, str(Path(__file__).parent.parent))
-        from utils.gateway_diagnostic import GatewayDiagnostic
+    if not _HAS_GATEWAY_DIAG:
+        print("\nError: Could not load gateway diagnostic module")
+        print("Make sure you're running from the MeshForge directory")
+        return False
 
-        diag = GatewayDiagnostic()
+    try:
+        diag = _GatewayDiagnostic()
         print(diag.run_wizard())
         return True
-    except ImportError as e:
-        print(f"\nError: Could not load gateway diagnostic module: {e}")
-        print("Make sure you're running from the MeshForge directory")
+    except Exception as e:
+        print(f"\nError running gateway diagnostic: {e}")
         return False
 
 

--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -18,16 +18,14 @@ import socket
 import subprocess
 from pathlib import Path
 
-# Use centralized service checking
-try:
-    from utils.service_check import (
-        check_port as _check_port,
-        check_systemd_service,
-        check_process_running,
-    )
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_check_port, _check_systemd_service, _check_process_running, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_port', 'check_systemd_service', 'check_process_running'
+)
+
+_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
 
 
 # ANSI colors
@@ -68,7 +66,7 @@ def check_service(name):
     """
     try:
         if _HAS_SERVICE_CHECK:
-            is_running, is_enabled = check_systemd_service(name)
+            is_running, is_enabled = _check_systemd_service(name)
             status = 'active' if is_running else 'inactive'
         else:
             # Fallback to direct systemctl call
@@ -143,10 +141,9 @@ def get_local_ip():
 
 def _find_cli():
     """Find meshtastic CLI path using centralized resolver."""
-    try:
-        from utils.cli import find_meshtastic_cli
-        return find_meshtastic_cli()
-    except ImportError:
+    if _HAS_CLI:
+        return _find_meshtastic_cli()
+    else:
         import shutil
         return shutil.which('meshtastic')
 

--- a/src/commands/rnode.py
+++ b/src/commands/rnode.py
@@ -389,7 +389,7 @@ def probe_rnode(port: str, timeout: float = 2.0) -> Optional[Dict[str, Any]]:
 
             result['details']['raw_response'] = response[:64].hex() if response else ''
 
-    except serial.SerialException as e:
+    except _serial_mod.SerialException as e:
         logger.debug(f"Could not probe {port}: {e}")
         result['details']['error'] = str(e)
     except Exception as e:

--- a/src/commands/service.py
+++ b/src/commands/service.py
@@ -16,16 +16,12 @@ from typing import Optional, List
 from pathlib import Path
 
 from .base import CommandResult
-
-logger = logging.getLogger(__name__)
+from utils.safe_import import safe_import
 
 # Import centralized service checker (SINGLE SOURCE OF TRUTH)
-try:
-    from utils.service_check import check_service as _check_service
-    HAS_SERVICE_CHECK = True
-except ImportError:
-    _check_service = None
-    HAS_SERVICE_CHECK = False
+_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+
+logger = logging.getLogger(__name__)
 
 
 # Security: Regex for validating service names (alphanumeric, underscore, hyphen, @, .)
@@ -98,7 +94,7 @@ def check_status(name: str, port: Optional[int] = None) -> CommandResult:
 
     # Use centralized service checker for consistent detection (SINGLE SOURCE OF TRUTH)
     # This handles UDP/TCP port checks, pgrep, and systemd properly
-    if HAS_SERVICE_CHECK and name in ('rnsd', 'meshtasticd'):
+    if _HAS_SERVICE_CHECK and name in ('rnsd', 'meshtasticd'):
         service_status = _check_service(name)
         is_running = service_status.available
         status_detail = service_status.message or ("Running" if is_running else "Stopped")

--- a/src/config/hardware_config.py
+++ b/src/config/hardware_config.py
@@ -22,6 +22,11 @@ from rich.panel import Panel
 from rich.prompt import Prompt, Confirm
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
+from utils.safe_import import safe_import
+
+# YAML support (optional, for config validation)
+_yaml_mod, _HAS_YAML = safe_import('yaml')
+
 console = Console()
 
 # Paths
@@ -675,16 +680,16 @@ class HardwareConfigurator:
 
         # Validate YAML
         console.print("\n[cyan]Validating YAML syntax...[/cyan]")
-        try:
-            import yaml
-            with open(cfg_path) as f:
-                yaml.safe_load(f)
-            console.print("[green]YAML syntax is valid[/green]")
-        except ImportError:
+        if _HAS_YAML:
+            try:
+                with open(cfg_path) as f:
+                    _yaml_mod.safe_load(f)
+                console.print("[green]YAML syntax is valid[/green]")
+            except _yaml_mod.YAMLError as e:
+                console.print(f"[red]YAML Error: {e}[/red]")
+                console.print("[yellow]Please fix the syntax before applying[/yellow]")
+        else:
             console.print("[dim]PyYAML not installed, skipping validation[/dim]")
-        except yaml.YAMLError as e:
-            console.print(f"[red]YAML Error: {e}[/red]")
-            console.print("[yellow]Please fix the syntax before applying[/yellow]")
 
         if Confirm.ask("Restart meshtasticd to apply changes?", default=False):
             subprocess.run(['sudo', 'systemctl', 'restart', 'meshtasticd'], timeout=30)

--- a/src/config/lora.py
+++ b/src/config/lora.py
@@ -4,6 +4,11 @@ from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from rich.table import Table
 
+from utils.safe_import import safe_import
+
+# Meshtastic CLI finder (optional)
+_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+
 console = Console()
 
 
@@ -755,10 +760,9 @@ class LoRaConfigurator:
         """Find the meshtastic CLI executable - uses centralized utils.cli"""
         import os
 
-        try:
-            from utils.cli import find_meshtastic_cli
-            cli_path = find_meshtastic_cli()
-        except ImportError:
+        if _HAS_CLI:
+            cli_path = _find_meshtastic_cli()
+        else:
             import shutil
             cli_path = shutil.which('meshtastic')
 

--- a/src/config/radio_config.py
+++ b/src/config/radio_config.py
@@ -13,6 +13,11 @@ from rich.prompt import Prompt, Confirm, IntPrompt
 from rich.table import Table
 from rich.panel import Panel
 
+from utils.safe_import import safe_import
+
+# Meshtastic CLI finder (optional)
+_find_meshtastic_cli_fn, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+
 console = Console()
 
 
@@ -25,10 +30,9 @@ class RadioConfig:
 
     def _find_meshtastic_cli(self):
         """Find the meshtastic CLI executable - uses centralized utils.cli"""
-        try:
-            from utils.cli import find_meshtastic_cli
-            return find_meshtastic_cli()
-        except ImportError:
+        if _HAS_CLI:
+            return _find_meshtastic_cli_fn()
+        else:
             # Fallback if utils not available
             return shutil.which('meshtastic')
 

--- a/src/config/spi_hats.py
+++ b/src/config/spi_hats.py
@@ -10,13 +10,10 @@ from rich.panel import Panel
 
 from config.hardware import HardwareDetector
 from utils.logger import log
+from utils.safe_import import safe_import
 
-# Try to import enable_service helper, fall back to direct subprocess
-try:
-    from utils.service_check import enable_service
-    _HAS_ENABLE_SERVICE = True
-except ImportError:
-    _HAS_ENABLE_SERVICE = False
+# Service management helper (optional)
+_enable_service, _HAS_ENABLE_SERVICE = safe_import('utils.service_check', 'enable_service')
 
 console = Console()
 
@@ -521,7 +518,7 @@ WantedBy=multi-user.target
 
             # Enable the service for next boot
             if _HAS_ENABLE_SERVICE:
-                success, msg = enable_service('meshtasticd-installer-resume.service')
+                success, msg = _enable_service('meshtasticd-installer-resume.service')
                 if not success:
                     log(f"Warning: {msg}", 'warning')
             else:

--- a/src/core/diagnostics/checks/system.py
+++ b/src/core/diagnostics/checks/system.py
@@ -10,6 +10,7 @@ import time
 import logging
 
 from ..models import CheckResult, CheckStatus, CheckCategory
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
@@ -59,12 +60,11 @@ def check_pip_packages() -> CheckResult:
     installed = []
     missing = []
 
-    import importlib
     for display_name, module_name in required.items():
-        try:
-            importlib.import_module(module_name)
+        _mod, _available = safe_import(module_name)
+        if _available:
             installed.append(display_name)
-        except ImportError:
+        else:
             missing.append(display_name)
 
     duration = (time.time() - start) * 1000

--- a/src/core/diagnostics/engine.py
+++ b/src/core/diagnostics/engine.py
@@ -79,19 +79,17 @@ logger = logging.getLogger(__name__)
 
 # Import centralized path utility for sudo compatibility
 from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
 
 # Backward compatibility alias
 _get_real_user_home = get_real_user_home
 
-# Import notification classifier for prioritization
-try:
-    from utils.classifier import (
-        NotificationClassifier, NotificationCategory,
-        create_notification_system, ClassificationResult
-    )
-    CLASSIFIER_AVAILABLE = True
-except ImportError:
-    CLASSIFIER_AVAILABLE = False
+# Module-level safe imports — notification classifier for prioritization
+_NotificationClassifier, _NotificationCategory, _create_notification_system, _ClassificationResult, _HAS_CLASSIFIER = safe_import(
+    'utils.classifier',
+    'NotificationClassifier', 'NotificationCategory',
+    'create_notification_system', 'ClassificationResult'
+)
 
 
 class DiagnosticEngine:
@@ -154,9 +152,9 @@ class DiagnosticEngine:
         # Notification classifier for "tap on shoulder" pattern
         self._notification_classifier = None
         self._notification_callbacks: List[EventCallback] = []
-        if CLASSIFIER_AVAILABLE:
+        if _HAS_CLASSIFIER:
             fixes_path = self._diag_dir / 'notification_fixes.json'
-            self._notification_classifier = create_notification_system(
+            self._notification_classifier = _create_notification_system(
                 bounce_threshold=0.2,
                 fixes_path=fixes_path
             )
@@ -529,7 +527,7 @@ class DiagnosticEngine:
         if not self._notification_classifier or not self._notification_classifier.fix_registry:
             return False
 
-        result = ClassificationResult(
+        result = _ClassificationResult(
             input_id=event_id,
             category="unknown",
             confidence=0.5

--- a/src/core/meshtastic_cli.py
+++ b/src/core/meshtastic_cli.py
@@ -31,6 +31,11 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_find_meshtastic_cli, _HAS_CLI_UTIL = safe_import('utils.cli', 'find_meshtastic_cli')
+
 logger = logging.getLogger(__name__)
 
 
@@ -83,11 +88,9 @@ class MeshtasticCLI:
 
     def _find_cli(self) -> Optional[str]:
         """Find meshtastic CLI using centralized path resolver."""
-        try:
-            from utils.cli import find_meshtastic_cli
-            return find_meshtastic_cli()
-        except ImportError:
-            return shutil.which('meshtastic')
+        if _HAS_CLI_UTIL:
+            return _find_meshtastic_cli()
+        return shutil.which('meshtastic')
 
     def _build_base_args(self) -> List[str]:
         """Build base CLI arguments for connection."""

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -35,6 +35,11 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 from enum import Enum
 
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_find_meshtastic_cli, _HAS_CLI_UTIL = safe_import('utils.cli', 'find_meshtastic_cli')
+
 logger = logging.getLogger(__name__)
 
 
@@ -393,11 +398,9 @@ General:
 
     def is_python_cli_installed(self) -> bool:
         """Check if Python meshtastic CLI is installed."""
-        try:
-            from utils.cli import find_meshtastic_cli
-            return find_meshtastic_cli() is not None
-        except ImportError:
-            return shutil.which("meshtastic") is not None
+        if _HAS_CLI_UTIL:
+            return _find_meshtastic_cli() is not None
+        return shutil.which("meshtastic") is not None
 
     def get_native_deb_url(self, arch: str = "arm64") -> str:
         """

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -31,20 +31,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, Dict, List, Callable, Any
 
-try:
-    import yaml
-    HAS_YAML = True
-except ImportError:
-    HAS_YAML = False
+from utils.safe_import import safe_import
 
+# Module-level safe imports
+_yaml, _HAS_YAML = safe_import('yaml')
 # Import centralized port checker for consistency across MeshForge
 # See: utils/service_check.py - SINGLE SOURCE OF TRUTH
-try:
-    from utils.service_check import check_port as _centralized_check_port
-    HAS_SERVICE_CHECK = True
-except ImportError:
-    _centralized_check_port = None
-    HAS_SERVICE_CHECK = False
+_centralized_check_port, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_port')
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -177,10 +170,10 @@ class ServiceOrchestrator:
 
         # Load from config file
         if self._config_path and self._config_path.exists():
-            if HAS_YAML:
+            if _HAS_YAML:
                 try:
                     with open(self._config_path) as f:
-                        file_config = yaml.safe_load(f)
+                        file_config = _yaml.safe_load(f)
                         if file_config and 'noc' in file_config:
                             noc_config = file_config['noc']
                             # Merge configs
@@ -377,7 +370,7 @@ class ServiceOrchestrator:
 
         Uses centralized port checker from utils/service_check.py for consistency.
         """
-        if HAS_SERVICE_CHECK and _centralized_check_port is not None:
+        if _HAS_SERVICE_CHECK and _centralized_check_port is not None:
             return _centralized_check_port(port, host, timeout)
 
         # Fallback if service_check not available

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -17,20 +17,18 @@ import logging
 # Add src to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils import emoji as em
+from utils.safe_import import safe_import
 
-# Import unified commands layer
-try:
-    from commands import service, hardware
-    COMMANDS_AVAILABLE = True
-except ImportError:
-    COMMANDS_AVAILABLE = False
+# Module-level safe imports
+_service, _hardware, _HAS_COMMANDS = safe_import('commands', 'service', 'hardware')
+COMMANDS_AVAILABLE = _HAS_COMMANDS
 
-# Import centralized service checker for fallback
-try:
-    from utils.service_check import check_service, ServiceState
-    SERVICE_CHECK_AVAILABLE = True
-except ImportError:
-    SERVICE_CHECK_AVAILABLE = False
+_check_service, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'ServiceState'
+)
+SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
+
+_meshtastic, _HAS_MESHTASTIC = safe_import('meshtastic')
 
 console = Console()
 logger = logging.getLogger(__name__)
@@ -47,7 +45,7 @@ class StatusDashboard:
         """Get meshtasticd service status using commands layer"""
         if COMMANDS_AVAILABLE:
             try:
-                result = service.check_status('meshtasticd')
+                result = _service.check_status('meshtasticd')
                 status_data = result.data
 
                 # Check for misconfiguration (SPI HAT with USB placeholder)
@@ -73,16 +71,16 @@ class StatusDashboard:
             # Fallback to centralized service checker or direct subprocess call
             if SERVICE_CHECK_AVAILABLE:
                 try:
-                    status = check_service('meshtasticd')
+                    status = _check_service('meshtasticd')
                     # Map ServiceState to dashboard status format
-                    if status.state == ServiceState.AVAILABLE:
+                    if status.state == _ServiceState.AVAILABLE:
                         return {
                             'status': 'active',
                             'running': True,
                             'color': 'green',
                             'message': status.message
                         }
-                    elif status.state == ServiceState.DEGRADED:
+                    elif status.state == _ServiceState.DEGRADED:
                         # Check if it's a SPI HAT misconfiguration
                         if 'WRONG CONFIG' in status.message:
                             return {
@@ -170,7 +168,7 @@ class StatusDashboard:
         if meshtasticd_path:
             if COMMANDS_AVAILABLE:
                 try:
-                    result = service.get_version('meshtasticd')
+                    result = _service.get_version('meshtasticd')
                     if result.success:
                         return result.data.get('version', 'Native')
                 except Exception as e:
@@ -201,11 +199,8 @@ class StatusDashboard:
             return f'USB ({usb_devices[0].name})'
 
         # Check for meshtastic Python package
-        try:
-            import meshtastic
-            return f'CLI {getattr(meshtastic, "__version__", "")}'.strip()
-        except ImportError:
-            pass
+        if _HAS_MESHTASTIC:
+            return f'CLI {getattr(_meshtastic, "__version__", "")}'.strip()
 
         return 'Not installed'
 

--- a/src/diagnostics/system_diagnostics.py
+++ b/src/diagnostics/system_diagnostics.py
@@ -22,13 +22,12 @@ from rich.table import Table
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from utils import emoji as em
+from utils.safe_import import safe_import
 
-# Try to use centralized service checker
-try:
-    from utils.service_check import check_service, check_systemd_service, ServiceState
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
+# Module-level safe imports
+_check_service, _check_systemd_service, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState'
+)
 
 console = Console()
 
@@ -782,7 +781,7 @@ class SystemDiagnostics:
         try:
             # Use centralized service checker if available
             if _HAS_SERVICE_CHECK:
-                status = check_service('meshtasticd')
+                status = _check_service('meshtasticd')
                 return status.available
             else:
                 # Fallback to direct systemctl call
@@ -799,7 +798,7 @@ class SystemDiagnostics:
         try:
             # Use centralized service checker if available
             if _HAS_SERVICE_CHECK:
-                is_running, is_enabled = check_systemd_service('meshtasticd')
+                is_running, is_enabled = _check_systemd_service('meshtasticd')
                 return is_enabled
             else:
                 # Fallback to direct systemctl call

--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -11,7 +11,17 @@ from dataclasses import dataclass, asdict, field
 from typing import Optional, List, Dict, Any, Tuple
 import logging
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
+
+# Import centralized path utility for sudo compatibility
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
+# Import config drift validation (optional)
+_validate_gateway_rns_config, _HAS_CONFIG_DRIFT = safe_import(
+    'utils.config_drift', 'validate_gateway_rns_config'
+)
 
 
 # =============================================================================
@@ -112,21 +122,20 @@ def validate_speed_hop_combination(speed: int, hop_limit: int) -> Optional[Confi
         )
     return None
 
-# Import centralized path utility for sudo compatibility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
-    def get_real_user_home() -> Path:
-        """Fallback for when utils.paths is not in Python path."""
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+def get_real_user_home() -> Path:
+    """Get real user home directory with sudo compatibility."""
+    if _HAS_PATHS:
+        return _get_real_user_home()
+    # Fallback for when utils.paths is not in Python path
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+        candidate = Path(f'/home/{sudo_user}')
+        return candidate
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        candidate = Path(f'/home/{logname}')
+        return candidate
+    return Path('/root')
 
 
 @dataclass
@@ -644,14 +653,12 @@ class GatewayConfig:
 
         # Config drift detection: check if gateway's RNS config path
         # matches what rnsd is actually using
-        try:
-            from utils.config_drift import validate_gateway_rns_config
-            drift_errors = validate_gateway_rns_config(self)
-            errors.extend(drift_errors)
-        except ImportError:
-            pass  # config_drift module not available
-        except Exception as e:
-            logger.debug("Config drift check failed: %s", e)
+        if _HAS_CONFIG_DRIFT:
+            try:
+                drift_errors = _validate_gateway_rns_config(self)
+                errors.extend(drift_errors)
+            except Exception as e:
+                logger.debug("Config drift check failed: %s", e)
 
         # Determine if valid (only errors count, not warnings/info)
         is_valid = not any(e.severity == "error" for e in errors)

--- a/src/gateway/mesh_bridge.py
+++ b/src/gateway/mesh_bridge.py
@@ -21,8 +21,14 @@ from dataclasses import dataclass, field
 from typing import Optional, Dict, Set, Callable, Any
 
 from .config import GatewayConfig, MeshtasticBridgeConfig, MeshtasticConfig
+from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
+
+# Import meshtastic library (optional - graceful fallback)
+_meshtastic, _HAS_MESHTASTIC = safe_import('meshtastic')
+_meshtastic_tcp, _HAS_MESHTASTIC_TCP = safe_import('meshtastic.tcp_interface')
+_pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
 
 
 @dataclass
@@ -306,14 +312,14 @@ class MeshtasticPresetBridge:
 
     def _connect_meshtastic(self, config: MeshtasticConfig, name: str, callback) -> tuple:
         """Connect to a Meshtastic interface"""
-        try:
-            import meshtastic
-            import meshtastic.tcp_interface
-            from pubsub import pub
+        if not _HAS_MESHTASTIC or not _HAS_MESHTASTIC_TCP or not _HAS_PUBSUB:
+            logger.error("Meshtastic library not installed")
+            return None, False
 
+        try:
             logger.info(f"Connecting to {name} Meshtastic at {config.host}:{config.port}")
 
-            interface = meshtastic.tcp_interface.TCPInterface(hostname=config.host)
+            interface = _meshtastic_tcp.TCPInterface(hostname=config.host)
 
             # Subscribe with unique topic name to avoid conflicts
             topic_name = f"meshtastic.receive.{name}"
@@ -322,16 +328,13 @@ class MeshtasticPresetBridge:
                 callback(packet)
 
             # Use a unique subscription key
-            pub.subscribe(on_receive, "meshtastic.receive")
+            _pub.subscribe(on_receive, "meshtastic.receive")
 
             logger.info(f"Connected to {name} ({config.preset})")
             self._notify_status(f"{name}_connected")
 
             return interface, True
 
-        except ImportError:
-            logger.error("Meshtastic library not installed")
-            return None, False
         except Exception as e:
             logger.error(f"Failed to connect to {name}: {e}")
             return None, False

--- a/src/gateway/meshtastic_handler.py
+++ b/src/gateway/meshtastic_handler.py
@@ -23,12 +23,27 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from .config import GatewayConfig
 from .node_tracker import UnifiedNode
 from .reconnect import ReconnectStrategy
+from utils.safe_import import safe_import
 
 if TYPE_CHECKING:
     from .bridge_health import BridgeHealthMonitor
     from .node_tracker import UnifiedNodeTracker
 
 logger = logging.getLogger(__name__)
+
+# Import connection utilities (optional - graceful fallback)
+_clear_stale_connections, _HAS_STALE_CONN = safe_import(
+    'utils.meshtastic_connection', 'clear_stale_connections'
+)
+_get_connection_manager, _HAS_CONN_MANAGER = safe_import(
+    'utils.meshtastic_connection', 'get_connection_manager'
+)
+_wait_for_cooldown, _HAS_COOLDOWN = safe_import(
+    'utils.meshtastic_connection', 'wait_for_cooldown'
+)
+_broadcast_message, _HAS_WEBSOCKET = safe_import(
+    'utils.websocket_server', 'broadcast_message'
+)
 
 
 class MeshtasticHandler:
@@ -126,17 +141,14 @@ class MeshtasticHandler:
                     # blocks all reconnection. Detect and clear it early (3 attempts
                     # ≈ 7 seconds) instead of waiting for all 10 to exhaust.
                     if self._reconnect.attempts == 3:
-                        try:
-                            from utils.meshtastic_connection import clear_stale_connections
-                            cleared = clear_stale_connections(self.config.meshtastic.port)
+                        if _HAS_STALE_CONN:
+                            cleared = _clear_stale_connections(self.config.meshtastic.port)
                             if cleared:
                                 self.health.record_connection_event(
                                     "meshtastic", "self_healed",
                                     "Cleared zombie CLOSE-WAIT connection"
                                 )
                                 self._reconnect.reset()
-                        except ImportError:
-                            pass
 
                     logger.info(f"Attempting Meshtastic connection "
                                f"(attempt {self._reconnect.attempts + 1})...")

--- a/src/installer/meshtasticd.py
+++ b/src/installer/meshtasticd.py
@@ -16,16 +16,13 @@ from utils.system import (
     enable_service
 )
 from utils.logger import log, log_command, log_exception
+from utils.safe_import import safe_import
 
-# Import centralized service checker - SINGLE SOURCE OF TRUTH
-try:
-    from utils.service_check import check_service, check_port, ServiceState
-    SERVICE_CHECK_AVAILABLE = True
-except ImportError:
-    check_service = None
-    check_port = None
-    ServiceState = None
-    SERVICE_CHECK_AVAILABLE = False
+# Module-level safe imports - SINGLE SOURCE OF TRUTH
+_check_service, _check_port, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_port', 'ServiceState'
+)
+SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
 
 console = Console()
 
@@ -351,8 +348,8 @@ class MeshtasticdInstaller:
 
         # Test 2: Check if service is running (use centralized checker)
         console.print("  [dim]Test 2: Checking service status...[/dim]")
-        if SERVICE_CHECK_AVAILABLE and check_service is not None:
-            status = check_service('meshtasticd')
+        if SERVICE_CHECK_AVAILABLE:
+            status = _check_service('meshtasticd')
             if status.available:
                 console.print("    [green]✓ meshtasticd service is running[/green]")
                 tests_passed += 1

--- a/src/launcher_tui/updates_mixin.py
+++ b/src/launcher_tui/updates_mixin.py
@@ -11,22 +11,19 @@ import subprocess
 import logging
 from typing import Dict, Any, Optional, Tuple
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
 
 # Import version checker
-try:
-    from updates.version_checker import check_all_versions, VersionInfo
-    _HAS_VERSION_CHECKER = True
-except ImportError:
-    _HAS_VERSION_CHECKER = False
-    VersionInfo = None
+_check_all_versions, _VersionInfo, _HAS_VERSION_CHECKER = safe_import(
+    'updates.version_checker', 'check_all_versions', 'VersionInfo'
+)
 
 # Import service check for restart after updates
-try:
-    from utils.service_check import apply_config_and_restart
-    _HAS_SERVICE_CHECK = True
-except ImportError:
-    _HAS_SERVICE_CHECK = False
+_apply_config_and_restart, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'apply_config_and_restart'
+)
 
 
 class UpdatesMixin:
@@ -79,7 +76,7 @@ class UpdatesMixin:
         self.dialog.infobox("Checking for Updates", "Querying version information...")
 
         try:
-            versions = check_all_versions()
+            versions = _check_all_versions()
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to check versions:\n{e}")
             return None
@@ -126,7 +123,7 @@ class UpdatesMixin:
         self.dialog.infobox("Checking Updates", "Checking which components need updates...")
 
         try:
-            versions = check_all_versions()
+            versions = _check_all_versions()
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to check versions:\n{e}")
             return
@@ -180,7 +177,7 @@ class UpdatesMixin:
     def _update_meshtasticd(self):
         """Update meshtasticd package."""
         try:
-            versions = check_all_versions()
+            versions = _check_all_versions()
             info = versions.get('meshtasticd')
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to check version:\n{e}")
@@ -215,7 +212,7 @@ class UpdatesMixin:
             # Restart the service
             if _HAS_SERVICE_CHECK:
                 self.dialog.infobox("Restarting", "Restarting meshtasticd service...")
-                apply_config_and_restart('meshtasticd')
+                _apply_config_and_restart('meshtasticd')
 
             self.dialog.msgbox(
                 "Update Complete",
@@ -231,7 +228,7 @@ class UpdatesMixin:
     def _update_cli(self):
         """Update Meshtastic CLI."""
         try:
-            versions = check_all_versions()
+            versions = _check_all_versions()
             info = versions.get('cli')
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to check version:\n{e}")
@@ -284,7 +281,7 @@ class UpdatesMixin:
     def _firmware_info(self):
         """Show firmware update information."""
         try:
-            versions = check_all_versions()
+            versions = _check_all_versions()
             info = versions.get('firmware')
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to check version:\n{e}")

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -39,20 +39,27 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-# Import centralized path utility for sudo compatibility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+_NodeMonitor_src, _HAS_MONITOR_SRC = safe_import('src.monitoring', 'NodeMonitor')
+_NodeMonitor_rel, _HAS_MONITOR_REL = safe_import('monitoring', 'NodeMonitor')
+
+
+def get_real_user_home() -> Path:
+    """Get real user home even under sudo."""
+    if _HAS_PATHS:
+        return _get_real_user_home()
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+        candidate = Path(f'/home/{sudo_user}')
+        return candidate
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        candidate = Path(f'/home/{logname}')
+        return candidate
+    return Path('/root')
 
 # Config file location
 CONFIG_DIR = get_real_user_home() / '.config' / 'meshtastic-monitor'
@@ -175,16 +182,14 @@ def run_monitor(host: str, port: int, json_output: bool, watch: bool, interval: 
     """Main monitoring function"""
     global _running
 
-    try:
-        from src.monitoring import NodeMonitor
-    except ImportError:
-        try:
-            # Handle running from different directories
-            from monitoring import NodeMonitor
-        except ImportError:
-            print("Error: Could not import NodeMonitor. Make sure you're running from the project root.")
-            print("Usage: python3 -m src.monitor")
-            sys.exit(1)
+    if _HAS_MONITOR_SRC:
+        NodeMonitor = _NodeMonitor_src
+    elif _HAS_MONITOR_REL:
+        NodeMonitor = _NodeMonitor_rel
+    else:
+        print("Error: Could not import NodeMonitor. Make sure you're running from the project root.")
+        print("Usage: python3 -m src.monitor")
+        sys.exit(1)
 
     if not json_output:
         print_banner()

--- a/src/monitoring/pskreporter_subscriber.py
+++ b/src/monitoring/pskreporter_subscriber.py
@@ -53,6 +53,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 # Import centralized path utility for sudo compatibility
 from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_mqtt, _HAS_PAHO_MQTT = safe_import('paho.mqtt.client')
 
 logger = logging.getLogger(__name__)
 
@@ -218,11 +222,11 @@ class PSKReporterSubscriber:
 
     def _connect(self) -> bool:
         """Connect to PSKReporter MQTT broker."""
-        try:
-            import paho.mqtt.client as mqtt
-        except ImportError:
+        if not _HAS_PAHO_MQTT:
             logger.error("paho-mqtt not installed. Run: pip install paho-mqtt")
             return False
+
+        mqtt = _mqtt
 
         try:
             client_id = f"meshforge_pskr_{int(time.time())}"

--- a/src/monitoring/rns_sniffer.py
+++ b/src/monitoring/rns_sniffer.py
@@ -37,6 +37,9 @@ RNS, _HAS_RNS = safe_import('RNS')
     'MeshPacket', 'PacketProtocol', 'PacketDirection', 'PacketTree',
     'PacketField', 'FieldType'
 )
+_get_traffic_inspector, _HAS_GET_TRAFFIC_INSPECTOR = safe_import(
+    'monitoring.traffic_inspector', 'get_traffic_inspector'
+)
 
 
 # =============================================================================
@@ -397,13 +400,11 @@ class RNSSniffer:
         if not self._hooks_installed:
             return
 
-        try:
-            import RNS
+        if _HAS_RNS:
             # RNS doesn't have unregister_announce_handler, but handler
             # won't be called after we stop since we check _running
-            self._hooks_installed = False
-        except ImportError:
             pass
+        self._hooks_installed = False
 
     def _capture_inbound_packet(self, raw: bytes, interface) -> None:
         """Capture an inbound packet (called from RNS hook)."""
@@ -740,9 +741,11 @@ class RNSSniffer:
         Returns:
             True if path request was sent
         """
-        try:
-            import RNS
+        if not _HAS_RNS:
+            logger.warning("RNS not available for path probe")
+            return False
 
+        try:
             dest_hash = bytes.fromhex(dest_hash_hex)
 
             # Request path
@@ -758,9 +761,6 @@ class RNSSniffer:
 
             return True
 
-        except ImportError:
-            logger.warning("RNS not available for path probe")
-            return False
         except Exception as e:
             logger.error(f"Path probe failed: {e}")
             return False
@@ -777,122 +777,116 @@ def convert_to_mesh_packet(rns_packet: RNSPacketInfo):
     This allows RNS packets to be viewed alongside Meshtastic packets
     with consistent filtering and analysis.
     """
-    try:
-        from monitoring.traffic_inspector import (
-            MeshPacket, PacketProtocol, PacketDirection, PacketTree,
-            PacketField, FieldType
-        )
-
-        # Map direction
-        dir_map = {
-            "inbound": PacketDirection.INBOUND,
-            "outbound": PacketDirection.OUTBOUND,
-            "internal": PacketDirection.INTERNAL,
-        }
-        direction = dir_map.get(rns_packet.direction, PacketDirection.INBOUND)
-
-        # Create MeshPacket
-        packet = MeshPacket(
-            id=rns_packet.id,
-            timestamp=rns_packet.timestamp,
-            direction=direction,
-            protocol=PacketProtocol.RNS,
-            source=rns_packet.source_hash.hex() if rns_packet.source_hash else "",
-            destination=rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
-            hops_taken=rns_packet.hops,
-            payload=rns_packet.payload,
-            rns_dest_hash=rns_packet.destination_hash,
-            rns_interface=rns_packet.interface_name,
-            rns_service=rns_packet.announce_aspect,
-            size=len(rns_packet.raw_bytes) if rns_packet.raw_bytes else rns_packet.payload_size,
-            raw_bytes=rns_packet.raw_bytes,
-        )
-
-        # Build protocol tree
-        tree = PacketTree()
-
-        # Frame layer
-        frame = tree.add_layer("Frame", "frame")
-        tree.add_field(frame, "Timestamp", "frame.time",
-                      packet.timestamp, FieldType.TIMESTAMP)
-        tree.add_field(frame, "Direction", "frame.direction",
-                      direction.value, FieldType.ENUM)
-        tree.add_field(frame, "Size", "frame.size",
-                      packet.size, FieldType.INTEGER)
-        tree.add_field(frame, "Protocol", "frame.protocol",
-                      "rns", FieldType.STRING)
-
-        # RNS layer
-        rns_layer = tree.add_layer("Reticulum", "rns")
-
-        # Packet type
-        tree.add_field(rns_layer, "Packet Type", "rns.type",
-                      rns_packet.packet_type.name, FieldType.STRING,
-                      "RNS packet type")
-
-        # Destination hash
-        tree.add_field(rns_layer, "Destination Hash", "rns.dest_hash",
-                      rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
-                      FieldType.BYTES, "16-byte destination hash")
-
-        # Hops
-        tree.add_field(rns_layer, "Hops", "rns.hops",
-                      rns_packet.hops, FieldType.INTEGER,
-                      "Number of hops traversed")
-
-        # Interface
-        tree.add_field(rns_layer, "Interface", "rns.interface",
-                      rns_packet.interface_name, FieldType.STRING)
-        tree.add_field(rns_layer, "Interface Type", "rns.iface_type",
-                      rns_packet.interface_type.value, FieldType.STRING)
-
-        # Header fields
-        header = PacketField(name="Header", abbrev="rns.header",
-                            value=None, field_type=FieldType.NESTED)
-        rns_layer.children.append(header)
-        tree.add_field(header, "Flags", "rns.header.flags",
-                      rns_packet.header_flags, FieldType.INTEGER)
-        tree.add_field(header, "Hop Count", "rns.header.hops",
-                      rns_packet.header_hops, FieldType.INTEGER)
-        tree.add_field(header, "Context", "rns.context",
-                      rns_packet.context, FieldType.INTEGER)
-
-        # Announce-specific fields
-        if rns_packet.packet_type == RNSPacketType.ANNOUNCE:
-            announce = PacketField(name="Announce", abbrev="rns.announce",
-                                  value=None, field_type=FieldType.NESTED)
-            rns_layer.children.append(announce)
-
-            tree.add_field(announce, "Aspect", "rns.announce.aspect",
-                          rns_packet.announce_aspect, FieldType.STRING)
-            if rns_packet.source_hash:
-                tree.add_field(announce, "Identity", "rns.announce.identity",
-                              rns_packet.source_hash.hex(), FieldType.BYTES)
-            if rns_packet.announce_app_data:
-                tree.add_field(announce, "App Data Size", "rns.announce.app_size",
-                              len(rns_packet.announce_app_data), FieldType.INTEGER)
-
-        # Link-specific fields
-        if rns_packet.link_id:
-            link = PacketField(name="Link", abbrev="rns.link",
-                              value=None, field_type=FieldType.NESTED)
-            rns_layer.children.append(link)
-
-            tree.add_field(link, "Link ID", "rns.link.id",
-                          rns_packet.link_id.hex(), FieldType.BYTES)
-            tree.add_field(link, "State", "rns.link.state",
-                          rns_packet.link_state.value, FieldType.STRING)
-
-        # Payload
-        tree.add_field(rns_layer, "Payload Size", "rns.payload_size",
-                      rns_packet.payload_size, FieldType.INTEGER)
-
-        packet.tree = tree
-        return packet
-
-    except ImportError:
+    if not _HAS_TRAFFIC_INSPECTOR:
         logger.debug("TrafficInspector not available for conversion")
         return None
+
+    # Map direction
+    dir_map = {
+        "inbound": PacketDirection.INBOUND,
+        "outbound": PacketDirection.OUTBOUND,
+        "internal": PacketDirection.INTERNAL,
+    }
+    direction = dir_map.get(rns_packet.direction, PacketDirection.INBOUND)
+
+    # Create MeshPacket
+    packet = MeshPacket(
+        id=rns_packet.id,
+        timestamp=rns_packet.timestamp,
+        direction=direction,
+        protocol=PacketProtocol.RNS,
+        source=rns_packet.source_hash.hex() if rns_packet.source_hash else "",
+        destination=rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
+        hops_taken=rns_packet.hops,
+        payload=rns_packet.payload,
+        rns_dest_hash=rns_packet.destination_hash,
+        rns_interface=rns_packet.interface_name,
+        rns_service=rns_packet.announce_aspect,
+        size=len(rns_packet.raw_bytes) if rns_packet.raw_bytes else rns_packet.payload_size,
+        raw_bytes=rns_packet.raw_bytes,
+    )
+
+    # Build protocol tree
+    tree = PacketTree()
+
+    # Frame layer
+    frame = tree.add_layer("Frame", "frame")
+    tree.add_field(frame, "Timestamp", "frame.time",
+                  packet.timestamp, FieldType.TIMESTAMP)
+    tree.add_field(frame, "Direction", "frame.direction",
+                  direction.value, FieldType.ENUM)
+    tree.add_field(frame, "Size", "frame.size",
+                  packet.size, FieldType.INTEGER)
+    tree.add_field(frame, "Protocol", "frame.protocol",
+                  "rns", FieldType.STRING)
+
+    # RNS layer
+    rns_layer = tree.add_layer("Reticulum", "rns")
+
+    # Packet type
+    tree.add_field(rns_layer, "Packet Type", "rns.type",
+                  rns_packet.packet_type.name, FieldType.STRING,
+                  "RNS packet type")
+
+    # Destination hash
+    tree.add_field(rns_layer, "Destination Hash", "rns.dest_hash",
+                  rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
+                  FieldType.BYTES, "16-byte destination hash")
+
+    # Hops
+    tree.add_field(rns_layer, "Hops", "rns.hops",
+                  rns_packet.hops, FieldType.INTEGER,
+                  "Number of hops traversed")
+
+    # Interface
+    tree.add_field(rns_layer, "Interface", "rns.interface",
+                  rns_packet.interface_name, FieldType.STRING)
+    tree.add_field(rns_layer, "Interface Type", "rns.iface_type",
+                  rns_packet.interface_type.value, FieldType.STRING)
+
+    # Header fields
+    header = PacketField(name="Header", abbrev="rns.header",
+                        value=None, field_type=FieldType.NESTED)
+    rns_layer.children.append(header)
+    tree.add_field(header, "Flags", "rns.header.flags",
+                  rns_packet.header_flags, FieldType.INTEGER)
+    tree.add_field(header, "Hop Count", "rns.header.hops",
+                  rns_packet.header_hops, FieldType.INTEGER)
+    tree.add_field(header, "Context", "rns.context",
+                  rns_packet.context, FieldType.INTEGER)
+
+    # Announce-specific fields
+    if rns_packet.packet_type == RNSPacketType.ANNOUNCE:
+        announce = PacketField(name="Announce", abbrev="rns.announce",
+                              value=None, field_type=FieldType.NESTED)
+        rns_layer.children.append(announce)
+
+        tree.add_field(announce, "Aspect", "rns.announce.aspect",
+                      rns_packet.announce_aspect, FieldType.STRING)
+        if rns_packet.source_hash:
+            tree.add_field(announce, "Identity", "rns.announce.identity",
+                          rns_packet.source_hash.hex(), FieldType.BYTES)
+        if rns_packet.announce_app_data:
+            tree.add_field(announce, "App Data Size", "rns.announce.app_size",
+                          len(rns_packet.announce_app_data), FieldType.INTEGER)
+
+    # Link-specific fields
+    if rns_packet.link_id:
+        link = PacketField(name="Link", abbrev="rns.link",
+                          value=None, field_type=FieldType.NESTED)
+        rns_layer.children.append(link)
+
+        tree.add_field(link, "Link ID", "rns.link.id",
+                      rns_packet.link_id.hex(), FieldType.BYTES)
+        tree.add_field(link, "State", "rns.link.state",
+                      rns_packet.link_state.value, FieldType.STRING)
+
+    # Payload
+    tree.add_field(rns_layer, "Payload Size", "rns.payload_size",
+                  rns_packet.payload_size, FieldType.INTEGER)
+
+    packet.tree = tree
+    return packet
 
 
 # =============================================================================
@@ -941,30 +935,27 @@ def integrate_with_traffic_inspector() -> bool:
     Registers a callback that converts RNS packets to MeshPackets
     and feeds them into the unified traffic capture.
     """
-    try:
-        from monitoring.traffic_inspector import get_traffic_inspector
-
-        inspector = get_traffic_inspector()
-        sniffer = get_rns_sniffer()
-
-        def on_rns_packet(rns_packet: RNSPacketInfo):
-            """Forward RNS packets to TrafficInspector."""
-            mesh_packet = convert_to_mesh_packet(rns_packet)
-            if mesh_packet:
-                # Create metadata for the capture
-                metadata = {
-                    "protocol": "rns",
-                    "dest_hash": rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
-                    "hops": rns_packet.hops,
-                    "interface": rns_packet.interface_name,
-                    "packet_type": rns_packet.packet_type.name,
-                }
-                inspector.capture(rns_packet.raw_bytes, metadata)
-
-        sniffer.register_callback(on_rns_packet)
-        logger.info("RNS Sniffer integrated with TrafficInspector")
-        return True
-
-    except ImportError as e:
-        logger.debug(f"Could not integrate with TrafficInspector: {e}")
+    if not _HAS_GET_TRAFFIC_INSPECTOR:
+        logger.debug("Could not integrate with TrafficInspector: module not available")
         return False
+
+    inspector = _get_traffic_inspector()
+    sniffer = get_rns_sniffer()
+
+    def on_rns_packet(rns_packet: RNSPacketInfo):
+        """Forward RNS packets to TrafficInspector."""
+        mesh_packet = convert_to_mesh_packet(rns_packet)
+        if mesh_packet:
+            # Create metadata for the capture
+            metadata = {
+                "protocol": "rns",
+                "dest_hash": rns_packet.destination_hash.hex() if rns_packet.destination_hash else "",
+                "hops": rns_packet.hops,
+                "interface": rns_packet.interface_name,
+                "packet_type": rns_packet.packet_type.name,
+            }
+            inspector.capture(rns_packet.raw_bytes, metadata)
+
+    sniffer.register_callback(on_rns_packet)
+    logger.info("RNS Sniffer integrated with TrafficInspector")
+    return True

--- a/src/monitoring/tcp_monitor.py
+++ b/src/monitoring/tcp_monitor.py
@@ -36,14 +36,15 @@ import ipaddress
 import struct
 import os
 
+from utils.safe_import import safe_import
+
 logger = logging.getLogger(__name__)
 
-# Try to import psutil for cross-platform socket monitoring
-try:
-    import psutil
-    HAS_PSUTIL = True
-except ImportError:
-    HAS_PSUTIL = False
+# Module-level safe imports
+_psutil, HAS_PSUTIL = safe_import('psutil')
+if HAS_PSUTIL:
+    psutil = _psutil
+else:
     logger.warning("psutil not available - falling back to /proc/net/tcp parsing")
 
 

--- a/src/monitoring/traffic_inspector.py
+++ b/src/monitoring/traffic_inspector.py
@@ -35,6 +35,11 @@ import logging
 from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
+
 # Re-export all models for backwards compatibility
 from .traffic_models import (
     FieldType,
@@ -361,9 +366,12 @@ def start_packet_capture() -> bool:
     if _capture_subscribed:
         return False
 
-    try:
-        from pubsub import pub
+    if not _HAS_PUBSUB:
+        logger.warning("pubsub not available - cannot start packet capture")
+        return False
 
+    try:
+        pub = _pub
         inspector = get_traffic_inspector()
 
         def on_meshtastic_packet(packet, interface=None):
@@ -409,9 +417,6 @@ def start_packet_capture() -> bool:
         logger.info("Traffic capture started - subscribed to meshtastic.receive")
         return True
 
-    except ImportError:
-        logger.warning("pubsub not available - cannot start packet capture")
-        return False
     except Exception as e:
         logger.error(f"Failed to start packet capture: {e}")
         return False

--- a/src/monitoring/traffic_storage.py
+++ b/src/monitoring/traffic_storage.py
@@ -35,9 +35,14 @@ from .packet_dissectors import (
 )
 
 # Import centralized path utility for sudo compatibility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
+from utils.safe_import import safe_import
+
+# Module-level safe imports
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
+if _HAS_PATHS:
+    get_real_user_home = _get_real_user_home
+else:
     def get_real_user_home() -> Path:
         """Fallback for when utils.paths is not in Python path."""
         sudo_user = os.environ.get('SUDO_USER', '')

--- a/src/services/service_manager.py
+++ b/src/services/service_manager.py
@@ -6,15 +6,13 @@ from rich.prompt import Prompt, Confirm
 from rich.panel import Panel
 from rich.table import Table
 
-# Import centralized service checker - SINGLE SOURCE OF TRUTH
-try:
-    from utils.service_check import check_service, check_port, ServiceState
-    SERVICE_CHECK_AVAILABLE = True
-except ImportError:
-    check_service = None
-    check_port = None
-    ServiceState = None
-    SERVICE_CHECK_AVAILABLE = False
+from utils.safe_import import safe_import
+
+# Module-level safe imports - SINGLE SOURCE OF TRUTH
+_check_service, _check_port, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_port', 'ServiceState'
+)
+SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
 
 console = Console()
 
@@ -60,9 +58,9 @@ class ServiceManager:
     def get_status(self):
         """Get service status"""
         # Use centralized service checker if available (SINGLE SOURCE OF TRUTH)
-        if SERVICE_CHECK_AVAILABLE and check_service is not None:
+        if SERVICE_CHECK_AVAILABLE:
             try:
-                status = check_service(self.SERVICE_NAME)
+                status = _check_service(self.SERVICE_NAME)
                 # Also get detailed output for display
                 result = self._run_systemctl('status')
                 return {

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -23,23 +23,18 @@ from enum import Enum
 # Setup logging
 logger = logging.getLogger(__name__)
 
-# Import centralized service checker - SINGLE SOURCE OF TRUTH
-try:
-    from utils.service_check import (
-        check_service as _check_service_central,
-        check_port,
-        enable_service,
-        ServiceState as CentralServiceState
-    )
-    SERVICE_CHECK_AVAILABLE = True
-    _HAS_ENABLE_SERVICE = True
-except ImportError:
-    _check_service_central = None
-    check_port = None
-    enable_service = None
-    CentralServiceState = None
-    SERVICE_CHECK_AVAILABLE = False
-    _HAS_ENABLE_SERVICE = False
+from utils.safe_import import safe_import
+
+# Module-level safe imports - SINGLE SOURCE OF TRUTH
+_check_service_central, _check_port, _enable_service, _CentralServiceState, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_port', 'enable_service', 'ServiceState'
+)
+SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
+_HAS_ENABLE_SERVICE = _HAS_SERVICE_CHECK
+
+_get_real_user_home_mod, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
+_ReticulumPaths, _HAS_RETICULUM_PATHS = safe_import('utils.paths', 'ReticulumPaths')
 
 
 class WizardServiceState(Enum):
@@ -145,17 +140,15 @@ class SetupWizard:
 
     def _get_real_home(self) -> Path:
         """Get real user home even when running as sudo"""
-        try:
-            from utils.paths import get_real_user_home
-            return get_real_user_home()
-        except ImportError:
-            sudo_user = os.environ.get('SUDO_USER', '')
-            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-                return Path(f"/home/{sudo_user}")
-            logname = os.environ.get('LOGNAME', '')
-            if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-                return Path(f"/home/{logname}")
-            return Path('/root')
+        if _HAS_PATHS:
+            return _get_real_user_home_mod()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+            return Path(f"/home/{sudo_user}")
+        logname = os.environ.get('LOGNAME', '')
+        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+            return Path(f"/home/{logname}")
+        return Path('/root')
 
     def _setup_logging(self):
         """Setup file logging for the wizard"""
@@ -311,13 +304,13 @@ class SetupWizard:
             status.systemd_unit = svc['systemd']
 
             # Use centralized service checker if available
-            if SERVICE_CHECK_AVAILABLE and _check_service_central is not None:
+            if SERVICE_CHECK_AVAILABLE:
                 try:
                     central_status = _check_service_central(svc['name'])
                     if central_status.available:
                         status.state = WizardServiceState.RUNNING
                         status.notes.append(f"Running ({central_status.detection_method})")
-                    elif central_status.state == CentralServiceState.NOT_INSTALLED:
+                    elif central_status.state == _CentralServiceState.NOT_INSTALLED:
                         # Keep NOT_INSTALLED state
                         pass
                     elif status.state == WizardServiceState.INSTALLED:

--- a/src/utils/active_health_probe.py
+++ b/src/utils/active_health_probe.py
@@ -38,6 +38,10 @@ from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, List
 from enum import Enum
 
+from utils.safe_import import safe_import
+
+_emit_service_status, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_service_status')
+
 logger = logging.getLogger(__name__)
 
 
@@ -498,15 +502,14 @@ def _emit_state_change(service_name: str, new_state: HealthState) -> None:
     Emits a ServiceEvent whenever a service transitions between states,
     enabling the status bar and other subscribers to react without polling.
     """
-    try:
-        from utils.event_bus import emit_service_status
+    if _HAS_EVENT_BUS:
         available = new_state == HealthState.HEALTHY
-        emit_service_status(
+        _emit_service_status(
             service_name=service_name,
             available=available,
             message=f"{service_name}: {new_state.value}",
         )
-    except ImportError:
+    else:
         logger.debug("event_bus not available for health probe callback")
 
 

--- a/src/utils/analytics.py
+++ b/src/utils/analytics.py
@@ -18,23 +18,27 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
+from utils.safe_import import safe_import
+
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
 logger = logging.getLogger(__name__)
 
-# Import path utility
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
+
+def get_real_user_home() -> Path:
+    """Sudo-safe home directory resolution."""
+    if _HAS_PATHS:
+        return _get_real_user_home()
     import os
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+        candidate = Path(f'/home/{sudo_user}')
+        return candidate
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        candidate = Path(f'/home/{logname}')
+        return candidate
+    return Path('/root')
 
 
 @dataclass

--- a/src/utils/aredn.py
+++ b/src/utils/aredn.py
@@ -21,10 +21,13 @@ from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
-try:
+from utils.safe_import import safe_import
+
+_urllib_mod, _HAS_URLLIB = safe_import('urllib.request')
+if _HAS_URLLIB:
     import urllib.request
     import urllib.error
-except ImportError:
+else:
     urllib = None
 
 logger = logging.getLogger(__name__)

--- a/src/utils/broker_profiles.py
+++ b/src/utils/broker_profiles.py
@@ -29,20 +29,30 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
 
-logger = logging.getLogger(__name__)
+from utils.safe_import import safe_import
 
 # Import centralized path utility - see persistent_issues.md Issue #1
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+
+# Import service management helpers
+_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+_apply_config_and_restart, _HAS_APPLY_RESTART = safe_import('utils.service_check', 'apply_config_and_restart')
+_enable_service, _HAS_ENABLE_SERVICE = safe_import('utils.service_check', 'enable_service')
+
+logger = logging.getLogger(__name__)
+
+
+def get_real_user_home() -> Path:
+    """Sudo-safe home directory resolution."""
+    if _HAS_PATHS:
+        return _get_real_user_home()
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
+        return Path(f'/home/{sudo_user}')
+    logname = os.environ.get('LOGNAME', '')
+    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
+        return Path(f'/home/{logname}')
+    return Path('/root')
 
 
 class BrokerType(Enum):
@@ -662,12 +672,9 @@ def check_mosquitto_running() -> Tuple[bool, str]:
     Returns:
         (running, message) tuple
     """
-    try:
-        from utils.service_check import check_service
-        status = check_service('mosquitto')
+    if _HAS_SERVICE_CHECK:
+        status = _check_service('mosquitto')
         return status.available, status.message
-    except ImportError:
-        pass
 
     # Fallback: check via systemctl
     try:
@@ -690,11 +697,8 @@ def restart_mosquitto() -> Tuple[bool, str]:
     if os.geteuid() != 0:
         return False, "Root privileges required. Run with sudo."
 
-    try:
-        from utils.service_check import apply_config_and_restart
-        return apply_config_and_restart('mosquitto')
-    except ImportError:
-        pass
+    if _HAS_APPLY_RESTART:
+        return _apply_config_and_restart('mosquitto')
 
     # Fallback
     try:
@@ -720,11 +724,8 @@ def enable_mosquitto_at_boot() -> Tuple[bool, str]:
     if os.geteuid() != 0:
         return False, "Root privileges required. Run with sudo."
 
-    try:
-        from utils.service_check import enable_service
-        return enable_service('mosquitto', start=True)
-    except ImportError:
-        pass
+    if _HAS_ENABLE_SERVICE:
+        return _enable_service('mosquitto', start=True)
 
     # Fallback
     try:

--- a/src/utils/claude_assistant.py
+++ b/src/utils/claude_assistant.py
@@ -42,6 +42,12 @@ from datetime import datetime
 from typing import Dict, List, Optional, Any, Callable
 from enum import Enum
 
+from utils.safe_import import safe_import
+
+_anthropic_mod, _HAS_ANTHROPIC = safe_import('anthropic')
+_get_latency_monitor, _HAS_LATENCY = safe_import('utils.latency_monitor', 'get_latency_monitor')
+_get_diag_engine, _HAS_DIAG_ENGINE = safe_import('utils.diagnostic_engine', 'get_diagnostic_engine')
+
 # Import standalone components
 from utils.diagnostic_engine import (
     DiagnosticEngine, get_diagnostic_engine, diagnose,
@@ -159,15 +165,15 @@ Always prioritize safety - never suggest actions that could damage hardware
     def _get_client(self):
         """Get or create Claude API client."""
         if self._client is None and self._api_key:
-            try:
-                import anthropic
-                self._client = anthropic.Anthropic(api_key=self._api_key)
-            except ImportError:
+            if not _HAS_ANTHROPIC:
                 logger.warning("anthropic package not installed. Run: pip install anthropic")
                 self._mode = AssistantMode.STANDALONE
-            except Exception as e:
-                logger.error(f"Failed to initialize Claude client: {e}")
-                self._mode = AssistantMode.STANDALONE
+            else:
+                try:
+                    self._client = _anthropic_mod.Anthropic(api_key=self._api_key)
+                except Exception as e:
+                    logger.error(f"Failed to initialize Claude client: {e}")
+                    self._mode = AssistantMode.STANDALONE
         return self._client
 
     def set_expertise_level(self, level: ExpertiseLevel) -> None:
@@ -351,42 +357,38 @@ Always prioritize safety - never suggest actions that could damage hardware
                     parts.append(f"{len(events)} recent events")
 
         # Live service latency from NOC monitor
-        try:
-            from utils.latency_monitor import get_latency_monitor
-            monitor = get_latency_monitor(auto_start=False)
-            if monitor._services:
-                svc_parts = []
-                for svc in monitor._services.values():
-                    if svc.samples:
-                        svc_parts.append(
-                            f"{svc.name}:{svc.status}"
-                            f"({svc.avg_rtt_ms:.0f}ms)"
-                        )
-                if svc_parts:
-                    parts.append(f"services=[{', '.join(svc_parts)}]")
+        if _HAS_LATENCY:
+            try:
+                monitor = _get_latency_monitor(auto_start=False)
+                if monitor._services:
+                    svc_parts = []
+                    for svc in monitor._services.values():
+                        if svc.samples:
+                            svc_parts.append(
+                                f"{svc.name}:{svc.status}"
+                                f"({svc.avg_rtt_ms:.0f}ms)"
+                            )
+                    if svc_parts:
+                        parts.append(f"services=[{', '.join(svc_parts)}]")
 
-                degraded = monitor.get_degraded()
-                if degraded:
-                    parts.append(f"DEGRADED: {', '.join(degraded)}")
-        except ImportError:
-            pass
-        except Exception as e:
+                    degraded = monitor.get_degraded()
+                    if degraded:
+                        parts.append(f"DEGRADED: {', '.join(degraded)}")
+            except Exception as e:
             logger.debug(f"Failed to get latency context: {e}")
 
         # Recent diagnostics
-        try:
-            from utils.diagnostic_engine import get_diagnostic_engine
-            engine = get_diagnostic_engine()
-            recent = engine.get_recent_diagnoses(limit=3)
-            if recent:
-                diag_parts = [
-                    f"{d.symptom.category.name}:{d.symptom.message[:40]}"
-                    for d in recent
-                ]
-                parts.append(f"recent_diag=[{'; '.join(diag_parts)}]")
-        except ImportError:
-            pass
-        except Exception as e:
+        if _HAS_DIAG_ENGINE:
+            try:
+                engine = _get_diag_engine()
+                recent = engine.get_recent_diagnoses(limit=3)
+                if recent:
+                    diag_parts = [
+                        f"{d.symptom.category.name}:{d.symptom.message[:40]}"
+                        for d in recent
+                    ]
+                    parts.append(f"recent_diag=[{'; '.join(diag_parts)}]")
+            except Exception as e:
             logger.debug(f"Failed to get diagnostic context: {e}")
 
         return ", ".join(parts)

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -11,6 +11,10 @@ from rich.table import Table
 from rich.panel import Panel
 import time
 
+from utils.safe_import import safe_import
+
+_run_cli_async_gtk, _HAS_COMMON_GTK = safe_import('utils.common', 'run_cli_async_gtk')
+
 console = Console()
 
 
@@ -200,11 +204,10 @@ def run_meshtastic_async(args, callback, host='localhost', timeout=30):
     Returns:
         The started thread
     """
-    try:
-        from utils.common import run_cli_async_gtk
+    if _HAS_COMMON_GTK:
         cli_path = find_meshtastic_cli()
-        return run_cli_async_gtk(args, callback, cli_path=cli_path, host=host, timeout=timeout)
-    except ImportError:
+        return _run_cli_async_gtk(args, callback, cli_path=cli_path, host=host, timeout=timeout)
+    else:
         # Fallback implementation
         import threading
 

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -17,6 +17,11 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
+from utils.safe_import import safe_import
+
+_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+_GLib, _HAS_GLIB = safe_import('gi.repository', 'GLib')
+
 logger = logging.getLogger(__name__)
 
 # Type variable for generic settings
@@ -220,10 +225,9 @@ def run_cli_async(
         # Find CLI if not provided
         nonlocal cli_path
         if cli_path is None:
-            try:
-                from utils.cli import find_meshtastic_cli
-                cli_path = find_meshtastic_cli()
-            except ImportError:
+            if _HAS_CLI:
+                cli_path = _find_meshtastic_cli()
+            else:
                 import shutil
                 cli_path = shutil.which('meshtastic')
 
@@ -278,14 +282,12 @@ def run_cli_async_gtk(
     Returns:
         The started thread
     """
-    try:
-        from gi.repository import GLib
-
+    if _HAS_GLIB:
         def gtk_callback(success: bool, stdout: str, stderr: str):
-            GLib.idle_add(callback, success, stdout, stderr)
+            _GLib.idle_add(callback, success, stdout, stderr)
 
         return run_cli_async(args, gtk_callback, cli_path, host, timeout)
-    except ImportError:
+    else:
         # GTK not available, fall back to direct callback
         return run_cli_async(args, callback, cli_path, host, timeout)
 


### PR DESCRIPTION
…ch 2)

Convert try/except ImportError blocks to module-level safe_import() calls in remaining config/, core/, commands/, cli/, gateway/ (partial), monitoring/, utils/ (partial), launcher_tui/ (partial), and misc root files.

36 additional files converted. Agents still processing remaining files.

https://claude.ai/code/session_018tKswAad6eVpd4UhRHof6G