### PR TITLE
Add alpha install instructions for MeshCore integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,27 @@ sudo bash scripts/install_noc.sh --force-native        # Force SPI mode
 sudo bash scripts/install_noc.sh --force-python        # Force USB mode
 ```
 
+### Alpha Install (MeshCore Integration)
+
+To install the alpha version with MeshCore support (3-way routing between
+Meshtastic, Reticulum, and MeshCore networks):
+
+```bash
+git clone https://github.com/Nursedude/meshforge.git
+cd meshforge
+git checkout alpha/meshcore-bridge
+sudo bash scripts/install_noc.sh
+```
+
+The alpha branch (`0.6.0-alpha`) includes:
+- **MeshCore handler** — companion radio detection and management
+- **3-way message routing** — Meshtastic ↔ RNS ↔ MeshCore bridge
+- **Canonical message format** — unified multi-protocol message representation
+- **MeshCore TUI menu** — device management from the terminal interface
+
+> **Note:** The alpha branch is experimental and periodically rebased from `main`.
+> Report issues on the [alpha/meshcore-bridge](https://github.com/Nursedude/meshforge/issues) tracker.
+
 ### Already Have meshtasticd?
 
 ```bash


### PR DESCRIPTION
## Summary
Added documentation for the alpha version of meshforge that includes MeshCore network support, enabling 3-way message routing between Meshtastic, Reticulum, and MeshCore networks.

## Changes
- Added new "Alpha Install (MeshCore Integration)" section to README.md
- Documented installation steps for the `alpha/meshcore-bridge` branch
- Listed key alpha features:
  - MeshCore handler for companion radio detection and management
  - 3-way message routing between Meshtastic, RNS, and MeshCore
  - Canonical message format for unified multi-protocol representation
  - MeshCore TUI menu for device management
- Added note about experimental status and periodic rebasing from main branch
- Included link to alpha branch issue tracker for bug reporting

## Details
The documentation provides clear guidance for users interested in testing the experimental MeshCore integration while setting appropriate expectations about the alpha branch's stability and maintenance model.

https://claude.ai/code/session_01UKY6c4eX8A6aznLgYKnE7z