### PR TITLE
fix: Use UDP bind-test for RNS port 37428 instead of TCP connect

### DIFF
--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -116,14 +116,30 @@ def check_rns_port():
         except Exception:
             pass
 
-    # Check shared instance port
+    # Check shared instance port (RNS uses UDP, not TCP)
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(2)
-        result = sock.connect_ex(('127.0.0.1', 37428))
-        sock.close()
-        if result == 0:
-            print_status("RNS shared instance", True, "listening on 37428")
+        from utils.service_check import check_udp_port
+        port_bound = check_udp_port(37428)
+    except ImportError:
+        # Fallback: inline UDP bind test
+        port_bound = False
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(2)
+            sock.bind(('127.0.0.1', 37428))
+            sock.close()
+            # Bind succeeded = port NOT in use
+        except OSError as e:
+            if e.errno in (98, 48, 10048):  # EADDRINUSE
+                port_bound = True
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+    try:
+        if port_bound:
+            print_status("RNS shared instance", True, "listening on UDP 37428")
         else:
             print_status("RNS shared instance", False, "not running")
     except Exception as e:

--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -21,8 +21,8 @@ from pathlib import Path
 from utils.safe_import import safe_import
 
 # Module-level safe imports
-_check_port, _check_systemd_service, _check_process_running, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_port', 'check_systemd_service', 'check_process_running'
+_check_port, _check_udp_port, _check_systemd_service, _check_process_running, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_port', 'check_udp_port', 'check_systemd_service', 'check_process_running'
 )
 
 _find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
@@ -107,15 +107,39 @@ def _is_meshforge_process_running():
     return False
 
 
-def check_port(port):
-    """Check if a TCP port is listening.
+# UDP ports that require bind-test instead of TCP connect
+_UDP_PORTS = {37428}  # RNS shared instance
 
-    Uses centralized service_check module when available.
+
+def check_port(port):
+    """Check if a port is in use.
+
+    Uses UDP bind-test for known UDP ports (e.g., RNS 37428),
+    TCP connect for everything else.
     """
+    if port in _UDP_PORTS:
+        if _HAS_SERVICE_CHECK:
+            return _check_udp_port(port)
+        # Fallback: inline UDP bind test
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            sock.settimeout(1)
+            sock.bind(('127.0.0.1', port))
+            sock.close()
+            return False  # Bind succeeded = port NOT in use
+        except OSError as e:
+            return e.errno in (98, 48, 10048)  # EADDRINUSE = in use
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+        return False
+
     if _HAS_SERVICE_CHECK:
         return _check_port(port, host='127.0.0.1', timeout=1.0)
 
-    # Fallback to direct socket check
+    # Fallback to direct TCP socket check
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         sock.settimeout(1)

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 from utils.safe_import import safe_import
 
 # Import centralized service checking
-check_systemd_service, check_process_running, _check_port, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port'
+check_systemd_service, check_process_running, _check_port, _check_udp_port, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port', 'check_udp_port'
 )
 
 # Optional modules for quick actions
@@ -275,12 +275,26 @@ class QuickActionsMixin:
             (1883, 'MQTT broker'),
         ]
 
+        # RNS uses UDP port 37428, all others are TCP
+        _udp_ports = {37428}
+
         for port, desc in ports:
             try:
-                if _HAS_SERVICE_CHECK:
+                if port in _udp_ports:
+                    if _HAS_SERVICE_CHECK:
+                        port_open = _check_udp_port(port)
+                    else:
+                        try:
+                            with sock.socket(sock.AF_INET, sock.SOCK_DGRAM) as s:
+                                s.settimeout(1)
+                                s.bind(('127.0.0.1', port))
+                                port_open = False  # Bind OK = not in use
+                        except OSError as e:
+                            port_open = e.errno in (98, 48, 10048)
+                elif _HAS_SERVICE_CHECK:
                     port_open = _check_port(port, host='127.0.0.1', timeout=1.0)
                 else:
-                    # Fallback to direct socket check
+                    # Fallback to direct TCP socket check
                     with sock.socket(sock.AF_INET, sock.SOCK_STREAM) as s:
                         s.settimeout(1)
                         result = s.connect_ex(('127.0.0.1', port))

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -17,8 +17,8 @@ from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 from utils.safe_import import safe_import
 
-check_process_running, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running'
+check_process_running, check_udp_port, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', 'check_udp_port'
 )
 
 get_identity_path, create_identities, list_known_destinations, \
@@ -120,17 +120,32 @@ class RNSDiagnosticsMixin:
             print(f"  Could not check: {e}")
 
         # Check if shared instance port is actually listening
-        import socket
+        # RNS uses UDP port 37428, NOT TCP — must use UDP bind test
         try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                s.settimeout(1)
-                port_ok = s.connect_ex(('127.0.0.1', 37428)) == 0
+            if _HAS_SERVICE_CHECK:
+                port_ok = check_udp_port(37428)
+            else:
+                # Fallback: try UDP bind test inline
+                import socket
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    sock.settimeout(1)
+                    sock.bind(('127.0.0.1', 37428))
+                    sock.close()
+                    port_ok = False  # Bind succeeded = port NOT in use
+                except OSError as e:
+                    port_ok = e.errno in (98, 48, 10048)  # EADDRINUSE = port in use
+                finally:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
             if running and not port_ok:
                 print("  ! rnsd running but port 37428 NOT listening")
                 warnings.append("rnsd active but shared instance port not bound")
             elif running and port_ok:
                 print(f"  Shared instance port 37428: listening")
-        except OSError:
+        except Exception:
             pass
 
         # Summary
@@ -346,20 +361,32 @@ class RNSDiagnosticsMixin:
             print("Try restarting rnsd: sudo systemctl restart rnsd")
 
     def _wait_for_rns_port(self, max_wait: int = 10) -> bool:
-        """Wait for rnsd to start listening on port 37428.
+        """Wait for rnsd to start listening on UDP port 37428.
 
-        Polls the port with 1-second intervals. Returns True if port
-        becomes available, False if timeout expires.
+        Polls the port with 1-second intervals using UDP bind test.
+        Returns True if port becomes available, False if timeout expires.
         """
-        import socket
         for i in range(max_wait):
-            try:
-                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                    s.settimeout(1)
-                    if s.connect_ex(('127.0.0.1', 37428)) == 0:
+            if _HAS_SERVICE_CHECK:
+                if check_udp_port(37428):
+                    return True
+            else:
+                # Fallback: inline UDP bind test
+                import socket
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                    sock.settimeout(1)
+                    sock.bind(('127.0.0.1', 37428))
+                    sock.close()
+                    # Bind succeeded = port NOT in use, keep waiting
+                except OSError as e:
+                    if e.errno in (98, 48, 10048):  # EADDRINUSE
                         return True
-            except OSError:
-                pass
+                finally:
+                    try:
+                        sock.close()
+                    except Exception:
+                        pass
             time.sleep(1)
         return False
 

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -1151,17 +1151,30 @@ class MapDataCollector:
         """
         features = []
 
-        # Quick check if rnsd shared instance is running (port 37428)
+        # Quick check if rnsd shared instance is running (UDP port 37428)
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(2)
-            result = sock.connect_ex(('localhost', 37428))
-            sock.close()
-            if result != 0:
+            from utils.service_check import check_udp_port
+            if not check_udp_port(37428):
                 logger.debug("rnsd shared instance not available on port 37428")
                 return []
-        except OSError:
-            return []
+        except ImportError:
+            # Fallback: inline UDP bind test
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                sock.settimeout(2)
+                sock.bind(('127.0.0.1', 37428))
+                sock.close()
+                # Bind succeeded = port NOT in use
+                logger.debug("rnsd shared instance not available on port 37428")
+                return []
+            except OSError as e:
+                if e.errno not in (98, 48, 10048):  # Not EADDRINUSE = real error
+                    return []
+            finally:
+                try:
+                    sock.close()
+                except Exception:
+                    pass
 
         if not _HAS_RNS:
             logger.debug("RNS module not available for direct query")


### PR DESCRIPTION
RNS shared instance uses UDP port 37428, but all diagnostic and status checks were using TCP socket connect (SOCK_STREAM), which always reports the port as "not listening" even when rnsd is properly bound. This caused false "rnsd running but port 37428 NOT listening" warnings and made the repair tool's _wait_for_rns_port() never succeed.

Fixed in 5 files:
- rns_diagnostics_mixin.py: connectivity check + _wait_for_rns_port()
- cli/diagnose.py: shared instance check
- cli/status.py: generic check_port() now UDP-aware for known UDP ports
- quick_actions_mixin.py: port check display
- map_data_collector.py: rnsd availability check

All use check_udp_port() from service_check.py (which already had the correct implementation) with inline UDP bind-test fallbacks.

https://claude.ai/code/session_01JfCF3odTWUH5UHZaNAn6o2