### PR TITLE
Add MeshCore support to message routing classifier

### DIFF
--- a/src/gateway/message_routing.py
+++ b/src/gateway/message_routing.py
@@ -126,12 +126,15 @@ class MessageRouter:
 
     def _classify_message(self, msg) -> bool:
         """Classify message using confidence-scored routing."""
-        msg_id = f"{msg.source_network}:{msg.source_id}:{msg.timestamp.isoformat()}"
+        # Support both CanonicalMessage (source_address) and BridgedMessage (source_id)
+        source_id = getattr(msg, 'source_address', '') or getattr(msg, 'source_id', '')
+        dest_id = getattr(msg, 'destination_address', '') or getattr(msg, 'destination_id', '')
+        msg_id = f"{msg.source_network}:{source_id}:{msg.timestamp.isoformat()}"
 
         result = self._classifier.classify(msg_id, {
             'source_network': msg.source_network,
-            'source_id': msg.source_id,
-            'destination_id': msg.destination_id,
+            'source_id': source_id,
+            'destination_id': dest_id,
             'content': msg.content,
             'is_broadcast': msg.is_broadcast,
             'metadata': msg.metadata
@@ -145,7 +148,7 @@ class MessageRouter:
                 self.stats['bounced'] += 1
             logger.info(
                 f"Message bounced (confidence {result.confidence:.2f}): "
-                f"{msg.source_id[:8]}... -> {result.bounce_reason}"
+                f"{source_id[:8]}... -> {result.bounce_reason}"
             )
             # Bounced messages go to queue category, don't bridge immediately
             return result.category == RoutingCategory.QUEUE.value
@@ -160,7 +163,11 @@ class MessageRouter:
         # Determine if we should bridge based on category
         if result.category == RoutingCategory.DROP.value:
             return False
-        elif result.category in (RoutingCategory.BRIDGE_RNS.value, RoutingCategory.BRIDGE_MESH.value):
+        elif result.category in (
+            RoutingCategory.BRIDGE_RNS.value,
+            RoutingCategory.BRIDGE_MESH.value,
+            RoutingCategory.BRIDGE_MESHCORE.value,
+        ):
             return True
         elif result.category == RoutingCategory.QUEUE.value:
             # Queued items need manual review

--- a/src/utils/classifier.py
+++ b/src/utils/classifier.py
@@ -369,6 +369,7 @@ class RoutingCategory(Enum):
     """Message routing categories - small bucket"""
     BRIDGE_RNS = "bridge_to_rns"
     BRIDGE_MESH = "bridge_to_mesh"
+    BRIDGE_MESHCORE = "bridge_to_meshcore"
     DROP = "drop"
     QUEUE = "queue_for_review"
 
@@ -408,10 +409,12 @@ class RoutingClassifier(Classifier):
         reasons = []
         metadata = {'matched_rules': []}
 
-        # Determine direction
+        # Determine direction based on source network
         if source_network == 'meshtastic':
             default_category = RoutingCategory.BRIDGE_RNS.value
         elif source_network == 'rns':
+            default_category = RoutingCategory.BRIDGE_MESH.value
+        elif source_network == 'meshcore':
             default_category = RoutingCategory.BRIDGE_MESH.value
         else:
             return (RoutingCategory.DROP.value, 0.1, "Unknown source network", {})
@@ -462,6 +465,14 @@ class RoutingClassifier(Classifier):
         if direction == 'mesh_to_rns' and source_network != 'meshtastic':
             return False
         if direction == 'rns_to_mesh' and source_network != 'rns':
+            return False
+        if direction == 'mesh_to_meshcore' and source_network != 'meshtastic':
+            return False
+        if direction == 'meshcore_to_mesh' and source_network != 'meshcore':
+            return False
+        if direction == 'rns_to_meshcore' and source_network != 'rns':
+            return False
+        if direction == 'meshcore_to_rns' and source_network != 'meshcore':
             return False
 
         # Source filter (regex pattern)

--- a/tests/test_tribridge_integration.py
+++ b/tests/test_tribridge_integration.py
@@ -120,10 +120,9 @@ def _make_msg(source_network, content="Hello mesh", source_id="node123",
               origin=None):
     """Helper to create a message object for routing tests.
 
-    Uses SimpleNamespace because MessageRouter._classify_message accesses
-    msg.source_id and msg.destination_id directly (not via getattr),
-    while CanonicalMessage uses source_address/destination_address.
-    SimpleNamespace provides all attributes the router expects.
+    Uses SimpleNamespace to provide both CanonicalMessage-style attributes
+    (source_address/destination_address) and BridgedMessage-style attributes
+    (source_id/destination_id) so tests work with both message types.
     """
     msg = SimpleNamespace(
         content=content,
@@ -223,14 +222,18 @@ class TestInternetOriginFiltering:
 class TestDirectionalRouting:
     """Test specific directional routing rules for 3-way bridging.
 
-    Tests the legacy routing path (no classifier) to verify direction
-    matching logic, since the classifier currently only knows meshtastic
-    and rns sources (meshcore support is pending classifier update).
+    Tests both classifier and legacy routing paths for all three networks
+    (meshtastic, meshcore, rns) including meshcore-specific directions.
     """
 
     def test_mesh_to_meshcore_rule_matches(self, directional_router):
         """mesh_to_meshcore rule allows Meshtastic->MeshCore."""
         msg = _make_msg("meshtastic", "To MeshCore")
+        assert directional_router.should_bridge(msg) is True
+
+    def test_meshcore_to_mesh_rule_matches(self, directional_router):
+        """meshcore_to_mesh rule allows MeshCore->Meshtastic via classifier."""
+        msg = _make_msg("meshcore", "To Meshtastic")
         assert directional_router.should_bridge(msg) is True
 
     @patch('gateway.message_routing.CLASSIFIER_AVAILABLE', False)
@@ -245,6 +248,11 @@ class TestDirectionalRouting:
     def test_rns_to_meshcore_rule_matches(self, directional_router):
         """rns_to_meshcore rule allows RNS->MeshCore."""
         msg = _make_msg("rns", "To MeshCore")
+        assert directional_router.should_bridge(msg) is True
+
+    def test_meshcore_to_rns_rule_matches(self, directional_router):
+        """meshcore_to_rns rule allows MeshCore->RNS via classifier."""
+        msg = _make_msg("meshcore", "To RNS")
         assert directional_router.should_bridge(msg) is True
 
     @patch('gateway.message_routing.CLASSIFIER_AVAILABLE', False)


### PR DESCRIPTION
## Summary
This PR extends the message routing classifier to support MeshCore as a third network type alongside Meshtastic and RNS, enabling bidirectional routing between all three networks.

## Key Changes

- **Classifier routing categories**: Added `BRIDGE_MESHCORE` category to support routing messages to MeshCore
- **Direction matching**: Implemented direction validation for all 6 routing paths:
  - `mesh_to_meshcore` (Meshtastic → MeshCore)
  - `meshcore_to_mesh` (MeshCore → Meshtastic)
  - `rns_to_meshcore` (RNS → MeshCore)
  - `meshcore_to_rns` (MeshCore → RNS)
  - Plus existing `mesh_to_rns` and `rns_to_mesh` paths
- **Message attribute compatibility**: Updated `_classify_message()` to support both CanonicalMessage-style attributes (`source_address`/`destination_address`) and BridgedMessage-style attributes (`source_id`/`destination_id`) using `getattr()` fallbacks
- **Default routing**: Set MeshCore messages to default to `BRIDGE_MESH` category (bridging to Meshtastic)
- **Test coverage**: Added new test cases for MeshCore→Meshtastic and MeshCore→RNS routing paths, updated test documentation to reflect full 3-way network support

## Implementation Details

The classifier now properly validates that routing rules match the source network direction. For example, a `meshcore_to_mesh` rule will only match messages originating from the MeshCore network. The message attribute handling uses defensive `getattr()` calls to gracefully support different message object types without requiring strict type checking.

https://claude.ai/code/session_01DhFagwCRMCdwxuBU4ySv95