### PR TITLE
fix: Fix cli/status.py import error and suppress raw tracebacks in RN…

### DIFF
--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -18,6 +18,11 @@ import socket
 import subprocess
 from pathlib import Path
 
+# Ensure src directory is in path for imports
+_src_dir = Path(__file__).parent.parent
+if str(_src_dir) not in sys.path:
+    sys.path.insert(0, str(_src_dir))
+
 from utils.safe_import import safe_import
 
 # Module-level safe imports

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -737,8 +737,7 @@ class RNSDiagnosticsMixin:
                 # RNS shared instance issue — DIAGNOSE, don't auto-fix.
                 # Auto-fix was the #1 source of regressions (see persistent_issues.md).
                 # Policy: show what's wrong, let the user decide what to do.
-                if result.returncode == 0 and result.stdout:
-                    print(result.stdout, end='')
+                # Don't dump raw stdout — the diagnostic path below shows actionable info.
                 print(f"\nRNS connectivity issue detected.")
 
                 # Check if rnsd is actually running
@@ -815,12 +814,10 @@ class RNSDiagnosticsMixin:
                 if result.stdout:
                     print(result.stdout, end='')
                 if result.stderr and result.stderr.strip():
-                    # Only show stderr if it contains actual error info
+                    # Show concise error hint — not raw tracebacks
                     stderr_lower = result.stderr.lower()
-                    if "error" in stderr_lower or "failed" in stderr_lower or "exception" in stderr_lower:
-                        print(f"\nNote: {tool_name} reported an issue:")
-                        for line in result.stderr.strip().split('\n')[-3:]:
-                            print(f"  {line}")
+                    if "error" in stderr_lower or "traceback" in stderr_lower or "exception" in stderr_lower:
+                        print(f"\n{tool_name} reported an error. Check: sudo journalctl -u rnsd -n 10")
         except FileNotFoundError:
             print(f"\n{tool_name} not found. Is RNS installed?")
             print("Install: pipx install rns")

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -770,7 +770,6 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                 shutil.which('rnsd') or '/usr/local/bin/rnsd'
             )
             print("  Running rnsd directly to capture error...")
-            print("  " + "-" * 46)
             output = ""
             try:
                 r = subprocess.run(
@@ -779,15 +778,26 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                 )
                 output = ((r.stdout or "") + (r.stderr or "")).strip()
                 if output:
-                    for line in output.splitlines()[-20:]:
-                        print(f"  {line}")
+                    # Detect known error patterns and show actionable messages
+                    lower_output = output.lower()
+                    if 'address already in use' in lower_output:
+                        print("  Cause: Port conflict (another process holds the port)")
+                    elif 'permission' in lower_output and 'denied' in lower_output:
+                        print("  Cause: Permission denied")
+                    elif 'connection refused' in lower_output:
+                        print("  Cause: meshtasticd not running (Connection refused)")
+                        print("  Fix: sudo systemctl start meshtasticd")
+                    else:
+                        # Unknown error — show last 5 lines (not raw 20-line traceback)
+                        for line in output.splitlines()[-5:]:
+                            print(f"  {line}")
+                    print(f"  Full log: sudo journalctl -u rnsd -n 20")
                 else:
                     print("  (no output captured)")
             except subprocess.TimeoutExpired:
                 print("  rnsd hung (no crash within 10s — likely a blocking interface)")
             except (OSError, FileNotFoundError) as e:
                 print(f"  Could not run rnsd: {e}")
-            print("  " + "-" * 46)
 
             # Detect missing meshtastic module and offer to install
             if 'meshtastic module' in output.lower() or 'meshtastic' in output.lower():


### PR DESCRIPTION
…S tools

- Add sys.path setup to cli/status.py (same pattern as diagnose.py) so it works when invoked as subprocess from TUI
- Remove raw stdout dump in _run_rns_tool() error path — diagnostic handler already provides actionable messages
- Replace raw stderr fragment dump with clean one-line log hint
- Replace 20-line raw traceback dump in repair with pattern-matched error messages (port conflict, permission, connection refused, etc.)

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ