### PR TITLE
Add RNS interface health monitoring and NomadNet/rnsd coexistence diagnostics

### DIFF
--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -8,7 +8,9 @@ Usage:
     sudo python3 src/cli/diagnose.py  # For full diagnostics
 """
 
+import collections
 import os
+import re
 import sys
 import socket
 import subprocess
@@ -33,6 +35,10 @@ _find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
 
 _GatewayDiagnostic, _HAS_GATEWAY_DIAG = safe_import(
     'utils.gateway_diagnostic', 'GatewayDiagnostic'
+)
+
+_get_udp_port_owner, _HAS_PORT_OWNER = safe_import(
+    'utils.service_check', 'get_udp_port_owner'
 )
 
 
@@ -140,6 +146,12 @@ def check_rns_port():
     try:
         if port_bound:
             print_status("RNS shared instance", True, "listening on UDP 37428")
+            # Show which process owns the port
+            if _HAS_PORT_OWNER:
+                owner = _get_udp_port_owner(37428)
+                if owner:
+                    proc_name, pid = owner
+                    print(f"    Owner: {proc_name} (PID {pid})")
         else:
             # Check if share_instance is disabled in config
             hint = "not running"
@@ -154,6 +166,19 @@ def check_rns_port():
             except ImportError:
                 pass
             print_status("RNS shared instance", False, hint)
+
+            # Check if another process is holding the port
+            if _HAS_PORT_OWNER:
+                owner = _get_udp_port_owner(37428)
+                if owner:
+                    proc_name, pid = owner
+                    print(f"    Port held by: {proc_name} (PID {pid})")
+                    if 'nomadnet' in proc_name.lower():
+                        print("    NOTE: NomadNet is holding port 37428.")
+                        print("    rnsd cannot bind while NomadNet owns "
+                              "this port.")
+                        print("    Fix: Stop NomadNet, start rnsd first, "
+                              "then NomadNet.")
     except Exception as e:
         print_status("RNS shared instance", False, str(e))
 
@@ -273,8 +298,135 @@ def check_rns_config():
         print("    Run 'rnsd' once to create default config")
 
 
+def check_rns_interfaces():
+    """Check RNS interface status via rnstatus.
+
+    Parses rnstatus output to show per-interface TX/RX counters.
+    Detects RX-only interfaces (link establishment failing) and
+    zero-traffic interfaces (not yet active).
+    """
+    print_header("RNS INTERFACES")
+
+    rnstatus_path = shutil.which('rnstatus')
+    if not rnstatus_path:
+        # Check user local bin
+        user_home = get_real_user_home()
+        candidate = user_home / '.local' / 'bin' / 'rnstatus'
+        if candidate.exists():
+            rnstatus_path = str(candidate)
+
+    if not rnstatus_path:
+        print_status("rnstatus", False,
+                     "not found (install RNS: pipx install rns)")
+        return
+
+    try:
+        result = subprocess.run(
+            [rnstatus_path],
+            capture_output=True, text=True, timeout=15
+        )
+        combined = (result.stdout or '') + (result.stderr or '')
+        if ('no shared' in combined.lower()
+                or 'could not' in combined.lower()):
+            print_status("RNS shared instance", False,
+                         "cannot connect to rnsd")
+            return
+
+        # Parse interface lines from rnstatus output
+        # Format:  InterfaceName[DisplayName]
+        #   Traffic   : ↑NNN B  NNN bps
+        #               ↓NNN B  NNN bps
+        current_iface = None
+        tx_cache = {}
+        rx_only_ifaces = []
+        zero_traffic_ifaces = []
+        any_iface_found = False
+
+        for line in combined.splitlines():
+            # Interface header line
+            iface_match = re.match(
+                r'\s*(\w+)\[(.+?)\]', line
+            )
+            if iface_match:
+                current_iface = (
+                    f"{iface_match.group(1)}[{iface_match.group(2)}]"
+                )
+                any_iface_found = True
+                continue
+
+            # TX line (↑ = upload/transmit)
+            tx_match = re.search(r'↑\s*([\d,.]+)\s*(\w+)', line)
+            if tx_match and current_iface:
+                tx_val = tx_match.group(1).replace(',', '')
+                tx_unit = tx_match.group(2)
+                tx_cache[current_iface] = (
+                    float(tx_val), tx_unit
+                )
+
+            # RX line (↓ = download/receive)
+            rx_match = re.search(r'↓\s*([\d,.]+)\s*(\w+)', line)
+            if rx_match and current_iface:
+                rx_val = rx_match.group(1).replace(',', '')
+                rx_unit = rx_match.group(2)
+
+                tx_info = tx_cache.get(
+                    current_iface, (0, 'B')
+                )
+                tx_bytes = tx_info[0]
+                rx_bytes = float(rx_val)
+
+                if rx_bytes > 0 and tx_bytes == 0:
+                    print_status(
+                        current_iface, False,
+                        f"RX-only (↑0 ↓{rx_val} {rx_unit})"
+                    )
+                    rx_only_ifaces.append(current_iface)
+                elif rx_bytes == 0 and tx_bytes == 0:
+                    print_status(
+                        current_iface, False,
+                        "no traffic (↑0 ↓0)"
+                    )
+                    zero_traffic_ifaces.append(current_iface)
+                else:
+                    print_status(
+                        current_iface, True,
+                        f"↑{tx_info[0]:.0f} {tx_info[1]}  "
+                        f"↓{rx_val} {rx_unit}"
+                    )
+                current_iface = None
+
+        if rx_only_ifaces:
+            print()
+            print("  WARNING: RX-only interfaces detected.")
+            print("  Packets received but link establishment "
+                  "(SYN/ACK) failing.")
+            print("  Common causes:")
+            print("    - Shared instance not fully initialized")
+            print("    - NomadNet/rnsd port conflict on 37428")
+            print("    - Blocking interface preventing startup")
+
+        if zero_traffic_ifaces:
+            mesh_zero = [i for i in zero_traffic_ifaces
+                         if 'Meshtastic' in i]
+            if mesh_zero:
+                print()
+                print("  NOTE: Meshtastic interface(s) show zero "
+                      "traffic.")
+                print("  If rnsd just restarted, allow 60-90s for "
+                      "link establishment.")
+
+        if not any_iface_found:
+            print("  No interfaces found in rnstatus output.")
+
+    except FileNotFoundError:
+        print_status("rnstatus", False, "not found")
+    except subprocess.TimeoutExpired:
+        print_status("rnstatus", False,
+                     "timed out (rnsd may be unresponsive)")
+
+
 def check_nomadnet():
-    """Check NomadNet installation."""
+    """Check NomadNet installation and recent logs."""
     print_header("NOMADNET")
 
     # Check if installed
@@ -301,6 +453,53 @@ def check_nomadnet():
                 print(f"    Running (PIDs: {', '.join(pids)})")
         except Exception:
             pass
+
+        # Read NomadNet logfile for recent errors
+        user_home = get_real_user_home()
+        logfile = user_home / '.nomadnetwork' / 'logfile'
+        if logfile.exists():
+            try:
+                with open(logfile, 'r') as f:
+                    last_lines = list(
+                        collections.deque(f, maxlen=10)
+                    )
+                error_found = False
+                for line in last_lines:
+                    if ('AuthenticationError' in line
+                            or 'digest' in line.lower()):
+                        print_status(
+                            "NomadNet log", False,
+                            "RPC auth failure (identity mismatch)"
+                        )
+                        print("    Fix: Ensure rnsd and NomadNet use "
+                              "same RNS config")
+                        error_found = True
+                        break
+                    elif 'PermissionError' in line:
+                        print_status(
+                            "NomadNet log", False,
+                            "permission denied in recent logs"
+                        )
+                        print("    Check: ls -la ~/.nomadnetwork/")
+                        error_found = True
+                        break
+                    elif ('ModuleNotFoundError' in line
+                            or 'ImportError' in line):
+                        print_status(
+                            "NomadNet log", False,
+                            "missing Python dependency"
+                        )
+                        print("    Fix: pipx reinstall nomadnet")
+                        error_found = True
+                        break
+                if not error_found:
+                    print_status("NomadNet log", True,
+                                 "no recent errors")
+            except PermissionError:
+                print_status("NomadNet log", False,
+                             f"cannot read {logfile}")
+        else:
+            print(f"    Log: {logfile} (not found yet)")
     else:
         print_status("NomadNet", False, "not installed")
         print("    Install with: pipx install nomadnet")
@@ -523,7 +722,8 @@ def check_logs():
     for name, cmd in log_sources:
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
-            lines = [l for l in result.stdout.strip().split('\n') if l and '-- No entries --' not in l]
+            lines = [l for l in result.stdout.strip().split('\n')
+                     if l and '-- No entries --' not in l]
             if lines:
                 print(f"\n  {name} errors ({len(lines)} recent):")
                 for line in lines[:3]:  # Show first 3
@@ -532,6 +732,31 @@ def check_logs():
                 print_status(f"{name} errors", True, "none")
         except Exception:
             pass
+
+    # NomadNet logfile (not in journalctl — uses its own logfile)
+    user_home = get_real_user_home()
+    nomadnet_log = user_home / '.nomadnetwork' / 'logfile'
+    if nomadnet_log.exists():
+        try:
+            with open(nomadnet_log, 'r') as f:
+                lines = list(collections.deque(f, maxlen=20))
+            error_patterns = [
+                'Error', 'Exception', 'CRITICAL',
+                'AuthenticationError', 'PermissionError',
+            ]
+            error_lines = [
+                line for line in lines
+                if any(p in line for p in error_patterns)
+            ]
+            if error_lines:
+                print(f"\n  NomadNet errors "
+                      f"({len(error_lines)} recent):")
+                for line in error_lines[:3]:
+                    print(f"    {line[:80]}")
+            else:
+                print_status("NomadNet errors", True, "none")
+        except (OSError, PermissionError):
+            print_status("NomadNet log", False, "cannot read")
 
 
 def check_ham_callsign():
@@ -631,6 +856,7 @@ Examples:
     check_cli()
     check_rns_port()
     check_rns_config()
+    check_rns_interfaces()
     check_nomadnet()
     check_processes()
 

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -53,7 +53,7 @@ class RNSDiagnosticsMixin:
         warnings = []
 
         # 1. Service status
-        print("[1/5] Checking rnsd service...")
+        print("[1/6] Checking rnsd service...")
         status = get_status()
         status_data = status.data or {}
         running = status_data.get('rnsd_running', False)
@@ -93,19 +93,47 @@ class RNSDiagnosticsMixin:
         nomadnet_conflict = self._check_nomadnet_conflict()
         if nomadnet_conflict:
             print(f"  NomadNet: RUNNING (port conflict!)")
+            # Show port 37428 owner for clarity
+            try:
+                from utils.service_check import get_udp_port_owner
+                owner = get_udp_port_owner(37428)
+                if owner:
+                    proc_name, pid = owner
+                    print(f"  Port 37428 owner: {proc_name} (PID {pid})")
+            except ImportError:
+                pass
         if service_state == 'failed' or (not running and nomadnet_conflict):
             print("")
             if nomadnet_conflict:
-                print("  WARNING: NomadNet is holding the RNS shared instance port.")
-                print("  rnsd cannot bind port 37428 while NomadNet is running.")
-                print("  Fix: stop NomadNet first, or disable rnsd and let NomadNet")
+                print("  WARNING: NomadNet is holding the RNS shared "
+                      "instance port.")
+                print("  rnsd cannot bind port 37428 while NomadNet "
+                      "is running.")
+                print("  Fix: stop NomadNet first, or disable rnsd "
+                      "and let NomadNet")
                 print("  serve as the shared instance.")
+                # Show NomadNet log tail for context
+                nn_logfile = (get_real_user_home()
+                              / '.nomadnetwork' / 'logfile')
+                if nn_logfile.exists():
+                    try:
+                        import collections
+                        with open(nn_logfile, 'r') as f:
+                            last_lines = list(
+                                collections.deque(f, maxlen=5)
+                            )
+                        if last_lines:
+                            print("\n  Recent NomadNet log entries:")
+                            for line in last_lines:
+                                print(f"    {line[:100]}")
+                    except (OSError, PermissionError):
+                        print("    (cannot read NomadNet logfile)")
             elif service_state == 'failed':
                 print("  WARNING: rnsd has crashed. Check logs:")
                 print("    sudo journalctl -u rnsd -n 30")
 
         # 2. Config check
-        print("\n[2/5] Checking configuration...")
+        print("\n[2/6] Checking configuration...")
         config_exists = status_data.get('config_exists', False)
         print(f"  Config: {'found' if config_exists else 'MISSING'}")
         if config_exists:
@@ -113,7 +141,7 @@ class RNSDiagnosticsMixin:
             print(f"  Interfaces: {iface_count}")
 
         # 3. Identity check
-        print("\n[3/5] Checking identity...")
+        print("\n[3/6] Checking identity...")
         identity_exists = status_data.get('identity_exists', False)
         print(f"  Gateway identity: {'found' if identity_exists else 'not created'}")
         config_dir = ReticulumPaths.get_config_dir()
@@ -121,7 +149,7 @@ class RNSDiagnosticsMixin:
         print(f"  RNS identity: {'found' if rns_identity.exists() else 'not created'}")
 
         # 4. Full connectivity check
-        print("\n[4/5] Running connectivity check...")
+        print("\n[4/6] Running connectivity check...")
         conn = check_connectivity()
         conn_data = conn.data or {}
         print(f"  RNS importable: {'yes' if conn_data.get('can_import_rns') else 'NO'}")
@@ -135,7 +163,7 @@ class RNSDiagnosticsMixin:
         warnings.extend(conn_data.get('warnings', []))
 
         # 5. Interface dependencies
-        print("\n[5/5] Checking interface dependencies...")
+        print("\n[5/6] Checking interface dependencies...")
         try:
             blocking = self._find_blocking_interfaces()
             if blocking:
@@ -172,19 +200,63 @@ class RNSDiagnosticsMixin:
                         pass
             if running and not port_ok:
                 print("  ! rnsd running but port 37428 NOT listening")
+                # Show who owns the port (if anyone)
+                try:
+                    from utils.service_check import get_udp_port_owner
+                    owner = get_udp_port_owner(37428)
+                    if owner:
+                        proc_name, pid = owner
+                        print(f"    Port held by: {proc_name} "
+                              f"(PID {pid})")
+                except ImportError:
+                    pass
                 # Check if share_instance is enabled in config
                 share_ok = conn_data.get('share_instance', None)
                 if share_ok is False:
-                    print("    Cause: share_instance is not enabled in [reticulum] config")
-                    print("    Fix: Add 'share_instance = Yes' to [reticulum] section,")
-                    print("         then restart: sudo systemctl restart rnsd")
-                    issues.append("share_instance not enabled — gateway cannot connect to rnsd")
+                    print("    Cause: share_instance is not "
+                          "enabled in [reticulum] config")
+                    print("    Fix: Add 'share_instance = Yes' "
+                          "to [reticulum] section,")
+                    print("         then restart: sudo systemctl "
+                          "restart rnsd")
+                    issues.append(
+                        "share_instance not enabled — gateway "
+                        "cannot connect to rnsd")
                 else:
-                    warnings.append("rnsd active but shared instance port not bound")
+                    warnings.append(
+                        "rnsd active but shared instance port "
+                        "not bound")
             elif running and port_ok:
                 print(f"  Shared instance port 37428: listening")
         except Exception:
             pass
+
+        # 6. Interface TX/RX health
+        print("\n[6/6] Checking interface traffic...")
+        try:
+            iface_health = self._check_rns_interface_health()
+            if iface_health:
+                rx_only_found = False
+                for name, tx, rx, healthy in iface_health:
+                    if healthy:
+                        print(f"  {name}: ↑{tx} ↓{rx}")
+                    else:
+                        print(f"  {name}: RX-ONLY (↑{tx} ↓{rx})")
+                        issues.append(
+                            f"Interface {name} is RX-only (no TX)")
+                        rx_only_found = True
+                if rx_only_found:
+                    print("\n  RX-only interfaces = link "
+                          "establishment failing.")
+                    print("  Common cause: shared instance port "
+                          "37428 not bound.")
+            else:
+                print("  Could not retrieve interface traffic "
+                      "(rnstatus not available or rnsd not "
+                      "connected)")
+        except Exception as e:
+            logger.debug("Interface health check failed: %s", e)
+            print(f"  Could not check: {e}")
 
         # Summary
         if issues:
@@ -854,6 +926,89 @@ class RNSDiagnosticsMixin:
             return result.returncode == 0
         except (subprocess.SubprocessError, OSError):
             return False
+
+    def _check_rns_interface_health(self):
+        """Run rnstatus and parse per-interface TX/RX counters.
+
+        Returns a list of (interface_name, tx_str, rx_str, is_healthy)
+        tuples. An interface is unhealthy if it has RX but zero TX
+        (link establishment / SYN/ACK failing).
+
+        Returns empty list if rnstatus is unavailable or fails.
+        """
+        rnstatus_path = shutil.which('rnstatus')
+        if not rnstatus_path:
+            user_home = get_real_user_home()
+            candidate = user_home / '.local' / 'bin' / 'rnstatus'
+            if candidate.exists():
+                rnstatus_path = str(candidate)
+        if not rnstatus_path:
+            return []
+
+        try:
+            result = subprocess.run(
+                [rnstatus_path],
+                capture_output=True, text=True, timeout=15
+            )
+            combined = (result.stdout or '') + (result.stderr or '')
+            if ('no shared' in combined.lower()
+                    or 'could not' in combined.lower()):
+                return []
+        except (subprocess.SubprocessError, FileNotFoundError,
+                OSError):
+            return []
+
+        interfaces = []
+        current_iface = None
+        tx_cache = {}
+
+        for line in combined.splitlines():
+            # Interface header: InterfaceType[DisplayName]
+            iface_match = re.match(r'\s*(\w+)\[(.+?)\]', line)
+            if iface_match:
+                current_iface = (
+                    f"{iface_match.group(1)}"
+                    f"[{iface_match.group(2)}]"
+                )
+                continue
+
+            # TX line: ↑NNN B  NNN bps
+            tx_match = re.search(
+                r'↑\s*([\d,.]+)\s*(\w+)', line
+            )
+            if tx_match and current_iface:
+                tx_cache[current_iface] = (
+                    tx_match.group(1).replace(',', ''),
+                    tx_match.group(2),
+                )
+
+            # RX line: ↓NNN B  NNN bps
+            rx_match = re.search(
+                r'↓\s*([\d,.]+)\s*(\w+)', line
+            )
+            if rx_match and current_iface:
+                rx_val = rx_match.group(1).replace(',', '')
+                rx_unit = rx_match.group(2)
+                tx_info = tx_cache.get(
+                    current_iface, ('0', 'B')
+                )
+                tx_str = f"{tx_info[0]} {tx_info[1]}"
+                rx_str = f"{rx_val} {rx_unit}"
+
+                try:
+                    tx_bytes = float(tx_info[0])
+                    rx_bytes = float(rx_val)
+                except ValueError:
+                    tx_bytes = rx_bytes = 0
+
+                # Healthy if TX > 0, or both are 0 (just started)
+                healthy = not (rx_bytes > 0 and tx_bytes == 0)
+                interfaces.append(
+                    (current_iface, tx_str, rx_str, healthy)
+                )
+                current_iface = None
+
+        return interfaces
 
     def _diagnose_rns_port_conflict(self):
         """Diagnose and offer to fix RNS port conflicts from the TUI."""

--- a/src/utils/diagnostic_rules.py
+++ b/src/utils/diagnostic_rules.py
@@ -975,3 +975,92 @@ def load_mesh_rules(engine: "DiagnosticEngine") -> None:
         auto_recoverable=False,
         confidence_base=0.75,
     ))
+
+    # ===== RNS / NOMADNET COEXISTENCE RULES =====
+
+    engine.add_rule(DiagnosticRule(
+        name="rns_interface_rx_only",
+        pattern=(
+            r"(?i)(interface|rns).*(rx.?only|no.*tx|"
+            r"receive.*only|no.*transmit)"
+        ),
+        category=Category.CONNECTIVITY,
+        cause_template=(
+            "RNS interface is receiving packets but not transmitting. "
+            "Link establishment (SYN/ACK) is failing, typically because "
+            "the shared instance port 37428 is not bound or another "
+            "process (NomadNet) is holding it."
+        ),
+        evidence_checks=[
+            make_service_active_check("rnsd"),
+        ],
+        suggestions=[
+            "Check port 37428 owner: sudo ss -ulnp | grep 37428",
+            "If NomadNet owns port 37428: stop NomadNet, restart "
+            "rnsd, then restart NomadNet",
+            "Check share_instance = Yes in Reticulum config",
+            "Run rnstatus to see per-interface TX/RX counters",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.85,
+    ))
+
+    engine.add_rule(DiagnosticRule(
+        name="nomadnet_rnsd_port_conflict",
+        pattern=(
+            r"(?i)(nomadnet|nomad.?net).*(conflict|port|37428|"
+            r"shared.?instance|holding)"
+        ),
+        category=Category.CONFIGURATION,
+        cause_template=(
+            "NomadNet and rnsd are competing for the RNS shared "
+            "instance port (UDP 37428). Both create their own "
+            "Reticulum instance with share_instance=Yes, but only "
+            "one can bind the port. Correct startup order: rnsd "
+            "first, then NomadNet (as client)."
+        ),
+        evidence_checks=[
+            make_service_active_check("rnsd"),
+            make_process_check("nomadnet"),
+        ],
+        suggestions=[
+            "Stop NomadNet: pkill -f nomadnet",
+            "Restart rnsd: sudo systemctl restart rnsd",
+            "Wait for port 37428 to be listening",
+            "Start NomadNet (will connect as client to rnsd)",
+            "Correct boot order: rnsd -> NomadNet -> MeshForge",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.9,
+    ))
+
+    engine.add_rule(DiagnosticRule(
+        name="rns_shared_instance_not_listening",
+        pattern=(
+            r"(?i)(shared.?instance|37428|port).*(not.?listen|"
+            r"not.?bound|waiting|unavailable)"
+        ),
+        category=Category.CONNECTIVITY,
+        cause_template=(
+            "The RNS shared instance port (UDP 37428) is not bound. "
+            "This prevents client applications (NomadNet, rnstatus, "
+            "MeshForge gateway) from connecting to rnsd. Causes: "
+            "share_instance not enabled, blocking interface "
+            "preventing rnsd initialization, or NomadNet holding "
+            "the port."
+        ),
+        evidence_checks=[
+            make_service_active_check("rnsd"),
+            make_process_check("nomadnet"),
+        ],
+        suggestions=[
+            "Check share_instance = Yes in [reticulum] config",
+            "Check for NomadNet port conflict: pgrep -f nomadnet",
+            "Check for blocking interfaces: RNS > Diagnostics in "
+            "MeshForge",
+            "Restart rnsd: sudo systemctl restart rnsd",
+            "Check rnsd logs: sudo journalctl -u rnsd -n 30",
+        ],
+        auto_recoverable=False,
+        confidence_base=0.85,
+    ))

--- a/src/utils/knowledge_content.py
+++ b/src/utils/knowledge_content.py
@@ -1110,6 +1110,175 @@ Common Issues:
         ],
     ))
 
+    # --- NomadNet / rnsd coexistence ---
+
+    kb._add_guide(TroubleshootingGuide(
+        problem="nomadnet_rnsd_coexistence",
+        description=(
+            "NomadNet and rnsd competing for shared instance "
+            "port 37428"
+        ),
+        prerequisites=["rnsd installed", "NomadNet installed"],
+        steps=[
+            TroubleshootingStep(
+                instruction="Check who owns port 37428",
+                command="sudo ss -ulnp | grep 37428",
+                expected_result="rnsd should own the port",
+                if_fail=(
+                    "If NomadNet owns it, startup order is wrong"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction="Stop NomadNet",
+                command="pkill -f nomadnet",
+                expected_result="NomadNet processes terminated",
+            ),
+            TroubleshootingStep(
+                instruction="Restart rnsd so it claims the port",
+                command="sudo systemctl restart rnsd",
+                expected_result="Active: active (running)",
+                if_fail=(
+                    "Check journalctl -u rnsd for errors"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction=(
+                    "Verify rnsd owns port 37428"
+                ),
+                command="sudo ss -ulnp | grep 37428",
+                expected_result="rnsd shown as port owner",
+                if_fail=(
+                    "Check share_instance = Yes in config"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction=(
+                    "Start NomadNet (connects as client)"
+                ),
+                command="nomadnet --daemon",
+                expected_result=(
+                    "NomadNet connects to rnsd shared instance"
+                ),
+                if_fail=(
+                    "Check NomadNet logfile: "
+                    "~/.nomadnetwork/logfile"
+                ),
+            ),
+        ],
+        related_problems=[
+            "rnsd_not_starting", "rns_path_failure",
+        ],
+    ))
+
+    kb._add_guide(TroubleshootingGuide(
+        problem="rns_interface_rx_only",
+        description=(
+            "RNS interfaces show RX traffic but zero TX — "
+            "link establishment failing"
+        ),
+        prerequisites=[
+            "rnsd running",
+            "At least one interface enabled",
+        ],
+        steps=[
+            TroubleshootingStep(
+                instruction=(
+                    "Check interface TX/RX counters"
+                ),
+                command="rnstatus",
+                expected_result=(
+                    "Both TX and RX byte counts should be "
+                    "non-zero"
+                ),
+                if_fail=(
+                    "Interfaces with 0 TX cannot establish "
+                    "links"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction=(
+                    "Check if shared instance port is "
+                    "listening"
+                ),
+                command="sudo ss -ulnp | grep 37428",
+                expected_result=(
+                    "rnsd bound to port 37428"
+                ),
+                if_fail=(
+                    "rnsd may not have finished initializing, "
+                    "or NomadNet may be holding the port"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction=(
+                    "Check for blocking interfaces in config"
+                ),
+                expected_result=(
+                    "All enabled interfaces have dependencies "
+                    "met"
+                ),
+                if_fail=(
+                    "Disable the blocking interface or start "
+                    "its dependency"
+                ),
+            ),
+            TroubleshootingStep(
+                instruction=(
+                    "Restart rnsd to reinitialize interfaces"
+                ),
+                command="sudo systemctl restart rnsd",
+                expected_result=(
+                    "Active: active (running), then rnstatus "
+                    "shows TX > 0"
+                ),
+            ),
+        ],
+        related_problems=[
+            "nomadnet_rnsd_coexistence",
+            "rnsd_not_starting",
+        ],
+    ))
+
+    kb._add_entry(KnowledgeEntry(
+        topic=KnowledgeTopic.RETICULUM,
+        title="NomadNet and rnsd Coexistence",
+        content="""
+NomadNet and rnsd both create Reticulum instances. When both set
+share_instance = Yes, they compete for UDP port 37428.
+
+Correct startup order:
+1. rnsd starts first, binds port 37428 (shared instance)
+2. NomadNet starts second, detects rnsd and connects as client
+3. MeshForge gateway connects as another client
+
+If NomadNet starts first:
+- NomadNet binds port 37428
+- rnsd fails to bind, enters crash loop
+- MeshForge gateway may connect to NomadNet instead of rnsd
+- Some interfaces (Meshtastic_Interface) only available via rnsd
+
+Diagnosis:
+- sudo ss -ulnp | grep 37428 -- shows who owns the port
+- RX-only interfaces in rnstatus -- rnsd initialized but can't TX
+- NomadNet logfile: ~/.nomadnetwork/logfile
+
+Fix:
+- Stop NomadNet: pkill -f nomadnet
+- Restart rnsd: sudo systemctl restart rnsd
+- Wait for port 37428, then start NomadNet
+- For boot: set rnsd to start before NomadNet in systemd
+""",
+        keywords=[
+            "nomadnet", "rnsd", "coexistence", "port", "37428",
+            "shared instance", "conflict", "startup order",
+        ],
+        related_entries=[
+            "Reticulum Network Stack",
+            "RNS Transport and Routing",
+        ],
+        expertise_level="intermediate",
+    ))
+
 
 def load_aredn_knowledge(kb: "KnowledgeBase") -> None:
     """Load AREDN (Amateur Radio Emergency Data Network) knowledge."""

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import os
+import re
 import socket
 import subprocess
 import logging
@@ -63,6 +64,7 @@ __all__ = [
     'require_service',      # Check with exception on failure
     'check_port',           # TCP port check (utility)
     'check_udp_port',       # UDP port check (utility)
+    'get_udp_port_owner',   # UDP port owner lookup (process name + PID)
     'check_process_running', # Process check via pgrep (utility)
     'check_systemd_service', # Systemd status check
     # Service management
@@ -327,6 +329,77 @@ def check_udp_port(port: int, host: str = '127.0.0.1', timeout: float = 2.0) -> 
                     pass
 
     return False
+
+
+def get_udp_port_owner(port: int) -> Optional[Tuple[str, int]]:
+    """Get the process name and PID that owns a UDP port.
+
+    Primary: ``ss -ulnp``. Fallback: ``/proc/net/udp`` inode scan.
+
+    Args:
+        port: UDP port number to check.
+
+    Returns:
+        Tuple of ``(process_name, pid)`` if found, ``None`` otherwise.
+    """
+    # Primary: ss -ulnp shows process info for UDP listeners
+    try:
+        result = subprocess.run(
+            ['ss', '-ulnp', 'sport', '=', f':{port}'],
+            capture_output=True, text=True, timeout=5
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            # Parse users:(("process",pid=NNN,fd=N)) pattern
+            m = re.search(
+                r'users:\(\("([^"]+)",pid=(\d+)',
+                result.stdout
+            )
+            if m:
+                return (m.group(1), int(m.group(2)))
+    except (subprocess.SubprocessError, FileNotFoundError, OSError):
+        pass
+
+    # Fallback: find inode in /proc/net/udp, then scan /proc/*/fd
+    hex_port = f'{port:04X}'
+    target_inode = None
+    for proc_path in ('/proc/net/udp', '/proc/net/udp6'):
+        try:
+            with open(proc_path, 'r') as f:
+                for line in f:
+                    parts = line.split()
+                    if len(parts) >= 10:
+                        local = parts[1]
+                        if local.endswith(':' + hex_port):
+                            target_inode = parts[9]
+                            break
+            if target_inode:
+                break
+        except (OSError, IOError):
+            continue
+
+    if not target_inode:
+        return None
+
+    # Scan /proc/*/fd for the inode
+    proc_dir = Path('/proc')
+    for pid_dir in proc_dir.iterdir():
+        if not pid_dir.name.isdigit():
+            continue
+        fd_dir = pid_dir / 'fd'
+        try:
+            for fd in fd_dir.iterdir():
+                try:
+                    link = os.readlink(str(fd))
+                    if f'socket:[{target_inode}]' in link:
+                        comm_path = pid_dir / 'comm'
+                        name = comm_path.read_text().strip()
+                        return (name, int(pid_dir.name))
+                except (OSError, ValueError):
+                    continue
+        except (OSError, PermissionError):
+            continue
+
+    return None
 
 
 def check_process_running(process_name: str) -> bool:


### PR DESCRIPTION
## Summary
Enhanced diagnostic capabilities to detect and troubleshoot RNS interface health issues and NomadNet/rnsd port conflicts. Added interface TX/RX monitoring, UDP port owner detection, and comprehensive troubleshooting guides for shared instance port contention.

## Key Changes

### Diagnostic Tools
- **UDP port owner detection** (`service_check.py`): New `get_udp_port_owner()` function to identify which process owns UDP port 37428, using `ss -ulnp` with `/proc/net/udp` fallback
- **Interface health monitoring** (`diagnose.py`): New `check_rns_interfaces()` function that parses `rnstatus` output to detect:
  - RX-only interfaces (receiving packets but zero TX — link establishment failing)
  - Zero-traffic interfaces (not yet active)
  - Per-interface TX/RX byte counters
- **NomadNet log analysis** (`diagnose.py`): Enhanced `check_nomadnet()` to read recent logfile entries and detect authentication, permission, and import errors

### TUI Enhancements
- **Interface health check** (`rns_diagnostics_mixin.py`): New `_check_rns_interface_health()` method to display per-interface traffic in diagnostics
- **Port conflict visibility**: Show port 37428 owner when NomadNet/rnsd conflict detected
- **NomadNet log tail**: Display recent NomadNet logfile entries when port conflict occurs
- **Updated progress counters**: Diagnostics now show [1/6] through [6/6] to reflect new interface health check

### Knowledge Base & Rules
- **Troubleshooting guides** (`knowledge_content.py`):
  - `nomadnet_rnsd_coexistence`: Step-by-step resolution for port 37428 conflicts
  - `rns_interface_rx_only`: Diagnosis and recovery for RX-only interfaces
  - Knowledge entry explaining correct startup order and coexistence patterns
- **Diagnostic rules** (`diagnostic_rules.py`):
  - `rns_interface_rx_only`: Detects RX-only interface patterns
  - `nomadnet_rnsd_port_conflict`: Identifies port contention scenarios
  - `rns_shared_instance_not_listening`: Detects unbound shared instance port

## Implementation Details
- Port owner detection uses regex parsing of `ss` output (`users:(("process",pid=NNN))` pattern)
- Interface parsing extracts TX/RX from `rnstatus` output using arrow symbols (↑ for TX, ↓ for RX)
- RX-only detection: interfaces with RX > 0 and TX == 0 indicate link establishment failure
- Graceful degradation: all new features check for tool availability and fail safely if missing
- NomadNet logfile monitoring uses `collections.deque` for efficient tail reading

https://claude.ai/code/session_01CAJZRf2WKxK9tHehYi2ki7