### PR TITLE
fix: installer deploys RNS config + validates share_instance + enable…

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -995,11 +995,41 @@ if $INSTALL_RNS; then
     chmod 755 /etc/reticulum/storage/resources
     chmod 755 /etc/reticulum/interfaces
 
+    # Deploy reticulum config — template if none exists, validate if it does
+    if [[ ! -f /etc/reticulum/config ]]; then
+        if [[ -f "$INSTALL_DIR/templates/reticulum.conf" ]]; then
+            cp "$INSTALL_DIR/templates/reticulum.conf" /etc/reticulum/config
+            chmod 644 /etc/reticulum/config
+            echo -e "  ${GREEN}✓ RNS config deployed (share_instance=Yes)${NC}"
+        else
+            echo -e "  ${YELLOW}⚠ No config template found — rnsd will create default${NC}"
+        fi
+    else
+        # Existing config — validate share_instance is enabled
+        # Without this, rnsd runs but port 37428 never binds
+        if grep -q '^\s*share_instance\s*=\s*[Yy]es' /etc/reticulum/config 2>/dev/null || \
+           grep -q '^\s*share_instance\s*=\s*[Tt]rue' /etc/reticulum/config 2>/dev/null; then
+            echo -e "  Existing config preserved (share_instance=Yes)"
+        else
+            echo -e "  ${YELLOW}⚠ Existing config has share_instance disabled${NC}"
+            if grep -q '^\s*share_instance' /etc/reticulum/config 2>/dev/null; then
+                sed -i 's/^\(\s*\)share_instance\s*=.*/\1share_instance = Yes/' /etc/reticulum/config
+            elif grep -q '^\[reticulum\]' /etc/reticulum/config 2>/dev/null; then
+                sed -i '/^\[reticulum\]/a\  share_instance = Yes' /etc/reticulum/config
+            fi
+            echo -e "  ${GREEN}✓ Fixed: share_instance = Yes${NC}"
+        fi
+    fi
+
     # Create systemd service (deploy from template or create inline)
     echo "  Setting up rnsd systemd service..."
 
-    # Find rnsd binary
-    RNSD_BIN=$(command -v rnsd 2>/dev/null || echo "/usr/local/bin/rnsd")
+    # Find rnsd binary — prefer venv (has all dependencies)
+    if [[ -x "$VENV_DIR/bin/rnsd" ]]; then
+        RNSD_BIN="$VENV_DIR/bin/rnsd"
+    else
+        RNSD_BIN=$(command -v rnsd 2>/dev/null || echo "/usr/local/bin/rnsd")
+    fi
 
     # System-wide service (root) - based on templates/systemd/rnsd-user.service
     # but adapted for system-level (User=root, absolute paths)
@@ -1054,6 +1084,9 @@ RNSD_SERVICE
     fi
 
     systemctl daemon-reload
+    systemctl enable rnsd 2>/dev/null
+    systemctl start rnsd 2>/dev/null
+    echo -e "  ${GREEN}✓ rnsd enabled and started${NC}"
 
     echo -e "  ${GREEN}✓ Reticulum installed${NC}"
 else

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -872,8 +872,8 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         import re as _re
                         if _re.search(r'^\s*share_instance\s*=', config_content, _re.MULTILINE):
                             fixed = _re.sub(
-                                r'^(\s*)share_instance\s*=\s*\S+',
-                                r'\1share_instance = Yes',
+                                r'^(\s*share_instance\s*=\s*).*$',
+                                r'\1Yes',
                                 config_content,
                                 count=1,
                                 flags=_re.MULTILINE
@@ -890,6 +890,11 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         if _HAS_SERVICE_CHECK and _sudo_write:
                             ok, msg = _sudo_write(str(config_path), fixed)
                             if ok:
+                                # Verify the write took effect
+                                verify = config_path.read_text()
+                                if not _parse_share_instance(verify):
+                                    print("  WARNING: Config write did not take effect")
+                                    return False
                                 print("  Fixed: share_instance = Yes")
                                 # Restart and re-check
                                 stop_service('rnsd')
@@ -994,14 +999,14 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         missing_ordering = False
         if 'meshtasticd.service' not in content:
             try:
-                from utils.rns_utils import ReticulumPaths
                 rns_config = ReticulumPaths.get_config_file()
                 if rns_config.exists():
                     rns_content = rns_config.read_text()
-                    if 'Meshtastic' in rns_content:
+                    # Match actual interface section, not comments
+                    if re.search(r'^\s*\[\[.*Meshtastic', rns_content, re.MULTILINE):
                         missing_ordering = True
-            except Exception:
-                pass
+            except Exception as e:
+                print(f"  Warning: Could not check RNS config: {e}")
 
         if not misplaced_directives and not wrong_rnsd_path and not missing_ordering:
             return False


### PR DESCRIPTION
…s rnsd

Root cause: the installer never deployed templates/reticulum.conf to /etc/reticulum/config, and never ran systemctl enable/start rnsd. When rnsd first ran, RNS auto-generated a default config with share_instance = No, so port 37428 never bound. This cascaded to: rns:- → bridge:- → messages stuck.

Changes to install_noc.sh:
- Deploy reticulum.conf template if no config exists
- Validate share_instance = Yes in existing configs (sed fix if wrong)
- Prefer venv rnsd binary (has all dependencies) over system rnsd
- Enable and start rnsd after service file creation

Changes to rns_menu_mixin.py (code quality from review):
- Meshtasticd ordering check uses regex for interface sections instead of broad 'Meshtastic' string match that hit comments
- Log exceptions instead of silent pass in ordering check
- share_instance regex replaces entire line value (handles comments)
- Verify config write took effect before restarting rnsd

https://claude.ai/code/session_01U8eMvCxG2q9M8fcHseEryJ