### PR TITLE
Fix non-interruptible daemon loops with threading.Event

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -2,6 +2,28 @@
 
 > **Purpose**: Document recurring issues and their proper fixes to prevent regression.
 > This serves as institutional memory for development.
+>
+> **Last audited**: 2026-02-20 — Cross-referenced against code review health check (2026-01-24)
+
+---
+
+## Health Check Reconciliation (2026-02-20)
+
+The code review health check (2026-01-24) identified 5 critical (C1-C5) and 1 high (H1)
+issues. After auditing the current codebase, here is their status:
+
+| ID | Issue | Status | Evidence |
+|----|-------|--------|----------|
+| C1 | LXMF Source None after partial RNS init | **MITIGATED** | Guard at `rns_bridge.py:579-580` returns False instead of crashing |
+| C2 | reconnect.py raises None on early interruption | **FIXED** | `reconnect.py:176-178` raises ConnectionError |
+| C3 | Unbounded node tracking dicts (memory leak) | **FIXED** | MAX_NODES caps + eviction in node_tracker.py and node_monitor.py |
+| C4 | Stats dict race conditions (24 racy increments) | **FIXED** | threading.Lock added across all affected files |
+| C5 | Atomic write uses deterministic temp path | **FIXED** | `paths.py` uses `tempfile.mkstemp()` for unique temp files |
+| H1 | Non-interruptible shutdown in daemon loops | **FIXED** (2026-02-20) | All daemon loops now use `_stop_event.wait()` instead of `time.sleep()` |
+
+**Key lesson**: File-scoped fixes applied between Jan 24 — Feb 20 resolved C2-C5 individually,
+but the pattern-scoped approach recommended by the health check (grep codebase for all instances)
+was only partially followed for H1. Four files still have blocking `time.sleep()` in daemon loops.
 
 ---
 
@@ -228,14 +250,17 @@ def test_rns(self): ...  # Now _HAS_RNS is True
 ### Symptom
 Files exceed the 1,500 line guideline from CLAUDE.md, making them difficult to navigate, test, and maintain.
 
-### Current Status (2026-02-06)
+### Current Status (2026-02-20)
 
 **Python files over 1,500 lines:**
 
 | File | Lines | Status | Notes |
 |------|-------|--------|-------|
-| `src/utils/knowledge_content.py` | 1,688 | OK | Content file by design - no split needed |
-| `src/gateway/rns_bridge.py` | 1,614 | MONITOR | Down from 1,991; MeshtasticHandler extracted |
+| `src/utils/knowledge_content.py` | 1,824 | OK | Content file by design - no split needed |
+| `src/launcher_tui/service_menu_mixin.py` | 1,611 | MONITOR | OpenHamClock/MQTT extraction candidates |
+| `src/gateway/rns_bridge.py` | 1,525 | MONITOR | MeshCoreBridgeMixin + MessageRouter + gateway_cli extracted |
+| `src/launcher_tui/main.py` | 1,516 | MONITOR | 33 mixins, borderline |
+| `src/utils/map_data_collector.py` | 1,516 | MONITOR | Borderline |
 
 **Previously over threshold (NOW RESOLVED):**
 
@@ -714,7 +739,7 @@ if current_time - last_check >= 30:
 
 ---
 
-*Last updated: 2026-01-23 - Removed stale Textual/Flask/Web UI references after UI consolidation*
+*Last updated: 2026-02-20 - Health check reconciliation; updated issue statuses*
 
 ---
 
@@ -839,11 +864,11 @@ def _on_message(self, event):
 
 ### Implementation Priority
 
-| Component | Effort | Impact | Priority |
-|-----------|--------|--------|----------|
-| Service Detection Simplification | LOW | HIGH | 1 - Do first |
-| Status Display Separation | MEDIUM | HIGH | 2 |
-| RX Message Events | HIGH | MEDIUM | 3 - Requires event bus |
+| Component | Effort | Impact | Priority | Status (2026-02-20) |
+|-----------|--------|--------|----------|---------------------|
+| Service Detection Simplification | LOW | HIGH | 1 | **DONE** — systemctl trusted as SSOT for systemd services |
+| Status Display Separation | MEDIUM | HIGH | 2 | OPEN |
+| RX Message Events | HIGH | MEDIUM | 3 | OPEN — Requires event bus |
 
 ### Files to Modify
 

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -207,6 +207,7 @@ class AgentDaemon:
 
         # Background threads
         self._running = threading.Event()
+        self._stop_event = threading.Event()
         self._metrics_thread: Optional[threading.Thread] = None
         self._health_thread: Optional[threading.Thread] = None
 
@@ -250,6 +251,7 @@ class AgentDaemon:
 
                 # Start background threads
                 self._running.set()
+                self._stop_event.clear()
                 self._start_background_threads()
 
                 # Register signal handlers
@@ -278,6 +280,7 @@ class AgentDaemon:
 
             # Stop background threads
             self._running.clear()
+            self._stop_event.set()
 
             if self._metrics_thread:
                 self._metrics_thread.join(timeout=timeout / 3)
@@ -511,7 +514,9 @@ class AgentDaemon:
         from agent.protocol import Message, MessageType
 
         while self._running.is_set():
-            time.sleep(self.config.metrics_interval)
+            self._stop_event.wait(self.config.metrics_interval)
+            if self._stop_event.is_set():
+                break
 
             if not self._protocol or not self._protocol.is_connected:
                 continue

--- a/src/gateway/rns_transport.py
+++ b/src/gateway/rns_transport.py
@@ -466,14 +466,16 @@ class RNSMeshtasticTransport:
 
                 # Send each fragment with delay
                 for fragment in fragments:
-                    if not self._running:
+                    if not self._running or self._stop_event.is_set():
                         break
 
                     self._send_fragment(fragment, destination)
 
                     # Delay between fragments based on speed preset
                     if len(fragments) > 1:
-                        time.sleep(self._fragment_delay)
+                        self._stop_event.wait(self._fragment_delay)
+                        if self._stop_event.is_set():
+                            break
 
                 self.stats.packets_sent += 1
                 self.stats.bytes_sent += len(packet)

--- a/src/utils/influxdb_exporter.py
+++ b/src/utils/influxdb_exporter.py
@@ -116,6 +116,7 @@ class InfluxDBExporter:
 
         # Background flush thread
         self._running = False
+        self._stop_event = threading.Event()
         self._flush_thread: Optional[threading.Thread] = None
 
         # Determine API version
@@ -502,13 +503,14 @@ class InfluxDBExporter:
         interval = interval or self._flush_interval
 
         def export_loop():
-            while self._running:
+            while self._running and not self._stop_event.is_set():
                 try:
                     self.write_metrics()
                 except Exception as e:
                     logger.debug(f"InfluxDB export error: {e}")
-                time.sleep(interval)
+                self._stop_event.wait(interval)
 
+        self._stop_event.clear()
         self._flush_thread = threading.Thread(target=export_loop, daemon=True)
         self._flush_thread.start()
         logger.info(f"InfluxDB exporter started (interval: {interval}s)")
@@ -516,6 +518,7 @@ class InfluxDBExporter:
     def stop(self) -> None:
         """Stop background export thread."""
         self._running = False
+        self._stop_event.set()
         if self._flush_thread:
             self._flush_thread.join(timeout=5)
             self._flush_thread = None

--- a/src/utils/latency_monitor.py
+++ b/src/utils/latency_monitor.py
@@ -154,6 +154,7 @@ class LatencyMonitor:
         self._services: Dict[str, ServiceHealth] = {}
         self._interval = interval_sec
         self._running = False
+        self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
         self._lock = threading.Lock()
 
@@ -201,19 +202,16 @@ class LatencyMonitor:
     def stop(self):
         """Stop background monitoring."""
         self._running = False
+        self._stop_event.set()
         if self._thread:
             self._thread.join(timeout=5)
             self._thread = None
 
     def _run(self):
         """Background probe loop."""
-        while self._running:
+        while self._running and not self._stop_event.is_set():
             self.probe_once()
-            # Sleep in small increments for responsive shutdown
-            for _ in range(int(self._interval * 10)):
-                if not self._running:
-                    break
-                time.sleep(0.1)
+            self._stop_event.wait(self._interval)
 
 
 # Module-level singleton for shared access


### PR DESCRIPTION
## Summary

Replace blocking `time.sleep()` calls in daemon loops with `threading.Event.wait(timeout)` to enable responsive shutdown across the codebase. This addresses issue **H1** from the 2026-01-24 code review health check and implements the pattern-scoped fix recommended in the persistent issues audit.

## Key Changes

- **latency_monitor.py**: Replace sleep loop with `_stop_event.wait(interval)` in `_run()` method
- **agent.py**: Add `_stop_event` and replace `time.sleep()` with `_stop_event.wait()` in `_metrics_loop()`
- **influxdb_exporter.py**: Add `_stop_event` and replace blocking sleep with `_stop_event.wait(interval)` in export loop
- **rns_transport.py**: Replace fragment delay sleep with `_stop_event.wait()` in `_send_loop()`
- **persistent_issues.md**: 
  - Document health check reconciliation (2026-02-20) with status table for C1-C5 and H1
  - Update file size monitoring table with current line counts
  - Mark Service Detection Simplification as DONE
  - Note that H1 fix was only partially applied initially (4 files still had blocking sleeps)

## Implementation Details

All daemon loops now follow the pattern:
```python
self._stop_event = threading.Event()  # In __init__

# In stop():
self._stop_event.set()

# In loop:
self._stop_event.wait(timeout)  # Replaces time.sleep(timeout)
```

This allows `stop()` to immediately wake sleeping threads rather than waiting for the next sleep interval to expire, enabling graceful shutdown within the configured timeout.

https://claude.ai/code/session_01DAUygM4btRipvzX6HoC69V