### PR TITLE
Update session notes and documentation with TUI-Bridge API wiring backlog

### DIFF
--- a/.claude/TODO_PRIORITIES.md
+++ b/.claude/TODO_PRIORITIES.md
@@ -1,6 +1,6 @@
 # MeshForge Development Priorities
 
-> **Last Updated:** 2026-02-12
+> **Last Updated:** 2026-02-17
 > **Maintainer:** WH6GXZ / Dude AI
 
 ---
@@ -56,6 +56,12 @@
 - [x] **Install pytest** - Available in environment
 - [x] **Add tests for gateway transport** - 39 tests for transport layer
 - [x] **Add tests for network diagnostics** - 28 tests (2026-01-15)
+
+### TUI-Bridge API Wiring
+- [ ] **MeshCore node listing** - Wire `_meshcore_nodes()` to live node tracker (filter `meshcore:` prefix) — currently placeholder text
+- [ ] **MeshCore stats** - Wire `_meshcore_stats()` to bridge stats API (`meshcore_rx/tx/acks`) — currently static help text
+- [ ] **Classifier MeshCore 3-way routing** - Verify `BRIDGE_MESHCORE` end-to-end with MeshCore source network (enum exists in `classifier.py`)
+- [ ] **Auto-review reliability triage** - Review 64 reliability issues: real vs false positive classification
 
 ---
 
@@ -189,12 +195,13 @@
 
 | File | Lines | Status |
 |------|-------|--------|
-| knowledge_content.py | 1,824 | Over - static content data, acceptable by design |
-| rns_bridge.py | 1,694 | **Over - needs extraction** |
-| map_data_collector.py | 1,509 | Borderline, monitor |
-| launcher_tui/main.py | 1,488 | Under threshold |
+| knowledge_content.py | 1,824 | Over — content file by design, acceptable |
+| service_menu_mixin.py | 1,611 | Over — monitor; OpenHamClock/MQTT candidates for extraction |
+| rns_bridge.py | 1,525 | Over — MeshCoreBridgeMixin + MessageRouter + gateway_cli extracted |
+| map_data_collector.py | 1,516 | Borderline, monitor |
+| launcher_tui/main.py | 1,516 | Borderline — 33 mixins, monitor |
 
-*Last updated: 2026-02-12*
+*Last updated: 2026-02-17*
 
 ---
 

--- a/.claude/session_notes.md
+++ b/.claude/session_notes.md
@@ -1,8 +1,8 @@
 # MeshForge Session Notes
 
-**Last Updated**: 2026-02-13
+**Last Updated**: 2026-02-17
 **Version**: v0.5.4-beta
-**Codebase**: 261 Python files, 291K+ lines, 4,046+ tests
+**Codebase**: 261 Python files, 291K+ lines, 1,411+ tests (gateway-essential)
 
 ---
 
@@ -131,7 +131,7 @@
 
 ---
 
-## Project Health Snapshot (2026-02-14)
+## Project Health Snapshot (2026-02-17)
 
 | Metric | Value | Status |
 |--------|-------|--------|
@@ -149,6 +149,24 @@
 ---
 
 ## Session Log
+
+### Session: Session Notes, README & Task List Update (2026-02-17)
+
+**What**: Updated session notes, TODO_PRIORITIES.md, and README.md with current backlog items from TUI-bridge API wiring work.
+
+**New backlog items added**:
+1. **MeshCore node listing** — `meshcore_mixin.py:_meshcore_nodes()` placeholder → wire to node_tracker
+2. **MeshCore stats** — `meshcore_mixin.py:_meshcore_stats()` static text → wire to bridge stats API
+3. **Classifier MeshCore categories** — `BRIDGE_MESHCORE` already in enum (`classifier.py:372`), needs end-to-end verification
+4. **Auto-review reliability triage** — 64 issues need real vs false positive classification
+
+**Findings**: `BRIDGE_MESHCORE` was already added to `RoutingCategory` enum with `meshcore` source network handling in the classifier. The TUI mixin (`meshcore_mixin.py`) has the menu structure wired but `_meshcore_nodes()` and `_meshcore_stats()` display placeholder guidance instead of live data.
+
+**Files modified**: `.claude/session_notes.md`, `.claude/TODO_PRIORITIES.md`, `README.md`
+
+**Entropy watch**: Documentation-only session. No code changes. Clean.
+
+---
 
 ### Session: Gateway Focus — Trim & Stabilize (2026-02-14)
 
@@ -295,6 +313,12 @@
 3. ~~**rnsd connection stable**~~ **DONE** (auto-fix removed, diagnose-don't-fix policy enforced)
 4. **Hardware test**: Deploy on MOC1/MOC2 with actual meshtasticd + rnsd + mosquitto
 5. **Verify end-to-end**: Send message Meshtastic → gateway → RNS and back
+
+**P1 — TUI-Bridge API Wiring**:
+1. **MeshCore node listing**: `meshcore_mixin.py:_meshcore_nodes()` shows placeholder text — wire to live `node_tracker` when bridge is running (filter by `meshcore:` prefix)
+2. **MeshCore stats**: `meshcore_mixin.py:_meshcore_stats()` shows static help text — wire to bridge stats API (`meshcore_rx`, `meshcore_tx`, `meshcore_acks`) when available
+3. **Classifier MeshCore categories**: `BRIDGE_MESHCORE` already exists in `RoutingCategory` enum (`classifier.py:372`) — verify 3-way classifier routing works end-to-end with MeshCore source network
+4. **Auto-review reliability triage**: 64 reliability issues from auto-review need manual review to separate real issues from false positives
 
 **P2 — After gateway works**:
 1. Event bus for RX message propagation (Issue #20 Phase 3)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.5.4--beta-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-green.svg" alt="License"></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/python-3.9+-yellow.svg" alt="Python"></a>
-  <a href="https://github.com/Nursedude/meshforge/actions"><img src="https://img.shields.io/badge/tests-1424%20passing-brightgreen.svg" alt="Tests"></a>
+  <a href="https://github.com/Nursedude/meshforge/actions"><img src="https://img.shields.io/badge/tests-1411%20passing-brightgreen.svg" alt="Tests"></a>
 </p>
 
 <p align="center">
@@ -296,6 +296,7 @@ python3 -c "from src.__version__ import show_version_history; show_version_histo
 | **AI PRO Mode** | Claude API integration, log analysis, predictive diagnostics | Beta (requires API key) |
 | **Protobuf HTTP Client** | Full device config via protobuf HTTP (8 device + 13 module configs, channels, traceroute, neighbor info) | Beta |
 | **Config API** | RESTful configuration management with NGINX reliability patterns | Beta |
+| **MeshCore** | Companion radio management, device detection, 3-way bridge classifier, TUI menu | Alpha |
 | **uConsole AIO V2** | Hardware detection, GPIO power control, meshtasticd auto-config | Code Ready (hardware Q2 2026) |
 
 **Status key:** Stable = tested in the field | Beta = works but needs soak time | Alpha = architecture solid, needs testing | Code Ready = implemented, no hardware to validate
@@ -610,11 +611,11 @@ sudo python3 src/utils/map_data_service.py
 ```
 src/
 ├── launcher_tui/          # Terminal UI (primary interface)
-│   ├── main.py            # NOC dispatcher + menus (1,512 lines)
+│   ├── main.py            # NOC dispatcher + menus (1,516 lines)
 │   ├── backend.py         # whiptail/dialog abstraction
 │   ├── startup_checks.py  # Environment checks + conflict resolution
 │   ├── status_bar.py      # Service status bar
-│   └── *_mixin.py         # 42 feature modules (RF, channels, AI, system, etc.)
+│   └── *_mixin.py         # 45 feature modules (RF, channels, AI, MeshCore, system, etc.)
 ├── gateway/               # Multi-mesh bridge
 │   ├── rns_bridge.py      # Meshtastic ↔ RNS transport
 │   ├── message_queue.py   # Persistent SQLite queue
@@ -789,7 +790,7 @@ connection (port 4403):
 
 ### Test Coverage
 
-**1,424 tests passing** across 42 gateway-essential test files:
+**1,411 tests passing** across 45 gateway-essential test files:
 
 | Test File | Tests | Covers |
 |-----------|-------|--------|
@@ -800,7 +801,7 @@ connection (port 4403):
 | `test_message_queue.py` | 72 | Persistent SQLite queue, retry policy, dead letter, overflow shedding |
 | `test_reconnect.py` | 45 | Exponential backoff, jitter, slow start recovery, thread safety |
 
-*Note: Test suite trimmed from 4,017 to 1,424 in v0.5.4 to focus on gateway-essential coverage. Non-gateway tests (RF tools, TUI mixins, monitoring, analytics, plugins) removed.*
+*Note: Test suite trimmed from 4,017 to 1,411 in v0.5.4 to focus on gateway-essential coverage. Non-gateway tests (RF tools, TUI mixins, monitoring, analytics, plugins) removed.*
 
 ```bash
 python3 -m pytest tests/ -v            # Run all tests


### PR DESCRIPTION
## Summary
Updated session notes, priority documentation, and README with current backlog items from TUI-bridge API wiring work. This is a documentation-only update reflecting the current state of MeshCore integration and pending work items.

## Key Changes

- **Session notes**: Added new session entry (2026-02-17) documenting TUI-Bridge API wiring findings:
  - `meshcore_mixin.py:_meshcore_nodes()` has placeholder text, needs wiring to live node_tracker
  - `meshcore_mixin.py:_meshcore_stats()` shows static help text, needs wiring to bridge stats API
  - `BRIDGE_MESHCORE` already exists in classifier enum, needs end-to-end verification
  - 64 reliability issues from auto-review need manual triage

- **Priority backlog**: Added new "TUI-Bridge API Wiring" section under Priority 1 with 4 specific tasks:
  - MeshCore node listing wiring
  - MeshCore stats API integration
  - Classifier 3-way routing verification
  - Auto-review reliability triage

- **Code metrics**: Updated file size tracking in TODO_PRIORITIES.md:
  - `rns_bridge.py`: 1,694 → 1,525 lines (after MeshCoreBridgeMixin extraction)
  - `service_menu_mixin.py`: 1,611 lines (new entry, monitor)
  - `launcher_tui/main.py`: 1,488 → 1,516 lines

- **README**: 
  - Updated test count: 1,424 → 1,411 (gateway-essential focus)
  - Added MeshCore to feature matrix (Alpha status)
  - Updated mixin count: 42 → 45 feature modules
  - Updated documentation timestamps

## Notable Details

- No source code changes; documentation reflects completed MeshCoreBridgeMixin extraction
- Backlog items are concrete and actionable with specific file/function references
- Test count reduction reflects intentional trim to gateway-essential coverage in v0.5.4

https://claude.ai/code/session_01JycbmTuR8cRMLXUAfGra3a