### PR TITLE
fix: Handle Debian-managed meshtastic package conflicts in pip install

### DIFF
--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -520,11 +520,48 @@ class NomadNetClientMixin:
                             error_hints.append("Permission denied accessing files")
                             error_hints.append(f"Check ownership: ls -la ~/.nomadnetwork/")
                         break
+                    elif 'meshtastic' in line.lower() and (
+                        'critical' in line.lower() or 'requires' in line.lower()
+                        or 'no module' in line.lower() or 'modulenotfounderror' in line.lower()
+                    ):
+                        error_hints.append("rnsd cannot load the meshtastic module")
+                        error_hints.append("The Meshtastic_Interface.py plugin requires meshtastic")
+                        error_hints.append(
+                            "Fix: sudo pip3 install --break-system-packages "
+                            "--ignore-installed meshtastic"
+                        )
+                        error_hints.append("Then: sudo systemctl restart rnsd")
+                        break
                     elif 'ModuleNotFoundError' in line or 'ImportError' in line:
                         error_hints.append("Missing Python dependencies")
                         error_hints.append("Try: pipx reinstall nomadnet")
                         break
             except (OSError, PermissionError):
+                pass
+
+        # If no NomadNet-specific error found, check rnsd journal for clues.
+        # NomadNet fails when rnsd is down due to meshtastic module issue.
+        if not error_hints:
+            try:
+                journal_r = subprocess.run(
+                    ['journalctl', '-u', 'rnsd', '-n', '20', '--no-pager', '-q'],
+                    capture_output=True, text=True, timeout=5
+                )
+                journal_text = journal_r.stdout.lower()
+                if 'meshtastic' in journal_text and (
+                    'critical' in journal_text or 'module' in journal_text
+                ):
+                    error_hints.append("rnsd crashed because the meshtastic module is missing")
+                    error_hints.append("NomadNet depends on rnsd for network access")
+                    error_hints.append(
+                        "Fix: sudo pip3 install --break-system-packages "
+                        "--ignore-installed meshtastic"
+                    )
+                    error_hints.append("Then: sudo systemctl restart rnsd")
+                elif 'status=255' in journal_text or 'exception' in journal_text:
+                    error_hints.append("rnsd is crashing (exit code 255)")
+                    error_hints.append("Check: sudo journalctl -u rnsd -n 30")
+            except (subprocess.SubprocessError, OSError):
                 pass
 
         if error_hints:

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -582,21 +582,46 @@ class RNSDiagnosticsMixin:
                     install_cmd = [rnsd_python, '-m', 'pip', 'install',
                                     '--break-system-packages', pip_name]
                     if _HAS_SERVICE_CHECK:
-                        install_cmd = _sudo_cmd(install_cmd)
+                        base_cmd = _sudo_cmd(install_cmd)
                     elif os.getuid() != 0:
-                        install_cmd = ['sudo'] + install_cmd
+                        base_cmd = ['sudo'] + install_cmd
+                    else:
+                        base_cmd = install_cmd
                     result = subprocess.run(
-                        install_cmd,
+                        base_cmd,
                         capture_output=True, text=True, timeout=120
                     )
                     if result.returncode == 0:
                         print(f"  {pip_name}: installed")
                     else:
-                        # Show last line of error for context
-                        err_lines = (result.stderr or result.stdout or '').strip().split('\n')
-                        print(f"  {pip_name}: FAILED")
-                        if err_lines:
-                            print(f"    {err_lines[-1]}")
+                        # Detect Debian-managed package conflict:
+                        # pip says "installed by debian/apt" when it refuses
+                        # to overwrite an apt-owned package.
+                        err_text = (result.stderr or result.stdout or '').lower()
+                        if 'installed by' in err_text or 'externally-managed' in err_text:
+                            print(f"  {pip_name}: Debian package conflict, retrying with --ignore-installed...")
+                            retry_cmd = [rnsd_python, '-m', 'pip', 'install',
+                                         '--break-system-packages', '--ignore-installed', pip_name]
+                            if _HAS_SERVICE_CHECK:
+                                retry_cmd = _sudo_cmd(retry_cmd)
+                            elif os.getuid() != 0:
+                                retry_cmd = ['sudo'] + retry_cmd
+                            retry = subprocess.run(
+                                retry_cmd,
+                                capture_output=True, text=True, timeout=120
+                            )
+                            if retry.returncode == 0:
+                                print(f"  {pip_name}: installed (bypassed Debian package)")
+                            else:
+                                err_lines = (retry.stderr or retry.stdout or '').strip().split('\n')
+                                print(f"  {pip_name}: FAILED (even with --ignore-installed)")
+                                if err_lines:
+                                    print(f"    {err_lines[-1]}")
+                        else:
+                            err_lines = (result.stderr or result.stdout or '').strip().split('\n')
+                            print(f"  {pip_name}: FAILED")
+                            if err_lines:
+                                print(f"    {err_lines[-1]}")
                 except subprocess.TimeoutExpired:
                     print(f"  {pip_name}: timed out (network issue?)")
                 except (subprocess.SubprocessError, OSError) as e:

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -802,6 +802,15 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
                         [str(venv_pip), 'install', 'meshtastic'],
                         capture_output=True, text=True, timeout=120
                     )
+                    if pip_r.returncode != 0:
+                        # Retry with --ignore-installed for Debian package conflicts
+                        err_text = (pip_r.stderr or pip_r.stdout or '').lower()
+                        if 'installed by' in err_text or 'externally-managed' in err_text:
+                            print("  Debian package conflict, retrying with --ignore-installed...")
+                            pip_r = subprocess.run(
+                                [str(venv_pip), 'install', '--ignore-installed', 'meshtastic'],
+                                capture_output=True, text=True, timeout=120
+                            )
                     if pip_r.returncode == 0:
                         print("  meshtastic installed. Restarting rnsd...")
                         # Reset failed state and restart
@@ -1047,6 +1056,15 @@ WantedBy=multi-user.target
                     [str(venv_pip), 'install', '-q', 'meshtastic'],
                     capture_output=True, text=True, timeout=120
                 )
+                if pip_result.returncode != 0:
+                    # Retry with --ignore-installed for Debian package conflicts
+                    err_text = (pip_result.stderr or pip_result.stdout or '').lower()
+                    if 'installed by' in err_text or 'externally-managed' in err_text:
+                        print("  Debian package conflict, retrying...")
+                        pip_result = subprocess.run(
+                            [str(venv_pip), 'install', '-q', '--ignore-installed', 'meshtastic'],
+                            capture_output=True, text=True, timeout=120
+                        )
                 meshtastic_installed = pip_result.returncode == 0
 
             restart_hint = "Restart rnsd to load the new interface:\n  sudo systemctl restart rnsd"


### PR DESCRIPTION
When meshtastic was installed via apt (python3-meshtastic), pip refuses to overwrite it even with --break-system-packages. All three TUI pip install paths now retry with --ignore-installed when they detect the "installed by debian" error.

Also improves NomadNet error diagnosis to detect meshtastic module failures — both from the NomadNet logfile and from rnsd journal output.

Fixes:
- _ensure_rnsd_dependencies(): retry with --ignore-installed on conflict
- Crash recovery venv pip: same retry pattern
- Plugin installer venv pip: same retry pattern
- NomadNet diagnosis: detect meshtastic/rnsd cascade failure

https://claude.ai/code/session_0112AhLNjA3GHvTzamKfDqyo