### PR TITLE
feat: Add live RNS status monitor with auto-refresh

### DIFF
--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 from rns_sniffer_mixin import RNSSnifferMixin
 from rns_config_mixin import RNSConfigMixin
 from rns_diagnostics_mixin import RNSDiagnosticsMixin
+from rns_monitor_mixin import RNSMonitorMixin
 
 # Import centralized path utility - SINGLE SOURCE OF TRUTH for all paths
 # See: utils/paths.py (ReticulumPaths, get_real_user_home)
@@ -48,12 +49,13 @@ detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
 )
 
 
-class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
+class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMonitorMixin):
     """Mixin providing RNS/Reticulum menu functionality.
 
     Inherits sniffer methods from RNSSnifferMixin.
     Inherits config methods from RNSConfigMixin.
     Inherits diagnostics methods from RNSDiagnosticsMixin.
+    Inherits monitor methods from RNSMonitorMixin.
     """
 
     def _rns_menu(self):
@@ -61,6 +63,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
         while True:
             choices = [
                 ("status", "RNS Status (rnstatus)"),
+                ("monitor", "Live RNS Monitor (auto-refresh)"),
                 ("paths", "RNS Path Table (rnpath)"),
                 ("sniffer", "RNS Traffic Sniffer (Wireshark-grade)"),
                 ("topology", "Network Topology (graph view)"),
@@ -91,6 +94,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin):
                 break
 
             dispatch = {
+                "monitor": ("Live RNS Monitor", self._rns_status_monitor),
                 "sniffer": ("RNS Traffic Sniffer", self._rns_traffic_sniffer),
                 "topology": ("Network Topology", self._topology_menu),
                 "quality": ("Link Quality Analysis", self._link_quality_menu),

--- a/src/launcher_tui/rns_monitor_mixin.py
+++ b/src/launcher_tui/rns_monitor_mixin.py
@@ -1,0 +1,356 @@
+"""
+RNS Monitor Mixin - Live RNS status monitoring with auto-refresh.
+
+Extracted as its own mixin per CLAUDE.md file size guidelines.
+Provides a clear-screen + loop pattern similar to the log viewer,
+with ANSI color-coded interface status display.
+"""
+
+import logging
+import subprocess
+import time
+
+from backend import clear_screen
+from utils.rns_status_parser import (
+    run_rnstatus,
+    InterfaceStatus,
+    InterfaceMode,
+    RNSStatus,
+)
+from utils.safe_import import safe_import
+
+check_service, check_udp_port, start_service, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_udp_port', 'start_service',
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# ANSI colors (matching dashboard_mixin.py patterns)
+# ---------------------------------------------------------------------------
+_GREEN = "\033[0;32m"
+_RED = "\033[0;31m"
+_YELLOW = "\033[0;33m"
+_DIM = "\033[2m"
+_BOLD = "\033[1m"
+_RESET = "\033[0m"
+
+
+def _color_status(status: InterfaceStatus) -> str:
+    """Return colored status indicator."""
+    if status == InterfaceStatus.UP:
+        return f"{_GREEN}\u25cf Up{_RESET}"
+    elif status == InterfaceStatus.DOWN:
+        return f"{_RED}\u25cf Down{_RESET}"
+    return f"{_DIM}\u25cf ???{_RESET}"
+
+
+def _color_dot(ok: bool) -> str:
+    """Return green or red dot."""
+    if ok:
+        return f"{_GREEN}\u25cf{_RESET}"
+    return f"{_RED}\u25cf{_RESET}"
+
+
+def _truncate(text: str, width: int) -> str:
+    """Truncate text to width with ellipsis if needed."""
+    if len(text) <= width:
+        return text
+    return text[:width - 1] + "\u2026"
+
+
+class RNSMonitorMixin:
+    """Mixin providing live RNS status monitoring."""
+
+    def _rns_status_monitor(self):
+        """Entry point — select refresh interval and start the monitor."""
+        choices = [
+            ("5", "5 seconds (default)"),
+            ("3", "3 seconds (fast)"),
+            ("10", "10 seconds"),
+            ("30", "30 seconds (low overhead)"),
+        ]
+
+        choice = self.dialog.menu(
+            "Monitor Refresh Rate",
+            "Select auto-refresh interval:",
+            choices,
+        )
+
+        if choice is None:
+            return
+
+        try:
+            interval = int(choice)
+        except (ValueError, TypeError):
+            interval = 5
+
+        self._rns_monitor_loop(interval)
+
+    def _rns_monitor_loop(self, interval: int):
+        """Live display loop — clears screen and redraws on each cycle.
+
+        Args:
+            interval: Seconds between refreshes.
+        """
+        last_good = None  # type: Optional[RNSStatus]
+        rnsd_was_failed = False
+
+        try:
+            while True:
+                # Fetch fresh status
+                status = run_rnstatus()
+                service_state = self._check_rnsd_service_state()
+
+                # Track last good status for stale display
+                if status.parse_error is None and status.interfaces:
+                    last_good = status
+
+                # Track if rnsd was in failed state
+                if service_state.get('systemd_state') == 'failed':
+                    rnsd_was_failed = True
+
+                # Render
+                clear_screen()
+                self._render_monitor_display(
+                    status, service_state, last_good, interval,
+                )
+
+                # Countdown display
+                for remaining in range(interval, 0, -1):
+                    # Move cursor to last line and update countdown
+                    print(
+                        f"\r{_DIM}Ctrl+C to exit | "
+                        f"Next refresh in {remaining}s{_RESET}  ",
+                        end="", flush=True,
+                    )
+                    time.sleep(1)
+
+        except KeyboardInterrupt:
+            pass
+
+        print()  # Clean line after Ctrl+C
+
+        # Offer restart if rnsd was in failed state
+        if rnsd_was_failed and _HAS_SERVICE_CHECK:
+            if self.dialog.yesno(
+                "rnsd Failed",
+                "rnsd was in FAILED state during monitoring.\n\n"
+                "Restart rnsd now?",
+            ):
+                success, msg = start_service('rnsd')
+                if success:
+                    print("rnsd restarted.")
+                else:
+                    print(f"Failed to restart rnsd: {msg}")
+
+        self._wait_for_enter()
+
+    def _check_rnsd_service_state(self) -> dict:
+        """Check rnsd service health via service_check.py.
+
+        Returns:
+            Dict with keys: systemd_state, port_bound, pid
+        """
+        result = {
+            'systemd_state': 'unknown',
+            'port_bound': False,
+            'pid': None,
+        }
+
+        if not _HAS_SERVICE_CHECK:
+            return result
+
+        try:
+            svc = check_service('rnsd')
+            result['systemd_state'] = svc.state.value
+        except Exception as e:
+            logger.debug("check_service('rnsd') failed: %s", e)
+
+        try:
+            result['port_bound'] = check_udp_port(37428)
+        except Exception as e:
+            logger.debug("check_udp_port(37428) failed: %s", e)
+
+        # Get PID via pgrep
+        try:
+            proc = subprocess.run(
+                ['pgrep', '-f', 'rnsd'],
+                capture_output=True, text=True, timeout=5,
+            )
+            if proc.returncode == 0 and proc.stdout.strip():
+                pids = proc.stdout.strip().split('\n')
+                result['pid'] = pids[0]
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        return result
+
+    def _render_monitor_display(
+        self,
+        status: RNSStatus,
+        service: dict,
+        last_good,  # Optional[RNSStatus]
+        interval: int,
+    ):
+        """Render the ANSI-colored monitor display.
+
+        Args:
+            status: Current parsed rnstatus output.
+            service: Service state dict from _check_rnsd_service_state.
+            last_good: Last successful status (for stale display).
+            interval: Current refresh interval.
+        """
+        # Header
+        print(f"{_BOLD}=== RNS Live Monitor ==={_RESET}"
+              f"                         {_DIM}refresh: {interval}s{_RESET}")
+        print()
+
+        # --- Service Health ---
+        print(f"{_BOLD}SERVICE{_RESET}")
+
+        # rnsd systemd state
+        sd_state = service.get('systemd_state', 'unknown')
+        pid = service.get('pid')
+        port_bound = service.get('port_bound', False)
+
+        if sd_state == 'available':
+            pid_str = f" (PID {pid})" if pid else ""
+            print(f"  rnsd:      {_color_dot(True)} active{pid_str}")
+        elif sd_state == 'failed':
+            print(f"  rnsd:      {_color_dot(False)} FAILED")
+        elif sd_state == 'not_running':
+            print(f"  rnsd:      {_DIM}\u25cb stopped{_RESET}")
+        else:
+            print(f"  rnsd:      {_DIM}\u25cf {sd_state}{_RESET}")
+
+        # Port 37428
+        print(f"  Port 37428: {_color_dot(port_bound)}"
+              f" {'bound' if port_bound else 'NOT bound'}")
+
+        # Transport
+        if status.transport.running:
+            print(f"  Transport: {_color_dot(True)} running"
+                  f"    Uptime: {status.transport.uptime_str}")
+        elif status.parse_error:
+            print(f"  Transport: {_DIM}\u25cf unavailable{_RESET}")
+        else:
+            print(f"  Transport: {_color_dot(False)} not running")
+
+        print()
+
+        # --- Error banner ---
+        if status.parse_error:
+            print(f"  {_RED}ERROR: rnsd not responding{_RESET}")
+            # Show concise error
+            err_line = status.parse_error.split('\n')[0][:70]
+            print(f"  {_DIM}{err_line}{_RESET}")
+
+            if last_good and last_good.interfaces:
+                print(f"\n  {_YELLOW}Showing last known state (STALE):{_RESET}")
+                self._render_interface_table(last_good)
+            else:
+                print(f"\n  {_DIM}No previous status available.{_RESET}")
+                print(f"  {_DIM}Check: sudo journalctl -u rnsd -n 20{_RESET}")
+            print()
+            return
+
+        # --- Interface Table ---
+        self._render_interface_table(status)
+
+        # --- Warnings ---
+        warnings = []
+
+        rx_only = status.rx_only_interfaces
+        if rx_only:
+            for iface in rx_only:
+                warnings.append(
+                    f"  {_YELLOW}! {iface.full_name}: "
+                    f"RX-only (link establishment failing){_RESET}"
+                )
+
+        zero = status.zero_traffic_interfaces
+        if zero:
+            for iface in zero:
+                # Skip Shared Instance — it often has zero traffic
+                if iface.type_name == "Shared Instance":
+                    continue
+                warnings.append(
+                    f"  {_YELLOW}! {iface.full_name}: "
+                    f"zero traffic{_RESET}"
+                )
+
+        if status.any_down:
+            for iface in status.interfaces:
+                if iface.status == InterfaceStatus.DOWN:
+                    warnings.append(
+                        f"  {_RED}! {iface.full_name}: DOWN{_RESET}"
+                    )
+
+        if warnings:
+            print()
+            print(f"{_BOLD}WARNINGS{_RESET}")
+            for w in warnings:
+                print(w)
+
+        print()
+
+    def _render_interface_table(self, status: RNSStatus):
+        """Render the interface table portion of the display."""
+        count = len(status.interfaces)
+        print(f"{_BOLD}INTERFACES ({count}){_RESET}")
+
+        if not status.interfaces:
+            print(f"  {_DIM}No interfaces found{_RESET}")
+            return
+
+        # Header row
+        print(f"  {'Name':<38} {'Status':<10} {'Rate':<12} "
+              f"{'TX':<12} {'RX':<12}")
+        print(f"  {'-' * 38} {'-' * 10} {'-' * 12} {'-' * 12} {'-' * 12}")
+
+        for iface in status.interfaces:
+            name = _truncate(iface.full_name, 38)
+
+            # Status with color
+            status_str = _color_status(iface.status)
+
+            # Rate
+            rate = _truncate(iface.rate, 12) if iface.rate else ""
+
+            # Traffic
+            tx_str = f"\u2191{iface.tx.bytes_total:.0f} {iface.tx.bytes_unit}"
+            rx_str = f"\u2193{iface.rx.bytes_total:.0f} {iface.rx.bytes_unit}"
+
+            # Add bps if non-zero
+            if iface.tx.bps > 0:
+                tx_str += f" {iface.tx.bps:.0f}{iface.tx.bps_unit}"
+            if iface.rx.bps > 0:
+                rx_str += f" {iface.rx.bps:.0f}{iface.rx.bps_unit}"
+
+            tx_str = _truncate(tx_str, 12)
+            rx_str = _truncate(rx_str, 12)
+
+            # Highlight unhealthy rows
+            row_prefix = ""
+            row_suffix = ""
+            if iface.is_rx_only:
+                row_prefix = _YELLOW
+                row_suffix = _RESET
+            elif iface.status == InterfaceStatus.DOWN:
+                row_prefix = _RED
+                row_suffix = _RESET
+
+            # The status_str already contains ANSI codes which affect alignment.
+            # Print name separately to control alignment.
+            print(
+                f"  {row_prefix}{name:<38}{row_suffix} "
+                f"{status_str:<20} "
+                f"{row_prefix}{rate:<12} {tx_str:<12} {rx_str:<12}{row_suffix}"
+            )
+
+            # Extra info line for AutoInterface peers or Shared Instance serving
+            if iface.peers is not None:
+                print(f"  {_DIM}{'':38}   Peers: {iface.peers}{_RESET}")
+            if iface.serving is not None:
+                print(f"  {_DIM}{'':38}   Serving: {iface.serving} program(s){_RESET}")

--- a/src/utils/rns_status_parser.py
+++ b/src/utils/rns_status_parser.py
@@ -1,0 +1,341 @@
+"""
+RNS Status Parser — Structured parsing of rnstatus CLI output.
+
+Provides dataclasses and a parser function that converts the raw text
+output of ``rnstatus`` into typed Python objects.
+
+Used by:
+- rns_monitor_mixin.py  (live status monitor)
+- rns_diagnostics_mixin.py  (health checks — future consolidation)
+
+No external dependencies — pure stdlib.
+"""
+
+import logging
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import List, Optional
+
+from utils.paths import get_real_user_home
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class InterfaceStatus(Enum):
+    UP = "Up"
+    DOWN = "Down"
+    UNKNOWN = "Unknown"
+
+
+class InterfaceMode(Enum):
+    FULL = "Full"
+    GATEWAY = "Gateway"
+    ACCESS_POINT = "Access Point"
+    BOUNDARY = "Boundary"
+    UNKNOWN = "Unknown"
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TrafficCounters:
+    """TX or RX traffic data from a single rnstatus line."""
+    bytes_total: float = 0.0
+    bytes_unit: str = "B"
+    bps: float = 0.0
+    bps_unit: str = "bps"
+
+
+@dataclass
+class RNSInterface:
+    """Parsed data for a single RNS interface."""
+    type_name: str          # e.g. "TCPInterface", "Shared Instance"
+    display_name: str       # e.g. "HawaiiNet RNS/192.168.86.38:4242"
+    status: InterfaceStatus = InterfaceStatus.UNKNOWN
+    mode: InterfaceMode = InterfaceMode.UNKNOWN
+    rate: str = ""          # e.g. "10.00 Mbps"
+    peers: Optional[int] = None
+    serving: Optional[int] = None
+    tx: TrafficCounters = field(default_factory=TrafficCounters)
+    rx: TrafficCounters = field(default_factory=TrafficCounters)
+
+    @property
+    def full_name(self) -> str:
+        return f"{self.type_name}[{self.display_name}]"
+
+    @property
+    def is_healthy(self) -> bool:
+        """True unless RX > 0 with TX == 0 (link establishment failing)."""
+        return not (self.rx.bytes_total > 0 and self.tx.bytes_total == 0)
+
+    @property
+    def is_rx_only(self) -> bool:
+        return self.rx.bytes_total > 0 and self.tx.bytes_total == 0
+
+    @property
+    def is_zero_traffic(self) -> bool:
+        return self.rx.bytes_total == 0 and self.tx.bytes_total == 0
+
+
+@dataclass
+class TransportStatus:
+    """Transport instance information from rnstatus footer."""
+    running: bool = False
+    instance_hash: str = ""
+    uptime_str: str = ""
+
+
+@dataclass
+class RNSStatus:
+    """Complete parsed rnstatus output."""
+    interfaces: List[RNSInterface] = field(default_factory=list)
+    transport: TransportStatus = field(default_factory=TransportStatus)
+    raw_output: str = ""
+    parse_error: Optional[str] = None
+
+    @property
+    def all_up(self) -> bool:
+        return (
+            len(self.interfaces) > 0
+            and all(i.status == InterfaceStatus.UP for i in self.interfaces)
+        )
+
+    @property
+    def any_down(self) -> bool:
+        return any(i.status == InterfaceStatus.DOWN for i in self.interfaces)
+
+    @property
+    def rx_only_interfaces(self) -> List[RNSInterface]:
+        return [i for i in self.interfaces if i.is_rx_only]
+
+    @property
+    def zero_traffic_interfaces(self) -> List[RNSInterface]:
+        return [i for i in self.interfaces if i.is_zero_traffic]
+
+
+# ---------------------------------------------------------------------------
+# Compiled regexes
+# ---------------------------------------------------------------------------
+
+# Interface header — uses [\w\s]+? to match "Shared Instance" (space)
+_IFACE_RE = re.compile(r'^\s*([\w\s]+?)\[(.+?)\]')
+_STATUS_RE = re.compile(r'^\s*Status\s*:\s*(\S+)')
+_MODE_RE = re.compile(r'^\s*Mode\s*:\s*(.+)')
+_RATE_RE = re.compile(r'^\s*Rate\s*:\s*(.+)')
+_PEERS_RE = re.compile(r'^\s*Peers\s*:\s*(\d+)')
+_SERVING_RE = re.compile(r'^\s*Serving\s*:\s*(\d+)')
+
+# Traffic — bytes value, unit, then bps value, unit
+# Handles both "↑242 B  0 bps" and "↑1,234 KiB  500 Kbps"
+_TX_RE = re.compile(r'↑\s*([\d,.]+)\s*(\w+)\s+([\d,.]+)\s*(\w+)')
+_RX_RE = re.compile(r'↓\s*([\d,.]+)\s*(\w+)\s+([\d,.]+)\s*(\w+)')
+
+# Transport footer
+_TRANSPORT_RE = re.compile(r'Transport Instance\s+<?(\S+?)>?\s+running')
+_UPTIME_RE = re.compile(r'Uptime is\s+(.+)')
+
+# Error patterns in rnstatus output (must not match valid interface headers).
+# "Shared Instance[...]" is a valid interface — only match error messages.
+_ERROR_PATTERNS = (
+    "no shared instance",
+    "could not connect",
+    "could not get shared instance",
+    "authenticationerror",
+    "digest mismatch",
+)
+
+# Status mapping
+_STATUS_MAP = {
+    "up": InterfaceStatus.UP,
+    "down": InterfaceStatus.DOWN,
+}
+
+# Mode mapping
+_MODE_MAP = {
+    "full": InterfaceMode.FULL,
+    "gateway": InterfaceMode.GATEWAY,
+    "access point": InterfaceMode.ACCESS_POINT,
+    "boundary": InterfaceMode.BOUNDARY,
+}
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def parse_rnstatus(output: str) -> RNSStatus:
+    """Parse raw ``rnstatus`` text into an :class:`RNSStatus` object.
+
+    Args:
+        output: Raw stdout+stderr from running ``rnstatus``.
+
+    Returns:
+        Populated RNSStatus. If the output contains error patterns,
+        ``parse_error`` will be set and ``interfaces`` may be empty.
+    """
+    result = RNSStatus(raw_output=output)
+
+    if not output or not output.strip():
+        return result
+
+    # Detect error output
+    lower = output.lower()
+    for pattern in _ERROR_PATTERNS:
+        if pattern in lower:
+            result.parse_error = output.strip()
+            break
+
+    current: Optional[RNSInterface] = None
+
+    for line in output.splitlines():
+        # --- Interface header ---
+        m = _IFACE_RE.match(line)
+        if m:
+            # Save previous interface
+            if current is not None:
+                result.interfaces.append(current)
+            current = RNSInterface(
+                type_name=m.group(1).strip(),
+                display_name=m.group(2).strip(),
+            )
+            continue
+
+        # --- Properties (only if we have a current interface) ---
+        if current is not None:
+            m = _STATUS_RE.match(line)
+            if m:
+                current.status = _STATUS_MAP.get(
+                    m.group(1).lower(), InterfaceStatus.UNKNOWN
+                )
+                continue
+
+            m = _MODE_RE.match(line)
+            if m:
+                current.mode = _MODE_MAP.get(
+                    m.group(1).strip().lower(), InterfaceMode.UNKNOWN
+                )
+                continue
+
+            m = _RATE_RE.match(line)
+            if m:
+                current.rate = m.group(1).strip()
+                continue
+
+            m = _PEERS_RE.match(line)
+            if m:
+                try:
+                    current.peers = int(m.group(1))
+                except ValueError:
+                    pass
+                continue
+
+            m = _SERVING_RE.match(line)
+            if m:
+                try:
+                    current.serving = int(m.group(1))
+                except ValueError:
+                    pass
+                continue
+
+            # --- Traffic lines ---
+            m = _TX_RE.search(line)
+            if m:
+                try:
+                    current.tx = TrafficCounters(
+                        bytes_total=float(m.group(1).replace(',', '')),
+                        bytes_unit=m.group(2),
+                        bps=float(m.group(3).replace(',', '')),
+                        bps_unit=m.group(4),
+                    )
+                except ValueError:
+                    pass
+                continue
+
+            m = _RX_RE.search(line)
+            if m:
+                try:
+                    current.rx = TrafficCounters(
+                        bytes_total=float(m.group(1).replace(',', '')),
+                        bytes_unit=m.group(2),
+                        bps=float(m.group(3).replace(',', '')),
+                        bps_unit=m.group(4),
+                    )
+                except ValueError:
+                    pass
+                continue
+
+        # --- Transport footer (outside any interface) ---
+        m = _TRANSPORT_RE.search(line)
+        if m:
+            result.transport.running = True
+            result.transport.instance_hash = m.group(1)
+            continue
+
+        m = _UPTIME_RE.search(line)
+        if m:
+            result.transport.uptime_str = m.group(1).strip()
+            continue
+
+    # Don't forget the last interface
+    if current is not None:
+        result.interfaces.append(current)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+
+def _find_rnstatus_binary() -> Optional[str]:
+    """Locate the rnstatus binary on the system."""
+    path = shutil.which('rnstatus')
+    if path:
+        return path
+    # Pip --user installs land here
+    candidate = get_real_user_home() / '.local' / 'bin' / 'rnstatus'
+    if candidate.exists():
+        return str(candidate)
+    return None
+
+
+def run_rnstatus() -> RNSStatus:
+    """Run ``rnstatus`` and return parsed output.
+
+    Returns:
+        RNSStatus with ``parse_error`` set if rnsd is unreachable
+        or the binary is missing.
+    """
+    rnstatus_path = _find_rnstatus_binary()
+    if not rnstatus_path:
+        return RNSStatus(
+            parse_error="rnstatus binary not found. Install RNS: pip install rns"
+        )
+
+    try:
+        proc = subprocess.run(
+            [rnstatus_path],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        combined = (proc.stdout or "") + (proc.stderr or "")
+        return parse_rnstatus(combined)
+    except subprocess.TimeoutExpired:
+        return RNSStatus(parse_error="rnstatus timed out (rnsd unresponsive)")
+    except FileNotFoundError:
+        return RNSStatus(parse_error=f"rnstatus not found at {rnstatus_path}")
+    except OSError as e:
+        return RNSStatus(parse_error=f"Failed to run rnstatus: {e}")

--- a/tests/test_rns_status_parser.py
+++ b/tests/test_rns_status_parser.py
@@ -1,0 +1,435 @@
+"""
+Tests for RNS status parser.
+
+Tests the pure parsing logic using real rnstatus output samples.
+No external dependencies or network access required.
+
+Run: python3 -m pytest tests/test_rns_status_parser.py -v
+"""
+
+import pytest
+import subprocess
+from unittest.mock import patch, MagicMock
+from pathlib import Path
+
+import sys
+import os
+
+# Ensure src/ is on the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from utils.rns_status_parser import (
+    parse_rnstatus,
+    RNSStatus,
+    RNSInterface,
+    InterfaceStatus,
+    InterfaceMode,
+    TrafficCounters,
+    TransportStatus,
+    _find_rnstatus_binary,
+    run_rnstatus,
+)
+
+
+# ---------------------------------------------------------------------------
+# Sample rnstatus outputs
+# ---------------------------------------------------------------------------
+
+FULL_OUTPUT = """\
+ Shared Instance[rns/meshforge moc2 rns]
+    Status    : Up
+    Serving   : 0 programs
+    Rate      : 1.00 Gbps
+    Traffic   : ↑242 B  0 bps
+                ↓978 B  0 bps
+
+ AutoInterface[Default Interface]
+    Status    : Up
+    Mode      : Full
+    Rate      : 10.00 Mbps
+    Peers     : 1 reachable
+    Traffic   : ↑239 B  0 bps
+                ↓0 B    0 bps
+
+ TCPInterface[HawaiiNet RNS/192.168.86.38:4242]
+    Status    : Up
+    Mode      : Full
+    Rate      : 10.00 Mbps
+    Traffic   : ↑439 B  0 bps
+                ↓239 B  0 bps
+
+ MeshtasticInterface[Meshtastic Gateway]
+    Status    : Up
+    Mode      : Full
+    Rate      : 500.00 bps
+    Traffic   : ↑239 B  0 bps
+                ↓0 B    0 bps
+
+ MeshtasticInterface[Meshtastic Short Turbo]
+    Status    : Up
+    Mode      : Gateway
+    Rate      : 500.00 bps
+    Traffic   : ↑239 B  0 bps
+                ↓0 B    0 bps
+
+ Transport Instance <1a7cc0821444f4977d6c0571141ce5f3> running
+ Uptime is 58m and 33.58s
+"""
+
+ERROR_OUTPUT = "Could not get shared instance status"
+
+DOWN_INTERFACE = """\
+ TCPInterface[Dead Link]
+    Status    : Down
+    Mode      : Full
+    Rate      : 10.00 Mbps
+    Traffic   : ↑0 B  0 bps
+                ↓0 B  0 bps
+"""
+
+RX_ONLY_OUTPUT = """\
+ TCPInterface[Broken Link]
+    Status    : Up
+    Mode      : Full
+    Rate      : 10.00 Mbps
+    Traffic   : ↑0 B  0 bps
+                ↓500 B  10 bps
+"""
+
+LARGE_TRAFFIC = """\
+ TCPInterface[Busy Link]
+    Status    : Up
+    Mode      : Full
+    Rate      : 100.00 Mbps
+    Traffic   : ↑1,234 KiB  500 Kbps
+                ↓5,678 MiB  2 Mbps
+"""
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_rnstatus
+# ---------------------------------------------------------------------------
+
+
+class TestParseInterfaceCount:
+    def test_full_output_has_five_interfaces(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert len(result.interfaces) == 5
+
+    def test_empty_output_has_no_interfaces(self):
+        result = parse_rnstatus("")
+        assert len(result.interfaces) == 0
+
+    def test_single_interface(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        assert len(result.interfaces) == 1
+
+
+class TestParseInterfaceTypes:
+    def test_shared_instance_type(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert shared.type_name == "Shared Instance"
+
+    def test_auto_interface_type(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        auto = result.interfaces[1]
+        assert auto.type_name == "AutoInterface"
+
+    def test_tcp_interface_type(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.type_name == "TCPInterface"
+
+    def test_meshtastic_interface_type(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        mesh = result.interfaces[3]
+        assert mesh.type_name == "MeshtasticInterface"
+
+
+class TestParseDisplayNames:
+    def test_shared_instance_name(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.interfaces[0].display_name == "rns/meshforge moc2 rns"
+
+    def test_auto_interface_name(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.interfaces[1].display_name == "Default Interface"
+
+    def test_tcp_interface_name_with_address(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert "192.168.86.38:4242" in result.interfaces[2].display_name
+
+    def test_full_name_property(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.interfaces[2].full_name == "TCPInterface[HawaiiNet RNS/192.168.86.38:4242]"
+
+
+class TestParseStatus:
+    def test_all_up(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert all(i.status == InterfaceStatus.UP for i in result.interfaces)
+
+    def test_down_interface(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        assert result.interfaces[0].status == InterfaceStatus.DOWN
+
+    def test_all_up_property_true(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.all_up is True
+
+    def test_all_up_property_false_when_empty(self):
+        result = parse_rnstatus("")
+        assert result.all_up is False
+
+    def test_any_down_property(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        assert result.any_down is True
+
+
+class TestParseMode:
+    def test_full_mode(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.mode == InterfaceMode.FULL
+
+    def test_gateway_mode(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        turbo = result.interfaces[4]
+        assert turbo.mode == InterfaceMode.GATEWAY
+
+    def test_shared_instance_no_mode(self):
+        """Shared Instance has Serving instead of Mode."""
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert shared.mode == InterfaceMode.UNKNOWN
+
+    def test_access_point_mode(self):
+        """Mode with space in value must be parsed correctly."""
+        output = """\
+ TCPInterface[AP Node]
+    Status    : Up
+    Mode      : Access Point
+    Rate      : 10.00 Mbps
+    Traffic   : \u2191100 B  0 bps
+                \u2193200 B  0 bps
+"""
+        result = parse_rnstatus(output)
+        assert result.interfaces[0].mode == InterfaceMode.ACCESS_POINT
+
+
+class TestParseRate:
+    def test_gbps_rate(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert "1.00 Gbps" in shared.rate
+
+    def test_mbps_rate(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert "10.00 Mbps" in tcp.rate
+
+    def test_bps_rate(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        mesh = result.interfaces[3]
+        assert "500" in mesh.rate
+
+
+class TestParsePeers:
+    def test_auto_interface_peers(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        auto = result.interfaces[1]
+        assert auto.peers == 1
+
+    def test_tcp_interface_no_peers(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.peers is None
+
+
+class TestParseServing:
+    def test_shared_instance_serving(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert shared.serving == 0
+
+    def test_non_shared_no_serving(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.serving is None
+
+
+class TestParseTraffic:
+    def test_tx_bytes(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.tx.bytes_total == 439.0
+        assert tcp.tx.bytes_unit == "B"
+
+    def test_rx_bytes(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]
+        assert tcp.rx.bytes_total == 239.0
+        assert tcp.rx.bytes_unit == "B"
+
+    def test_tx_bps(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert shared.tx.bps == 0.0
+
+    def test_rx_bps(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        shared = result.interfaces[0]
+        assert shared.rx.bps == 0.0
+
+    def test_large_traffic_comma_separated(self):
+        result = parse_rnstatus(LARGE_TRAFFIC)
+        iface = result.interfaces[0]
+        assert iface.tx.bytes_total == 1234.0
+        assert iface.tx.bytes_unit == "KiB"
+        assert iface.tx.bps == 500.0
+        assert iface.tx.bps_unit == "Kbps"
+
+    def test_large_rx_values(self):
+        result = parse_rnstatus(LARGE_TRAFFIC)
+        iface = result.interfaces[0]
+        assert iface.rx.bytes_total == 5678.0
+        assert iface.rx.bytes_unit == "MiB"
+        assert iface.rx.bps == 2.0
+        assert iface.rx.bps_unit == "Mbps"
+
+
+class TestTrafficHealth:
+    def test_healthy_interface(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        tcp = result.interfaces[2]  # Has both TX and RX
+        assert tcp.is_healthy is True
+
+    def test_rx_only_is_unhealthy(self):
+        result = parse_rnstatus(RX_ONLY_OUTPUT)
+        iface = result.interfaces[0]
+        assert iface.is_healthy is False
+        assert iface.is_rx_only is True
+
+    def test_zero_traffic(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        iface = result.interfaces[0]
+        assert iface.is_zero_traffic is True
+
+    def test_rx_only_interfaces_property(self):
+        result = parse_rnstatus(RX_ONLY_OUTPUT)
+        assert len(result.rx_only_interfaces) == 1
+
+    def test_zero_traffic_interfaces_property(self):
+        """In FULL_OUTPUT all interfaces have TX > 0, so none are zero-traffic."""
+        result = parse_rnstatus(FULL_OUTPUT)
+        zero = result.zero_traffic_interfaces
+        assert len(zero) == 0
+
+    def test_zero_traffic_detected_in_down_interface(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        assert len(result.zero_traffic_interfaces) == 1
+
+
+class TestParseTransport:
+    def test_transport_running(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.transport.running is True
+
+    def test_transport_hash(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.transport.instance_hash == "1a7cc0821444f4977d6c0571141ce5f3"
+
+    def test_uptime(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert "58m" in result.transport.uptime_str
+        assert "33.58s" in result.transport.uptime_str
+
+    def test_no_transport_in_minimal_output(self):
+        result = parse_rnstatus(DOWN_INTERFACE)
+        assert result.transport.running is False
+        assert result.transport.uptime_str == ""
+
+
+class TestErrorHandling:
+    def test_error_output_sets_parse_error(self):
+        result = parse_rnstatus(ERROR_OUTPUT)
+        assert result.parse_error is not None
+        assert len(result.interfaces) == 0
+
+    def test_empty_string(self):
+        result = parse_rnstatus("")
+        assert result.parse_error is None
+        assert len(result.interfaces) == 0
+
+    def test_none_like_empty(self):
+        """Whitespace-only output."""
+        result = parse_rnstatus("   \n\n  ")
+        assert len(result.interfaces) == 0
+
+    def test_raw_output_preserved(self):
+        result = parse_rnstatus(FULL_OUTPUT)
+        assert result.raw_output == FULL_OUTPUT
+
+    def test_shared_instance_error(self):
+        result = parse_rnstatus("Could not get shared instance status")
+        assert result.parse_error is not None
+
+    def test_auth_error(self):
+        result = parse_rnstatus("AuthenticationError: digest mismatch on shared instance")
+        assert result.parse_error is not None
+
+
+class TestFindBinary:
+    @patch('shutil.which', return_value='/usr/bin/rnstatus')
+    def test_found_on_path(self, mock_which):
+        assert _find_rnstatus_binary() == '/usr/bin/rnstatus'
+
+    @patch('shutil.which', return_value=None)
+    @patch('utils.rns_status_parser.get_real_user_home')
+    def test_found_in_local_bin(self, mock_home, mock_which):
+        mock_home.return_value = Path('/home/testuser')
+        candidate = Path('/home/testuser/.local/bin/rnstatus')
+        with patch.object(Path, 'exists', return_value=True):
+            result = _find_rnstatus_binary()
+            assert result is not None
+
+    @patch('shutil.which', return_value=None)
+    @patch('utils.rns_status_parser.get_real_user_home')
+    def test_not_found(self, mock_home, mock_which):
+        mock_home.return_value = Path('/home/testuser')
+        with patch.object(Path, 'exists', return_value=False):
+            assert _find_rnstatus_binary() is None
+
+
+class TestRunRnstatus:
+    @patch('utils.rns_status_parser._find_rnstatus_binary', return_value=None)
+    def test_missing_binary(self, mock_find):
+        result = run_rnstatus()
+        assert result.parse_error is not None
+        assert "not found" in result.parse_error
+
+    @patch('utils.rns_status_parser._find_rnstatus_binary', return_value='/usr/bin/rnstatus')
+    @patch('subprocess.run')
+    def test_successful_run(self, mock_run, mock_find):
+        mock_run.return_value = MagicMock(
+            stdout=FULL_OUTPUT,
+            stderr="",
+        )
+        result = run_rnstatus()
+        assert len(result.interfaces) == 5
+        assert result.parse_error is None
+
+    @patch('utils.rns_status_parser._find_rnstatus_binary', return_value='/usr/bin/rnstatus')
+    @patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='rnstatus', timeout=15))
+    def test_timeout(self, mock_run, mock_find):
+        result = run_rnstatus()
+        assert result.parse_error is not None
+        assert "timed out" in result.parse_error
+
+    @patch('utils.rns_status_parser._find_rnstatus_binary', return_value='/usr/bin/rnstatus')
+    @patch('subprocess.run', side_effect=OSError("Permission denied"))
+    def test_os_error(self, mock_run, mock_find):
+        result = run_rnstatus()
+        assert result.parse_error is not None
+        assert "Failed" in result.parse_error


### PR DESCRIPTION
Add a structured rnstatus parser (rns_status_parser.py) and a live monitor TUI mixin that auto-refreshes RNS interface status, traffic counters, transport state, and service health with ANSI color coding. Accessible from RNS menu as "Live RNS Monitor" with configurable refresh intervals (3/5/10/30s). Detects degradation patterns like RX-only interfaces, zero traffic, and rnsd failures in real-time.

Includes 56 unit tests for the parser covering all interface types, traffic parsing, error handling, and edge cases.

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ