### PR TITLE
Consolidate safe_import usage and remove fallback implementations

### DIFF
--- a/src/config/hardware_config.py
+++ b/src/config/hardware_config.py
@@ -9,12 +9,15 @@ Provides interactive tools for:
 - Safe reboot with application check
 """
 
+import logging
 import subprocess
 import os
 import shutil
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 from rich.console import Console
 from rich.table import Table
@@ -334,8 +337,8 @@ class HardwareConfigurator:
                 console.print("[green]dtoverlay=spi0-0cs is already configured[/green]")
                 input("\nPress Enter to continue...")
                 return
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("SPI overlay check failed: %s", e)
 
         if not Confirm.ask("Add dtoverlay=spi0-0cs to config.txt?", default=True):
             return
@@ -395,8 +398,8 @@ class HardwareConfigurator:
                     for p in parts:
                         if p not in ['--', '']:
                             i2c_devices.append(f"0x{p}")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("I2C device scan failed: %s", e)
         table.add_row("I2C", i2c_status, ', '.join(i2c_devices[:5]) or "-")
 
         # Serial

--- a/src/config/rns_config.py
+++ b/src/config/rns_config.py
@@ -459,7 +459,12 @@ class RNSConfigGenerator:
             config_path = ReticulumPaths.get_config_file()
             config_dir = config_path.parent
         else:
-            config_path = Path(path).expanduser()
+            # Resolve ~ using sudo-safe home directory (MF001)
+            path_str = str(path)
+            if path_str.startswith('~'):
+                from utils.paths import get_real_user_home
+                path_str = str(get_real_user_home()) + path_str[1:]
+            config_path = Path(path_str)
             config_dir = config_path.parent
 
         # Create directory if needed

--- a/src/core/diagnostics/checks/ham_radio.py
+++ b/src/core/diagnostics/checks/ham_radio.py
@@ -10,23 +10,9 @@ import logging
 from pathlib import Path
 
 from ..models import CheckResult, CheckStatus, CheckCategory
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+from utils.paths import get_real_user_home as _resolve_user_home
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_user_home() -> Path:
-    """Resolve user home directory with sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    # Fallback for when utils.paths is not in Python path
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    return Path.home()
 
 
 def check_callsign() -> CheckResult:

--- a/src/core/diagnostics/checks/meshtastic.py
+++ b/src/core/diagnostics/checks/meshtastic.py
@@ -13,24 +13,12 @@ from pathlib import Path
 from typing import List
 
 from ..models import CheckResult, CheckStatus, CheckCategory
+from utils.paths import get_real_user_home as _resolve_user_home
 from utils.safe_import import safe_import
 
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 _meshtastic_mod, _HAS_MESHTASTIC = safe_import('meshtastic')
 
 logger = logging.getLogger(__name__)
-
-
-def _resolve_user_home() -> Path:
-    """Resolve user home directory with sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    # Fallback for when utils.paths is not in Python path
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    return Path.home()
 
 
 def check_meshtastic_installed() -> CheckResult:

--- a/src/diagnostics/site_planner.py
+++ b/src/diagnostics/site_planner.py
@@ -9,11 +9,14 @@ Integrates with Meshtastic Site Planner for:
 Reference: https://meshtastic.org/docs/software/site-planner/
 """
 
+import logging
 import os
 import subprocess
 import webbrowser
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from rich.console import Console
 from rich.panel import Panel
@@ -370,8 +373,8 @@ class SitePlanner:
                     if 'latitude' in line.lower():
                         # Parse latitude/longitude
                         pass  # Would need actual parsing
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("GPSD location detection failed: %s", e)
         return None
 
     def _set_manual_location(self):
@@ -602,8 +605,8 @@ class SitePlanner:
                 if result.returncode == 0:
                     console.print(f"[green]Opened in browser[/green]")
                     return
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Failed to open browser: %s", e)
 
         # No display or xdg-open failed - just show the URL
         console.print(f"\n[cyan]Open this URL in your browser:[/cyan]")

--- a/src/diagnostics/system_diagnostics.py
+++ b/src/diagnostics/system_diagnostics.py
@@ -8,12 +8,15 @@ Provides comprehensive system health checks including:
 - RF/LoRa diagnostics
 """
 
+import logging
 import os
 import socket
 import subprocess
 import time
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 from rich.console import Console
 from rich.panel import Panel
@@ -185,8 +188,8 @@ class SystemDiagnostics:
                     idx = parts.index('via')
                     if idx + 1 < len(parts):
                         return parts[idx + 1]
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Default gateway detection failed: %s", e)
         return None
 
     def _dns_resolve(self, hostname: str) -> bool:
@@ -275,8 +278,8 @@ class SystemDiagnostics:
                 lines = result.stdout.split('\n')
                 count = sum(1 for line in lines if '!' in line or 'Node' in line)
                 return max(count, 1)  # At least this node
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Mesh node count failed: %s", e)
         return None
 
     def _check_mesh_activity(self) -> bool:
@@ -288,8 +291,8 @@ class SystemDiagnostics:
             )
             if result.returncode == 0:
                 return 'received' in result.stdout.lower() or 'packet' in result.stdout.lower()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Mesh activity check failed: %s", e)
         return False
 
     def mqtt_connection_test(self):
@@ -454,8 +457,8 @@ class SystemDiagnostics:
                 total_delta = total2 - total
                 if total_delta > 0:
                     return (1 - idle_delta / total_delta) * 100
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("CPU usage calculation failed: %s", e)
         return 0.0
 
     def _get_cpu_temperature(self) -> Optional[float]:
@@ -477,8 +480,8 @@ class SystemDiagnostics:
                 temp_str = result.stdout.strip()
                 temp = float(temp_str.split('=')[1].replace("'C", ""))
                 return temp
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("CPU temperature read failed: %s", e)
         return None
 
     def _get_memory_info(self) -> tuple:
@@ -570,8 +573,8 @@ class SystemDiagnostics:
                     issues.append("Soft temp limit has occurred")
 
                 return ", ".join(issues) if issues else None
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Throttle status check failed: %s", e)
         return None
 
     def lora_diagnostics(self):
@@ -619,8 +622,8 @@ class SystemDiagnostics:
                 output = result.stdout.lower()
                 if 'ch340' in output or 'cp210' in output or 'ft232' in output:
                     return "USB Serial LoRa Module"
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("USB LoRa device detection failed: %s", e)
 
         # Check SPI devices
         if Path('/dev/spidev0.0').exists():
@@ -699,8 +702,8 @@ class SystemDiagnostics:
                             if addr != '--' and addr != 'UU':
                                 devices.append(f"0x{addr}")
                 return ", ".join(devices) if devices else ""
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("I2C device detection failed: %s", e)
         return ""
 
     def _list_serial_ports(self) -> list:
@@ -820,8 +823,8 @@ class SystemDiagnostics:
             )
             if result.returncode == 0 and result.stdout.strip():
                 return result.stdout.strip().split('\n')
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Log error extraction failed: %s", e)
         return []
 
     def log_analysis(self):

--- a/src/gateway/meshtastic_handler.py
+++ b/src/gateway/meshtastic_handler.py
@@ -32,6 +32,7 @@ except ImportError:
     def broadcast_message(*args, **kwargs):
         pass
 from utils.safe_import import safe_import
+from utils.service_check import check_service
 
 if TYPE_CHECKING:
     from .bridge_health import BridgeHealthMonitor
@@ -191,6 +192,15 @@ class MeshtasticHandler:
             logger.warning("pubsub not available, using CLI fallback")
             self._connected = self._test_cli()
             return self._connected
+
+        # Pre-flight: verify meshtasticd is running before attempting TCP connection
+        status = check_service('meshtasticd')
+        if not status.available:
+            logger.warning("meshtasticd not available: %s", status.message)
+            if status.fix_hint:
+                logger.info("Fix: %s", status.fix_hint)
+            self._connected = False
+            return False
 
         try:
             host = self.config.meshtastic.host

--- a/src/gateway/mqtt_bridge_handler.py
+++ b/src/gateway/mqtt_bridge_handler.py
@@ -49,8 +49,9 @@ _get_protobuf_client, _HAS_PROTOBUF_CLIENT = safe_import(
     '.meshtastic_protobuf_client', 'get_protobuf_client', package='gateway',
 )
 
-# Optional paths utility
-_get_real_user_home_fn, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home as _get_real_user_home_fn
+from utils.service_check import check_service as _check_service
 
 if TYPE_CHECKING:
     from .bridge_health import BridgeHealthMonitor
@@ -163,8 +164,17 @@ class MQTTBridgeHandler:
             logger.error("paho-mqtt not installed. Install with: pip install paho-mqtt")
             return False
 
-        mqtt = _mqtt_mod
+        # Pre-flight: verify MQTT broker is running
         mqtt_cfg = self.config.mqtt_bridge
+        if mqtt_cfg.broker in ('localhost', '127.0.0.1', '::1'):
+            broker_status = _check_service('mosquitto')
+            if not broker_status.available:
+                logger.warning("MQTT broker not available: %s", broker_status.message)
+                if broker_status.fix_hint:
+                    logger.info("Fix: %s", broker_status.fix_hint)
+                return False
+
+        mqtt = _mqtt_mod
 
         try:
             # Create MQTT client
@@ -699,11 +709,7 @@ class MQTTBridgeHandler:
 
     def _get_user_bin(self):
         """Get user's local bin directory."""
-        if _HAS_PATHS:
-            return _get_real_user_home_fn() / '.local' / 'bin'
-        else:
-            from pathlib import Path
-            return Path.home() / '.local' / 'bin'
+        return _get_real_user_home_fn() / '.local' / 'bin'
 
     @staticmethod
     def _path_exists(path: str) -> bool:

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -1124,6 +1124,14 @@ class RNSMeshtasticBridge(MeshCoreBridgeMixin):
             self._rns_init_failed_permanently = True
             return
 
+        # Pre-flight: verify rnsd is available (advisory, not blocking)
+        rnsd_status = check_service('rnsd')
+        if not rnsd_status.available:
+            logger.warning("rnsd not available: %s", rnsd_status.message)
+            if rnsd_status.fix_hint:
+                logger.info("Fix: %s", rnsd_status.fix_hint)
+            # Continue anyway — RNS can init standalone without rnsd
+
         RNS = _RNS_mod
         LXMF = _LXMF_mod
 

--- a/src/launcher.py
+++ b/src/launcher.py
@@ -20,22 +20,7 @@ from utils.safe_import import safe_import
 _version_val, _HAS_VERSION = safe_import('__version__', '__version__')
 __version__ = _version_val if _HAS_VERSION else "0.5.0-beta"
 
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home
-else:
-    def get_real_user_home() -> Path:
-        """Fallback: resolve real user home under sudo."""
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+from utils.paths import get_real_user_home
 
 # NOC orchestrator for service management
 ServiceOrchestrator, ServiceState, _HAS_ORCHESTRATOR = safe_import(

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -23,21 +23,8 @@ from typing import Optional, List, Dict, Tuple
 
 logger = logging.getLogger(__name__)
 
+from utils.paths import get_real_user_home
 from utils.safe_import import safe_import
-
-# Import path utilities
-get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-if not _HAS_PATHS:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
 
 # Import service check
 check_service, apply_config_and_restart, _HAS_SERVICE_CHECK = safe_import(

--- a/src/launcher_tui/logs_menu_mixin.py
+++ b/src/launcher_tui/logs_menu_mixin.py
@@ -8,28 +8,7 @@ import os
 import subprocess
 from pathlib import Path
 from backend import clear_screen
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-
-def _fallback_get_real_user_home() -> Path:
-    """Fallback if utils.paths is unavailable."""
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        return Path(f'/home/{logname}')
-    return Path('/root')
-
-
-def get_real_user_home() -> Path:
-    """Get real user home, using utils.paths if available."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    return _fallback_get_real_user_home()
+from utils.paths import get_real_user_home
 
 
 class LogsMenuMixin:

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -14,12 +14,14 @@ from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
-from utils.safe_import import safe_import
-
-# Import centralized service checker - SINGLE SOURCE OF TRUTH
-check_service, check_systemd_service, ServiceState, apply_config_and_restart, _sudo_cmd, _HAS_APPLY_RESTART = safe_import(
-    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState', 'apply_config_and_restart', '_sudo_cmd'
+# Import centralized service checker - SINGLE SOURCE OF TRUTH (first-party)
+from utils.service_check import (
+    check_service, check_systemd_service, ServiceState,
+    apply_config_and_restart, _sudo_cmd,
 )
+_HAS_APPLY_RESTART = True
+
+from utils.safe_import import safe_import
 
 # Hoist function-level imports to module level
 _get_cli, _HAS_MESHTASTIC_CLI = safe_import('core.meshtastic_cli', 'get_cli')
@@ -123,23 +125,9 @@ class MeshtasticdConfigMixin:
 
         try:
             # ---- Service state (SINGLE SOURCE OF TRUTH: systemctl) ----
-            if check_service is not None and check_systemd_service is not None:
-                status = check_service('meshtasticd')
-                is_running = status.available
-                _, is_enabled = check_systemd_service('meshtasticd')
-            else:
-                # Fallback if service_check not available
-                result = subprocess.run(
-                    ['systemctl', 'status', 'meshtasticd'],
-                    capture_output=True,
-                    text=True,
-                    timeout=10
-                )
-                is_running = "active (running)" in result.stdout
-                is_enabled = subprocess.run(
-                    ['systemctl', 'is-enabled', 'meshtasticd'],
-                    capture_output=True, text=True, timeout=5
-                ).returncode == 0
+            status = check_service('meshtasticd')
+            is_running = status.available
+            _, is_enabled = check_systemd_service('meshtasticd')
 
             # ---- Preset detection (separate from service state) ----
             preset_display = "Unknown (select via Radio Presets)"
@@ -164,15 +152,23 @@ class MeshtasticdConfigMixin:
             config_d = Path('/etc/meshtasticd/config.d')
             active_configs = list(config_d.glob('*.yaml')) if config_d.exists() else []
 
-            # ---- Build display (service state and preset shown separately) ----
+            # ---- Build display (Issue #20 Phase 2: service state and
+            #      detection shown separately with actionable hints) ----
             text = "Meshtasticd Service Status:\n"
-            text += f"\nService: {'running' if is_running else 'stopped'}"
+            if is_running:
+                text += "\nService: RUNNING"
+            else:
+                text += "\nService: STOPPED"
+                if status.fix_hint:
+                    text += f"\n  Hint: {status.fix_hint}"
             text += f"\nBoot:    {'enabled' if is_enabled else 'not enabled (will not start on reboot)'}"
             text += f"\n\nPreset:  {preset_display}"
             if region_display:
                 text += f"\nRegion:  {region_display}"
             if detection_method:
                 text += f"\n  (detected via {detection_method})"
+            elif is_running and preset_display.startswith("Unknown"):
+                text += "\n  (CLI detection unavailable — select preset manually)"
             text += f"\n\nConfig File: {config_path}"
             text += f"\nConfig Exists: {'Yes' if config_exists else 'No'}"
             text += f"\n\nActive Hardware Configs: {len(active_configs)}"

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -35,22 +35,8 @@ check_process_running, start_service, stop_service, apply_config_and_restart, _s
     'utils.service_check', 'check_process_running', 'start_service', 'stop_service', 'apply_config_and_restart', '_sudo_cmd'
 )
 
-# Import for sudo-safe home directory - see persistent_issues.md Issue #1
-_get_real_user_home_mod, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home_mod
-else:
-    def get_real_user_home():
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
 
 class NomadNetClientMixin:

--- a/src/launcher_tui/radio_menu_mixin.py
+++ b/src/launcher_tui/radio_menu_mixin.py
@@ -9,22 +9,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from backend import clear_screen
-from utils.safe_import import safe_import
-
-# Import centralized path utility
-_get_real_user_home_mod, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home_mod
-else:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+from utils.paths import get_real_user_home
 
 
 class RadioMenuMixin:

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -28,17 +28,8 @@ logger = logging.getLogger(__name__)
 )
 _HAS_APPLY_RESTART = _HAS_SERVICE_CHECK
 
-# Import centralized path utility
-get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-if not _HAS_PATHS:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
 # Import port lockdown helpers
 (lock_port_external, unlock_port_external,

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -56,20 +56,8 @@ else:
     RNS_TCP_SERVER_PORT = 4242
     MQTT_PORT = 1883
 
-# Import path utilities
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home
-else:
-    def get_real_user_home() -> Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        # Fallback: check LOGNAME before defaulting to /root (MF001)
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
 # Import ReticulumPaths for _heal_rns_storage_dirs (directory creation only)
 _ReticulumPaths, _HAS_RETICULUM_PATHS = safe_import('utils.paths', 'ReticulumPaths')

--- a/src/launcher_tui/system_tools_mixin.py
+++ b/src/launcher_tui/system_tools_mixin.py
@@ -20,30 +20,10 @@ from backend import clear_screen
 logger = logging.getLogger(__name__)
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH
-try:
-    from utils.service_check import check_service, check_port, ServiceState, apply_config_and_restart
-except ImportError:
-    check_service = None
-    check_port = None
-    ServiceState = None
-    apply_config_and_restart = None
+from utils.service_check import check_service, check_port, ServiceState, apply_config_and_restart
 
-# Import for sudo-safe home directory - see persistent_issues.md Issue #1
-try:
-    from utils.paths import get_real_user_home
-except ImportError:
-    # Fallback if utils not available
-    def get_real_user_home():
-        import os
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            candidate = Path(f'/home/{sudo_user}')
-            return candidate
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            candidate = Path(f'/home/{logname}')
-            return candidate
-        return Path('/root')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
 
 class SystemToolsMixin:

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -42,24 +42,9 @@ from typing import Optional
 from utils.safe_import import safe_import
 
 # Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+from utils.paths import get_real_user_home
 _NodeMonitor_src, _HAS_MONITOR_SRC = safe_import('src.monitoring', 'NodeMonitor')
 _NodeMonitor_rel, _HAS_MONITOR_REL = safe_import('monitoring', 'NodeMonitor')
-
-
-def get_real_user_home() -> Path:
-    """Get real user home even under sudo."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
 
 # Config file location
 CONFIG_DIR = get_real_user_home() / '.config' / 'meshtastic-monitor'

--- a/src/monitoring/path_visualizer.py
+++ b/src/monitoring/path_visualizer.py
@@ -29,27 +29,12 @@ from html import escape as html_escape
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
+from utils.paths import get_real_user_home
 from utils.safe_import import safe_import
-
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 _HopInfo, _HopState, _MeshPacket, _HAS_TRAFFIC_INSPECTOR = safe_import(
     'monitoring.traffic_inspector', 'HopInfo', 'HopState', 'MeshPacket'
 )
-
-# Resolve get_real_user_home with fallback
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home
-else:
-    from pathlib import Path as _Path
-    import os
-
-    def get_real_user_home() -> _Path:
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return _Path(f'/home/{sudo_user}')
-        return _Path.home()
 
 # Resolve traffic inspector types with fallback
 if _HAS_TRAFFIC_INSPECTOR:

--- a/src/monitoring/rns_sniffer.py
+++ b/src/monitoring/rns_sniffer.py
@@ -441,16 +441,16 @@ class RNSSniffer:
                 try:
                     packet_info.announce_identity = announced_identity.hash
                     packet_info.source_hash = announced_identity.hash
-                except Exception:
-                    pass
+                except Exception as e:
+                    logger.debug("Failed to extract announce identity hash: %s", e)
 
             # Get hop count from Transport path table
             try:
                 if RNS.Transport.has_path(dest_hash):
                     hops = RNS.Transport.hops_to(dest_hash)
                     packet_info.hops = hops if hops is not None else 0
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Failed to get hop count for dest: %s", e)
 
             # Store packet
             self._store_packet(packet_info)

--- a/src/monitoring/tcp_monitor.py
+++ b/src/monitoring/tcp_monitor.py
@@ -316,8 +316,8 @@ class TCPMonitor:
                 if self.on_error:
                     try:
                         self.on_error(e)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning("on_error callback failed: %s", e)
 
             self._stop_event.wait(self.poll_interval)
 
@@ -343,8 +343,8 @@ class TCPMonitor:
                     if old_state != existing.state and self.on_connection_state_change:
                         try:
                             self.on_connection_state_change(existing, old_state)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning("on_connection_state_change callback failed: %s", e)
                 else:
                     # New connection
                     conn = TCPConnection(
@@ -364,8 +364,8 @@ class TCPMonitor:
                     if self.on_connection_added:
                         try:
                             self.on_connection_added(conn)
-                        except Exception:
-                            pass
+                        except Exception as e:
+                            logger.warning("on_connection_added callback failed: %s", e)
 
             # Find removed connections
             removed_ids = set(self._connections.keys()) - current_ids
@@ -374,8 +374,8 @@ class TCPMonitor:
                 if self.on_connection_removed:
                     try:
                         self.on_connection_removed(conn)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning("on_connection_removed callback failed: %s", e)
 
     def _get_tcp_connections(self) -> List[dict]:
         """Get current TCP connections from the system"""
@@ -609,8 +609,8 @@ class NetworkScanner:
         if self.on_device_found:
             try:
                 self.on_device_found(device)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("on_device_found callback failed: %s", e)
 
         return device
 
@@ -641,8 +641,8 @@ class NetworkScanner:
                 if self.on_progress:
                     try:
                         self.on_progress(completed[0], total)
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning("on_progress callback failed: %s", e)
 
         for ip in ip_addresses:
             if self._stop_event.is_set():
@@ -660,8 +660,8 @@ class NetworkScanner:
         if self.on_scan_complete:
             try:
                 self.on_scan_complete(devices)
-            except Exception:
-                pass
+            except Exception as e:
+                logger.warning("on_scan_complete callback failed: %s", e)
 
         return devices
 

--- a/src/monitoring/traffic_storage.py
+++ b/src/monitoring/traffic_storage.py
@@ -34,21 +34,8 @@ from .packet_dissectors import (
     RNSDissector,
 )
 
-# Import centralized path utility for sudo compatibility
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home
-else:
-    def get_real_user_home() -> Path:
-        """Fallback for when utils.paths is not in Python path."""
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        return Path('/root')
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
 

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -337,8 +337,8 @@ class SetupWizard:
                     if other_pids:
                         status.state = WizardServiceState.RUNNING
                         status.notes.append(f"Running as process (PID: {other_pids[0]})")
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Process check for %s failed: %s", svc['name'], e)
 
         self._log(f"Service {svc['name']}: {status.state.value}")
         return status
@@ -385,8 +385,8 @@ class SetupWizard:
                         if 'pgrep' not in line and str(os.getpid()) not in line:
                             rns_processes.append(proc_name)
                             break
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("RNS process detection failed for %s: %s", proc_name, e)
 
         if len(rns_processes) > 1:
             conflicts.append(
@@ -415,8 +415,8 @@ class SetupWizard:
                             f"CONFLICT: Port {port} ({service}) has multiple bindings.\n"
                             "  This may cause connection issues."
                         )
-            except Exception:
-                pass
+            except Exception as e:
+                logger.debug("Port conflict check failed for %d: %s", port, e)
 
         # Check for RNS shared instance config
         rns_status = self.service_status.get('rnsd')

--- a/src/utils/analytics.py
+++ b/src/utils/analytics.py
@@ -18,27 +18,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
-from utils.safe_import import safe_import
-
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-
-def get_real_user_home() -> Path:
-    """Sudo-safe home directory resolution."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
 
 
 @dataclass

--- a/src/utils/broker_profiles.py
+++ b/src/utils/broker_profiles.py
@@ -29,30 +29,10 @@ from enum import Enum
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List
 
-from utils.safe_import import safe_import
-
-# Import centralized path utility - see persistent_issues.md Issue #1
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-# Import service management helpers
-_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
-_apply_config_and_restart, _HAS_APPLY_RESTART = safe_import('utils.service_check', 'apply_config_and_restart')
-_enable_service, _HAS_ENABLE_SERVICE = safe_import('utils.service_check', 'enable_service')
+from utils.paths import get_real_user_home
+from utils.service_check import check_service as _check_service, apply_config_and_restart as _apply_config_and_restart, enable_service as _enable_service
 
 logger = logging.getLogger(__name__)
-
-
-def get_real_user_home() -> Path:
-    """Sudo-safe home directory resolution."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        return Path(f'/home/{logname}')
-    return Path('/root')
 
 
 class BrokerType(Enum):
@@ -672,20 +652,8 @@ def check_mosquitto_running() -> Tuple[bool, str]:
     Returns:
         (running, message) tuple
     """
-    if _HAS_SERVICE_CHECK:
-        status = _check_service('mosquitto')
-        return status.available, status.message
-
-    # Fallback: check via systemctl
-    try:
-        result = subprocess.run(
-            ["systemctl", "is-active", "mosquitto"],
-            capture_output=True, text=True, timeout=10
-        )
-        active = result.stdout.strip() == "active"
-        return active, "Running" if active else "Not running"
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return False, "Cannot determine status"
+    status = _check_service('mosquitto')
+    return status.available, status.message
 
 
 def restart_mosquitto() -> Tuple[bool, str]:
@@ -697,22 +665,7 @@ def restart_mosquitto() -> Tuple[bool, str]:
     if os.geteuid() != 0:
         return False, "Root privileges required. Run with sudo."
 
-    if _HAS_APPLY_RESTART:
-        return _apply_config_and_restart('mosquitto')
-
-    # Fallback
-    try:
-        result = subprocess.run(
-            ["systemctl", "restart", "mosquitto"],
-            capture_output=True, text=True, timeout=30
-        )
-        if result.returncode == 0:
-            return True, "Mosquitto restarted successfully"
-        return False, f"Restart failed: {result.stderr.strip()}"
-    except subprocess.TimeoutExpired:
-        return False, "Restart timed out"
-    except FileNotFoundError:
-        return False, "systemctl not found"
+    return _apply_config_and_restart('mosquitto')
 
 
 def enable_mosquitto_at_boot() -> Tuple[bool, str]:
@@ -724,22 +677,7 @@ def enable_mosquitto_at_boot() -> Tuple[bool, str]:
     if os.geteuid() != 0:
         return False, "Root privileges required. Run with sudo."
 
-    if _HAS_ENABLE_SERVICE:
-        return _enable_service('mosquitto', start=True)
-
-    # Fallback
-    try:
-        result = subprocess.run(
-            ["systemctl", "enable", "--now", "mosquitto"],
-            capture_output=True, text=True, timeout=30
-        )
-        if result.returncode == 0:
-            return True, "Mosquitto enabled at boot and started"
-        return False, f"Enable failed: {result.stderr.strip()}"
-    except subprocess.TimeoutExpired:
-        return False, "Enable timed out"
-    except FileNotFoundError:
-        return False, "systemctl not found"
+    return _enable_service('mosquitto', start=True)
 
 
 def get_meshtastic_mqtt_setup_commands(profile: BrokerProfile) -> str:

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -45,9 +45,10 @@ def find_meshtastic_cli():
             return user_path
 
     # Check common known locations
+    from utils.paths import get_real_user_home
     known_paths = [
         '/root/.local/bin/meshtastic',
-        os.path.expanduser('~/.local/bin/meshtastic'),
+        str(get_real_user_home() / '.local' / 'bin' / 'meshtastic'),
         '/usr/local/bin/meshtastic',
     ]
 

--- a/src/utils/firmware_downloader.py
+++ b/src/utils/firmware_downloader.py
@@ -16,27 +16,9 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, List, Optional, Any
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import path utilities
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home():
-    """Get real user home, with fallback for sudo-safe home directory."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f"/home/{sudo_user}")
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f"/home/{logname}")
-        return candidate
-    return Path('/root')
 
 
 @dataclass

--- a/src/utils/meshtastic_connection.py
+++ b/src/utils/meshtastic_connection.py
@@ -25,6 +25,7 @@ from enum import Enum
 from typing import Optional, List, Dict, Any
 
 from utils.safe_import import safe_import
+from utils.service_check import restart_service
 
 logger = logging.getLogger(__name__)
 
@@ -185,18 +186,15 @@ def clear_stale_connections(port: int = 4403) -> bool:
             f"restarting meshtasticd to clear"
         )
 
-        # Restart meshtasticd to clear the zombie — requires root (MeshForge runs as sudo)
-        restart = subprocess.run(
-            ['systemctl', 'restart', 'meshtasticd'],
-            capture_output=True, text=True, timeout=30
-        )
-        if restart.returncode == 0:
+        # Restart meshtasticd to clear the zombie — uses service_check helpers
+        success, msg = restart_service('meshtasticd')
+        if success:
             logger.info("meshtasticd restarted successfully, zombie connections cleared")
             # Give meshtasticd time to fully start and open its TCP port
             time.sleep(3)
             return True
         else:
-            logger.error(f"Failed to restart meshtasticd: {restart.stderr.strip()}")
+            logger.error("Failed to restart meshtasticd: %s", msg)
             return False
 
     except FileNotFoundError:

--- a/src/utils/metrics_history.py
+++ b/src/utils/metrics_history.py
@@ -41,20 +41,7 @@ from enum import Enum, auto
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any, Iterator
 
-from utils.safe_import import safe_import
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os as _os
-    sudo_user = _os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    return Path.home()
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/network_diagnostics.py
+++ b/src/utils/network_diagnostics.py
@@ -33,21 +33,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-# Safe import utility for consolidated ImportError handling
-from utils.safe_import import safe_import
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
 
-# Import centralized path utility for sudo compatibility
-get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-if not _HAS_PATHS:
-    # Ultimate fallback - handle sudo case
-    def get_real_user_home():
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+from utils.safe_import import safe_import
 
 # Import centralized service checking
 check_process_running, _HAS_SERVICE_CHECK = safe_import(

--- a/src/utils/node_history.py
+++ b/src/utils/node_history.py
@@ -29,27 +29,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
 
 
 # Default retention: 7 days

--- a/src/utils/topology_visualizer.py
+++ b/src/utils/topology_visualizer.py
@@ -29,20 +29,7 @@ from html import escape as html_escape
 from pathlib import Path
 from typing import Dict, List, Optional, Any, Tuple
 
-from utils.safe_import import safe_import
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    return Path.home()
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
 

--- a/src/utils/websocket_server.py
+++ b/src/utils/websocket_server.py
@@ -344,9 +344,12 @@ def get_websocket_server(port: int = 5001) -> MessageWebSocketServer:
 
 
 def start_websocket_server(port: int = 5001) -> bool:
-    """Start the global WebSocket server."""
+    """Start the global WebSocket server and subscribe to event bus."""
     server = get_websocket_server(port)
-    return server.start()
+    started = server.start()
+    if started:
+        subscribe_event_bus()
+    return started
 
 
 def stop_websocket_server():
@@ -364,3 +367,67 @@ def broadcast_message(message: Dict[str, Any]):
 def is_websocket_available() -> bool:
     """Check if WebSocket functionality is available."""
     return WEBSOCKETS_AVAILABLE
+
+
+# =============================================================================
+# Event Bus Integration (Issue #20 Phase 3)
+#
+# Subscribe to the MeshForge event bus so that RX messages, service status
+# changes, and node updates are pushed to all WebSocket clients in real-time.
+# =============================================================================
+
+_event_bus_subscribed = False
+
+
+def subscribe_event_bus():
+    """Subscribe WebSocket broadcasts to the event bus.
+
+    Call once after starting the WebSocket server. Subsequent calls are no-ops.
+    """
+    global _event_bus_subscribed
+    if _event_bus_subscribed:
+        return
+
+    try:
+        from utils.event_bus import event_bus
+    except ImportError:
+        logger.debug("event_bus not available, WebSocket event forwarding disabled")
+        return
+
+    def _on_message_event(event):
+        broadcast_message({
+            'type': 'message',
+            'direction': event.direction,
+            'content': event.content,
+            'node_id': event.node_id,
+            'node_name': event.node_name,
+            'channel': event.channel,
+            'network': event.network,
+            'timestamp': event.timestamp.isoformat(),
+        })
+
+    def _on_service_event(event):
+        broadcast_message({
+            'type': 'service_status',
+            'service': event.service_name,
+            'available': event.available,
+            'message': event.message,
+            'timestamp': event.timestamp.isoformat(),
+        })
+
+    def _on_node_event(event):
+        broadcast_message({
+            'type': 'node_update',
+            'event_type': event.event_type,
+            'node_id': event.node_id,
+            'node_name': event.node_name,
+            'latitude': event.latitude,
+            'longitude': event.longitude,
+            'timestamp': event.timestamp.isoformat(),
+        })
+
+    event_bus.subscribe('message', _on_message_event)
+    event_bus.subscribe('service', _on_service_event)
+    event_bus.subscribe('node', _on_node_event)
+    _event_bus_subscribed = True
+    logger.info("WebSocket server subscribed to event bus")

--- a/tests/test_meshtastic_handler.py
+++ b/tests/test_meshtastic_handler.py
@@ -121,10 +121,16 @@ class TestConnect:
     """Tests for connection establishment."""
 
     @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.check_service')
     @patch('gateway.meshtastic_handler.get_connection_manager')
     @patch('gateway.meshtastic_handler.pub', new_callable=MagicMock)
-    def test_connect_success(self, mock_pub, mock_get_cm, handler):
+    def test_connect_success(self, mock_pub, mock_get_cm, mock_check_service, handler):
         """Successful TCP connection via connection manager."""
+        # Pre-flight check passes
+        mock_status = MagicMock()
+        mock_status.available = True
+        mock_check_service.return_value = mock_status
+
         mock_cm = MagicMock()
         mock_cm.acquire_persistent.return_value = True
         mock_iface = MagicMock()
@@ -139,9 +145,14 @@ class TestConnect:
         assert handler.is_connected is True
 
     @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.check_service')
     @patch('gateway.meshtastic_handler.get_connection_manager')
-    def test_connect_acquire_fails(self, mock_get_cm, handler):
+    def test_connect_acquire_fails(self, mock_get_cm, mock_check_service, handler):
         """Connection fails when persistent acquire returns False."""
+        mock_status = MagicMock()
+        mock_status.available = True
+        mock_check_service.return_value = mock_status
+
         mock_cm = MagicMock()
         mock_cm.acquire_persistent.return_value = False
         mock_get_cm.return_value = mock_cm
@@ -152,9 +163,14 @@ class TestConnect:
         assert handler.is_connected is False
 
     @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.check_service')
     @patch('gateway.meshtastic_handler.get_connection_manager')
-    def test_connect_interface_none(self, mock_get_cm, handler):
+    def test_connect_interface_none(self, mock_get_cm, mock_check_service, handler):
         """Connection fails when interface is None."""
+        mock_status = MagicMock()
+        mock_status.available = True
+        mock_check_service.return_value = mock_status
+
         mock_cm = MagicMock()
         mock_cm.acquire_persistent.return_value = True
         mock_cm.get_interface.return_value = None
@@ -175,9 +191,14 @@ class TestConnect:
         assert handler.is_connected is True
 
     @patch('gateway.meshtastic_handler._HAS_PUBSUB', True)
+    @patch('gateway.meshtastic_handler.check_service')
     @patch('gateway.meshtastic_handler.get_connection_manager')
-    def test_connect_general_exception(self, mock_get_cm, handler):
+    def test_connect_general_exception(self, mock_get_cm, mock_check_service, handler):
         """General exception during connect returns False."""
+        mock_status = MagicMock()
+        mock_status.available = True
+        mock_check_service.return_value = mock_status
+
         mock_get_cm.side_effect = RuntimeError("boom")
         result = handler.connect()
 


### PR DESCRIPTION
## Summary
This PR eliminates redundant fallback implementations of `get_real_user_home()` across the codebase by enforcing direct imports from `utils.paths` and `utils.service_check`. It also removes conditional logic that checked for module availability via `safe_import`, treating first-party utilities as always available.

## Key Changes

### Path Utility Consolidation
- Replaced all `safe_import('utils.paths', 'get_real_user_home')` patterns with direct `from utils.paths import get_real_user_home`
- Removed 15+ duplicate fallback implementations of `get_real_user_home()` across modules:
  - `broker_profiles.py`, `analytics.py`, `firmware_downloader.py`, `node_history.py`
  - `launcher.py`, `radio_menu_mixin.py`, `logs_menu_mixin.py`, `monitor.py`
  - `path_visualizer.py`, `traffic_storage.py`, `network_diagnostics.py`
  - `ham_radio.py`, `meshtastic.py`, `startup_checks.py`, `first_run_mixin.py`
  - `metrics_history.py`, `topology_visualizer.py`, `service_menu_mixin.py`
  - `nomadnet_client_mixin.py`, `system_tools_mixin.py`

### Service Check Consolidation
- Replaced conditional `safe_import` patterns for `utils.service_check` with direct imports
- Removed fallback subprocess-based implementations in:
  - `broker_profiles.py`: `check_mosquitto_running()`, `restart_mosquitto()`, `enable_mosquitto_at_boot()`
  - `meshtasticd_config_mixin.py`: `_meshtasticd_status()`
- Removed `_HAS_*` flag checks that guarded fallback code paths

### WebSocket Event Bus Integration (Issue #20 Phase 3)
- Added `subscribe_event_bus()` function to `websocket_server.py` that subscribes to message, service, and node events
- Modified `start_websocket_server()` to automatically subscribe to event bus on startup
- Implemented event handlers that broadcast real-time updates to all connected WebSocket clients

### Service Pre-flight Checks
- Added pre-flight service availability checks in:
  - `meshtastic_handler.py`: Verify meshtasticd before TCP connection
  - `mqtt_bridge_handler.py`: Verify mosquitto before MQTT connection
  - `rns_bridge.py`: Advisory check for rnsd availability
- These checks use `check_service()` and log actionable fix hints when services are unavailable

### Improved Error Logging
- Enhanced exception handling throughout with explicit logging:
  - `system_diagnostics.py`: Added logger calls for gateway detection, mesh node count, mesh activity, CPU usage, and temperature failures
  - `tcp_monitor.py`: Added logging for callback failures
  - `rns_sniffer.py`: Added logging for announce identity extraction failures
  - `setup_wizard.py`: Added logging for process checks
  - `hardware_config.py`, `site_planner.py`: Added logging for configuration checks

### Test Updates
- Updated `test_meshtastic_handler.py` to mock `check_service` in connection tests

## Implementation Details
- All first-party utilities (`utils.paths`, `utils.service_check`) are now treated as mandatory dependencies
- Removed ~400 lines of redundant fallback code
- Maintains backward compatibility by preserving all public APIs
- Event bus integration is graceful—if unavailable, WebSocket server continues to function

https://claude.ai/code/session_01U6tWjRzJVGyvj82jdNEg9B