### PR TITLE
Document MeshCore gateway architecture and connection options

### DIFF
--- a/.claude/research/meshcore_proxy_analysis.md
+++ b/.claude/research/meshcore_proxy_analysis.md
@@ -411,28 +411,73 @@ class MessageTracer:
 |--------|---------------------------|-----------|
 | **Language** | C++ (embedded) | Python 3.9+ |
 | **Target** | Firmware (RAK4631, LoRa32u4II) | Linux/Raspberry Pi |
-| **Protocols** | MeshCore ↔ Meshtastic | RNS/LXMF ↔ Meshtastic |
-| **Message Format** | Canonical intermediate | Direct translation |
+| **Protocols** | MeshCore ↔ Meshtastic | MeshCore ↔ Meshtastic ↔ RNS/LXMF |
+| **Message Format** | Canonical intermediate | CanonicalMessage (implemented) |
 | **Reliability** | Counter overflow, config dedup | Exponential backoff, health monitor |
 | **Persistence** | None (RAM only) | SQLite message queue |
 | **UI** | WebSerial PWA | TUI (whiptail/dialog) |
-| **MQTT Handling** | Filter at bridge | Monitor/consume |
+| **MQTT Handling** | Filter at bridge | Filter + monitor (origin tracking) |
+
+---
+
+## Gateway Connection Architecture
+
+The MeshForge gateway bridges three mesh protocols. Each protocol connects to
+its radio differently:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   MeshForge Gateway Host                │
+│                                                         │
+│  Meshtastic radio ── USB ──> meshtasticd ── TCP :4403 ──┤
+│                                                         │
+│  MeshCore radio ─── USB serial ─────────────────────────┤──> Gateway
+│                  or TCP (WiFi firmware / ser2net)        │    Bridge
+│                  or BLE (future)                         │
+│                                                         │
+│  RNS transport ──── rnsd / direct ──────────────────────┤
+└─────────────────────────────────────────────────────────┘
+```
+
+### MeshCore companion radio connection options
+
+| Method | Transport | Config | Use Case |
+|--------|-----------|--------|----------|
+| **Serial** | USB cable | `device_path: /dev/ttyUSB1` | Most common — direct USB to companion radio |
+| **TCP** | WiFi / LAN | `tcp_host: <ip>, tcp_port: 4000` | Companion on WiFi firmware, or serial-to-TCP bridge |
+| **BLE** | Bluetooth LE | `connection_type: ble` | Wireless — config ready, pending meshcore_py support |
+
+### Meshtastic node connection
+
+Meshtastic uses a daemon (`meshtasticd`) that owns the serial connection to the
+radio. MeshForge connects to `meshtasticd` over TCP (default `localhost:4403`).
+The Meshtastic radio is typically USB-attached to the same host.
+
+### Typical two-radio gateway setup
+
+The simplest gateway setup uses two USB radios on the same host:
+- `/dev/ttyUSB0` — Meshtastic radio (managed by meshtasticd)
+- `/dev/ttyUSB1` — MeshCore companion radio (managed directly by MeshForge)
+
+Both radios are LoRa devices but operate on different frequencies and modulation
+parameters (see Protocol-Specific Radio Configuration above), so they do not
+interfere with each other.
 
 ---
 
 ## Implementation Roadmap
 
-### Phase 1: Reliability (Sprint)
-1. Implement circuit breaker for message queue
-2. Add cross-network health dependency checks
-3. Add message origin tracking
-4. Audit timeout coverage
+### Phase 1: Reliability — DONE
+1. ~~Implement circuit breaker for message queue~~
+2. ~~Add cross-network health dependency checks~~
+3. ~~Add message origin tracking~~
+4. ~~Audit timeout coverage~~
 
-### Phase 2: Extensibility (Sprint)
-1. Design canonical message format
-2. Implement protocol adapters (Meshtastic, RNS)
-3. Add lenient parsing mode
-4. Create protocol plugin interface
+### Phase 2: Extensibility — DONE
+1. ~~Design canonical message format~~ (CanonicalMessage)
+2. ~~Implement protocol adapters (Meshtastic, RNS, MeshCore)~~
+3. ~~Add lenient parsing mode~~
+4. ~~Create protocol plugin interface~~
 
 ### Phase 3: Observability (Sprint)
 1. Prometheus metrics export
@@ -440,16 +485,18 @@ class MessageTracer:
 3. Distributed tracing
 4. Health event persistence
 
-### Phase 4: MeshCore Support (Future)
-1. Add MeshCore protocol adapter
-2. Implement frequency switching logic
-3. Test interoperability
-4. Document integration
+### Phase 4: MeshCore Hardening (In Progress)
+1. ~~Add MeshCore protocol adapter~~ (meshcore_handler.py)
+2. ~~Implement three-way bridge routing~~ (meshcore_bridge_mixin.py)
+3. Wire up BLE transport when meshcore_py supports it
+4. Field test interoperability
 
 ---
 
 ## References
 
+- MeshCore: https://github.com/meshcore-dev/MeshCore
+- MeshCore CLI (Python): https://github.com/fdlamotte/meshcore-cli
 - MeshCore-Meshtastic-Proxy: https://github.com/wdunn001/MeshCore-Meshtastic-Proxy
 - MeshCore Protocol: Radio mesh at 910.525 MHz, SF7, BW 62.5 kHz
 - Meshtastic LongFast: 906.875 MHz, SF11, BW 250 kHz
@@ -458,3 +505,4 @@ class MessageTracer:
 ---
 
 *Analysis conducted for MeshForge v0.4.8-alpha enhancement planning*
+*Updated 2026-02-17: Reflects implemented MeshCore support and connection options*

--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -254,21 +254,26 @@ class MeshCoreConfig:
     """
     MeshCore companion radio configuration.
 
-    MeshCore uses a direct connection to a companion radio via USB serial
-    (or TCP/BLE). Unlike Meshtastic, there is no daemon — MeshForge manages
-    the connection directly via meshcore_py.
+    Unlike Meshtastic (which uses meshtasticd as a daemon), MeshForge connects
+    directly to the MeshCore companion radio via meshcore_py. Three connection
+    methods are supported:
+
+      serial  — USB cable to companion radio (most common for gateway setups)
+      tcp     — Network connection to a companion radio running WiFi firmware,
+                or to a serial-to-TCP bridge (e.g. ser2net)
+      ble     — Bluetooth LE (config ready; pending meshcore_py BLE transport)
 
     Requires: pip install meshcore (Python 3.10+)
     Hardware: MeshCore companion radio (RAK4631, Heltec V3, T-Deck, etc.)
     """
     enabled: bool = False
 
-    # Connection settings
-    device_path: str = "/dev/ttyUSB1"    # USB serial device
-    baud_rate: int = 115200
+    # Connection settings — choose one of: serial | tcp | ble
+    device_path: str = "/dev/ttyUSB1"    # Serial: USB device path
+    baud_rate: int = 115200              # Serial: baud rate
     connection_type: str = "serial"       # serial | tcp | ble
-    tcp_host: str = ""
-    tcp_port: int = 4000
+    tcp_host: str = ""                   # TCP: hostname or IP
+    tcp_port: int = 4000                 # TCP: port (meshcore-cli default 5000)
 
     # Message handling
     auto_fetch_messages: bool = True      # Start auto message fetching on connect

--- a/src/gateway/meshcore_handler.py
+++ b/src/gateway/meshcore_handler.py
@@ -11,8 +11,19 @@ Uses the same dependency injection pattern as MeshtasticHandler:
 - stats: Shared statistics dict
 - callbacks: Message/status notification
 
+Connection methods (meshcore-cli / meshcore_py):
+- Serial (USB): Direct USB to companion radio (e.g. /dev/ttyUSB1 @ 115200)
+- TCP/IP:       Network connection to companion radio on WiFi firmware
+                or a serial-to-TCP bridge (default port 4000)
+- BLE:          Bluetooth LE to companion radio (config ready, handler
+                pending meshcore_py BLE transport support)
+
+Typical gateway setup uses two radios on the same host:
+  Meshtastic radio  -->  meshtasticd (USB)  -->  TCP :4403  -->  MeshForge
+  MeshCore radio    -->  USB serial or TCP  ------------------>  MeshForge
+
 MeshCore differences from Meshtastic:
-- No daemon (direct USB serial connection via meshcore_py)
+- No daemon (MeshForge connects directly via meshcore_py)
 - Async API (wrapped in dedicated asyncio event loop thread)
 - Pure radio (no MQTT/internet origin — all messages are radio)
 - Up to 64 hops (vs 7 for Meshtastic)


### PR DESCRIPTION
## Summary

This PR updates documentation and configuration to clarify MeshCore radio connection architecture in the MeshForge gateway, reflecting completed implementation of MeshCore support and three-way protocol bridging.

## Key Changes

**Documentation (`meshcore_proxy_analysis.md`)**
- Updated protocol comparison table to reflect MeshCore ↔ Meshtastic ↔ RNS/LXMF three-way bridging
- Added new "Gateway Connection Architecture" section with ASCII diagram showing how three mesh protocols connect to the gateway host
- Documented three MeshCore companion radio connection methods (Serial/USB, TCP/IP, BLE) with use cases and configuration
- Clarified Meshtastic daemon architecture (meshtasticd TCP connection) vs. direct MeshCore connection
- Added typical two-radio gateway setup example
- Updated implementation roadmap to mark Phase 1-2 as complete and Phase 4 as "In Progress" with specific completed tasks
- Added references to MeshCore repositories and updated timestamp

**Configuration (`src/gateway/config.py`)**
- Expanded `MeshCoreConfig` docstring to explain three connection methods (serial, tcp, ble)
- Added inline comments clarifying which settings apply to each connection type
- Documented that BLE is config-ready but pending meshcore_py support
- Clarified TCP port default (4000) vs. meshcore-cli default (5000)

**Handler Documentation (`src/gateway/meshcore_handler.py`)**
- Added connection methods section documenting Serial, TCP/IP, and BLE transports
- Added typical gateway setup diagram showing two-radio configuration
- Clarified that MeshForge connects directly to MeshCore (no daemon) vs. Meshtastic's meshtasticd architecture

## Implementation Details

- No functional code changes; documentation-only update
- Reflects actual implementation state: MeshCore adapter, three-way bridge routing, and origin tracking are complete
- Provides clear guidance for users deploying two-radio gateway setups with USB or network-connected companion radios
- Maintains consistency across analysis document, configuration schema, and handler module documentation

https://claude.ai/code/session_01PntAUge3tT1ScEGaesfDii