### PR TITLE
fix: address review findings, update session notes

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -191,6 +191,32 @@ from utils.logging_utils import get_logger
 
 # Service availability checks - use before service-dependent operations
 from utils.service_check import check_service, check_port, ServiceState
+
+# Optional external dependencies — use safe_import
+from utils.safe_import import safe_import
+RNS, _HAS_RNS = safe_import('RNS')                              # External
+_pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')                 # External
+_yaml, _HAS_YAML = safe_import('yaml')                            # External
+
+# First-party modules — ALWAYS use direct imports (never safe_import)
+from utils.service_check import check_service    # ✓ Direct
+from utils.event_bus import emit_message         # ✓ Direct
+from gateway.rns_bridge import RNSMeshtasticBridge  # ✓ Direct
+```
+
+### Test Patching with safe_import
+
+When testing code that uses safe_import for external deps, patch the
+module-level `_HAS_*` flags directly — NOT `sys.modules`:
+
+```python
+# WRONG - flags already evaluated at import time
+@patch.dict('sys.modules', {'RNS': MagicMock()})
+def test_rns(self): ...  # _HAS_RNS is still False!
+
+# CORRECT - patch the flag directly
+@patch('gateway.rns_bridge._HAS_RNS', True)
+def test_rns(self): ...  # Now _HAS_RNS is True
 ```
 
 ---

--- a/.claude/foundations/technical_debt_plan.md
+++ b/.claude/foundations/technical_debt_plan.md
@@ -12,35 +12,29 @@
 
 ## Phase 1: Quick Wins (Low Risk)
 
-### 1.1 Import Boilerplate Consolidation
+### 1.1 Import Boilerplate Consolidation — COMPLETED (2026-02-14)
 
 **Problem**: ~489 `except ImportError` blocks across src/ (previously estimated at 86).
 
-> **Audit 2026-02-14**: Actual count is **489 `except ImportError` handlers** across
-> ~133 files. Top offenders: prometheus_exporter.py (15), ai_tools_mixin.py (13),
-> rns_bridge.py (13), map_data_collector.py (12). The original estimate of 86 only
-> counted gtk_ui/panels — the problem is project-wide.
+**Solution**: Created `utils/safe_import.py` — consolidates optional dependency imports.
 
-**Solution**: Create `utils/safe_import.py`
+**Status**: DONE in 3 phases:
+1. **Phase A** (batches 1-11): Converted ~490 try/except ImportError blocks to safe_import
+2. **Phase B** (review): Found 15 files where safe_import was over-applied to first-party
+   modules that always exist. Reverted those to direct imports. Net -199 lines.
+3. **Phase C** (cleanup): Code review caught `rich` being incorrectly wrapped as optional
+   in cli.py (it's a hard dependency in requirements.txt), and a dead `RNSMeshtasticBridge`
+   import in messaging.py. Both fixed.
 
-```python
-def safe_import(module: str, class_name: str = None, default=None):
-    """Import with automatic fallback."""
-    try:
-        module_obj = __import__(module, fromlist=[class_name] if class_name else [])
-        if class_name:
-            return (getattr(module_obj, class_name), True)
-        return (module_obj, True)
-    except ImportError:
-        return (default, False)
+**Key principle**: `safe_import` is ONLY for genuinely optional external libraries
+(meshtastic, RNS, LXMF, pubsub, psutil, paho.mqtt, serial, gi.repository, etc.).
+First-party modules (utils.*, gateway.*, commands.*, monitoring.*) get direct imports.
 
-# Usage:
-check_service, HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
-```
+**Test impact**: Tests that patched `sys.modules` to mock optional deps were broken
+because safe_import evaluates `_HAS_*` flags at module load time. Fixed by patching
+the `_HAS_*` flags directly: `@patch('gateway.rns_transport._HAS_MESHTASTIC', True)`.
 
-**Files to Update**: All src/**/*.py with try/except ImportError (~133 files)
-**Estimated Savings**: 500-800 lines (revised up from 200-300)
-**Risk**: LOW - Purely mechanical refactor
+**Risk**: LOW - Verified with 4071 passing tests
 
 ### 1.2 Configuration Centralization
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,31 @@ success, msg = daemon_reload()
 Legacy fallback patterns were removed in v0.5.2 (Issue #26). All code now imports
 directly from `utils.service_check` — no try/except compatibility shims needed.
 
+## safe_import Rules (utils/safe_import.py)
+
+`safe_import` wraps optional external dependencies. **Do NOT use it for first-party modules.**
+
+```python
+# CORRECT — external/optional dependency
+from utils.safe_import import safe_import
+RNS, _HAS_RNS = safe_import('RNS')
+
+# WRONG — first-party module, always exists
+_check_service, _HAS_SC = safe_import('utils.service_check', 'check_service')
+
+# CORRECT — first-party module, use direct import
+from utils.service_check import check_service
+```
+
+**When to use safe_import**: meshtastic, RNS, LXMF, pubsub, psutil, paho.mqtt,
+serial, gi.repository, yaml — genuinely optional external packages.
+
+**Test patching**: Patch `_HAS_*` flags directly, not `sys.modules`:
+```python
+@patch('gateway.rns_transport._HAS_MESHTASTIC', True)  # ✓
+@patch.dict('sys.modules', {'meshtastic': MagicMock()})  # ✗ flags already set
+```
+
 ## File Size Guidelines
 
 Split files exceeding 1,500 lines (see `.claude/foundations/persistent_issues.md` Issue #6):

--- a/src/commands/messaging.py
+++ b/src/commands/messaging.py
@@ -35,7 +35,6 @@ from .base import CommandResult
 from utils.paths import get_real_user_home
 
 from utils.event_bus import emit_message
-from gateway import RNSMeshtasticBridge
 from commands import gateway as cmd_gateway
 from commands import meshtastic as cmd_meshtastic
 from utils.message_listener import (
@@ -314,21 +313,20 @@ def send_message(
 
         if send_success:
             # Emit TX event to EventBus for status bar and subscribers
-            if emit_message is not None:
-                try:
-                    emit_message(
-                        direction='tx',
-                        content=content[:100],  # Truncate for event
-                        node_id=destination or "broadcast",
-                        network=network,
-                        raw_data={
-                            'message_id': message_id,
-                            'chunks': len(chunks),
-                            'destination': destination,
-                        },
-                    )
-                except Exception as e:
-                    logger.debug(f"TX event emission failed: {e}")
+            try:
+                emit_message(
+                    direction='tx',
+                    content=content[:100],  # Truncate for event
+                    node_id=destination or "broadcast",
+                    network=network,
+                    raw_data={
+                        'message_id': message_id,
+                        'chunks': len(chunks),
+                        'destination': destination,
+                    },
+                )
+            except Exception as e:
+                logger.debug(f"TX event emission failed: {e}")
 
             return CommandResult.ok(
                 f"Message sent ({len(chunks)} chunk(s))",

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -5,30 +5,17 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
+from rich.prompt import Prompt, Confirm
+from rich.table import Table
+from rich.panel import Panel
 
 from utils.safe_import import safe_import
 
-# rich is optional — TUI/headless environments may not have it
-_, _HAS_RICH = safe_import('rich')
-if _HAS_RICH:
-    from rich.console import Console
-    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
-    from rich.prompt import Prompt, Confirm
-    from rich.table import Table
-    from rich.panel import Panel
-    console = Console()
-else:
-    # Minimal fallback so find_meshtastic_cli() always works
-    Console = Progress = SpinnerColumn = TextColumn = BarColumn = None
-    Prompt = Confirm = Table = Panel = None
-
-    class _FallbackConsole:
-        """Stub console for when rich is not installed."""
-        def print(self, *args, **kwargs):
-            pass
-    console = _FallbackConsole()
-
 _run_cli_async_gtk, _HAS_COMMON_GTK = safe_import('utils.common', 'run_cli_async_gtk')
+
+console = Console()
 
 
 def find_meshtastic_cli():


### PR DESCRIPTION
Code fixes:
- cli.py: Revert safe_import wrapping for rich — it's a hard dependency (requirements.txt: rich>=13.0.0, 27+ files import it directly). The _FallbackConsole stub was incomplete and would crash on create_progress(), show_table(), etc. if rich were actually missing.
- messaging.py: Remove dead RNSMeshtasticBridge import (unused) and dead `emit_message is not None` guard (always a function after converting to direct import).

Session notes updated:
- CLAUDE.md: Added safe_import rules section — when to use it, when not to, and how to patch _HAS_* flags in tests
- technical_debt_plan.md: Phase 1.1 marked COMPLETED with results
- persistent_issues.md: Added safe_import import patterns and test patching guidance to Quick Reference

4071 tests pass, 19 skipped, 0 failures.

https://claude.ai/code/session_015MPuE8aSHw4KszuiRWC9fh