### PR TITLE
Fix RNS UDP port detection and improve service reliability

### DIFF
--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -267,19 +267,25 @@ class RNSDiagnosticsMixin:
             # RNS tools may log errors to stdout or stderr depending on config
             combined = (result.stdout or "") + (result.stderr or "")
 
-            if result.returncode == 0:
-                # Success - show normal output
-                if result.stdout:
-                    print(result.stdout, end='')
-            elif "address already in use" in combined.lower():
+            # Check for error patterns BEFORE returncode — rnstatus returns
+            # exit code 0 even when the shared instance is unreachable.
+            lower_combined = combined.lower()
+            has_shared_error = any(p in lower_combined for p in (
+                "no shared", "could not connect", "could not get",
+                "shared instance", "authenticationerror", "digest",
+            ))
+
+            if "address already in use" in lower_combined:
                 # Suppress noisy traceback, show actionable diagnostics
                 print("\nError: RNS port conflict (Address already in use)")
                 print("Another process is bound to the RNS AutoInterface port.\n")
                 self._diagnose_rns_port_conflict()
-            elif "no shared" in combined.lower() or "could not connect" in combined.lower() or "could not get" in combined.lower() or "shared instance" in combined.lower() or "authenticationerror" in combined.lower() or "digest" in combined.lower():
+            elif has_shared_error:
                 # RNS shared instance issue — DIAGNOSE, don't auto-fix.
                 # Auto-fix was the #1 source of regressions (see persistent_issues.md).
                 # Policy: show what's wrong, let the user decide what to do.
+                if result.returncode == 0 and result.stdout:
+                    print(result.stdout, end='')
                 print(f"\nRNS connectivity issue detected.")
 
                 # Check if rnsd is actually running
@@ -346,6 +352,10 @@ class RNSDiagnosticsMixin:
                     else:
                         # Port never came up — show diagnostics
                         self._diagnose_rns_connectivity(combined)
+            elif result.returncode == 0:
+                # Clean success — no error patterns detected
+                if result.stdout:
+                    print(result.stdout, end='')
             else:
                 # Other error - DON'T auto-fix, just show output
                 # RNS tools may return non-zero for benign reasons (empty table, no paths)

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -30,8 +30,8 @@ from backend import clear_screen
 # --- Optional dependency imports via safe_import ---
 from utils.safe_import import safe_import
 
-check_process_running, start_service, stop_service, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running', 'start_service', 'stop_service', '_sudo_cmd'
+check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', 'check_udp_port', 'start_service', 'stop_service', '_sudo_cmd'
 )
 
 get_identity_path, create_identities, list_known_destinations, \
@@ -704,12 +704,19 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
         # Step 3: Verify shared instance is now available
         print(f"\n[3/3] Verifying shared instance...")
         try:
-            # Check if rnsd is listening on port 37428
-            result = subprocess.run(
-                ['ss', '-tlnp'],
-                capture_output=True, text=True, timeout=5
-            )
-            if '37428' in result.stdout:
+            # Check if rnsd is listening on UDP port 37428
+            # Port 37428 is UDP, not TCP — must use UDP check
+            port_ok = False
+            if _HAS_SERVICE_CHECK and check_udp_port:
+                port_ok = check_udp_port(37428)
+            else:
+                # Fallback: ss with UDP flag
+                result = subprocess.run(
+                    ['ss', '-ulnp'],
+                    capture_output=True, text=True, timeout=5
+                )
+                port_ok = '37428' in result.stdout
+            if port_ok:
                 print("  SUCCESS: rnsd is now listening on port 37428")
                 print("\n" + "=" * 50)
                 print("RNS shared instance is now available!")

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -581,12 +581,18 @@ class SetupWizard:
             rnsd_path = shutil.which('rnsd') or '/usr/local/bin/rnsd'
             service_content = f'''[Unit]
 Description=Reticulum Network Stack Daemon
-After=network.target
+After=network-online.target
+Wants=network-online.target
+
+# Stop crash-looping after 5 failures in 60 seconds
+# (e.g., NomadNet holding port 37428)
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
 Type=simple
 ExecStart={rnsd_path}
-Restart=always
+Restart=on-failure
 RestartSec=5
 
 [Install]


### PR DESCRIPTION
## Summary
This PR improves RNS (Reticulum Network Stack) service detection and reliability by fixing UDP port checking, refining error detection logic, and enhancing systemd service configuration.

## Key Changes

### RNS Menu Mixin (`rns_menu_mixin.py`)
- Added `check_udp_port` import from `utils.service_check` for proper UDP port detection
- Fixed port 37428 verification in `_repair_rns_shared_instance()` to check UDP instead of TCP
  - Changed from `ss -tlnp` (TCP listening) to `ss -ulnp` (UDP listening)
  - Added fallback to `check_udp_port()` function when available
  - Updated comment to clarify port 37428 is UDP, not TCP

### RNS Diagnostics Mixin (`rns_diagnostics_mixin.py`)
- Refactored error detection in `_run_rns_tool()` to check for error patterns **before** evaluating return code
  - Reason: `rnstatus` returns exit code 0 even when shared instance is unreachable
- Consolidated error pattern matching into a single `has_shared_error` check for maintainability
- Improved output handling:
  - Print stdout for shared instance errors when returncode is 0
  - Moved success case (returncode == 0 with no error patterns) to end of conditional chain
- Preserved diagnostic behavior without auto-fixing (per project policy)

### Setup Wizard (`setup_wizard.py`)
- Enhanced rnsd systemd service configuration:
  - Changed `After=network.target` to `After=network-online.target` with `Wants=network-online.target` for proper startup ordering
  - Added crash-loop protection: `StartLimitIntervalSec=60` and `StartLimitBurst=5` (max 5 failures per 60 seconds)
  - Changed restart policy from `Restart=always` to `Restart=on-failure` to prevent unnecessary restarts on clean exits
  - Added explanatory comment about NomadNet port conflicts

## Implementation Details
- The UDP port check is critical because port 37428 is UDP-based; TCP checks would incorrectly report the service as unavailable
- Error detection now prioritizes pattern matching over exit codes, making diagnostics more reliable for tools with inconsistent return codes
- Service restart limits prevent crash-looping when port conflicts occur (e.g., NomadNet holding port 37428)

https://claude.ai/code/session_01P7KWA5sJajnkgkQrJsZ9pT