### PR TITLE
fix: rnsd crash loop — add meshtasticd ordering + initial connect retry

### DIFF
--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -860,6 +860,8 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         - StartLimitIntervalSec in [Service] instead of [Unit]
         - ExecStart pointing to system rnsd instead of venv rnsd
           (venv has all dependencies like meshtastic)
+        - Missing After=meshtasticd.service when MeshtasticInterface is
+          configured (rnsd crashes if meshtasticd isn't ready yet)
 
         Returns True if the service file was fixed (daemon-reload needed).
         """
@@ -905,7 +907,23 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
             elif venv_rnsd.exists() and current_rnsd != str(venv_rnsd):
                 wrong_rnsd_path = True
 
-        if not misplaced_directives and not wrong_rnsd_path:
+        # Check for missing meshtasticd ordering dependency.
+        # If a MeshtasticInterface is configured, rnsd must start AFTER
+        # meshtasticd — otherwise the initial TCP connect fails and rnsd
+        # crashes with "Connection refused".
+        missing_ordering = False
+        if 'meshtasticd.service' not in content:
+            try:
+                from utils.rns_utils import ReticulumPaths
+                rns_config = ReticulumPaths.get_config_file()
+                if rns_config.exists():
+                    rns_content = rns_config.read_text()
+                    if 'Meshtastic' in rns_content:
+                        missing_ordering = True
+            except Exception:
+                pass
+
+        if not misplaced_directives and not wrong_rnsd_path and not missing_ordering:
             return False
 
         # Report what we're fixing
@@ -917,6 +935,9 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
             elif venv_rnsd.exists():
                 print(f"  Found: ExecStart uses {current_rnsd}")
                 print(f"         Should use venv: {venv_rnsd}")
+        if missing_ordering:
+            print("  Found: Missing After=meshtasticd.service")
+            print("         rnsd can crash if meshtasticd isn't ready")
         print("  Regenerating rnsd.service...")
 
         # Prefer venv rnsd — it has all dependencies
@@ -932,7 +953,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
             return False
         service_content = f'''[Unit]
 Description=Reticulum Network Stack Daemon
-After=network-online.target
+After=network-online.target meshtasticd.service
 Wants=network-online.target
 
 # Stop crash-looping after 5 failures in 60 seconds

--- a/templates/interfaces/Meshtastic_Interface.py
+++ b/templates/interfaces/Meshtastic_Interface.py
@@ -98,11 +98,23 @@ class MeshtasticInterface(Interface):
         pub.subscribe(self.connection_complete, "meshtastic.connection.established")
         pub.subscribe(self.connection_closed, "meshtastic.connection.lost")
 
-        try:
-            self.open_interface()
-        except Exception as e:
-            RNS.log("Meshtastic: Could not open meshtastic interface " + str(self), RNS.LOG_ERROR)
-            raise e
+        max_retries = 3
+        base_delay = 5
+        for attempt in range(max_retries):
+            try:
+                self.open_interface()
+                break
+            except Exception as e:
+                if attempt == max_retries - 1:
+                    RNS.log("Meshtastic: Could not open interface after "
+                            + str(max_retries) + " attempts: " + str(e), RNS.LOG_ERROR)
+                    raise e
+                delay = base_delay * (2 ** attempt)
+                RNS.log("Meshtastic: Connect failed (" + str(e)
+                        + "), retrying in " + str(delay) + "s ("
+                        + str(attempt + 1) + "/" + str(max_retries) + ")",
+                        RNS.LOG_WARNING)
+                time.sleep(delay)
 
     def open_interface(self):
         if self.port:


### PR DESCRIPTION
Root cause: rnsd starts before meshtasticd is ready, Meshtastic_Interface TCP connect gets "Connection refused", and rnsd crashes immediately. systemd restarts it into the same crash → port 37428 never binds → everything downstream fails (NomadNet, gateway, rnstatus).

Two fixes:
- rnsd.service template: After=meshtasticd.service (systemd ordering)
- Meshtastic_Interface.py: retry initial connect 3x with backoff (same pattern as connection_closed reconnect, but for first connect)

Repair wizard now detects missing ordering in existing service files when MeshtasticInterface is configured.

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ