### PR TITLE
refactor: simplify over-engineered safe_import conversions

### DIFF
--- a/src/commands/device_backup.py
+++ b/src/commands/device_backup.py
@@ -17,34 +17,13 @@ from pathlib import Path
 from typing import Dict, Optional, List
 from dataclasses import dataclass, asdict
 
+from utils.paths import get_real_user_home
+from utils.cli import find_meshtastic_cli
 from utils.safe_import import safe_import
 
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
 _yaml, _HAS_YAML = safe_import('yaml')
 
 logger = logging.getLogger(__name__)
-
-
-def _fallback_get_real_user_home():
-    """Fallback when utils.paths is not available."""
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
-
-
-def get_real_user_home():
-    """Get real user home, using utils.paths if available."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    return _fallback_get_real_user_home()
 
 
 @dataclass
@@ -154,11 +133,7 @@ def create_backup(
 
     try:
         # Find meshtastic CLI
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             result['error'] = "meshtastic CLI not found - install with: pipx install meshtastic[cli]"
@@ -344,11 +319,7 @@ def restore_backup(
             return result
 
         # Find meshtastic CLI
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             result['error'] = "meshtastic CLI not found - install with: pipx install meshtastic[cli]"

--- a/src/commands/gateway.py
+++ b/src/commands/gateway.py
@@ -13,19 +13,15 @@ from typing import Optional, Dict, Any
 
 from .base import CommandResult
 from utils.safe_import import safe_import
+from gateway.rns_bridge import RNSMeshtasticBridge
+from gateway.config import RNSOverMeshtasticConfig
+from gateway.rns_transport import create_rns_transport, RNSMeshtasticTransport
 
 logger = logging.getLogger(__name__)
 
-# Optional dependencies — safe_import returns (*attrs, available_bool)
-RNSMeshtasticBridge, _HAS_BRIDGE = safe_import(
-    'gateway.rns_bridge', 'RNSMeshtasticBridge'
-)
-RNSOverMeshtasticConfig, _HAS_TRANSPORT_CONFIG = safe_import(
-    'gateway.config', 'RNSOverMeshtasticConfig'
-)
-create_rns_transport, RNSMeshtasticTransport, _HAS_TRANSPORT = safe_import(
-    'gateway.rns_transport', 'create_rns_transport', 'RNSMeshtasticTransport'
-)
+_HAS_BRIDGE = True
+_HAS_TRANSPORT_CONFIG = True
+_HAS_TRANSPORT = True
 
 # Module-level bridge instance (singleton pattern)
 _bridge_instance = None

--- a/src/commands/meshtastic.py
+++ b/src/commands/meshtastic.py
@@ -14,10 +14,7 @@ from pathlib import Path
 
 from .base import CommandResult
 from utils.paths import get_real_user_home
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_diagnose_pubsub, _HAS_MESSAGE_LISTENER = safe_import('utils.message_listener', 'diagnose_pubsub')
+from utils.message_listener import diagnose_pubsub
 
 logger = logging.getLogger(__name__)
 
@@ -843,10 +840,7 @@ def diagnose_messaging() -> CommandResult:
         )
 
     # Check pubsub (for RX)
-    if _HAS_MESSAGE_LISTENER:
-        diagnostics['pubsub'] = _diagnose_pubsub()
-    else:
-        diagnostics['pubsub']['error'] = 'message_listener not available'
+    diagnostics['pubsub'] = diagnose_pubsub()
 
     return CommandResult.ok(
         "Messaging diagnostics complete",

--- a/src/commands/messaging.py
+++ b/src/commands/messaging.py
@@ -34,28 +34,16 @@ from dataclasses import dataclass, field
 from .base import CommandResult
 from utils.paths import get_real_user_home
 
-from utils.safe_import import safe_import
+from utils.event_bus import emit_message
+from gateway import RNSMeshtasticBridge
+from commands import gateway as cmd_gateway
+from commands import meshtastic as cmd_meshtastic
+from utils.message_listener import (
+    start_listener, get_listener, stop_listener,
+    get_listener_status, diagnose_pubsub,
+)
 
 logger = logging.getLogger(__name__)
-
-# Optional dependencies — module-level safe imports
-_emit_message, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_message')
-
-_RNSMeshtasticBridge, _HAS_GATEWAY_MODULE = safe_import(
-    'gateway', 'RNSMeshtasticBridge'
-)
-
-_cmd_gateway, _HAS_CMD_GATEWAY = safe_import('commands.gateway')
-
-_cmd_meshtastic, _HAS_CMD_MESHTASTIC = safe_import('commands.meshtastic')
-
-(_start_listener, _get_listener, _stop_listener,
- _get_listener_status, _diagnose_pubsub,
- _HAS_MSG_LISTENER) = safe_import(
-    'utils.message_listener',
-    'start_listener', 'get_listener', 'stop_listener',
-    'get_listener_status', 'diagnose_pubsub',
-)
 
 # Maximum message length before chunking
 MAX_MESSAGE_LENGTH = 160
@@ -217,7 +205,7 @@ def send_message(
 
     try:
         # Get bridge instance (if available)
-        # _HAS_GATEWAY_MODULE / _RNSMeshtasticBridge checked at module level
+        # RNSMeshtasticBridge available via direct import
         # bridge = get_active_bridge()  # Would get active bridge here
 
         # Store message
@@ -241,19 +229,18 @@ def send_message(
         if network == "meshtastic":
             # Try gateway first, then fall back to direct CLI
             gateway_available = False
-            if _HAS_CMD_GATEWAY:
-                try:
-                    status = _cmd_gateway.get_status()
-                    if status.success and status.data.get('running') and status.data.get('meshtastic_connected'):
-                        gateway_available = True
-                except Exception:
-                    pass
+            try:
+                status = cmd_gateway.get_status()
+                if status.success and status.data.get('running') and status.data.get('meshtastic_connected'):
+                    gateway_available = True
+            except Exception:
+                pass
 
             if gateway_available:
                 # Use gateway bridge
                 try:
                     for chunk in chunks:
-                        result = _cmd_gateway.send_to_meshtastic(chunk, destination, channel)
+                        result = cmd_gateway.send_to_meshtastic(chunk, destination, channel)
                         if not result.success:
                             send_error = result.message
                             break
@@ -267,62 +254,55 @@ def send_message(
 
             # Fallback to direct meshtastic CLI if gateway failed
             if not send_success:
-                if not _HAS_CMD_MESHTASTIC:
-                    if not send_error:
-                        send_error = "meshtastic module not available"
-                else:
-                    try:
-                        for chunk in chunks:
-                            # Use send_dm for direct messages, send_broadcast for channels
-                            if destination and destination != '!ffffffff':
-                                result = _cmd_meshtastic.send_dm(
-                                    text=chunk,
-                                    dest=destination,
-                                    ack=False,
-                                    high_reliability=high_reliability
-                                )
-                            else:
-                                result = _cmd_meshtastic.send_broadcast(
-                                    text=chunk,
-                                    channel_index=channel if channel > 0 else 1,
-                                    hop_limit=7 if high_reliability else 3
-                                )
-                            if not result.success:
-                                send_error = result.message
-                                break
-                        else:
-                            send_success = True
-                            send_error = None  # Clear any previous error
-                    except Exception as e:
-                        if not send_error:  # Don't overwrite gateway error
-                            send_error = f"Direct send failed: {e}"
-                        logger.error(f"Failed to send via direct meshtastic: {e}")
-
-        elif network == "rns":
-            # RNS messages go through gateway only
-            if not _HAS_CMD_GATEWAY:
-                send_error = "Gateway module not available"
-            else:
                 try:
-                    # Validate destination is valid hex before attempting conversion
-                    if destination:
-                        clean_dest = destination.lstrip('!')
-                        if not all(c in '0123456789abcdefABCDEF' for c in clean_dest):
-                            return CommandResult.fail(
-                                f"Invalid RNS destination: {destination}\n"
-                                "Must be a hex hash (e.g. a1b2c3d4e5f6...)"
-                            )
                     for chunk in chunks:
-                        dest_bytes = bytes.fromhex(destination.lstrip('!')) if destination else None
-                        result = _cmd_gateway.send_to_rns(chunk, dest_bytes)
+                        # Use send_dm for direct messages, send_broadcast for channels
+                        if destination and destination != '!ffffffff':
+                            result = cmd_meshtastic.send_dm(
+                                text=chunk,
+                                dest=destination,
+                                ack=False,
+                                high_reliability=high_reliability
+                            )
+                        else:
+                            result = cmd_meshtastic.send_broadcast(
+                                text=chunk,
+                                channel_index=channel if channel > 0 else 1,
+                                hop_limit=7 if high_reliability else 3
+                            )
                         if not result.success:
                             send_error = result.message
                             break
                     else:
                         send_success = True
+                        send_error = None  # Clear any previous error
                 except Exception as e:
-                    send_error = f"RNS send failed: {e}"
-                    logger.error(f"Failed to send via RNS: {e}")
+                    if not send_error:  # Don't overwrite gateway error
+                        send_error = f"Direct send failed: {e}"
+                    logger.error(f"Failed to send via direct meshtastic: {e}")
+
+        elif network == "rns":
+            # RNS messages go through gateway only
+            try:
+                # Validate destination is valid hex before attempting conversion
+                if destination:
+                    clean_dest = destination.lstrip('!')
+                    if not all(c in '0123456789abcdefABCDEF' for c in clean_dest):
+                        return CommandResult.fail(
+                            f"Invalid RNS destination: {destination}\n"
+                            "Must be a hex hash (e.g. a1b2c3d4e5f6...)"
+                        )
+                for chunk in chunks:
+                    dest_bytes = bytes.fromhex(destination.lstrip('!')) if destination else None
+                    result = cmd_gateway.send_to_rns(chunk, dest_bytes)
+                    if not result.success:
+                        send_error = result.message
+                        break
+                else:
+                    send_success = True
+            except Exception as e:
+                send_error = f"RNS send failed: {e}"
+                logger.error(f"Failed to send via RNS: {e}")
 
         # Update delivery status
         if send_success:
@@ -334,9 +314,9 @@ def send_message(
 
         if send_success:
             # Emit TX event to EventBus for status bar and subscribers
-            if _HAS_EVENT_BUS and _emit_message is not None:
+            if emit_message is not None:
                 try:
-                    _emit_message(
+                    emit_message(
                         direction='tx',
                         content=content[:100],  # Truncate for event
                         node_id=destination or "broadcast",
@@ -668,17 +648,11 @@ def start_receiving(
             print(f"New message from {msg['from_id']}: {msg['content']}")
         result = messaging.start_receiving(callback=on_message)
     """
-    if not _HAS_MSG_LISTENER:
-        return CommandResult.fail(
-            "Message listener not available",
-            fix_hint="Ensure utils/message_listener.py exists"
-        )
-
     try:
-        success = _start_listener(host=host)
+        success = start_listener(host=host)
 
         if callback:
-            listener = _get_listener()
+            listener = get_listener()
             listener.add_callback(callback)
 
         if success:
@@ -708,11 +682,8 @@ def stop_receiving() -> CommandResult:
     Returns:
         CommandResult with status
     """
-    if not _HAS_MSG_LISTENER:
-        return CommandResult.fail("Error stopping listener: module not available")
-
     try:
-        _stop_listener()
+        stop_listener()
         return CommandResult.ok("Message listener stopped")
     except Exception as e:
         return CommandResult.fail(f"Error stopping listener: {e}")
@@ -725,13 +696,7 @@ def get_rx_status() -> CommandResult:
     Returns:
         CommandResult with listener state, message count, etc.
     """
-    if not _HAS_MSG_LISTENER:
-        return CommandResult.ok(
-            "RX status: not initialized",
-            data={'state': 'disconnected', 'error': 'Listener not available'}
-        )
-
-    status = _get_listener_status()
+    status = get_listener_status()
     return CommandResult.ok(
         f"RX status: {status['state']}",
         data=status
@@ -756,20 +721,7 @@ def diagnose() -> CommandResult:
     Returns:
         CommandResult with diagnostic data and recommendations
     """
-    if _HAS_CMD_MESHTASTIC:
-        return _cmd_meshtastic.diagnose_messaging()
-
-    # Fallback minimal diagnostics
-    diagnostics = {
-        'error': 'meshtastic module not available',
-        'rx_status': {},
-    }
-
-    if _HAS_MSG_LISTENER:
-        diagnostics['rx_status'] = _get_listener_status()
-        diagnostics['pubsub'] = _diagnose_pubsub()
-
-    return CommandResult.ok("Limited diagnostics", data=diagnostics)
+    return cmd_meshtastic.diagnose_messaging()
 
 
 def get_routing_info() -> CommandResult:
@@ -779,11 +731,6 @@ def get_routing_info() -> CommandResult:
     Returns:
         CommandResult with hop_limit, device_role, and routing notes
     """
-    if not _HAS_CMD_MESHTASTIC:
-        return CommandResult.fail(
-            "Cannot get routing info - meshtastic module not available"
-        )
-
     info = {
         'hop_limit': None,
         'device_role': None,
@@ -792,12 +739,12 @@ def get_routing_info() -> CommandResult:
     }
 
     # Get hop limit
-    hop_result = _cmd_meshtastic.get_hop_limit()
+    hop_result = cmd_meshtastic.get_hop_limit()
     if hop_result.success and hop_result.data:
         info['hop_limit'] = hop_result.data.get('hop_limit')
 
     # Get device role
-    role_result = _cmd_meshtastic.get_device_role()
+    role_result = cmd_meshtastic.get_device_role()
     if role_result.success and role_result.data:
         info['device_role'] = role_result.data.get('role')
         info['role_description'] = role_result.data.get('description')

--- a/src/commands/propagation.py
+++ b/src/commands/propagation.py
@@ -32,28 +32,25 @@ from typing import Optional, Dict, Any, List
 from dataclasses import dataclass, field
 
 from .base import CommandResult
-from utils.safe_import import safe_import
+from utils.common import SettingsManager
+from utils.space_weather import SpaceWeatherAPI
+from monitoring.pskreporter_subscriber import get_pskreporter_subscriber
 
 logger = logging.getLogger(__name__)
 
-# Module-level safe imports
-SettingsManager, _HAS_SETTINGS = safe_import('utils.common', 'SettingsManager')
-SpaceWeatherAPI, _HAS_SPACE_WEATHER = safe_import('utils.space_weather', 'SpaceWeatherAPI')
-get_pskreporter_subscriber, _HAS_PSKREPORTER = safe_import(
-    'monitoring.pskreporter_subscriber', 'get_pskreporter_subscriber'
-)
+# Backward-compatible constants (modules are always available)
+_HAS_SETTINGS = True
+_HAS_SPACE_WEATHER = True
+_HAS_PSKREPORTER = True
 
 # Settings persistence for source configuration
-if _HAS_SETTINGS:
-    _settings = SettingsManager("propagation", defaults={
-        "sources": {
-            "openhamclock": {"host": "localhost", "port": 3000, "enabled": False, "timeout": 10},
-            "hamclock": {"host": "localhost", "port": 8080, "enabled": False, "timeout": 10},
-            "pskreporter": {"enabled": False, "callsign": "", "bands": [], "modes": []},
-        }
-    })
-else:
-    _settings = None
+_settings = SettingsManager("propagation", defaults={
+    "sources": {
+        "openhamclock": {"host": "localhost", "port": 3000, "enabled": False, "timeout": 10},
+        "hamclock": {"host": "localhost", "port": 8080, "enabled": False, "timeout": 10},
+        "pskreporter": {"enabled": False, "callsign": "", "bands": [], "modes": []},
+    }
+})
 
 
 class DataSource(Enum):

--- a/src/commands/rnode.py
+++ b/src/commands/rnode.py
@@ -20,34 +20,13 @@ from pathlib import Path
 from typing import List, Dict, Optional, Any
 from dataclasses import dataclass
 
+from commands.base import CommandResult
 from utils.safe_import import safe_import
 
-# Module-level safe imports
-_CommandResultImported, _HAS_COMMAND_BASE = safe_import('commands.base', 'CommandResult')
 _serial_tools, _HAS_SERIAL_TOOLS = safe_import('serial.tools.list_ports')
 _serial_mod, _HAS_SERIAL = safe_import('serial')
 
 logger = logging.getLogger(__name__)
-
-# Use imported CommandResult or define fallback
-if _HAS_COMMAND_BASE:
-    CommandResult = _CommandResultImported
-else:
-    from dataclasses import dataclass as _dataclass
-
-    @_dataclass
-    class CommandResult:
-        success: bool
-        message: str
-        data: Any = None
-
-        @classmethod
-        def ok(cls, message: str, data: Any = None):
-            return cls(success=True, message=message, data=data)
-
-        @classmethod
-        def fail(cls, message: str, data: Any = None):
-            return cls(success=False, message=message, data=data)
 
 
 # ============================================================================

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -19,11 +19,11 @@ from dataclasses import dataclass, field
 
 from .base import CommandResult
 from utils.safe_import import safe_import
+from utils.service_check import check_service
 
 logger = logging.getLogger(__name__)
 
-# Import centralized service checker (SINGLE SOURCE OF TRUTH)
-check_service, HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+HAS_SERVICE_CHECK = True
 
 # RNS module (optional — not installed on all systems)
 RNS, _HAS_RNS = safe_import('RNS')

--- a/src/commands/service.py
+++ b/src/commands/service.py
@@ -16,10 +16,10 @@ from typing import Optional, List
 from pathlib import Path
 
 from .base import CommandResult
-from utils.safe_import import safe_import
+from utils.service_check import check_service
 
-# Import centralized service checker (SINGLE SOURCE OF TRUTH)
-_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
+# Expose for tests that check module attributes
+HAS_SERVICE_CHECK = True
 
 logger = logging.getLogger(__name__)
 
@@ -94,8 +94,8 @@ def check_status(name: str, port: Optional[int] = None) -> CommandResult:
 
     # Use centralized service checker for consistent detection (SINGLE SOURCE OF TRUTH)
     # This handles UDP/TCP port checks, pgrep, and systemd properly
-    if _HAS_SERVICE_CHECK and name in ('rnsd', 'meshtasticd'):
-        service_status = _check_service(name)
+    if name in ('rnsd', 'meshtasticd'):
+        service_status = check_service(name)
         is_running = service_status.available
         status_detail = service_status.message or ("Running" if is_running else "Stopped")
         port_open = is_running  # If service responds, port is effectively "open"

--- a/src/gateway/meshtastic_handler.py
+++ b/src/gateway/meshtastic_handler.py
@@ -23,6 +23,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from .config import GatewayConfig
 from .node_tracker import UnifiedNode
 from .reconnect import ReconnectStrategy
+from utils.meshtastic_connection import (
+    clear_stale_connections, get_connection_manager, wait_for_cooldown
+)
+from utils.websocket_server import broadcast_message
 from utils.safe_import import safe_import
 
 if TYPE_CHECKING:
@@ -31,20 +35,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Import connection utilities (optional - graceful fallback)
-_clear_stale_connections, _HAS_STALE_CONN = safe_import(
-    'utils.meshtastic_connection', 'clear_stale_connections'
-)
-_get_connection_manager, _HAS_CONN_MANAGER = safe_import(
-    'utils.meshtastic_connection', 'get_connection_manager'
-)
-_wait_for_cooldown, _HAS_COOLDOWN = safe_import(
-    'utils.meshtastic_connection', 'wait_for_cooldown'
-)
-_broadcast_message, _HAS_WEBSOCKET = safe_import(
-    'utils.websocket_server', 'broadcast_message'
-)
-_pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
+# pubsub is an external dependency (pypubsub) - keep safe_import
+pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
 
 
 class MeshtasticHandler:
@@ -142,14 +134,13 @@ class MeshtasticHandler:
                     # blocks all reconnection. Detect and clear it early (3 attempts
                     # ≈ 7 seconds) instead of waiting for all 10 to exhaust.
                     if self._reconnect.attempts == 3:
-                        if _HAS_STALE_CONN:
-                            cleared = _clear_stale_connections(self.config.meshtastic.port)
-                            if cleared:
-                                self.health.record_connection_event(
-                                    "meshtastic", "self_healed",
-                                    "Cleared zombie CLOSE-WAIT connection"
-                                )
-                                self._reconnect.reset()
+                        cleared = clear_stale_connections(self.config.meshtastic.port)
+                        if cleared:
+                            self.health.record_connection_event(
+                                "meshtastic", "self_healed",
+                                "Cleared zombie CLOSE-WAIT connection"
+                            )
+                            self._reconnect.reset()
 
                     logger.info(f"Attempting Meshtastic connection "
                                f"(attempt {self._reconnect.attempts + 1})...")
@@ -192,8 +183,8 @@ class MeshtasticHandler:
         Returns:
             True if connection successful, False otherwise.
         """
-        if not (_HAS_PUBSUB and _HAS_CONN_MANAGER):
-            logger.warning("Meshtastic/connection manager not available, using CLI fallback")
+        if not _HAS_PUBSUB:
+            logger.warning("pubsub not available, using CLI fallback")
             self._connected = self._test_cli()
             return self._connected
 
@@ -205,7 +196,7 @@ class MeshtasticHandler:
 
             # Use singleton connection manager to prevent connection conflicts
             # meshtasticd only allows ONE TCP client - this ensures we share
-            self._conn_manager = _get_connection_manager(host, port)
+            self._conn_manager = get_connection_manager(host, port)
 
             # Acquire persistent connection (stays open for message receiving)
             if not self._conn_manager.acquire_persistent(owner="gateway_bridge"):
@@ -226,7 +217,7 @@ class MeshtasticHandler:
                 self._on_receive(packet)
 
             self._pubsub_handler = on_receive
-            _pub.subscribe(self._pubsub_handler, "meshtastic.receive")
+            pub.subscribe(self._pubsub_handler, "meshtastic.receive")
 
             # Get initial node list
             self._update_nodes()
@@ -431,20 +422,19 @@ class MeshtasticHandler:
             logger.debug(f"Could not store incoming message: {e}")
 
         # Broadcast to WebSocket for real-time web UI updates
-        if _HAS_WEBSOCKET:
-            try:
-                _broadcast_message({
-                    'from_id': from_id,
-                    'to_id': to_id,
-                    'content': text,
-                    'channel': packet.get('channel', 0),
-                    'snr': packet.get('rxSnr'),
-                    'rssi': packet.get('rxRssi'),
-                    'timestamp': datetime.now().isoformat(),
-                    'is_broadcast': to_id is None,
-                })
-            except Exception as e:
-                logger.debug(f"Could not broadcast to WebSocket: {e}")
+        try:
+            broadcast_message({
+                'from_id': from_id,
+                'to_id': to_id,
+                'content': text,
+                'channel': packet.get('channel', 0),
+                'snr': packet.get('rxSnr'),
+                'rssi': packet.get('rxRssi'),
+                'timestamp': datetime.now().isoformat(),
+                'is_broadcast': to_id is None,
+            })
+        except Exception as e:
+            logger.debug(f"Could not broadcast to WebSocket: {e}")
 
         # Queue for bridging if routing rules allow it (non-blocking to prevent deadlock)
         if self._mesh_to_rns_queue is not None:
@@ -567,10 +557,7 @@ class MeshtasticHandler:
         self._notify_status("meshtastic_disconnected")
 
         # Wait for cooldown before reconnect attempt
-        if _HAS_COOLDOWN:
-            _wait_for_cooldown()
-        else:
-            self._stop_event.wait(2)
+        wait_for_cooldown()
 
     def _update_nodes(self) -> None:
         """Update node tracker with Meshtastic nodes."""

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -53,37 +53,30 @@ import os
 from utils.paths import get_real_user_home, ReticulumPaths
 
 # Import service checker for pre-flight checks (Issue #3)
-check_service, ServiceState, HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'ServiceState'
-)
+from utils.service_check import check_service, ServiceState
+HAS_SERVICE_CHECK = True
 
 # Import event bus for RX message notifications (Issue #17 Phase 3)
-emit_message, HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_message')
+from utils.event_bus import emit_message
+HAS_EVENT_BUS = True
 
 # Import RNS sniffer for Wireshark-grade packet capture
-(get_rns_sniffer, RNSPacketInfo, RNSPacketType,
- start_rns_capture, integrate_with_traffic_inspector,
- HAS_RNS_SNIFFER) = safe_import(
-    'monitoring.rns_sniffer',
-    'get_rns_sniffer', 'RNSPacketInfo', 'RNSPacketType',
-    'start_rns_capture', 'integrate_with_traffic_inspector'
+from monitoring.rns_sniffer import (
+    get_rns_sniffer, RNSPacketInfo, RNSPacketType,
+    start_rns_capture, integrate_with_traffic_inspector
 )
+HAS_RNS_SNIFFER = True
 
 # Import RNS and LXMF modules (optional - for mesh bridge)
 _RNS_mod, _HAS_RNS = safe_import('RNS')
 _LXMF_mod, _HAS_LXMF = safe_import('LXMF')
 
-# Import config drift detection (optional)
-(_detect_rnsd_config_drift, _get_rnsd_effective_config_dir,
- _HAS_CONFIG_DRIFT) = safe_import(
-    'utils.config_drift', 'detect_rnsd_config_drift', 'get_rnsd_effective_config_dir'
-)
+# Import config drift detection
+from utils.config_drift import detect_rnsd_config_drift, get_rnsd_effective_config_dir
 
-# Import WebSocket server helpers (optional)
-(_start_ws_server, _is_ws_available, _stop_ws_server,
- _HAS_WS_SERVER) = safe_import(
-    'utils.websocket_server',
-    'start_websocket_server', 'is_websocket_available', 'stop_websocket_server'
+# Import WebSocket server helpers
+from utils.websocket_server import (
+    start_websocket_server, is_websocket_available, stop_websocket_server
 )
 
 
@@ -946,26 +939,21 @@ class RNSMeshtasticBridge:
             # Active drift fix: prefer rnsd's actual config path over default
             # resolution. This prevents the gateway from reading a different
             # config than the running daemon (e.g. ~/.reticulum vs /etc/reticulum)
-            if _HAS_CONFIG_DRIFT:
-                drift = _detect_rnsd_config_drift()
-                if drift.drifted:
-                    logger.warning(drift.message)
-                    if drift.fix_hint:
-                        logger.info("Drift fix: %s", drift.fix_hint)
-                    # Use rnsd's actual path as the active fix
-                    config_dir = str(drift.rnsd_config_dir)
-                    logger.info("Active fix: using rnsd's config dir %s "
-                               "instead of gateway's resolved %s",
-                               drift.rnsd_config_dir, drift.gateway_config_dir)
-                else:
-                    rns_config = ReticulumPaths.get_config_file()
-                    logger.info(f"RNS config path: {rns_config} "
-                               f"(exists: {rns_config.exists()}) "
-                               f"[{drift.detection_method}]")
+            drift = detect_rnsd_config_drift()
+            if drift.drifted:
+                logger.warning(drift.message)
+                if drift.fix_hint:
+                    logger.info("Drift fix: %s", drift.fix_hint)
+                # Use rnsd's actual path as the active fix
+                config_dir = str(drift.rnsd_config_dir)
+                logger.info("Active fix: using rnsd's config dir %s "
+                           "instead of gateway's resolved %s",
+                           drift.rnsd_config_dir, drift.gateway_config_dir)
             else:
                 rns_config = ReticulumPaths.get_config_file()
                 logger.info(f"RNS config path: {rns_config} "
-                           f"(exists: {rns_config.exists()})")
+                           f"(exists: {rns_config.exists()}) "
+                           f"[{drift.detection_method}]")
 
         try:
             if rns_pids:
@@ -1032,8 +1020,8 @@ class RNSMeshtasticBridge:
                 config_dir = self.config.rns.config_dir or None
 
                 # Active drift fix: prefer rnsd's actual config path
-                if not config_dir and _HAS_CONFIG_DRIFT:
-                    effective = _get_rnsd_effective_config_dir()
+                if not config_dir:
+                    effective = get_rnsd_effective_config_dir()
                     config_dir = str(effective)
 
                 if rns_pids:
@@ -1433,13 +1421,9 @@ class RNSMeshtasticBridge:
 
     def _start_websocket_server(self):
         """Start WebSocket server for real-time message broadcast to web UI."""
-        if not _HAS_WS_SERVER:
-            logger.debug("WebSocket server module not available")
-            return
-
         try:
-            if _is_ws_available():
-                if _start_ws_server(port=5001):
+            if is_websocket_available():
+                if start_websocket_server(port=5001):
                     logger.info("WebSocket server started on port 5001")
                     self._websocket_started = True
                 else:
@@ -1451,9 +1435,9 @@ class RNSMeshtasticBridge:
 
     def _stop_websocket_server(self):
         """Stop WebSocket server."""
-        if getattr(self, '_websocket_started', False) and _HAS_WS_SERVER:
+        if getattr(self, '_websocket_started', False):
             try:
-                _stop_ws_server()
+                stop_websocket_server()
                 logger.info("WebSocket server stopped")
             except Exception as e:
                 logger.debug(f"Error stopping WebSocket server: {e}")

--- a/src/monitoring/node_monitor.py
+++ b/src/monitoring/node_monitor.py
@@ -25,36 +25,16 @@ logger = logging.getLogger(__name__)
 if not logger.handlers:
     logger.setLevel(logging.WARNING)
 
+from utils.meshtastic_connection import (
+    MESHTASTIC_CONNECTION_LOCK, wait_for_cooldown, safe_close_interface
+)
 from utils.safe_import import safe_import
 
-# Module-level safe imports
-(_MESHTASTIC_CONNECTION_LOCK, _wait_for_cooldown, _safe_close_interface,
- _HAS_MESHTASTIC_CONNECTION) = safe_import(
-    'utils.meshtastic_connection',
-    'MESHTASTIC_CONNECTION_LOCK', 'wait_for_cooldown', 'safe_close_interface'
-)
-
+# Module-level safe imports for external dependencies
 _TCPInterface, _HAS_TCP_INTERFACE = safe_import(
     'meshtastic.tcp_interface', 'TCPInterface'
 )
 _pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
-
-# Import global connection lock - meshtasticd only supports one TCP connection
-if _HAS_MESHTASTIC_CONNECTION:
-    MESHTASTIC_CONNECTION_LOCK = _MESHTASTIC_CONNECTION_LOCK
-    wait_for_cooldown = _wait_for_cooldown
-    safe_close_interface = _safe_close_interface
-else:
-    # Fallback if utils not available
-    MESHTASTIC_CONNECTION_LOCK = threading.Lock()
-    def wait_for_cooldown():
-        time.sleep(1.0)
-    def safe_close_interface(iface):
-        if iface:
-            try:
-                iface.close()
-            except Exception:
-                pass
 
 
 class ConnectionState(Enum):

--- a/src/monitoring/rns_sniffer.py
+++ b/src/monitoring/rns_sniffer.py
@@ -25,21 +25,16 @@ from pathlib import Path
 from queue import Queue, Empty, Full
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+from monitoring.traffic_inspector import (
+    MeshPacket, PacketProtocol, PacketDirection, PacketTree,
+    PacketField, FieldType, get_traffic_inspector
+)
 from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
-# Module-level safe imports
+# RNS is an external dependency - keep safe_import
 RNS, _HAS_RNS = safe_import('RNS')
-(MeshPacket, PacketProtocol, PacketDirection, PacketTree,
- PacketField, FieldType, _HAS_TRAFFIC_INSPECTOR) = safe_import(
-    'monitoring.traffic_inspector',
-    'MeshPacket', 'PacketProtocol', 'PacketDirection', 'PacketTree',
-    'PacketField', 'FieldType'
-)
-_get_traffic_inspector, _HAS_GET_TRAFFIC_INSPECTOR = safe_import(
-    'monitoring.traffic_inspector', 'get_traffic_inspector'
-)
 
 
 # =============================================================================
@@ -777,10 +772,6 @@ def convert_to_mesh_packet(rns_packet: RNSPacketInfo):
     This allows RNS packets to be viewed alongside Meshtastic packets
     with consistent filtering and analysis.
     """
-    if not _HAS_TRAFFIC_INSPECTOR:
-        logger.debug("TrafficInspector not available for conversion")
-        return None
-
     # Map direction
     dir_map = {
         "inbound": PacketDirection.INBOUND,
@@ -935,11 +926,7 @@ def integrate_with_traffic_inspector() -> bool:
     Registers a callback that converts RNS packets to MeshPackets
     and feeds them into the unified traffic capture.
     """
-    if not _HAS_GET_TRAFFIC_INSPECTOR:
-        logger.debug("Could not integrate with TrafficInspector: module not available")
-        return False
-
-    inspector = _get_traffic_inspector()
+    inspector = get_traffic_inspector()
     sniffer = get_rns_sniffer()
 
     def on_rns_packet(rns_packet: RNSPacketInfo):

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -3,19 +3,32 @@
 import os
 import shutil
 import subprocess
-from pathlib import Path
-from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
-from rich.prompt import Prompt, Confirm
-from rich.table import Table
-from rich.panel import Panel
 import time
+from pathlib import Path
 
 from utils.safe_import import safe_import
 
-_run_cli_async_gtk, _HAS_COMMON_GTK = safe_import('utils.common', 'run_cli_async_gtk')
+# rich is optional — TUI/headless environments may not have it
+_, _HAS_RICH = safe_import('rich')
+if _HAS_RICH:
+    from rich.console import Console
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
+    from rich.prompt import Prompt, Confirm
+    from rich.table import Table
+    from rich.panel import Panel
+    console = Console()
+else:
+    # Minimal fallback so find_meshtastic_cli() always works
+    Console = Progress = SpinnerColumn = TextColumn = BarColumn = None
+    Prompt = Confirm = Table = Panel = None
 
-console = Console()
+    class _FallbackConsole:
+        """Stub console for when rich is not installed."""
+        def print(self, *args, **kwargs):
+            pass
+    console = _FallbackConsole()
+
+_run_cli_async_gtk, _HAS_COMMON_GTK = safe_import('utils.common', 'run_cli_async_gtk')
 
 
 def find_meshtastic_cli():

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -17,9 +17,10 @@ import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
+from utils.cli import find_meshtastic_cli
 from utils.safe_import import safe_import
 
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+# gi.repository is an external dependency (PyGObject/GTK) - keep safe_import
 _GLib, _HAS_GLIB = safe_import('gi.repository', 'GLib')
 
 logger = logging.getLogger(__name__)
@@ -225,11 +226,7 @@ def run_cli_async(
         # Find CLI if not provided
         nonlocal cli_path
         if cli_path is None:
-            if _HAS_CLI:
-                cli_path = _find_meshtastic_cli()
-            else:
-                import shutil
-                cli_path = shutil.which('meshtastic')
+            cli_path = find_meshtastic_cli()
 
         if not cli_path:
             callback(False, "", "Meshtastic CLI not found. Install with: pipx install meshtastic[cli]")

--- a/tests/test_meshtastic_handler.py
+++ b/tests/test_meshtastic_handler.py
@@ -120,11 +120,11 @@ class TestHandlerInit:
 class TestConnect:
     """Tests for connection establishment."""
 
-    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
-    @patch('gateway.meshtastic_handler.pub', create=True)
+    @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.get_connection_manager')
+    @patch('gateway.meshtastic_handler.pub', new_callable=MagicMock)
     def test_connect_success(self, mock_pub, mock_get_cm, handler):
         """Successful TCP connection via connection manager."""
-        # Mock connection manager
         mock_cm = MagicMock()
         mock_cm.acquire_persistent.return_value = True
         mock_iface = MagicMock()
@@ -133,35 +133,26 @@ class TestConnect:
         mock_cm.get_interface.return_value = mock_iface
         mock_get_cm.return_value = mock_cm
 
-        # Patch the imports inside connect()
-        with patch.dict('sys.modules', {
-            'pubsub': MagicMock(),
-            'pubsub.pub': mock_pub,
-            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
-        }):
-            result = handler.connect()
+        result = handler.connect()
 
         assert result is True
         assert handler.is_connected is True
 
-    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
+    @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.get_connection_manager')
     def test_connect_acquire_fails(self, mock_get_cm, handler):
         """Connection fails when persistent acquire returns False."""
         mock_cm = MagicMock()
         mock_cm.acquire_persistent.return_value = False
         mock_get_cm.return_value = mock_cm
 
-        with patch.dict('sys.modules', {
-            'pubsub': MagicMock(),
-            'pubsub.pub': MagicMock(),
-            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
-        }):
-            result = handler.connect()
+        result = handler.connect()
 
         assert result is False
         assert handler.is_connected is False
 
-    @patch('gateway.meshtastic_handler.get_connection_manager', create=True)
+    @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.get_connection_manager')
     def test_connect_interface_none(self, mock_get_cm, handler):
         """Connection fails when interface is None."""
         mock_cm = MagicMock()
@@ -169,32 +160,26 @@ class TestConnect:
         mock_cm.get_interface.return_value = None
         mock_get_cm.return_value = mock_cm
 
-        with patch.dict('sys.modules', {
-            'pubsub': MagicMock(),
-            'pubsub.pub': MagicMock(),
-            'utils.meshtastic_connection': MagicMock(get_connection_manager=mock_get_cm),
-        }):
-            result = handler.connect()
+        result = handler.connect()
 
         assert result is False
         assert handler.is_connected is False
 
+    @patch('gateway.meshtastic_handler._HAS_PUBSUB', False)
     def test_connect_import_error_cli_fallback(self, handler):
-        """Falls back to CLI when meshtastic library not available."""
+        """Falls back to CLI when pubsub not available."""
         with patch.object(handler, '_test_cli', return_value=True):
-            # Force ImportError on the first import
-            with patch.dict('sys.modules', {'pubsub': None}):
-                with patch('builtins.__import__', side_effect=ImportError("No pubsub")):
-                    result = handler.connect()
+            result = handler.connect()
 
         # Should fall back to CLI
         assert handler.is_connected is True
 
-    def test_connect_general_exception(self, handler):
+    @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.get_connection_manager')
+    def test_connect_general_exception(self, mock_get_cm, handler):
         """General exception during connect returns False."""
-        with patch.dict('sys.modules', {'pubsub': None}):
-            with patch('builtins.__import__', side_effect=RuntimeError("boom")):
-                result = handler.connect()
+        mock_get_cm.side_effect = RuntimeError("boom")
+        result = handler.connect()
 
         assert result is False
         assert handler.is_connected is False

--- a/tests/test_predictive_analytics.py
+++ b/tests/test_predictive_analytics.py
@@ -263,7 +263,7 @@ class TestDiagnosticEngineIntegration:
         assert hasattr(Category, 'PREDICTIVE')
         assert Category.PREDICTIVE.value == 'predictive'
 
-    @patch('utils.analytics.get_predictive_analyzer')
+    @patch('utils.diagnostic_engine._get_predictive_analyzer')
     def test_check_predictive_alerts_returns_list(self, mock_get_analyzer):
         """Test that check_predictive_alerts returns a list."""
         from utils.diagnostic_engine import DiagnosticEngine
@@ -277,7 +277,7 @@ class TestDiagnosticEngineIntegration:
 
         assert isinstance(result, list)
 
-    @patch('utils.analytics.get_predictive_analyzer')
+    @patch('utils.diagnostic_engine._get_predictive_analyzer')
     def test_check_predictive_alerts_converts_to_diagnosis(self, mock_get_analyzer):
         """Test that predictive alerts are converted to Diagnosis objects."""
         from utils.diagnostic_engine import DiagnosticEngine, Category, Severity
@@ -307,7 +307,7 @@ class TestDiagnosticEngineIntegration:
         assert 'Test link degradation' in diagnosis.symptom.message
         assert diagnosis.confidence == 0.8
 
-    @patch('utils.analytics.get_predictive_analyzer')
+    @patch('utils.diagnostic_engine._get_predictive_analyzer')
     def test_check_predictive_alerts_handles_import_error(self, mock_get_analyzer):
         """Test graceful handling when analytics module unavailable."""
         from utils.diagnostic_engine import DiagnosticEngine

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -1441,26 +1441,13 @@ class TestBridgeLoop:
 class TestTestRNS:
     """Tests for _test_rns method."""
 
+    @patch('gateway.rns_bridge._HAS_RNS', True)
     def test_returns_true_when_importable(self, bridge):
-        with patch.dict('sys.modules', {'RNS': MagicMock()}):
-            assert bridge._test_rns() is True
+        assert bridge._test_rns() is True
 
+    @patch('gateway.rns_bridge._HAS_RNS', False)
     def test_returns_false_when_not_importable(self, bridge):
-        import builtins
-        original_import = builtins.__import__
-
-        def mock_import(name, *args, **kwargs):
-            if name == 'RNS':
-                raise ImportError("No module named 'RNS'")
-            return original_import(name, *args, **kwargs)
-
-        with patch('builtins.__import__', side_effect=mock_import):
-            saved = sys.modules.pop('RNS', None)
-            try:
-                assert bridge._test_rns() is False
-            finally:
-                if saved is not None:
-                    sys.modules['RNS'] = saved
+        assert bridge._test_rns() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_rns_transport.py
+++ b/tests/test_rns_transport.py
@@ -690,24 +690,22 @@ class TestGetStatus:
 class TestConnection:
     """Tests for connection management."""
 
-    @patch.dict('sys.modules', {
-        'meshtastic': MagicMock(),
-        'meshtastic.tcp_interface': MagicMock(),
-        'pubsub': MagicMock(),
-        'pubsub.pub': MagicMock(),
-    })
+    @patch('gateway.rns_transport._HAS_MESHTASTIC', True)
+    @patch('gateway.rns_transport._HAS_MESH_TCP', True)
+    @patch('gateway.rns_transport._HAS_PUBSUB', True)
+    @patch('gateway.rns_transport._meshtastic_tcp', MagicMock())
+    @patch('gateway.rns_transport._pub_mod', MagicMock())
     def test_connect_tcp_success(self, transport):
         """TCP connection succeeds."""
         result = transport._connect()
         assert result is True
         assert transport._connected is True
 
-    @patch.dict('sys.modules', {
-        'meshtastic': MagicMock(),
-        'meshtastic.serial_interface': MagicMock(),
-        'pubsub': MagicMock(),
-        'pubsub.pub': MagicMock(),
-    })
+    @patch('gateway.rns_transport._HAS_MESHTASTIC', True)
+    @patch('gateway.rns_transport._HAS_MESH_SERIAL', True)
+    @patch('gateway.rns_transport._HAS_PUBSUB', True)
+    @patch('gateway.rns_transport._meshtastic_serial', MagicMock())
+    @patch('gateway.rns_transport._pub_mod', MagicMock())
     def test_connect_serial(self):
         """Serial connection attempted."""
         config = RNSOverMeshtasticConfig(
@@ -718,12 +716,11 @@ class TestConnection:
         result = t._connect()
         assert result is True
 
-    @patch.dict('sys.modules', {
-        'meshtastic': MagicMock(),
-        'meshtastic.ble_interface': MagicMock(),
-        'pubsub': MagicMock(),
-        'pubsub.pub': MagicMock(),
-    })
+    @patch('gateway.rns_transport._HAS_MESHTASTIC', True)
+    @patch('gateway.rns_transport._HAS_MESH_BLE', True)
+    @patch('gateway.rns_transport._HAS_PUBSUB', True)
+    @patch('gateway.rns_transport._meshtastic_ble', MagicMock())
+    @patch('gateway.rns_transport._pub_mod', MagicMock())
     def test_connect_ble(self):
         """BLE connection attempted."""
         config = RNSOverMeshtasticConfig(
@@ -734,16 +731,12 @@ class TestConnection:
         result = t._connect()
         assert result is True
 
+    @patch('gateway.rns_transport._HAS_MESHTASTIC', True)
+    @patch('gateway.rns_transport._HAS_PUBSUB', True)
     def test_connect_unknown_type(self, transport):
         """Unknown connection type returns False."""
         transport.config.connection_type = "unknown"
-        # Mock meshtastic imports to get past ImportError
-        with patch.dict('sys.modules', {
-            'meshtastic': MagicMock(),
-            'pubsub': MagicMock(),
-            'pubsub.pub': MagicMock(),
-        }):
-            result = transport._connect()
+        result = transport._connect()
         assert result is False
 
     def test_connect_import_error(self, transport):

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -376,39 +376,40 @@ class TestSpaceWeather:
         """Test successful space weather fetch."""
         bar = StatusBar(version="1.0")
 
-        # Mock the SpaceWeatherAPI
+        # Mock the SpaceWeatherAPI via status_bar module attribute
         mock_data = MagicMock()
         mock_data.solar_flux = 145.5
         mock_data.k_index = 3
 
-        with patch('utils.space_weather.SpaceWeatherAPI') as MockAPI:
-            mock_api = MockAPI.return_value
-            mock_api.get_current_conditions.return_value = mock_data
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.return_value = mock_data
 
-            bar._check_space_weather()
+        with patch('status_bar._SpaceWeatherAPI', MockAPI):
+            with patch('status_bar._HAS_SPACE_WEATHER', True):
+                bar._check_space_weather()
 
-            assert bar._space_weather == "SFI:145 K:3"
+        assert bar._space_weather == "SFI:145 K:3"
 
     def test_space_weather_graceful_failure(self):
         """Space weather failure should not break status bar."""
         bar = StatusBar(version="1.0")
         bar._space_weather = "SFI:100 K:1"  # Previous value
 
-        with patch('utils.space_weather.SpaceWeatherAPI') as MockAPI:
-            mock_api = MockAPI.return_value
-            mock_api.get_current_conditions.side_effect = Exception("Network error")
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.side_effect = Exception("Network error")
 
-            bar._check_space_weather()
+        with patch('status_bar._SpaceWeatherAPI', MockAPI):
+            with patch('status_bar._HAS_SPACE_WEATHER', True):
+                bar._check_space_weather()
 
-            # Should be cleared on failure
-            assert bar._space_weather is None
+        # Should be cleared on failure
+        assert bar._space_weather is None
 
     def test_space_weather_import_error(self):
         """Missing space_weather module should not crash."""
         bar = StatusBar(version="1.0")
 
-        with patch.dict('sys.modules', {'utils.space_weather': None}):
-            # This will trigger ImportError in _check_space_weather
+        with patch('status_bar._HAS_SPACE_WEATHER', False):
             bar._check_space_weather()
             assert bar._space_weather is None
 
@@ -420,14 +421,15 @@ class TestSpaceWeather:
         mock_data.solar_flux = 120.0
         mock_data.k_index = None  # Not available
 
-        with patch('utils.space_weather.SpaceWeatherAPI') as MockAPI:
-            mock_api = MockAPI.return_value
-            mock_api.get_current_conditions.return_value = mock_data
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.return_value = mock_data
 
-            bar._check_space_weather()
+        with patch('status_bar._SpaceWeatherAPI', MockAPI):
+            with patch('status_bar._HAS_SPACE_WEATHER', True):
+                bar._check_space_weather()
 
-            assert bar._space_weather == "SFI:120"
-            assert "K:" not in bar._space_weather
+        assert bar._space_weather == "SFI:120"
+        assert "K:" not in bar._space_weather
 
 
 class TestStatusBarEdgeCases:
@@ -562,8 +564,9 @@ class TestSeedNodeCount:
         mock_tracker = MagicMock()
         mock_tracker.get_all_nodes.return_value = [MagicMock()] * 5
 
-        with patch('gateway.node_tracker.get_node_tracker', return_value=mock_tracker):
-            bar._seed_node_count()
+        with patch('status_bar._get_node_tracker', return_value=mock_tracker):
+            with patch('status_bar._HAS_NODE_TRACKER', True):
+                bar._seed_node_count()
 
         assert bar._node_count == 5
 
@@ -575,8 +578,9 @@ class TestSeedNodeCount:
         mock_tracker = MagicMock()
         mock_tracker.get_all_nodes.return_value = []
 
-        with patch('gateway.node_tracker.get_node_tracker', return_value=mock_tracker):
-            bar._seed_node_count()
+        with patch('status_bar._get_node_tracker', return_value=mock_tracker):
+            with patch('status_bar._HAS_NODE_TRACKER', True):
+                bar._seed_node_count()
 
         assert bar._node_count is None
 
@@ -585,7 +589,7 @@ class TestSeedNodeCount:
         bar = StatusBar(version="1.0")
         bar._node_count = None
 
-        with patch.dict('sys.modules', {'gateway.node_tracker': None}):
+        with patch('status_bar._HAS_NODE_TRACKER', False):
             bar._seed_node_count()
 
         assert bar._node_count is None


### PR DESCRIPTION
Replace safe_import for first-party modules with direct imports across 15 source files. The safe_import utility is designed for optional external dependencies (meshtastic, RNS, pubsub, rich, etc.) but was unnecessarily wrapping internal modules like utils.service_check, utils.paths, utils.event_bus, and gateway submodules that are always present.

Source changes:
- commands/{service,rns,propagation,messaging,gateway,rnode,meshtastic, device_backup}.py: Direct imports for first-party modules, removed dead fallback code (e.g., CommandResult stub in rnode.py, _fallback_get_real_user_home in device_backup.py)
- gateway/{meshtastic_handler,rns_bridge}.py: Direct imports for utils.service_check, utils.event_bus, utils.meshtastic_connection, monitoring.rns_sniffer, utils.config_drift
- monitoring/{node_monitor,rns_sniffer}.py: Direct imports for utils.meshtastic_connection, monitoring.traffic_inspector
- utils/cli.py: Wrap rich imports with safe_import (rich is optional)
- utils/common.py: Direct import for utils.cli

Test fixes:
- Patch module-level _HAS_* flags and safe_import names directly instead of patching sys.modules (which doesn't affect flags already evaluated at import time)
- test_rns_transport: Patch _HAS_MESHTASTIC/_HAS_PUBSUB flags
- test_rns_bridge: Patch _HAS_RNS flag
- test_status_bar: Patch status_bar._SpaceWeatherAPI and status_bar._get_node_tracker
- test_meshtastic_handler: Patch _HAS_PUBSUB and direct import names
- test_predictive_analytics: Patch diagnostic_engine._get_predictive_analyzer

Net: -199 lines, 4071 tests pass (0 failures, 19 skipped)

https://claude.ai/code/session_015MPuE8aSHw4KszuiRWC9fh