### PR TITLE
feat: Remove root requirement — MeshForge runs as normal user

### DIFF
--- a/src/launcher.py
+++ b/src/launcher.py
@@ -436,12 +436,6 @@ def main():
                 print(f"\n{Colors.YELLOW}Verification completed with issues.{Colors.NC}")
                 sys.exit(2)
 
-    # Check root
-    if os.geteuid() != 0:
-        print(f"\n{Colors.RED}Error: This application requires root/sudo privileges{Colors.NC}")
-        print(f"Please run with: {Colors.CYAN}sudo python3 src/launcher.py{Colors.NC}")
-        sys.exit(1)
-
     # Direct interface flag (skip menu)
     if '--tui' in sys.argv:
         launch_interface('1')

--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -44,6 +44,9 @@ ReviewOrchestrator, ReviewScope, _HAS_AUTO_REVIEW = safe_import(
     'utils.auto_review', 'ReviewOrchestrator', 'ReviewScope'
 )
 
+# Import _sudo_cmd for privileged systemctl calls
+_sudo_cmd, _HAS_SUDO_CMD = safe_import('utils.service_check', '_sudo_cmd')
+
 logger = logging.getLogger(__name__)
 
 
@@ -162,7 +165,7 @@ class AIToolsMixin:
 
             # Start the service
             subprocess.run(
-                ['systemctl', 'start', 'meshforge-map'],
+                _sudo_cmd(['systemctl', 'start', 'meshforge-map']),
                 capture_output=True, timeout=10
             )
 
@@ -422,7 +425,7 @@ class AIToolsMixin:
 
             # Start the service
             subprocess.run(
-                ['systemctl', 'start', 'meshforge-map'],
+                _sudo_cmd(['systemctl', 'start', 'meshforge-map']),
                 capture_output=True, timeout=10
             )
 

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -40,8 +40,8 @@ if not _HAS_PATHS:
         return Path('/root')
 
 # Import service check
-check_service, apply_config_and_restart, _HAS_APPLY_RESTART = safe_import(
-    'utils.service_check', 'check_service', 'apply_config_and_restart'
+check_service, apply_config_and_restart, _sudo_cmd, _HAS_APPLY_RESTART = safe_import(
+    'utils.service_check', 'check_service', 'apply_config_and_restart', '_sudo_cmd'
 )
 
 # Import device scanner
@@ -361,8 +361,8 @@ class FirstRunMixin:
             if _HAS_APPLY_RESTART:
                 success, msg = apply_config_and_restart('meshtasticd')
             else:
-                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
 
             self.dialog.msgbox(
                 "Configuration Applied",
@@ -557,8 +557,8 @@ class FirstRunMixin:
             if _HAS_APPLY_RESTART:
                 success, msg = apply_config_and_restart('meshtasticd')
             else:
-                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
 
             self.dialog.msgbox(
                 "Configuration Applied",
@@ -598,8 +598,8 @@ Serial:
             if _HAS_APPLY_RESTART:
                 success, msg = apply_config_and_restart('meshtasticd')
             else:
-                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
 
             self.dialog.msgbox(
                 "USB Configured",

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -54,8 +54,8 @@ from utils.paths import get_real_user_home, ReticulumPaths
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH for service status
 # See: utils/service_check.py and .claude/foundations/install_reliability_triage.md
-check_service, check_port, apply_config_and_restart, ServiceState, _HAS_APPLY_RESTART = safe_import(
-    'utils.service_check', 'check_service', 'check_port', 'apply_config_and_restart', 'ServiceState'
+check_service, check_port, apply_config_and_restart, ServiceState, _sudo_cmd, _HAS_APPLY_RESTART = safe_import(
+    'utils.service_check', 'check_service', 'check_port', 'apply_config_and_restart', 'ServiceState', '_sudo_cmd'
 )
 
 # Import dialog backend directly (not through package namespace)
@@ -375,11 +375,6 @@ class MeshForgeLauncher(
 
     def run(self):
         """Run the launcher."""
-        if not self.env['is_root']:
-            print("\nError: MeshForge requires root/sudo privileges")
-            print("Please run: sudo python3 src/launcher_tui/main.py")
-            sys.exit(1)
-
         if not self.dialog.available:
             # Fallback to basic launcher
             print("whiptail/dialog not available, using basic launcher...")
@@ -579,8 +574,8 @@ class MeshForgeLauncher(
                     if _HAS_APPLY_RESTART:
                         success, msg = apply_config_and_restart('meshtasticd')
                     else:
-                        subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                        subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                        subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                        subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
                     self.dialog.msgbox(
                         "Fixed",
                         "Removed usb-serial.yaml\n"
@@ -1150,10 +1145,10 @@ class MeshForgeLauncher(
 
             if choice == "reboot":
                 if self.dialog.yesno("Confirm Reboot", "Reboot the system now?"):
-                    subprocess.run(['systemctl', 'reboot'], timeout=30)
+                    subprocess.run(_sudo_cmd(['systemctl', 'reboot']), timeout=30)
             elif choice == "shutdown":
                 if self.dialog.yesno("Confirm Shutdown", "Shutdown the system now?"):
-                    subprocess.run(['systemctl', 'poweroff'], timeout=30)
+                    subprocess.run(_sudo_cmd(['systemctl', 'poweroff']), timeout=30)
 
     # --- NEW Submenu: About (a) ---
 

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -17,8 +17,8 @@ logger = logging.getLogger(__name__)
 from utils.safe_import import safe_import
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH
-check_service, check_systemd_service, ServiceState, apply_config_and_restart, _HAS_APPLY_RESTART = safe_import(
-    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState', 'apply_config_and_restart'
+check_service, check_systemd_service, ServiceState, apply_config_and_restart, _sudo_cmd, _HAS_APPLY_RESTART = safe_import(
+    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState', 'apply_config_and_restart', '_sudo_cmd'
 )
 
 # Hoist function-level imports to module level
@@ -529,9 +529,9 @@ Press Cancel to keep current values."""
             if _HAS_APPLY_RESTART:
                 success, msg = apply_config_and_restart('meshtasticd')
             else:
-                subprocess.run(['systemctl', 'daemon-reload'],
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']),
                                capture_output=True, timeout=10)
-                subprocess.run(['systemctl', 'restart', 'meshtasticd'],
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']),
                                capture_output=True, timeout=30)
 
             self.dialog.msgbox("Success",
@@ -1028,11 +1028,11 @@ Press Cancel to keep current values."""
                 else:
                     self.dialog.msgbox("Error", f"Restart failed:\n{msg}")
             else:
-                subprocess.run(['systemctl', 'daemon-reload'],
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']),
                                capture_output=True, timeout=10)
 
                 result = subprocess.run(
-                    ['systemctl', 'restart', 'meshtasticd'],
+                    _sudo_cmd(['systemctl', 'restart', 'meshtasticd']),
                     capture_output=True,
                     text=True,
                     timeout=30

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 from utils.safe_import import safe_import
 
 # Import centralized service checking
-check_process_running, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running'
+check_process_running, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', '_sudo_cmd'
 )
 
 # Import for sudo-safe home directory - see persistent_issues.md Issue #1
@@ -1168,7 +1168,7 @@ class NomadNetClientMixin:
                 # Just stop rnsd
                 self.dialog.infobox("Stopping rnsd", "Stopping rnsd service...")
                 try:
-                    subprocess.run(['systemctl', 'stop', 'rnsd'], capture_output=True, timeout=10)
+                    subprocess.run(_sudo_cmd(['systemctl', 'stop', 'rnsd']), capture_output=True, timeout=10)
                     subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
                     time.sleep(1)
                     self.dialog.msgbox(
@@ -1212,7 +1212,7 @@ class NomadNetClientMixin:
             elif choice == "stop":
                 self.dialog.infobox("Stopping rnsd", "Stopping rnsd service...")
                 try:
-                    subprocess.run(['systemctl', 'stop', 'rnsd'], capture_output=True, timeout=10)
+                    subprocess.run(_sudo_cmd(['systemctl', 'stop', 'rnsd']), capture_output=True, timeout=10)
                     subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
                     time.sleep(1)
                     self.dialog.msgbox(
@@ -1253,11 +1253,11 @@ Group={target_user}
             override_file.write_text(override_content)
 
             # Reload systemd and restart rnsd
-            subprocess.run(['systemctl', 'daemon-reload'], capture_output=True, timeout=10)
-            subprocess.run(['systemctl', 'stop', 'rnsd'], capture_output=True, timeout=10)
+            subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), capture_output=True, timeout=10)
+            subprocess.run(_sudo_cmd(['systemctl', 'stop', 'rnsd']), capture_output=True, timeout=10)
             subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
             time.sleep(1)
-            subprocess.run(['systemctl', 'start', 'rnsd'], capture_output=True, timeout=10)
+            subprocess.run(_sudo_cmd(['systemctl', 'start', 'rnsd']), capture_output=True, timeout=10)
             time.sleep(2)
 
             # Verify it's running as the right user now

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -29,8 +29,8 @@ logger = logging.getLogger(__name__)
 from utils.safe_import import safe_import
 
 # Import centralized service checking
-check_systemd_service, check_process_running, _check_port, _check_udp_port, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port', 'check_udp_port'
+check_systemd_service, check_process_running, _check_port, _check_udp_port, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port', 'check_udp_port', '_sudo_cmd'
 )
 
 # Optional modules for quick actions
@@ -219,7 +219,7 @@ class QuickActionsMixin:
         print("Restarting meshtasticd...\n")
         try:
             subprocess.run(
-                ['systemctl', 'restart', 'meshtasticd'],
+                _sudo_cmd(['systemctl', 'restart', 'meshtasticd']),
                 timeout=30
             )
             subprocess.run(
@@ -242,7 +242,7 @@ class QuickActionsMixin:
         print("Restarting rnsd...\n")
         try:
             subprocess.run(
-                ['systemctl', 'restart', 'rnsd'],
+                _sudo_cmd(['systemctl', 'restart', 'rnsd']),
                 timeout=30
             )
             subprocess.run(

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -17,8 +17,8 @@ from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 from utils.safe_import import safe_import
 
-check_process_running, check_udp_port, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running', 'check_udp_port'
+check_process_running, check_udp_port, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', 'check_udp_port', '_sudo_cmd'
 )
 
 get_identity_path, create_identities, list_known_destinations, \
@@ -304,7 +304,7 @@ class RNSDiagnosticsMixin:
                     ):
                         try:
                             subprocess.run(
-                                ['systemctl', 'start', 'rnsd'],
+                                _sudo_cmd(['systemctl', 'start', 'rnsd']),
                                 capture_output=True, text=True, timeout=30
                             )
                             print("Starting rnsd...")
@@ -493,7 +493,7 @@ class RNSDiagnosticsMixin:
 
                     print("Starting rnsd...")
                     subprocess.run(
-                        ['systemctl', 'start', 'rnsd'],
+                        _sudo_cmd(['systemctl', 'start', 'rnsd']),
                         capture_output=True, text=True, timeout=15
                     )
                     time.sleep(2)

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -30,8 +30,8 @@ from backend import clear_screen
 # --- Optional dependency imports via safe_import ---
 from utils.safe_import import safe_import
 
-check_process_running, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running'
+check_process_running, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', '_sudo_cmd'
 )
 
 get_identity_path, create_identities, list_known_destinations, \
@@ -624,7 +624,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
         print("  Stopping rnsd...")
         try:
             subprocess.run(
-                ['systemctl', 'stop', 'rnsd'],
+                _sudo_cmd(['systemctl', 'stop', 'rnsd']),
                 capture_output=True, text=True, timeout=10
             )
             time.sleep(1)  # Give it time to fully stop
@@ -694,7 +694,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
         print("  Starting rnsd...")
         try:
             result = subprocess.run(
-                ['systemctl', 'start', 'rnsd'],
+                _sudo_cmd(['systemctl', 'start', 'rnsd']),
                 capture_output=True, text=True, timeout=30
             )
             if result.returncode == 0:

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -18,11 +18,11 @@ logger = logging.getLogger(__name__)
 
 # Import centralized service checking
 (check_systemd_service, check_process_running, check_service,
- apply_config_and_restart, enable_service, ServiceState,
+ apply_config_and_restart, enable_service, ServiceState, _sudo_cmd,
  _HAS_SERVICE_CHECK) = safe_import(
     'utils.service_check',
     'check_systemd_service', 'check_process_running', 'check_service',
-    'apply_config_and_restart', 'enable_service', 'ServiceState',
+    'apply_config_and_restart', 'enable_service', 'ServiceState', '_sudo_cmd',
 )
 _HAS_APPLY_RESTART = _HAS_SERVICE_CHECK
 
@@ -208,12 +208,12 @@ class ServiceMenuMixin:
                     else:
                         # Try direct start
                         subprocess.run(
-                            ['systemctl', 'start', 'rnsd'],
+                            _sudo_cmd(['systemctl', 'start', 'rnsd']),
                             capture_output=True, text=True, timeout=15
                         )
                 else:
                     subprocess.run(
-                        ['systemctl', 'start', 'rnsd'],
+                        _sudo_cmd(['systemctl', 'start', 'rnsd']),
                         capture_output=True, text=True, timeout=15
                     )
                 time.sleep(2)
@@ -648,7 +648,7 @@ class ServiceMenuMixin:
         """Restart the meshtasticd service."""
         clear_screen()
         print("Restarting meshtasticd...\n")
-        subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30)
+        subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30)
         subprocess.run(['systemctl', 'status', 'meshtasticd', '--no-pager', '-l'], timeout=10)
         self._wait_for_enter()
 
@@ -659,7 +659,7 @@ class ServiceMenuMixin:
         if not self._has_systemd_unit('rnsd'):
             self._start_rnsd_direct()
         else:
-            subprocess.run(['systemctl', 'start', 'rnsd'], timeout=30)
+            subprocess.run(_sudo_cmd(['systemctl', 'start', 'rnsd']), timeout=30)
             subprocess.run(['systemctl', 'status', 'rnsd', '--no-pager', '-l'], timeout=10)
         self._wait_for_enter()
 
@@ -673,7 +673,7 @@ class ServiceMenuMixin:
             time.sleep(0.5)
             self._start_rnsd_direct()
         else:
-            subprocess.run(['systemctl', 'restart', 'rnsd'], timeout=30)
+            subprocess.run(_sudo_cmd(['systemctl', 'restart', 'rnsd']), timeout=30)
             subprocess.run(['systemctl', 'status', 'rnsd', '--no-pager', '-l'], timeout=10)
         self._wait_for_enter()
 
@@ -752,8 +752,8 @@ General:
                 if _HAS_APPLY_RESTART:
                     success, msg = apply_config_and_restart('meshtasticd')
                 else:
-                    subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                    subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                    subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                    subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
 
                 self.dialog.msgbox(
                     "Config Fixed",
@@ -898,9 +898,9 @@ WantedBy=multi-user.target
                 if not success:
                     self.dialog.msgbox("Warning", f"Service setup issue: {msg}")
             else:
-                subprocess.run(['systemctl', 'daemon-reload'], timeout=30, check=False)
-                subprocess.run(['systemctl', 'enable', 'meshtasticd'], timeout=30, check=False)
-                subprocess.run(['systemctl', 'restart', 'meshtasticd'], timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'daemon-reload']), timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'enable', 'meshtasticd']), timeout=30, check=False)
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', 'meshtasticd']), timeout=30, check=False)
 
             self.dialog.msgbox(
                 "Success",
@@ -1099,7 +1099,7 @@ WantedBy=multi-user.target
             if use_direct_rnsd:
                 self._start_rnsd_direct()
             else:
-                subprocess.run(['systemctl', 'start', service_name], timeout=30)
+                subprocess.run(_sudo_cmd(['systemctl', 'start', service_name]), timeout=30)
                 subprocess.run(
                     ['systemctl', 'status', service_name, '--no-pager', '-l'],
                     timeout=10
@@ -1113,7 +1113,7 @@ WantedBy=multi-user.target
                 if use_direct_rnsd:
                     self._stop_rnsd_direct()
                 else:
-                    subprocess.run(['systemctl', 'stop', service_name], timeout=30)
+                    subprocess.run(_sudo_cmd(['systemctl', 'stop', service_name]), timeout=30)
                     print(f"{service_name} stopped.")
                 self._wait_for_enter()
 
@@ -1125,7 +1125,7 @@ WantedBy=multi-user.target
                 time.sleep(0.5)
                 self._start_rnsd_direct()
             else:
-                subprocess.run(['systemctl', 'restart', service_name], timeout=30)
+                subprocess.run(_sudo_cmd(['systemctl', 'restart', service_name]), timeout=30)
                 subprocess.run(
                     ['systemctl', 'status', service_name, '--no-pager', '-l'],
                     timeout=10
@@ -1492,11 +1492,11 @@ WantedBy=multi-user.target
             else:
                 # Fallback to direct systemctl calls
                 subprocess.run(
-                    ['systemctl', 'enable', 'mosquitto'],
+                    _sudo_cmd(['systemctl', 'enable', 'mosquitto']),
                     timeout=30, check=False
                 )
                 subprocess.run(
-                    ['systemctl', 'start', 'mosquitto'],
+                    _sudo_cmd(['systemctl', 'start', 'mosquitto']),
                     timeout=30, check=False
                 )
 

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -248,8 +248,8 @@ class StartupChecker:
 
         # Ensure RNS storage directories exist (self-healing)
         # Prevents rnsd PermissionError on /etc/reticulum/storage/ratchets
-        if env.is_root:
-            self._heal_rns_storage_dirs()
+        # Runs as root or non-root — gracefully degrades if no permissions
+        self._heal_rns_storage_dirs()
 
         # Check services
         env.services = self._check_services()

--- a/src/launcher_tui/updates_mixin.py
+++ b/src/launcher_tui/updates_mixin.py
@@ -21,8 +21,8 @@ _check_all_versions, _VersionInfo, _HAS_VERSION_CHECKER = safe_import(
 )
 
 # Import service check for restart after updates
-_apply_config_and_restart, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'apply_config_and_restart'
+_apply_config_and_restart, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'apply_config_and_restart', '_sudo_cmd'
 )
 
 
@@ -441,7 +441,7 @@ class UpdatesMixin:
             # Reload systemd
             if svc_msgs:
                 subprocess.run(
-                    ['systemctl', 'daemon-reload'],
+                    _sudo_cmd(['systemctl', 'daemon-reload']),
                     capture_output=True, timeout=10
                 )
         except (OSError, PermissionError) as e:

--- a/src/launcher_tui/web_client_mixin.py
+++ b/src/launcher_tui/web_client_mixin.py
@@ -17,6 +17,11 @@ import socket
 import subprocess
 import threading
 
+from utils.safe_import import safe_import
+
+# Import _sudo_cmd for privileged systemctl calls
+_sudo_cmd, _HAS_SERVICE_CHECK = safe_import('utils.service_check', '_sudo_cmd')
+
 logger = logging.getLogger(__name__)
 
 
@@ -382,7 +387,7 @@ class WebClientMixin:
                 ok, restart_msg = apply_config_and_restart('meshtasticd')
             except ImportError:
                 result = subprocess.run(
-                    ['systemctl', 'restart', 'meshtasticd'],
+                    _sudo_cmd(['systemctl', 'restart', 'meshtasticd']),
                     capture_output=True, text=True, timeout=30
                 )
                 ok = result.returncode == 0

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -25,17 +25,36 @@ Usage:
         show_fix(status.fix_hint)
 """
 
+import os
 import socket
 import subprocess
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from enum import Enum
 
 from utils.ports import MESHTASTICD_PORT, MQTT_PORT, RNS_SHARED_INSTANCE_PORT
 
 logger = logging.getLogger(__name__)
+
+
+def _sudo_cmd(cmd: List[str]) -> List[str]:
+    """Prefix a command with 'sudo' when MeshForge is not running as root.
+
+    Allows MeshForge to run as a normal user and only elevate for
+    specific operations (systemctl, iptables, etc.).  When already root,
+    returns the command unchanged.
+
+    Args:
+        cmd: Command and arguments, e.g. ['systemctl', 'restart', 'rnsd']
+
+    Returns:
+        The command, possibly prefixed with ['sudo'].
+    """
+    if os.geteuid() != 0:
+        return ['sudo'] + cmd
+    return cmd
 
 # Public API - these are the functions/classes intended for external use
 __all__ = [
@@ -55,6 +74,8 @@ __all__ = [
     'unlock_port_external',      # Restore external access to a port
     'check_port_locked',         # Check if port is locked to localhost
     'persist_iptables',          # Save iptables rules to survive reboot
+    # Privilege elevation
+    '_sudo_cmd',            # Prefix command with sudo when not root
     # Data classes
     'ServiceStatus',        # Return type from check_service
     'ServiceState',         # Status enum (AVAILABLE, DEGRADED, FAILED, etc.)
@@ -733,20 +754,20 @@ def apply_config_and_restart(service_name: str = 'meshtasticd', timeout: int = 3
     """
     try:
         # Step 1: Reload systemd daemon to pick up any service file changes
-        daemon_reload = subprocess.run(
-            ['systemctl', 'daemon-reload'],
+        reload_cmd = subprocess.run(
+            _sudo_cmd(['systemctl', 'daemon-reload']),
             capture_output=True,
             text=True,
             timeout=timeout
         )
-        if daemon_reload.returncode != 0:
-            error_msg = daemon_reload.stderr.strip() or "daemon-reload failed"
+        if reload_cmd.returncode != 0:
+            error_msg = reload_cmd.stderr.strip() or "daemon-reload failed"
             logger.error(f"daemon-reload failed: {error_msg}")
             return False, f"daemon-reload failed: {error_msg}"
 
         # Step 2: Restart the service
         restart = subprocess.run(
-            ['systemctl', 'restart', service_name],
+            _sudo_cmd(['systemctl', 'restart', service_name]),
             capture_output=True,
             text=True,
             timeout=timeout
@@ -794,7 +815,7 @@ def daemon_reload(timeout: int = 30) -> Tuple[bool, str]:
     """
     try:
         result = subprocess.run(
-            ['systemctl', 'daemon-reload'],
+            _sudo_cmd(['systemctl', 'daemon-reload']),
             capture_output=True,
             text=True,
             timeout=timeout
@@ -847,7 +868,7 @@ def enable_service(service_name: str, start: bool = False, timeout: int = 30) ->
     try:
         # Step 1: Reload systemd daemon to pick up service file changes
         reload_result = subprocess.run(
-            ['systemctl', 'daemon-reload'],
+            _sudo_cmd(['systemctl', 'daemon-reload']),
             capture_output=True,
             text=True,
             timeout=timeout
@@ -859,7 +880,7 @@ def enable_service(service_name: str, start: bool = False, timeout: int = 30) ->
 
         # Step 2: Enable the service
         enable_result = subprocess.run(
-            ['systemctl', 'enable', service_name],
+            _sudo_cmd(['systemctl', 'enable', service_name]),
             capture_output=True,
             text=True,
             timeout=timeout
@@ -872,7 +893,7 @@ def enable_service(service_name: str, start: bool = False, timeout: int = 30) ->
         # Step 3: Optionally start the service
         if start:
             start_result = subprocess.run(
-                ['systemctl', 'start', service_name],
+                _sudo_cmd(['systemctl', 'start', service_name]),
                 capture_output=True,
                 text=True,
                 timeout=timeout
@@ -927,7 +948,7 @@ def lock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str]:
     try:
         # Check if rule already exists (idempotent)
         check = subprocess.run(
-            ['iptables', '-C', 'INPUT'] + rule_args,
+            _sudo_cmd(['iptables', '-C', 'INPUT'] + rule_args),
             capture_output=True, text=True, timeout=timeout
         )
         if check.returncode == 0:
@@ -936,7 +957,7 @@ def lock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str]:
 
         # Add the rule
         result = subprocess.run(
-            ['iptables', '-A', 'INPUT'] + rule_args,
+            _sudo_cmd(['iptables', '-A', 'INPUT'] + rule_args),
             capture_output=True, text=True, timeout=timeout
         )
         if result.returncode == 0:
@@ -972,7 +993,7 @@ def unlock_port_external(port: int = 9443, timeout: int = 10) -> Tuple[bool, str
 
     try:
         result = subprocess.run(
-            ['iptables', '-D', 'INPUT'] + rule_args,
+            _sudo_cmd(['iptables', '-D', 'INPUT'] + rule_args),
             capture_output=True, text=True, timeout=timeout
         )
         if result.returncode == 0:
@@ -1004,7 +1025,7 @@ def check_port_locked(port: int = 9443, timeout: int = 10) -> bool:
                  '!', '-s', '127.0.0.1', '-j', 'REJECT']
     try:
         result = subprocess.run(
-            ['iptables', '-C', 'INPUT'] + rule_args,
+            _sudo_cmd(['iptables', '-C', 'INPUT'] + rule_args),
             capture_output=True, text=True, timeout=timeout
         )
         return result.returncode == 0
@@ -1024,7 +1045,7 @@ def persist_iptables(timeout: int = 30) -> Tuple[bool, str]:
     # Method 1: netfilter-persistent (Debian/Ubuntu with iptables-persistent)
     try:
         result = subprocess.run(
-            ['netfilter-persistent', 'save'],
+            _sudo_cmd(['netfilter-persistent', 'save']),
             capture_output=True, text=True, timeout=timeout
         )
         if result.returncode == 0:
@@ -1049,7 +1070,7 @@ def persist_iptables(timeout: int = 30) -> Tuple[bool, str]:
         rules_file = rules_dir / 'rules.v4'
 
         save_result = subprocess.run(
-            ['iptables-save'],
+            _sudo_cmd(['iptables-save']),
             capture_output=True, text=True, timeout=timeout
         )
         if save_result.returncode != 0:


### PR DESCRIPTION
MeshForge no longer requires sudo to launch. Service control operations (systemctl, iptables) auto-elevate via sudo only when needed.

Changes:
- Add _sudo_cmd() helper in service_check.py: prefixes commands with 'sudo' when euid != 0, passes through when already root
- Update all centralized helpers (apply_config_and_restart, daemon_reload, enable_service, lock/unlock_port, persist_iptables) to use _sudo_cmd()
- Remove hard sys.exit(1) root gates in main.py and launcher.py
- Wrap all 40+ direct systemctl write calls across 12 TUI mixins
- Read-only systemctl calls (status, is-active, list-units) left unwrapped
- startup_checks: _heal_rns_storage_dirs now runs regardless of euid, gracefully degrades if no permissions

User runs 'meshforge' (no sudo). All monitoring, RF tools, diagnostics, and configuration viewing works immediately. When the user triggers a service restart or config write, that single operation elevates via sudo.

https://claude.ai/code/session_01JfCF3odTWUH5UHZaNAn6o2