### PR TITLE
fix: repair wizard ExecStart parsing, missing --service, pip pins

### DIFF
--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -588,7 +588,8 @@ class RNSDiagnosticsMixin:
                 svc_content = service_file.read_text()
                 exec_match = re.search(r'ExecStart\s*=\s*(.+)', svc_content)
                 if exec_match:
-                    candidate = Path(exec_match.group(1).strip())
+                    # Extract just the binary path, stripping args like --service
+                    candidate = Path(exec_match.group(1).strip().split()[0])
                     if candidate.exists():
                         rnsd_path = candidate
             except (OSError, PermissionError):
@@ -666,7 +667,8 @@ class RNSDiagnosticsMixin:
                 print(f"  Installing {pip_name}...")
                 try:
                     install_cmd = [rnsd_python, '-m', 'pip', 'install',
-                                    '--break-system-packages', pip_name]
+                                    '--break-system-packages', pip_name,
+                                    'cryptography>=45.0.7,<47', 'pyopenssl>=25.3.0']
                     if _HAS_SERVICE_CHECK:
                         base_cmd = _sudo_cmd(install_cmd)
                     elif os.getuid() != 0:
@@ -687,7 +689,8 @@ class RNSDiagnosticsMixin:
                         if 'installed by' in err_text or 'externally-managed' in err_text:
                             print(f"  {pip_name}: Debian package conflict, retrying with --ignore-installed...")
                             retry_cmd = [rnsd_python, '-m', 'pip', 'install',
-                                         '--break-system-packages', '--ignore-installed', pip_name]
+                                         '--break-system-packages', '--ignore-installed', pip_name,
+                                         'cryptography>=45.0.7,<47', 'pyopenssl>=25.3.0']
                             if _HAS_SERVICE_CHECK:
                                 retry_cmd = _sudo_cmd(retry_cmd)
                             elif os.getuid() != 0:

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -893,18 +893,21 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         # 2. ExecStart uses system rnsd when venv rnsd is available (venv has deps)
         wrong_rnsd_path = False
         current_rnsd = None
+        current_rnsd_binary = None
         exec_match = re.search(r'ExecStart\s*=\s*(.+)', content)
         if exec_match:
             current_rnsd = exec_match.group(1).strip()
+            # Extract just the binary path, stripping args like --service
+            current_rnsd_binary = current_rnsd.split()[0]
 
         venv_rnsd = Path('/opt/meshforge/venv/bin/rnsd')
 
-        if current_rnsd:
+        if current_rnsd_binary:
             # Critical: does the ExecStart binary actually exist?
-            if not Path(current_rnsd).exists():
+            if not Path(current_rnsd_binary).exists():
                 wrong_rnsd_path = True
             # Secondary: prefer venv rnsd if available (has all dependencies)
-            elif venv_rnsd.exists() and current_rnsd != str(venv_rnsd):
+            elif venv_rnsd.exists() and current_rnsd_binary != str(venv_rnsd):
                 wrong_rnsd_path = True
 
         # Check for missing meshtasticd ordering dependency.
@@ -929,11 +932,11 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         # Report what we're fixing
         if misplaced_directives:
             print("  Found: StartLimitIntervalSec in [Service] (should be [Unit])")
-        if wrong_rnsd_path and current_rnsd:
-            if not Path(current_rnsd).exists():
-                print(f"  Found: ExecStart binary missing: {current_rnsd}")
+        if wrong_rnsd_path and current_rnsd_binary:
+            if not Path(current_rnsd_binary).exists():
+                print(f"  Found: ExecStart binary missing: {current_rnsd_binary}")
             elif venv_rnsd.exists():
-                print(f"  Found: ExecStart uses {current_rnsd}")
+                print(f"  Found: ExecStart uses {current_rnsd_binary}")
                 print(f"         Should use venv: {venv_rnsd}")
         if missing_ordering:
             print("  Found: Missing After=meshtasticd.service")
@@ -963,7 +966,7 @@ StartLimitBurst=5
 
 [Service]
 Type=simple
-ExecStart={rnsd_path}
+ExecStart={rnsd_path} --service
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
Three interrelated bugs in the RNS repair wizard:

1. ExecStart parsing treated full value (e.g. "/usr/local/bin/rnsd --service") as a file path. Path.exists() always failed because "--service" was included in the filename. Now splits on whitespace to extract just the binary path. (rns_menu_mixin + rns_diagnostics)

2. Regenerated service file wrote ExecStart={path} without --service flag, so rnsd didn't run in proper daemon mode after repair.

3. _ensure_rnsd_dependencies() pip installs lacked cryptography and pyopenssl version pins, causing the resolver conflict warning even though requirements.txt and install_noc.sh were already fixed.

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ