### PR TITLE
fix: Detect rnsd zombie state in status bar (systemd active, port unb…

### DIFF
--- a/src/launcher_tui/network_tools_mixin.py
+++ b/src/launcher_tui/network_tools_mixin.py
@@ -16,6 +16,9 @@ import socket as sock
 import subprocess
 from pathlib import Path
 from backend import clear_screen
+from utils.safe_import import safe_import
+
+_check_udp_port, _HAS_UDP_CHECK = safe_import('utils.service_check', 'check_udp_port')
 
 logger = logging.getLogger(__name__)
 
@@ -208,21 +211,26 @@ class NetworkToolsMixin:
         # Port checks
         print("Port Checks:")
         ports = [
-            (4403, 'meshtasticd TCP API'),
-            (9443, 'meshtasticd Web Client'),
-            (37428, 'rnsd (RNS shared instance)'),
-            (1883, 'MQTT broker'),
+            (4403, 'tcp', 'meshtasticd TCP API'),
+            (9443, 'tcp', 'meshtasticd Web Client'),
+            (37428, 'udp', 'rnsd (RNS shared instance)'),
+            (1883, 'tcp', 'MQTT broker'),
         ]
 
-        for port, desc in ports:
+        for port, proto, desc in ports:
             try:
-                s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
-                try:
-                    s.settimeout(1)
-                    result = s.connect_ex(('127.0.0.1', port))
-                finally:
-                    s.close()
-                if result == 0:
+                if proto == 'udp' and _HAS_UDP_CHECK:
+                    is_open = _check_udp_port(port)
+                else:
+                    s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
+                    try:
+                        s.settimeout(1)
+                        result = s.connect_ex(('127.0.0.1', port))
+                    finally:
+                        s.close()
+                    is_open = (result == 0)
+
+                if is_open:
                     print(f"  \033[0;32m●\033[0m {port:<6} {desc}")
                 else:
                     print(f"  \033[2m○\033[0m {port:<6} {desc} (not listening)")

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -28,8 +28,8 @@ logger = logging.getLogger(__name__)
 from utils.safe_import import safe_import
 
 # Import centralized service checking
-check_systemd_service, check_process_running, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_systemd_service', 'check_process_running'
+check_systemd_service, check_process_running, _check_udp_port, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_udp_port'
 )
 
 # Import startup checker for enhanced status
@@ -45,6 +45,9 @@ _event_bus, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'event_bus')
 
 # Node tracker for initial node count seeding
 _get_node_tracker, _HAS_NODE_TRACKER = safe_import('gateway.node_tracker', 'get_node_tracker')
+
+# RNS shared instance port (UDP) — rnsd must bind this to be functional
+_RNS_PORT = 37428
 
 # Cache TTL in seconds — how often to re-check service status
 STATUS_CACHE_TTL = 10.0
@@ -173,6 +176,8 @@ class StatusBar:
         """Check if a systemd service is active.
 
         Uses centralized service_check module when available.
+        For rnsd, also verifies UDP port 37428 is bound — systemd can
+        report "active" while the service fails to bind its port (zombie).
 
         Args:
             service: Service unit name.
@@ -183,7 +188,14 @@ class StatusBar:
         try:
             if _HAS_SERVICE_CHECK:
                 is_running, _ = check_systemd_service(service)
-                return SYM_RUNNING if is_running else SYM_STOPPED
+                if not is_running:
+                    return SYM_STOPPED
+                # rnsd zombie detection: systemd active but port not bound
+                if service == 'rnsd' and _check_udp_port is not None:
+                    if not _check_udp_port(_RNS_PORT):
+                        logger.debug("rnsd active but port %d not bound", _RNS_PORT)
+                        return SYM_STOPPED
+                return SYM_RUNNING
 
             # Fallback to direct systemctl call
             result = subprocess.run(
@@ -191,6 +203,9 @@ class StatusBar:
                 capture_output=True, text=True, timeout=3
             )
             if result.stdout.strip() == 'active':
+                if service == 'rnsd' and _check_udp_port is not None:
+                    if not _check_udp_port(_RNS_PORT):
+                        return SYM_STOPPED
                 return SYM_RUNNING
             return SYM_STOPPED
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/src/utils/active_health_probe.py
+++ b/src/utils/active_health_probe.py
@@ -41,6 +41,7 @@ from enum import Enum
 from utils.safe_import import safe_import
 
 _emit_service_status, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_service_status')
+_check_udp_port_fn, _HAS_UDP_CHECK = safe_import('utils.service_check', 'check_udp_port')
 
 logger = logging.getLogger(__name__)
 
@@ -410,24 +411,32 @@ class ActiveHealthProbe:
         """
         Probe RNS shared instance port.
 
-        Checks if the UDP port is bound (service is listening).
-        RNS uses UDP, so we can't do a TCP connect test.
+        Primary: uses check_udp_port() from service_check which reads
+        /proc/net/udp for reliable detection. Falls back to bind test
+        if service_check is unavailable.
 
         Args:
             port: RNS shared instance port (default: 37428)
             host: Host to check (default: 127.0.0.1)
         """
+        # Primary: /proc/net/udp-based check (reliable)
+        if _HAS_UDP_CHECK:
+            try:
+                if _check_udp_port_fn(port, host):
+                    return HealthResult(healthy=True, reason="port_bound")
+                return HealthResult(healthy=False, reason="port_not_bound")
+            except Exception as e:
+                return HealthResult(healthy=False, reason=f"check_error: {e}")
+
+        # Fallback: bind test (unreliable with SO_REUSEADDR)
         sock = None
         try:
-            # Try to bind to the port - if it fails, port is in use (good!)
             sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             sock.settimeout(2)
             sock.bind((host, port))
-            # If we successfully bound, port was NOT in use
             return HealthResult(healthy=False, reason="port_not_bound")
         except OSError as e:
-            # EADDRINUSE means the port is already bound (service running)
-            if e.errno in (98, 48, 10048):  # Linux, macOS, Windows
+            if e.errno in (98, 48, 10048):  # EADDRINUSE
                 return HealthResult(healthy=True, reason="port_bound")
             return HealthResult(healthy=False, reason=f"socket_error: {e}")
         finally:

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -120,6 +120,57 @@ class TestServiceChecks:
         assert result in (SYM_UNKNOWN, SYM_STOPPED)
 
 
+class TestRnsdZombieDetection:
+    """Test rnsd zombie detection: systemd active but port not bound."""
+
+    def test_rnsd_zombie_shows_stopped(self):
+        """rnsd active in systemd but port 37428 not bound → stopped."""
+        bar = StatusBar(version="1.0")
+        with patch('status_bar.check_systemd_service', return_value=(True, True)):
+            with patch('status_bar._check_udp_port', return_value=False):
+                with patch('status_bar._HAS_SERVICE_CHECK', True):
+                    result = bar._check_systemd_active('rnsd')
+        assert result == SYM_STOPPED
+
+    def test_rnsd_healthy_shows_running(self):
+        """rnsd active in systemd and port 37428 bound → running."""
+        bar = StatusBar(version="1.0")
+        with patch('status_bar.check_systemd_service', return_value=(True, True)):
+            with patch('status_bar._check_udp_port', return_value=True):
+                with patch('status_bar._HAS_SERVICE_CHECK', True):
+                    result = bar._check_systemd_active('rnsd')
+        assert result == SYM_RUNNING
+
+    def test_rnsd_systemd_inactive_skips_port_check(self):
+        """rnsd not active in systemd → stopped without port check."""
+        bar = StatusBar(version="1.0")
+        with patch('status_bar.check_systemd_service', return_value=(False, False)):
+            with patch('status_bar._check_udp_port') as mock_udp:
+                with patch('status_bar._HAS_SERVICE_CHECK', True):
+                    result = bar._check_systemd_active('rnsd')
+        mock_udp.assert_not_called()
+        assert result == SYM_STOPPED
+
+    def test_meshtasticd_no_port_check(self):
+        """meshtasticd should not trigger UDP port check."""
+        bar = StatusBar(version="1.0")
+        with patch('status_bar.check_systemd_service', return_value=(True, True)):
+            with patch('status_bar._check_udp_port') as mock_udp:
+                with patch('status_bar._HAS_SERVICE_CHECK', True):
+                    result = bar._check_systemd_active('meshtasticd')
+        mock_udp.assert_not_called()
+        assert result == SYM_RUNNING
+
+    def test_udp_check_unavailable_falls_through(self):
+        """When check_udp_port is None (import failed), trust systemd only."""
+        bar = StatusBar(version="1.0")
+        with patch('status_bar.check_systemd_service', return_value=(True, True)):
+            with patch('status_bar._check_udp_port', None):
+                with patch('status_bar._HAS_SERVICE_CHECK', True):
+                    result = bar._check_systemd_active('rnsd')
+        assert result == SYM_RUNNING
+
+
 class TestBridgeCheck:
     """Test bridge status checking."""
 


### PR DESCRIPTION
…ound)

Status bar now verifies UDP port 37428 after systemd reports rnsd active. If port not bound, shows rns:- instead of misleading rns:*.

Also fixes:
- ActiveHealthProbe uses reliable /proc/net/udp check instead of bind test
- Network Status screen uses UDP (not TCP) for port 37428

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ