### PR TITLE
Add ReticulumPaths import to nomadnet_client_mixin

### DIFF
--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -26,6 +26,8 @@ from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
+from utils.paths import ReticulumPaths
+
 from utils.safe_import import safe_import
 
 # Import centralized service checking


### PR DESCRIPTION
## Summary
Added import for `ReticulumPaths` utility class from the `utils.paths` module to the nomadnet_client_mixin module.

## Key Changes
- Imported `ReticulumPaths` from `utils.paths` to make path utilities available in the nomadnet_client_mixin module
- Placed the import after the logger initialization and before the existing `safe_import` import for logical organization

## Implementation Details
The import is positioned in the module's import section following the logger setup, establishing access to Reticulum path utilities that may be needed for path resolution operations within the mixin class.

https://claude.ai/code/session_0112AhLNjA3GHvTzamKfDqyo