### PR TITLE
Suppress signal handler registration in background threads

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -5,10 +5,12 @@ Bridges Reticulum Network Stack and Meshtastic networks
 MeshCore bridge processing extracted to meshcore_bridge_mixin.py.
 """
 
+import signal as _signal_mod
 import threading
 import time
 import logging
 import subprocess
+from contextlib import contextmanager
 from queue import Queue, Empty, Full
 from datetime import datetime
 from typing import Optional, Callable, Dict, Any
@@ -1005,6 +1007,36 @@ class RNSMeshtasticBridge(MeshCoreBridgeMixin):
         except Exception as e:
             logger.debug(f"Persistent queue drain error: {e}")
 
+    @staticmethod
+    @contextmanager
+    def _suppress_signal_in_thread():
+        """Suppress signal.signal() calls when not in the main thread.
+
+        LXMF.LXMRouter() and RNS.Reticulum() internally register signal
+        handlers for graceful shutdown. When called from a background
+        thread, signal.signal() raises ValueError. This context manager
+        temporarily replaces signal.signal with a safe wrapper that
+        returns SIG_DFL instead of raising.
+
+        On the main thread, this is a no-op passthrough.
+        """
+        if threading.current_thread() is threading.main_thread():
+            yield
+            return
+
+        original = _signal_mod.signal
+
+        def _safe_signal(signalnum, handler):
+            # Cannot register signal handlers from non-main thread.
+            # Return default disposition; bridge has its own shutdown logic.
+            return _signal_mod.SIG_DFL
+
+        _signal_mod.signal = _safe_signal
+        try:
+            yield
+        finally:
+            _signal_mod.signal = original
+
     def _init_rns_main_thread(self):
         """Pre-initialize RNS from the main thread.
 
@@ -1095,44 +1127,49 @@ class RNSMeshtasticBridge(MeshCoreBridgeMixin):
         RNS = _RNS_mod
         LXMF = _LXMF_mod
 
-        try:
-            if self._rns_pre_initialized:
-                logger.info("RNS pre-initialized, proceeding to LXMF setup")
-            else:
-                # Fallback: init RNS from background thread.
-                # Works when rnsd is running (client mode, no signal handlers).
-                config_dir = self.config.rns.config_dir or None
-                if not config_dir:
+        # Both RNS.Reticulum() and LXMF.LXMRouter() register signal
+        # handlers internally. When _connect_rns is called from the
+        # background _rns_loop thread, signal.signal() raises ValueError.
+        # Suppress signal registration for the entire init sequence.
+        with self._suppress_signal_in_thread():
+            try:
+                if self._rns_pre_initialized:
+                    logger.info("RNS pre-initialized, proceeding to LXMF setup")
+                else:
+                    # Fallback: init RNS from background thread.
+                    # Works when rnsd is running (client mode, no signal handlers).
+                    config_dir = self.config.rns.config_dir or None
+                    if not config_dir:
+                        try:
+                            effective = get_rnsd_effective_config_dir()
+                            config_dir = str(effective)
+                        except Exception:
+                            pass  # Use RNS default resolution
+
                     try:
-                        effective = get_rnsd_effective_config_dir()
-                        config_dir = str(effective)
-                    except Exception:
-                        pass  # Use RNS default resolution
+                        self._reticulum = RNS.Reticulum(configdir=config_dir)
+                    except Exception as e:
+                        err_msg = str(e).lower()
+                        if "reinitialise" in err_msg or "already running" in err_msg:
+                            logger.info("RNS already initialized, proceeding to LXMF")
+                        elif "signal only works in main thread" in err_msg:
+                            logger.warning("RNS needs main thread init (no rnsd running?)")
+                            self._rns_init_failed_permanently = True
+                            self._connected_rns = False
+                            return
+                        elif hasattr(e, 'errno') and getattr(e, 'errno', None) == 98:
+                            logger.warning(f"RNS port conflict: {e} (will retry)")
+                            self._connected_rns = False
+                            return
+                        else:
+                            raise
 
-                try:
-                    self._reticulum = RNS.Reticulum(configdir=config_dir)
-                except Exception as e:
-                    err_msg = str(e).lower()
-                    if "reinitialise" in err_msg or "already running" in err_msg:
-                        logger.info("RNS already initialized, proceeding to LXMF")
-                    elif "signal only works in main thread" in err_msg:
-                        logger.warning("RNS needs main thread init (no rnsd running?)")
-                        self._rns_init_failed_permanently = True
-                        self._connected_rns = False
-                        return
-                    elif hasattr(e, 'errno') and getattr(e, 'errno', None) == 98:
-                        logger.warning(f"RNS port conflict: {e} (will retry)")
-                        self._connected_rns = False
-                        return
-                    else:
-                        raise
+                # Set up LXMF messaging on top of the RNS instance
+                self._setup_lxmf(RNS, LXMF)
 
-            # Set up LXMF messaging on top of the RNS instance
-            self._setup_lxmf(RNS, LXMF)
-
-        except Exception as e:
-            logger.error(f"Failed to connect to RNS: {e}")
-            self._connected_rns = False
+            except Exception as e:
+                logger.error(f"Failed to connect to RNS: {e}")
+                self._connected_rns = False
 
     def _setup_lxmf(self, RNS, LXMF):
         """Set up LXMF identity, router, and announce handler.

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -1182,6 +1182,68 @@ class TestRNSConnectionFlow:
         bridge._rns_loop()
         # Verify it ran without error (no assertion on logger needed)
 
+    def test_suppress_signal_noop_on_main_thread(self, bridge):
+        """Signal suppression is a no-op passthrough on the main thread."""
+        import signal
+        original = signal.signal
+        with bridge._suppress_signal_in_thread():
+            assert signal.signal is original
+
+    def test_suppress_signal_replaces_in_background_thread(self, bridge):
+        """Signal suppression replaces signal.signal in background threads."""
+        import signal
+        results = {}
+
+        def _check():
+            with bridge._suppress_signal_in_thread():
+                results['replaced'] = signal.signal is not _original
+                # Should return SIG_DFL instead of raising ValueError
+                results['retval'] = signal.signal(signal.SIGTERM, signal.SIG_DFL)
+            results['restored'] = signal.signal is _original
+
+        _original = signal.signal
+        t = threading.Thread(target=_check)
+        t.start()
+        t.join(timeout=5)
+
+        assert results.get('replaced') is True
+        assert results.get('retval') == signal.SIG_DFL
+        assert results.get('restored') is True
+
+    def test_connect_rns_lxmf_signal_error_handled(self, bridge):
+        """LXMF signal error in background thread is suppressed by context manager."""
+        import signal as _signal_mod
+        bridge._rns_pre_initialized = True
+
+        mock_rns = MagicMock()
+        mock_lxmf = MagicMock()
+
+        # Simulate LXMF.LXMRouter() calling signal.signal() internally
+        def lxmf_router_init(*args, **kwargs):
+            # This would fail in a real background thread without suppression
+            _signal_mod.signal(_signal_mod.SIGTERM, _signal_mod.SIG_DFL)
+            return MagicMock()
+
+        mock_lxmf.LXMRouter = lxmf_router_init
+
+        with patch('gateway.rns_bridge._RNS_mod', mock_rns), \
+             patch('gateway.rns_bridge._LXMF_mod', mock_lxmf), \
+             patch('gateway.rns_bridge._HAS_RNS', True), \
+             patch('gateway.rns_bridge._HAS_LXMF', True):
+            # Run from background thread to trigger suppression
+            errors = []
+            def _run():
+                try:
+                    bridge._connect_rns()
+                except Exception as e:
+                    errors.append(e)
+
+            t = threading.Thread(target=_run)
+            t.start()
+            t.join(timeout=5)
+
+            assert not errors, f"Unexpected errors: {errors}"
+
 
 # ---------------------------------------------------------------------------
 # Module-level headless helpers


### PR DESCRIPTION
## Summary
This PR fixes a `ValueError` that occurs when RNS and LXMF libraries attempt to register signal handlers from background threads. Both libraries internally call `signal.signal()` during initialization, which is only allowed from the main thread in Python.

## Changes
- **Added `_suppress_signal_in_thread()` context manager**: A static context manager that safely wraps `signal.signal()` calls when executed in background threads. On the main thread, it's a no-op passthrough. In background threads, it temporarily replaces `signal.signal()` with a safe wrapper that returns `SIG_DFL` instead of raising `ValueError`.

- **Wrapped RNS/LXMF initialization in `_connect_rns()`**: The entire RNS and LXMF initialization sequence is now wrapped with the signal suppression context manager, allowing these libraries to initialize successfully from the background `_rns_loop` thread.

- **Added comprehensive test coverage**: Three new tests verify:
  - Signal suppression is a no-op on the main thread
  - Signal suppression correctly replaces `signal.signal` in background threads
  - LXMF initialization with internal signal calls succeeds in background threads

## Implementation Details
- The context manager uses `threading.current_thread()` to detect if it's running on the main thread
- Signal handler restoration is guaranteed via try/finally block
- The solution is transparent to callers and doesn't affect normal signal handling on the main thread
- Works with both direct RNS initialization and LXMF router setup

https://claude.ai/code/session_01JfCF3odTWUH5UHZaNAn6o2