### PR TITLE
Pin cryptography version to resolve dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,11 @@ paho-mqtt>=1.6.0
 rns>=0.7.0
 lxmf>=0.4.0
 
-# PyOpenSSL - pin to >=25.3.0 to resolve dependency conflict:
-# System python3-openssl (25.0.0) requires cryptography<45, but RNS pulls
-# in cryptography 46.x. PyOpenSSL 25.3.0+ supports cryptography<47.
+# Cryptography / PyOpenSSL version alignment:
+# RNS pulls in cryptography 46.x (its constraint is >=3.4.7, so pip grabs latest).
+# PyOpenSSL <25.3.0 only supports cryptography<45, causing a resolver conflict.
+# Pin both explicitly so pip can resolve them together in a single pass.
+cryptography>=45.0.7,<47
 pyopenssl>=25.3.0
 
 # Meshtastic CLI is used for radio configuration (installed via pipx)


### PR DESCRIPTION
## Summary
Updated requirements.txt to explicitly pin the cryptography package version, ensuring compatibility between RNS, PyOpenSSL, and the system's cryptography library.

## Changes
- Added explicit cryptography version constraint (`>=45.0.7,<47`) to requirements.txt
- Updated comments to clarify the dependency resolution strategy and rationale for version pinning

## Details
RNS pulls in cryptography 46.x without an upper bound, while PyOpenSSL versions prior to 25.3.0 only support cryptography<45. This creates a resolver conflict when pip tries to satisfy all constraints. By explicitly pinning cryptography to a compatible range alongside the PyOpenSSL requirement, pip can now resolve all dependencies in a single pass without conflicts.

https://claude.ai/code/session_01BWtxKtshmYWchXQwd3YiGW