### PR TITLE
security: Consolidate safe_import misuse and remove GTK dead code

### DIFF
--- a/scripts/lint.py
+++ b/scripts/lint.py
@@ -3,11 +3,12 @@
 MeshForge Linter - Check for common issues and coding standards.
 
 Checks:
-- Path.home() violations (must use get_real_user_home for sudo compatibility)
-- shell=True in subprocess calls (security risk)
-- Bare except: clauses (should use except Exception:)
-- Missing timeout in subprocess calls
-- Command injection risks
+- MF001: Path.home() violations (must use get_real_user_home for sudo compatibility)
+- MF002: shell=True in subprocess calls (security risk)
+- MF003: Bare except: clauses (should use except Exception:)
+- MF004: Missing timeout in subprocess calls
+- MF005: GLib.idle_add check for thread-safe UI updates
+- MF006: safe_import for first-party modules (must use direct imports)
 
 Usage:
     python3 scripts/lint.py [files...]
@@ -188,6 +189,22 @@ class MeshForgeLinter:
                             filepath, lineno, Severity.WARNING, "MF004",
                             "subprocess call without timeout parameter"
                         ))
+
+        # MF006: safe_import for first-party modules
+        # First-party modules must use direct imports, not safe_import
+        if 'safe_import(' in line and 'safe_import.py' not in filepath:
+            first_party_prefixes = (
+                "'utils.", "'commands.", "'gateway.", "'core.",
+                "'launcher_tui.", "'config.", "'monitoring.", "'plugins.",
+                "'cli.", "'agent.", "'amateur.", "'diagnostics.", "'updates.",
+            )
+            if any(prefix in line for prefix in first_party_prefixes):
+                # Skip docstrings/comments/examples
+                if not stripped.startswith('#') and not stripped.startswith('"') and not stripped.startswith("'"):
+                    issues.append(LintIssue(
+                        filepath, lineno, Severity.ERROR, "MF006",
+                        "safe_import used for first-party module - use direct import instead"
+                    ))
 
         # MF005: GLib.idle_add check - UI updates from threads
         # Only check for actual GTK widget methods, not generic list operations

--- a/src/agent/agent.py
+++ b/src/agent/agent.py
@@ -52,8 +52,10 @@ from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
 
+# First-party imports — direct per CLAUDE.md
+from utils.paths import get_real_user_home
+
 # Module-level safe imports for optional dependencies
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 _create_gateway_config_api, _HAS_CONFIG_API = safe_import(
     'utils.config_api', 'create_gateway_config_api'
 )
@@ -128,15 +130,7 @@ class AgentConfig:
         # Set default data directory
         if not self.data_dir:
             # Use real user's home for sudo compatibility
-            if _HAS_PATHS:
-                home = _get_real_user_home()
-            else:
-                import os as _os
-                _sudo_user = _os.environ.get('SUDO_USER', '')
-                if _sudo_user and _sudo_user != 'root' and '/' not in _sudo_user and '..' not in _sudo_user:
-                    home = Path(f'/home/{_sudo_user}')
-                else:
-                    home = Path("/tmp")  # MF001: safe fallback for sudo
+            home = get_real_user_home()
             self.data_dir = str(home / ".config" / "meshforge" / "agent")
 
         # Set default PID file

--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -31,7 +31,7 @@ _check_service, _check_port, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
 )
 SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
 
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 _GatewayDiagnostic, _HAS_GATEWAY_DIAG = safe_import(
     'utils.gateway_diagnostic', 'GatewayDiagnostic'
@@ -236,33 +236,25 @@ def check_cli():
     """Check meshtastic CLI availability."""
     print_header("MESHTASTIC CLI")
 
-    if _HAS_CLI:
-        cli_path = _find_meshtastic_cli()
+    cli_path = find_meshtastic_cli()
 
-        if cli_path:
-            print_status("meshtastic CLI", True, cli_path)
+    if cli_path:
+        print_status("meshtastic CLI", True, cli_path)
 
-            # Get version
-            try:
-                result = subprocess.run(
-                    [cli_path, '--version'],
-                    capture_output=True, text=True, timeout=10
-                )
-                if result.returncode == 0:
-                    version = result.stdout.strip()
-                    print(f"    Version: {version}")
-            except Exception:
-                pass
-        else:
-            print_status("meshtastic CLI", False, "not found")
-            print("    Install with: pipx install meshtastic")
+        # Get version
+        try:
+            result = subprocess.run(
+                [cli_path, '--version'],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                version = result.stdout.strip()
+                print(f"    Version: {version}")
+        except Exception:
+            pass
     else:
-        # Fallback
-        cli_path = shutil.which('meshtastic')
-        if cli_path:
-            print_status("meshtastic CLI", True, cli_path)
-        else:
-            print_status("meshtastic CLI", False, "not found")
+        print_status("meshtastic CLI", False, "not found")
+        print("    Install with: pipx install meshtastic")
 
 
 def check_rns_config():

--- a/src/cli/status.py
+++ b/src/cli/status.py
@@ -30,7 +30,7 @@ _check_port, _check_udp_port, _check_systemd_service, _check_process_running, _H
     'utils.service_check', 'check_port', 'check_udp_port', 'check_systemd_service', 'check_process_running'
 )
 
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 
 # ANSI colors
@@ -170,11 +170,7 @@ def get_local_ip():
 
 def _find_cli():
     """Find meshtastic CLI path using centralized resolver."""
-    if _HAS_CLI:
-        return _find_meshtastic_cli()
-    else:
-        import shutil
-        return shutil.which('meshtastic')
+    return find_meshtastic_cli()
 
 
 def get_radio_info():

--- a/src/config/channel_presets.py
+++ b/src/config/channel_presets.py
@@ -9,19 +9,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 from utils.paths import get_real_user_home
-from utils.safe_import import safe_import
-
-# Import emoji helper for fallback support
-_em_mod, _HAS_EMOJI = safe_import('utils.emoji')
-
-if _HAS_EMOJI:
-    em = _em_mod
-else:
-    # Fallback if emoji module not available
-    class em:
-        @staticmethod
-        def get(emoji, fallback=''):
-            return fallback if fallback else emoji
+from utils import emoji as em
 
 console = Console()
 

--- a/src/config/lora.py
+++ b/src/config/lora.py
@@ -4,10 +4,7 @@ from rich.console import Console
 from rich.prompt import Prompt, Confirm
 from rich.table import Table
 
-from utils.safe_import import safe_import
-
-# Meshtastic CLI finder (optional)
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 console = Console()
 
@@ -760,11 +757,7 @@ class LoRaConfigurator:
         """Find the meshtastic CLI executable - uses centralized utils.cli"""
         import os
 
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         # Add directory to PATH for this session if found
         if cli_path:

--- a/src/config/radio_config.py
+++ b/src/config/radio_config.py
@@ -13,10 +13,7 @@ from rich.prompt import Prompt, Confirm, IntPrompt
 from rich.table import Table
 from rich.panel import Panel
 
-from utils.safe_import import safe_import
-
-# Meshtastic CLI finder (optional)
-_find_meshtastic_cli_fn, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 console = Console()
 
@@ -30,11 +27,7 @@ class RadioConfig:
 
     def _find_meshtastic_cli(self):
         """Find the meshtastic CLI executable - uses centralized utils.cli"""
-        if _HAS_CLI:
-            return _find_meshtastic_cli_fn()
-        else:
-            # Fallback if utils not available
-            return shutil.which('meshtastic')
+        return find_meshtastic_cli()
 
     def _run_cli(self, args, timeout=30):
         """Run meshtastic CLI command"""

--- a/src/core/diagnostics/checks/network.py
+++ b/src/core/diagnostics/checks/network.py
@@ -9,10 +9,7 @@ import time
 import logging
 
 from ..models import CheckResult, CheckStatus, CheckCategory
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_check_port_util, _HAS_PORT_CHECK = safe_import('utils.service_check', 'check_port')
+from utils.service_check import check_port
 
 logger = logging.getLogger(__name__)
 
@@ -21,42 +18,11 @@ def check_tcp_port(port: int, name: str, optional: bool = False) -> CheckResult:
     """Check if a TCP port is listening."""
     start = time.time()
 
-    # Use centralized port checker if available
-    if _HAS_PORT_CHECK and _check_port_util is not None:
-        try:
-            is_open = _check_port_util(port, '127.0.0.1', timeout=2.0)
-            duration = (time.time() - start) * 1000
-
-            if is_open:
-                return CheckResult(
-                    name=f"{name} (:{port})",
-                    category=CheckCategory.NETWORK,
-                    status=CheckStatus.PASS,
-                    message="Listening",
-                    duration_ms=duration
-                )
-            else:
-                return CheckResult(
-                    name=f"{name} (:{port})",
-                    category=CheckCategory.NETWORK,
-                    status=CheckStatus.SKIP if optional else CheckStatus.FAIL,
-                    message="Not reachable",
-                    fix_hint=f"Ensure {name} is running",
-                    duration_ms=duration
-                )
-        except Exception as e:
-            logger.warning(f"Centralized port check failed, falling back: {e}")
-            # Fall through to direct socket check
-
-    # Fallback: direct socket check (for standalone use or import failure)
     try:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(2)
-        result = sock.connect_ex(('127.0.0.1', port))
-        sock.close()
+        is_open = check_port(port, '127.0.0.1', timeout=2.0)
         duration = (time.time() - start) * 1000
 
-        if result == 0:
+        if is_open:
             return CheckResult(
                 name=f"{name} (:{port})",
                 category=CheckCategory.NETWORK,

--- a/src/core/meshtastic_cli.py
+++ b/src/core/meshtastic_cli.py
@@ -31,10 +31,7 @@ from dataclasses import dataclass, field
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_find_meshtastic_cli, _HAS_CLI_UTIL = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 logger = logging.getLogger(__name__)
 
@@ -88,9 +85,7 @@ class MeshtasticCLI:
 
     def _find_cli(self) -> Optional[str]:
         """Find meshtastic CLI using centralized path resolver."""
-        if _HAS_CLI_UTIL:
-            return _find_meshtastic_cli()
-        return shutil.which('meshtastic')
+        return find_meshtastic_cli()
 
     def _build_base_args(self) -> List[str]:
         """Build base CLI arguments for connection."""

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -35,10 +35,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Dict, Any
 from enum import Enum
 
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_find_meshtastic_cli, _HAS_CLI_UTIL = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 logger = logging.getLogger(__name__)
 
@@ -398,9 +395,7 @@ General:
 
     def is_python_cli_installed(self) -> bool:
         """Check if Python meshtastic CLI is installed."""
-        if _HAS_CLI_UTIL:
-            return _find_meshtastic_cli() is not None
-        return shutil.which("meshtastic") is not None
+        return find_meshtastic_cli() is not None
 
     def get_native_deb_url(self, arch: str = "arm64") -> str:
         """

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -37,7 +37,7 @@ from utils.safe_import import safe_import
 _yaml, _HAS_YAML = safe_import('yaml')
 # Import centralized port checker for consistency across MeshForge
 # See: utils/service_check.py - SINGLE SOURCE OF TRUTH
-_centralized_check_port, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_port')
+from utils.service_check import check_port as _centralized_check_port
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -370,18 +370,7 @@ class ServiceOrchestrator:
 
         Uses centralized port checker from utils/service_check.py for consistency.
         """
-        if _HAS_SERVICE_CHECK and _centralized_check_port is not None:
-            return _centralized_check_port(port, host, timeout)
-
-        # Fallback if service_check not available
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            sock.settimeout(timeout)
-            result = sock.connect_ex((host, port))
-            sock.close()
-            return result == 0
-        except (socket.error, OSError):
-            return False
+        return _centralized_check_port(port, host, timeout)
 
     def _check_command(self, command: List[str], timeout: int = 10) -> bool:
         """Run command and check for success."""

--- a/src/dashboard.py
+++ b/src/dashboard.py
@@ -19,14 +19,12 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from utils import emoji as em
 from utils.safe_import import safe_import
 
-# Module-level safe imports
-_service, _hardware, _HAS_COMMANDS = safe_import('commands', 'service', 'hardware')
-COMMANDS_AVAILABLE = _HAS_COMMANDS
+# Module-level imports
+from commands import service, hardware
+COMMANDS_AVAILABLE = True
 
-_check_service, _ServiceState, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'ServiceState'
-)
-SERVICE_CHECK_AVAILABLE = _HAS_SERVICE_CHECK
+from utils.service_check import check_service, ServiceState
+SERVICE_CHECK_AVAILABLE = True
 
 _meshtastic, _HAS_MESHTASTIC = safe_import('meshtastic')
 
@@ -45,7 +43,7 @@ class StatusDashboard:
         """Get meshtasticd service status using commands layer"""
         if COMMANDS_AVAILABLE:
             try:
-                result = _service.check_status('meshtasticd')
+                result = service.check_status('meshtasticd')
                 status_data = result.data
 
                 # Check for misconfiguration (SPI HAT with USB placeholder)
@@ -71,16 +69,16 @@ class StatusDashboard:
             # Fallback to centralized service checker or direct subprocess call
             if SERVICE_CHECK_AVAILABLE:
                 try:
-                    status = _check_service('meshtasticd')
+                    status = check_service('meshtasticd')
                     # Map ServiceState to dashboard status format
-                    if status.state == _ServiceState.AVAILABLE:
+                    if status.state == ServiceState.AVAILABLE:
                         return {
                             'status': 'active',
                             'running': True,
                             'color': 'green',
                             'message': status.message
                         }
-                    elif status.state == _ServiceState.DEGRADED:
+                    elif status.state == ServiceState.DEGRADED:
                         # Check if it's a SPI HAT misconfiguration
                         if 'WRONG CONFIG' in status.message:
                             return {
@@ -168,7 +166,7 @@ class StatusDashboard:
         if meshtasticd_path:
             if COMMANDS_AVAILABLE:
                 try:
-                    result = _service.get_version('meshtasticd')
+                    result = service.get_version('meshtasticd')
                     if result.success:
                         return result.data.get('version', 'Native')
                 except Exception as e:

--- a/src/gateway/config.py
+++ b/src/gateway/config.py
@@ -12,11 +12,9 @@ from typing import Optional, List, Dict, Any, Tuple
 import logging
 
 from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 # Import config drift validation (optional)
 _validate_gateway_rns_config, _HAS_CONFIG_DRIFT = safe_import(
@@ -138,22 +136,6 @@ def validate_speed_hop_combination(speed: int, hop_limit: int) -> Optional[Confi
             severity="info"
         )
     return None
-
-def get_real_user_home() -> Path:
-    """Get real user home directory with sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    # Fallback for when utils.paths is not in Python path
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
-
 
 @dataclass
 class MeshtasticConfig:

--- a/src/gateway/message_queue.py
+++ b/src/gateway/message_queue.py
@@ -30,23 +30,7 @@ from typing import Dict, List, Optional, Callable, Any
 from contextlib import contextmanager
 
 # Import centralized path utility for sudo compatibility
-import os
-from utils.safe_import import safe_import
-
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-if _HAS_PATHS:
-    get_real_user_home = _get_real_user_home
-else:
-    def get_real_user_home() -> Path:
-        """Fallback for when utils.paths is not in Python path."""
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f'/home/{sudo_user}')
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f'/home/{logname}')
-        return Path('/root')
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
 

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -49,7 +49,7 @@ from utils.safe_import import safe_import
 from utils.paths import get_real_user_home
 
 # Import event bus for node update events
-emit_node_update, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_node_update')
+from utils.event_bus import emit_node_update
 
 # Import RNS module (optional - for node discovery)
 _RNS_mod, _HAS_RNS = safe_import('RNS')
@@ -527,28 +527,27 @@ instance_control_port = 37429
                 logger.error(f"Callback error: {e}")
 
         # Emit to EventBus for decoupled subscribers (status bar, UI, etc.)
-        if _HAS_EVENT_BUS and emit_node_update is not None:
-            try:
-                # Map internal event names to EventBus event_type
-                event_type_map = {
-                    "update": "updated",
-                    "remove": "lost",
-                }
-                event_type = event_type_map.get(event, event)
+        try:
+            # Map internal event names to EventBus event_type
+            event_type_map = {
+                "update": "updated",
+                "remove": "lost",
+            }
+            event_type = event_type_map.get(event, event)
 
-                lat = node.position.latitude if node.position else None
-                lon = node.position.longitude if node.position else None
+            lat = node.position.latitude if node.position else None
+            lon = node.position.longitude if node.position else None
 
-                emit_node_update(
-                    event_type=event_type,
-                    node_id=node.id,
-                    node_name=node.name or "",
-                    latitude=lat,
-                    longitude=lon,
-                    raw_data=node.to_dict() if hasattr(node, 'to_dict') else None,
-                )
-            except Exception as e:
-                logger.debug(f"EventBus node emit failed: {e}")
+            emit_node_update(
+                event_type=event_type,
+                node_id=node.id,
+                node_name=node.name or "",
+                latitude=lat,
+                longitude=lon,
+                raw_data=node.to_dict() if hasattr(node, 'to_dict') else None,
+            )
+        except Exception as e:
+            logger.debug(f"EventBus node emit failed: {e}")
 
     def _cleanup_loop(self):
         """Periodically check node timeouts and save cache"""

--- a/src/gateway/profiles/__init__.py
+++ b/src/gateway/profiles/__init__.py
@@ -34,8 +34,7 @@ _yaml_mod, YAML_AVAILABLE = safe_import('yaml')
 if YAML_AVAILABLE:
     yaml = _yaml_mod
 
-# Import CLI finder utility (optional - graceful fallback)
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 logger = logging.getLogger(__name__)
 
@@ -248,11 +247,7 @@ class ProfileManager:
             }
 
         # Find meshtastic CLI
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             return {

--- a/src/launcher_tui/ai_tools_mixin.py
+++ b/src/launcher_tui/ai_tools_mixin.py
@@ -45,7 +45,7 @@ ReviewOrchestrator, ReviewScope, _HAS_AUTO_REVIEW = safe_import(
 )
 
 # Import service helpers for privileged systemctl calls
-_sudo_cmd, start_service, _HAS_SUDO_CMD = safe_import('utils.service_check', '_sudo_cmd', 'start_service')
+from utils.service_check import _sudo_cmd, start_service
 
 logger = logging.getLogger(__name__)
 

--- a/src/launcher_tui/amateur_radio_mixin.py
+++ b/src/launcher_tui/amateur_radio_mixin.py
@@ -14,8 +14,8 @@ import subprocess
 from backend import clear_screen
 from utils.safe_import import safe_import
 
-# Module-level safe imports — replaces scattered try/except ImportError blocks
-CallsignManager, _HAS_CALLSIGN = safe_import('amateur.callsign', 'CallsignManager')
+# Direct import — first-party module, always available
+from amateur.callsign import CallsignManager
 Part97Reference, ComplianceChecker, _HAS_COMPLIANCE = safe_import(
     'amateur.compliance', 'Part97Reference', 'ComplianceChecker'
 )
@@ -75,12 +75,6 @@ class AmateurRadioMixin:
         callsign = callsign.strip().upper()
         clear_screen()
         print(f"=== Callsign Lookup: {callsign} ===\n")
-
-        if not _HAS_CALLSIGN:
-            print("  Callsign module not available.")
-            print("  File: src/amateur/callsign.py")
-            self._wait_for_enter()
-            return
 
         print(f"Looking up {callsign}...\n")
 

--- a/src/launcher_tui/dashboard_mixin.py
+++ b/src/launcher_tui/dashboard_mixin.py
@@ -17,12 +17,12 @@ ServiceRunState, _HAS_STARTUP_CHECKS = safe_import('startup_checks', 'ServiceRun
 get_http_client, reset_http_client, _HAS_MESHTASTIC_HTTP = safe_import(
     'utils.meshtastic_http', 'get_http_client', 'reset_http_client'
 )
-MapDataCollector, _HAS_MAP_COLLECTOR = safe_import('utils.map_data_collector', 'MapDataCollector')
+from utils.map_data_collector import MapDataCollector
 generate_report, generate_and_save, _HAS_REPORT_GEN = safe_import(
     'utils.report_generator', 'generate_report', 'generate_and_save'
 )
-get_health_scorer, _HAS_HEALTH_SCORE = safe_import('utils.health_score', 'get_health_scorer')
-EASAlertsPlugin, _HAS_EAS = safe_import('plugins.eas_alerts', 'EASAlertsPlugin')
+from utils.health_score import get_health_scorer
+from plugins.eas_alerts import EASAlertsPlugin
 pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
 
 
@@ -220,27 +220,23 @@ class DashboardMixin:
 
         # Test 5: MapDataCollector
         print("[5/6] Testing MapDataCollector...")
-        if not _HAS_MAP_COLLECTOR:
-            results.append(("MapDataCollector", "SKIP", "Module not available"))
-            print("      \033[0;33mSKIP\033[0m - Module not available")
-        else:
-            try:
-                collector = MapDataCollector(enable_history=False)
-                geojson = collector.collect(max_age_seconds=30)
-                props = geojson.get('properties', {})
-                total = props.get('total_nodes', 0)
-                with_gps = props.get('nodes_with_position', 0)
-                sources = props.get('sources', {})
-                active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
-                if total > 0:
-                    results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
-                    print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")
-                else:
-                    results.append(("MapDataCollector", "WARN", "0 nodes returned"))
-                    print("      \033[0;33mWARN\033[0m - 0 nodes (check meshtasticd connection)")
-            except Exception as e:
-                results.append(("MapDataCollector", "FAIL", str(e)[:50]))
-                print(f"      \033[0;31mFAIL\033[0m - {e}")
+        try:
+            collector = MapDataCollector(enable_history=False)
+            geojson = collector.collect(max_age_seconds=30)
+            props = geojson.get('properties', {})
+            total = props.get('total_nodes', 0)
+            with_gps = props.get('nodes_with_position', 0)
+            sources = props.get('sources', {})
+            active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
+            if total > 0:
+                results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
+                print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")
+            else:
+                results.append(("MapDataCollector", "WARN", "0 nodes returned"))
+                print("      \033[0;33mWARN\033[0m - 0 nodes (check meshtasticd connection)")
+        except Exception as e:
+            results.append(("MapDataCollector", "FAIL", str(e)[:50]))
+            print(f"      \033[0;31mFAIL\033[0m - {e}")
 
         # Test 6: RNS path table
         print("[6/6] Testing RNS path table...")
@@ -357,12 +353,6 @@ class DashboardMixin:
         _sp.run(['clear'], check=False, timeout=5)
         print("=== Network Health Score ===\n")
 
-        if not _HAS_HEALTH_SCORE:
-            print("  Health score module not available.")
-            print("  File: src/utils/health_score.py")
-            self._wait_for_enter()
-            return
-
         scorer = get_health_scorer()
         snapshot = scorer.get_snapshot()
 
@@ -437,22 +427,21 @@ class DashboardMixin:
 
         # EAS / Weather alerts
         print()
-        if _HAS_EAS:
-            try:
-                plugin = EASAlertsPlugin()
-                eas_alerts = plugin.get_weather_alerts()
-                if eas_alerts:
-                    print(f"WEATHER ALERTS ({len(eas_alerts)}):")
-                    for alert in eas_alerts[:5]:
-                        severity = getattr(alert, 'severity', 'Unknown')
-                        headline = getattr(alert, 'headline', str(alert))
-                        if len(headline) > 65:
-                            headline = headline[:62] + "..."
-                        print(f"  \033[0;31m!\033[0m [{severity}] {headline}")
-                else:
-                    print("  Weather: No active alerts")
-            except Exception as e:
-                logger.debug("EAS alert check failed: %s", e)
+        try:
+            plugin = EASAlertsPlugin()
+            eas_alerts = plugin.get_weather_alerts()
+            if eas_alerts:
+                print(f"WEATHER ALERTS ({len(eas_alerts)}):")
+                for alert in eas_alerts[:5]:
+                    severity = getattr(alert, 'severity', 'Unknown')
+                    headline = getattr(alert, 'headline', str(alert))
+                    if len(headline) > 65:
+                        headline = headline[:62] + "..."
+                    print(f"  \033[0;31m!\033[0m [{severity}] {headline}")
+            else:
+                print("  Weather: No active alerts")
+        except Exception as e:
+            logger.debug("EAS alert check failed: %s", e)
 
         print()
         self._wait_for_enter()

--- a/src/launcher_tui/device_backup_mixin.py
+++ b/src/launcher_tui/device_backup_mixin.py
@@ -7,15 +7,10 @@ Provides UI for commands/device_backup.py functionality.
 
 import subprocess
 from backend import clear_screen
-from utils.safe_import import safe_import
-
-# Module-level safe imports
-_create_backup, _HAS_CREATE_BACKUP = safe_import('commands.device_backup', 'create_backup')
-_list_backups, _get_backup_dir, _HAS_LIST_BACKUPS = safe_import(
-    'commands.device_backup', 'list_backups', 'get_backup_dir'
-)
-_restore_backup, _HAS_RESTORE_BACKUP = safe_import('commands.device_backup', 'restore_backup')
-_delete_backup, _HAS_DELETE_BACKUP = safe_import('commands.device_backup', 'delete_backup')
+from commands.device_backup import create_backup
+from commands.device_backup import list_backups, get_backup_dir
+from commands.device_backup import restore_backup
+from commands.device_backup import delete_backup
 
 
 class DeviceBackupMixin:
@@ -53,10 +48,6 @@ class DeviceBackupMixin:
 
     def _create_device_backup(self):
         """Create a new device backup."""
-        if not _HAS_CREATE_BACKUP:
-            self.dialog.msgbox("Error", "Backup module not available.")
-            return
-
         # Ask for connection type
         conn_choices = [
             ("localhost", "Local TCP (localhost:4403)"),
@@ -116,7 +107,7 @@ class DeviceBackupMixin:
         self.dialog.infobox("Creating Backup", "Backing up device configuration...")
 
         # Create the backup
-        result = _create_backup(
+        result = create_backup(
             connection=connection,
             port=port,
             backup_type="full",
@@ -138,14 +129,10 @@ class DeviceBackupMixin:
 
     def _list_device_backups(self):
         """List available device backups."""
-        if not _HAS_LIST_BACKUPS:
-            self.dialog.msgbox("Error", "Backup module not available.")
-            return
-
-        backups = _list_backups()
+        backups = list_backups()
 
         if not backups:
-            backup_dir = _get_backup_dir()
+            backup_dir = get_backup_dir()
             self.dialog.msgbox(
                 "No Backups",
                 f"No backups found.\n\nBackup directory:\n{backup_dir}"
@@ -178,11 +165,7 @@ class DeviceBackupMixin:
 
     def _restore_device_backup(self):
         """Restore device from a backup."""
-        if not _HAS_RESTORE_BACKUP:
-            self.dialog.msgbox("Error", "Backup module not available.")
-            return
-
-        backups = _list_backups()
+        backups = list_backups()
 
         if not backups:
             self.dialog.msgbox("No Backups", "No backups available to restore.")
@@ -266,7 +249,7 @@ class DeviceBackupMixin:
         self.dialog.infobox("Restoring", "Restoring device configuration...")
 
         # Restore the backup
-        result = _restore_backup(
+        result = restore_backup(
             backup_id=selected,
             connection=connection,
             port=port
@@ -286,11 +269,7 @@ class DeviceBackupMixin:
 
     def _delete_device_backup(self):
         """Delete a device backup."""
-        if not _HAS_DELETE_BACKUP:
-            self.dialog.msgbox("Error", "Backup module not available.")
-            return
-
-        backups = _list_backups()
+        backups = list_backups()
 
         if not backups:
             self.dialog.msgbox("No Backups", "No backups available to delete.")
@@ -325,7 +304,7 @@ class DeviceBackupMixin:
             return
 
         # Delete the backup
-        result = _delete_backup(selected)
+        result = delete_backup(selected)
 
         if result['success']:
             self.dialog.msgbox("Deleted", "Backup deleted successfully.")

--- a/src/launcher_tui/emergency_mode_mixin.py
+++ b/src/launcher_tui/emergency_mode_mixin.py
@@ -17,12 +17,9 @@ import time
 import logging
 from typing import Optional
 from backend import clear_screen
-from utils.safe_import import safe_import
+from plugins.eas_alerts import EASAlertsPlugin
 
 logger = logging.getLogger(__name__)
-
-# Module-level safe imports
-_EASAlertsPlugin, _HAS_EAS = safe_import('plugins.eas_alerts', 'EASAlertsPlugin')
 
 # Emergency broadcast prefix for EMCOMM messages
 EMCOMM_PREFIX = "[EMCOMM] "
@@ -344,47 +341,43 @@ class EmergencyModeMixin:
         clear_screen()
         print("=== WEATHER / EAS ALERTS ===\n")
 
-        if not _HAS_EAS:
-            print("  EAS Alerts plugin not available.")
-            print("  Required: plugins/eas_alerts.py")
-        else:
+        try:
+            plugin = EASAlertsPlugin()
+
+            print("Checking NOAA weather alerts...")
+            alerts = plugin.get_weather_alerts()
+
+            if not alerts:
+                print("\n  No active weather alerts for your area.")
+                print("  (Configure location in MeshForge Settings)")
+            else:
+                print(f"\n  {len(alerts)} active alert(s):\n")
+                for i, alert in enumerate(alerts[:10], 1):
+                    severity = getattr(alert, 'severity', 'Unknown')
+                    headline = getattr(alert, 'headline', str(alert))
+                    # Truncate long headlines for terminal display
+                    if len(headline) > 70:
+                        headline = headline[:67] + "..."
+                    print(f"  {i}. [{severity}] {headline}")
+
+            # Also check volcano alerts if available
+            print("\nChecking USGS volcano alerts...")
             try:
-                plugin = _EASAlertsPlugin()
-
-                print("Checking NOAA weather alerts...")
-                alerts = plugin.get_weather_alerts()
-
-                if not alerts:
-                    print("\n  No active weather alerts for your area.")
-                    print("  (Configure location in MeshForge Settings)")
+                volcano_alerts = plugin.get_volcano_alerts()
+                if volcano_alerts:
+                    print(f"\n  {len(volcano_alerts)} volcano alert(s):")
+                    for alert in volcano_alerts[:5]:
+                        name = getattr(alert, 'volcano_name', str(alert))
+                        level = getattr(alert, 'alert_level', 'Unknown')
+                        print(f"  - [{level}] {name}")
                 else:
-                    print(f"\n  {len(alerts)} active alert(s):\n")
-                    for i, alert in enumerate(alerts[:10], 1):
-                        severity = getattr(alert, 'severity', 'Unknown')
-                        headline = getattr(alert, 'headline', str(alert))
-                        # Truncate long headlines for terminal display
-                        if len(headline) > 70:
-                            headline = headline[:67] + "..."
-                        print(f"  {i}. [{severity}] {headline}")
+                    print("  No active volcano alerts.")
+            except Exception:
+                print("  Volcano alert check unavailable.")
 
-                # Also check volcano alerts if available
-                print("\nChecking USGS volcano alerts...")
-                try:
-                    volcano_alerts = plugin.get_volcano_alerts()
-                    if volcano_alerts:
-                        print(f"\n  {len(volcano_alerts)} volcano alert(s):")
-                        for alert in volcano_alerts[:5]:
-                            name = getattr(alert, 'volcano_name', str(alert))
-                            level = getattr(alert, 'alert_level', 'Unknown')
-                            print(f"  - [{level}] {name}")
-                    else:
-                        print("  No active volcano alerts.")
-                except Exception:
-                    print("  Volcano alert check unavailable.")
-
-            except Exception as e:
-                print(f"  Alert check failed: {e}")
-                print("  (Check network connectivity)")
+        except Exception as e:
+            print(f"  Alert check failed: {e}")
+            print("  (Check network connectivity)")
 
         print()
         self._wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -32,7 +32,7 @@ check_service, apply_config_and_restart, _HAS_SERVICE_CHECK = safe_import(
 )
 
 # Import device scanner
-DeviceScanner, _HAS_DEVICE_SCANNER = safe_import('utils.device_scanner', 'DeviceScanner')
+from utils.device_scanner import DeviceScanner
 
 # Import startup checker for hardware detection
 StartupChecker, _HAS_STARTUP_CHECKER = safe_import('startup_checks', 'StartupChecker')
@@ -621,14 +621,6 @@ Serial:
                     )
                     lines = ["Hardware Detection\n", "=" * 40]
                     lines.append("\n✓ SPI Enabled (reboot required)")
-
-        if DeviceScanner is None:
-            if not spi_devices:
-                lines.append("\n✗ Device scanner not available")
-                lines.append("\nConnect a Meshtastic device via USB")
-                lines.append("or configure meshtasticd for HAT/SPI")
-            self.dialog.msgbox("Step 1: Hardware", "\n".join(lines))
-            return
 
         scanner = DeviceScanner()
         results = scanner.scan_all()

--- a/src/launcher_tui/latency_mixin.py
+++ b/src/launcher_tui/latency_mixin.py
@@ -7,12 +7,9 @@ Extracted as a mixin to keep main.py under 1,500 lines.
 
 import logging
 from backend import clear_screen
-from utils.safe_import import safe_import
+from utils.latency_monitor import get_latency_monitor
 
 logger = logging.getLogger(__name__)
-
-# Module-level safe imports
-_get_latency_monitor, _HAS_LATENCY = safe_import('utils.latency_monitor', 'get_latency_monitor')
 
 
 class LatencyMixin:
@@ -51,13 +48,7 @@ class LatencyMixin:
         clear_screen()
         print("=== Service Latency Status ===\n")
 
-        if not _HAS_LATENCY:
-            print("  Latency monitor module not available.")
-            print("  File: src/utils/latency_monitor.py")
-            self._wait_for_enter()
-            return
-
-        monitor = _get_latency_monitor(auto_start=False)
+        monitor = get_latency_monitor(auto_start=False)
         summary = monitor.get_summary()
 
         if not summary:
@@ -100,12 +91,7 @@ class LatencyMixin:
         clear_screen()
         print("=== Probing Services ===\n")
 
-        if not _HAS_LATENCY:
-            print("  Latency monitor module not available.")
-            self._wait_for_enter()
-            return
-
-        monitor = _get_latency_monitor(auto_start=False)
+        monitor = get_latency_monitor(auto_start=False)
         print("  Running probe cycle...\n")
         health = monitor.probe_once()
 
@@ -140,12 +126,7 @@ class LatencyMixin:
         clear_screen()
         print("=== Degraded / Down Services ===\n")
 
-        if not _HAS_LATENCY:
-            print("  Latency monitor module not available.")
-            self._wait_for_enter()
-            return
-
-        monitor = _get_latency_monitor(auto_start=False)
+        monitor = get_latency_monitor(auto_start=False)
         summary = monitor.get_summary()
 
         # Check if any data exists

--- a/src/launcher_tui/link_quality_mixin.py
+++ b/src/launcher_tui/link_quality_mixin.py
@@ -11,14 +11,11 @@ Provides link quality analysis tools:
 import logging
 from typing import Optional
 
-from utils.safe_import import safe_import
+from utils.link_quality import LinkQualityScorer
+from utils.link_quality import score_topology_edges
+from gateway.network_topology import get_network_topology
 
 logger = logging.getLogger(__name__)
-
-# Module-level safe imports
-_LinkQualityScorer, _HAS_LINK_QUALITY = safe_import('utils.link_quality', 'LinkQualityScorer')
-_score_topology_edges, _HAS_SCORE_TOPO = safe_import('utils.link_quality', 'score_topology_edges')
-_get_network_topology, _HAS_NET_TOPO = safe_import('gateway.network_topology', 'get_network_topology')
 
 
 class LinkQualityMixin:
@@ -60,21 +57,16 @@ class LinkQualityMixin:
 
     def _get_link_scorer(self):
         """Get the link quality scorer instance."""
-        if not _HAS_LINK_QUALITY:
-            return None
-        return _LinkQualityScorer()
+        return LinkQualityScorer()
 
     def _get_topology_scores(self):
         """Score all edges in the current topology."""
-        if not _HAS_SCORE_TOPO or not _HAS_NET_TOPO:
-            return None, None
-
         try:
-            topology = _get_network_topology()
+            topology = get_network_topology()
             if topology is None:
                 return None, None
 
-            return _score_topology_edges(topology), topology
+            return score_topology_edges(topology), topology
 
         except Exception as e:
             logger.error(f"Error scoring topology: {e}")

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -33,19 +33,15 @@ _launcher_dir = Path(__file__).parent
 if str(_launcher_dir) not in sys.path:
     sys.path.insert(0, str(_launcher_dir))
 
-from utils.safe_import import safe_import
-
 # Import version
-__version__, _HAS_VERSION = safe_import('__version__', '__version__')
-if not _HAS_VERSION:
-    __version__ = "0.5.0-beta"
+from __version__ import __version__
 
 # Import optional modules at module level
-_find_meshtastic_cli, _HAS_CLI_UTIL = safe_import('utils.cli', 'find_meshtastic_cli')
-_get_health_probe, _HAS_HEALTH_PROBE = safe_import('utils.active_health_probe', 'get_health_probe')
-_config_api_mod, _HAS_CONFIG_API = safe_import('utils.config_api')
-_lock_port_external, _HAS_PORT_LOCK = safe_import('utils.service_check', 'lock_port_external')
-_TopologyVisualizer, _HAS_TOPO_VIZ = safe_import('utils.topology_visualizer', 'TopologyVisualizer')
+from utils.cli import find_meshtastic_cli
+from utils.active_health_probe import get_health_probe
+from utils import config_api as config_api_mod
+from utils.service_check import lock_port_external
+from utils.topology_visualizer import TopologyVisualizer
 
 # Import centralized path utility - SINGLE SOURCE OF TRUTH for all paths
 # See: utils/paths.py (ReticulumPaths, get_real_user_home)
@@ -54,23 +50,14 @@ from utils.paths import get_real_user_home, ReticulumPaths
 
 # Import centralized service checker - SINGLE SOURCE OF TRUTH for service status
 # See: utils/service_check.py and .claude/foundations/install_reliability_triage.md
-check_service, check_port, apply_config_and_restart, ServiceState, _sudo_cmd, _HAS_APPLY_RESTART = safe_import(
-    'utils.service_check', 'check_service', 'check_port', 'apply_config_and_restart', 'ServiceState', '_sudo_cmd'
-)
+from utils.service_check import check_service, check_port, apply_config_and_restart, ServiceState, _sudo_cmd
 
 # Import dialog backend directly (not through package namespace)
 from backend import DialogBackend, clear_screen
 
 # Import startup checks and conflict resolution (v0.4.8)
-StartupChecker, EnvironmentState, ServiceRunState, HAS_STARTUP_CHECKS = safe_import(
-    'startup_checks', 'StartupChecker', 'EnvironmentState', 'ServiceRunState'
-)
-if HAS_STARTUP_CHECKS:
-    check_and_resolve_conflicts, _ = safe_import(
-        'conflict_resolver', 'check_and_resolve_conflicts'
-    )
-else:
-    check_and_resolve_conflicts = None
+from startup_checks import StartupChecker, EnvironmentState, ServiceRunState
+from conflict_resolver import check_and_resolve_conflicts
 
 # Import mixins to reduce file size
 from rf_tools_mixin import RFToolsMixin
@@ -172,7 +159,7 @@ class MeshForgeLauncher(
         self._bridge_log_path = None  # Path to active bridge log file
         self._config_api_server = None  # Config API HTTP server
         # Enhanced startup checker (v0.4.8)
-        self._startup_checker = StartupChecker() if HAS_STARTUP_CHECKS else None
+        self._startup_checker = StartupChecker()
         self._env_state: Optional[EnvironmentState] = None
 
     @staticmethod
@@ -194,10 +181,7 @@ class MeshForgeLauncher(
     def _get_meshtastic_cli(self) -> str:
         """Find the meshtastic CLI binary path, with caching."""
         if self._meshtastic_path is None:
-            if _HAS_CLI_UTIL:
-                self._meshtastic_path = _find_meshtastic_cli() or 'meshtastic'
-            else:
-                self._meshtastic_path = shutil.which('meshtastic') or 'meshtastic'
+            self._meshtastic_path = find_meshtastic_cli() or 'meshtastic'
         return self._meshtastic_path
 
     @staticmethod
@@ -425,12 +409,8 @@ class MeshForgeLauncher(
         rnsd, and mosquitto every 30 seconds. State changes are pushed
         to the EventBus, which the StatusBar subscribes to.
         """
-        if not _HAS_HEALTH_PROBE:
-            logger.debug("active_health_probe not available — health monitor disabled")
-            self._health_probe = None
-            return
         try:
-            self._health_probe = _get_health_probe(interval=30, fails=3, passes=2)
+            self._health_probe = get_health_probe(interval=30, fails=3, passes=2)
             self._health_probe.start()
             logger.info("Health monitor started (30s interval)")
         except Exception as e:
@@ -451,7 +431,7 @@ class MeshForgeLauncher(
         Returns:
             True to continue, False if user aborted
         """
-        if not HAS_STARTUP_CHECKS or not self._startup_checker:
+        if not self._startup_checker:
             return True
 
         # Get environment state
@@ -614,13 +594,9 @@ class MeshForgeLauncher(
         Provides RESTful configuration API on localhost:8081.
         Silent operation - no dialogs on failure.
         """
-        if not _HAS_CONFIG_API:
-            logger.debug("Config API module not available")
-            return
-
         try:
-            create_gateway_config_api = _config_api_mod.create_gateway_config_api
-            ConfigAPIServer = _config_api_mod.ConfigAPIServer
+            create_gateway_config_api = config_api_mod.create_gateway_config_api
+            ConfigAPIServer = config_api_mod.ConfigAPIServer
             api = create_gateway_config_api()
             self._config_api_server = ConfigAPIServer(api, host="127.0.0.1", port=8081)
             if self._config_api_server.start():
@@ -647,12 +623,8 @@ class MeshForgeLauncher(
 
         Silent operation - logs result but no dialogs on failure.
         """
-        if not _HAS_PORT_LOCK:
-            logger.debug("Port lockdown not available (missing service_check)")
-            return
-
         try:
-            success, msg = _lock_port_external(9443)
+            success, msg = lock_port_external(9443)
             if success:
                 logger.info("Startup port lock: %s", msg)
             else:
@@ -986,10 +958,6 @@ class MeshForgeLauncher(
 
     def _export_topology_data(self, format_type: str):
         """Export topology data in specified format."""
-        if not _HAS_TOPO_VIZ:
-            self.dialog.msgbox("Export Failed", "Topology visualizer module not available.")
-            return
-
         try:
             # Get topology from TopologyMixin (properly populated)
             topology = self._get_topology()
@@ -1002,7 +970,7 @@ class MeshForgeLauncher(
                 return
 
             # Create visualizer from actual topology data
-            viz = _TopologyVisualizer.from_topology(topology)
+            viz = TopologyVisualizer.from_topology(topology)
 
             if format_type == "geojson":
                 path, count = viz.export_geojson()

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -19,14 +19,11 @@ from utils.service_check import (
     check_service, check_systemd_service, ServiceState,
     apply_config_and_restart, _sudo_cmd,
 )
-_HAS_APPLY_RESTART = True
-
-from utils.safe_import import safe_import
 
 # Hoist function-level imports to module level
-_get_cli, _HAS_MESHTASTIC_CLI = safe_import('core.meshtastic_cli', 'get_cli')
-_get_http_client, _HAS_HTTP_CLIENT = safe_import('utils.meshtastic_http', 'get_http_client')
-_get_active_profile, _HAS_BROKER_PROFILES = safe_import('utils.broker_profiles', 'get_active_profile')
+from core.meshtastic_cli import get_cli
+from utils.meshtastic_http import get_http_client
+from utils.broker_profiles import get_active_profile
 
 
 class MeshtasticdConfigMixin:
@@ -386,60 +383,33 @@ Press Cancel to keep current values."""
 
         self.dialog.infobox("Applying", f"Applying {preset} preset...")
 
-        if _HAS_MESHTASTIC_CLI:
-            try:
-                cli = _get_cli()
+        try:
+            cli = get_cli()
 
-                # Apply modem preset
-                result = cli.set_lora_preset(preset)
-                if not result.success:
-                    self.dialog.msgbox("Error",
-                        f"Failed to set modem preset:\n{result.error}\n\n"
-                        "Ensure meshtastic CLI is installed and\n"
-                        "meshtasticd is running with region set.")
-                    return
+            # Apply modem preset
+            result = cli.set_lora_preset(preset)
+            if not result.success:
+                self.dialog.msgbox("Error",
+                    f"Failed to set modem preset:\n{result.error}\n\n"
+                    "Ensure meshtastic CLI is installed and\n"
+                    "meshtasticd is running with region set.")
+                return
 
-                # Apply frequency slot
-                slot_result = cli.set_channel_num(freq_slot)
-                slot_msg = ""
-                if not slot_result.success:
-                    slot_msg = f"\nFrequency slot: FAILED ({slot_result.error})"
-                else:
-                    slot_msg = f"\nFrequency slot: {freq_slot}"
+            # Apply frequency slot
+            slot_result = cli.set_channel_num(freq_slot)
+            slot_msg = ""
+            if not slot_result.success:
+                slot_msg = f"\nFrequency slot: FAILED ({slot_result.error})"
+            else:
+                slot_msg = f"\nFrequency slot: {freq_slot}"
 
-                self.dialog.msgbox("Success",
-                    f"{preset} preset applied!\n\n"
-                    f"Modem preset: {preset}{slot_msg}\n\n"
-                    "Settings applied via meshtastic CLI.\n"
-                    "Device will reboot to apply changes.")
-            except Exception as e:
-                self.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
-        else:
-            # Fallback: direct subprocess call
-            try:
-                cli_path = self._get_meshtastic_cli()
-                result = subprocess.run(
-                    [cli_path, '--host', 'localhost:4403',
-                     '--set', 'lora.modem_preset', preset],
-                    capture_output=True, text=True, timeout=30
-                )
-                if result.returncode != 0:
-                    self.dialog.msgbox("Error",
-                        f"Failed to apply preset:\n{result.stderr or result.stdout}")
-                    return
-
-                subprocess.run(
-                    [cli_path, '--host', 'localhost:4403',
-                     '--set', 'lora.channel_num', str(freq_slot)],
-                    capture_output=True, text=True, timeout=30
-                )
-
-                self.dialog.msgbox("Success",
-                    f"{preset} preset applied!\n"
-                    f"Frequency slot: {freq_slot}")
-
-            except Exception as e:
-                self.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
+            self.dialog.msgbox("Success",
+                f"{preset} preset applied!\n\n"
+                f"Modem preset: {preset}{slot_msg}\n\n"
+                "Settings applied via meshtastic CLI.\n"
+                "Device will reboot to apply changes.")
+        except Exception as e:
+            self.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
 
     def _hardware_config_menu(self):
         """Hardware configuration selection."""
@@ -592,16 +562,8 @@ Press Cancel to keep current values."""
         """Scan for phantom/incomplete nodes via HTTP API."""
         self.dialog.infobox("Scanning", "Fetching node list from meshtasticd...")
 
-        if not _HAS_HTTP_CLIENT:
-            self.dialog.msgbox(
-                "Module Not Available",
-                "HTTP client module not found.\n\n"
-                "Ensure src/utils/meshtastic_http.py exists."
-            )
-            return
-
         try:
-            client = _get_http_client()
+            client = get_http_client()
 
             if not client.is_available:
                 self.dialog.msgbox(
@@ -1118,10 +1080,9 @@ Press Cancel to keep current values."""
         """Set MQTT broker address."""
         # Default to active broker profile's host if available
         default_broker = "mqtt.meshtastic.org"
-        if _HAS_BROKER_PROFILES:
-            active = _get_active_profile()
-            if active:
-                default_broker = active.host
+        active = get_active_profile()
+        if active:
+            default_broker = active.host
 
         broker = self.dialog.inputbox(
             "MQTT Broker",

--- a/src/launcher_tui/messaging_mixin.py
+++ b/src/launcher_tui/messaging_mixin.py
@@ -12,7 +12,7 @@ from utils.safe_import import safe_import
 logger = logging.getLogger(__name__)
 
 # --- Optional dependencies (module-level) ---
-event_bus, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'event_bus')
+from utils.event_bus import event_bus
 
 (send_message, get_messages, get_conversations, get_stats,
  start_receiving, stop_receiving, get_rx_status,
@@ -75,10 +75,6 @@ class MessagingMixin:
         Press Enter to stop and return to menu.
         """
         import threading
-
-        if not _HAS_EVENT_BUS:
-            self.dialog.msgbox("Unavailable", "Event bus module not available.\nFile: src/utils/event_bus.py")
-            return
 
         clear_screen()
         print("=== Live Message Feed ===")

--- a/src/launcher_tui/metrics_mixin.py
+++ b/src/launcher_tui/metrics_mixin.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 get_metrics_history, MetricType, _HAS_METRICS_HISTORY = safe_import(
     'utils.metrics_history', 'get_metrics_history', 'MetricType'
 )
-get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+from utils.paths import get_real_user_home
 start_metrics_server, _HAS_METRICS_EXPORT = safe_import(
     'utils.metrics_export', 'start_metrics_server'
 )
@@ -427,20 +427,7 @@ class MetricsMixin:
             return
 
         # Default export path
-        if _HAS_PATHS:
-            export_dir = get_real_user_home() / ".cache" / "meshforge"
-        else:
-            import os
-            sudo_user = os.environ.get('SUDO_USER', '')
-            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-                export_dir = Path(f'/home/{sudo_user}') / ".cache" / "meshforge"
-            else:
-                # Fallback: use LOGNAME or /tmp to avoid /root with sudo (MF001)
-                logname = os.environ.get('LOGNAME', '')
-                if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-                    export_dir = Path(f'/home/{logname}') / ".cache" / "meshforge"
-                else:
-                    export_dir = Path('/tmp') / "meshforge"
+        export_dir = get_real_user_home() / ".cache" / "meshforge"
 
         export_dir.mkdir(parents=True, exist_ok=True)
 

--- a/src/launcher_tui/network_tools_mixin.py
+++ b/src/launcher_tui/network_tools_mixin.py
@@ -16,9 +16,7 @@ import socket as sock
 import subprocess
 from pathlib import Path
 from backend import clear_screen
-from utils.safe_import import safe_import
-
-_check_udp_port, _HAS_UDP_CHECK = safe_import('utils.service_check', 'check_udp_port')
+from utils.service_check import check_udp_port
 
 logger = logging.getLogger(__name__)
 
@@ -219,8 +217,8 @@ class NetworkToolsMixin:
 
         for port, proto, desc in ports:
             try:
-                if proto == 'udp' and _HAS_UDP_CHECK:
-                    is_open = _check_udp_port(port)
+                if proto == 'udp':
+                    is_open = check_udp_port(port)
                 else:
                     s = sock.socket(sock.AF_INET, sock.SOCK_STREAM)
                     try:

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -33,14 +33,12 @@ check_systemd_service, check_process_running, _check_port, _check_udp_port, appl
     'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port', 'check_udp_port', 'apply_config_and_restart', 'restart_service', '_sudo_cmd'
 )
 
-# Optional modules for quick actions
-generate_report, _HAS_REPORT_GENERATOR = safe_import('utils.report_generator', 'generate_report')
-NodeInventory, _HAS_NODE_INVENTORY = safe_import('utils.node_inventory', 'NodeInventory')
-GPSManager, _HAS_GPS_INTEGRATION = safe_import('utils.gps_integration', 'GPSManager')
-get_diagnostic_engine, _HAS_DIAGNOSTIC_ENGINE = safe_import(
-    'utils.diagnostic_engine', 'get_diagnostic_engine'
-)
-ChannelMonitor, _HAS_CHANNEL_SCAN = safe_import('utils.channel_scan', 'ChannelMonitor')
+# First-party modules for quick actions
+from utils.report_generator import generate_report
+from utils.node_inventory import NodeInventory
+from utils.gps_integration import GPSManager
+from utils.diagnostic_engine import get_diagnostic_engine
+from utils.channel_scan import ChannelMonitor
 
 
 # Quick action definitions: (tag, description, method_name)
@@ -312,26 +310,23 @@ class QuickActionsMixin:
         clear_screen()
         print("Generating status report...\n")
 
-        if not _HAS_REPORT_GENERATOR:
-            print("Error: Report generator module not available.")
-        else:
-            try:
-                report = generate_report()
-                # Print report, paginated
-                lines = report.split('\n')
-                for i, line in enumerate(lines):
-                    print(line)
-                    # Pause every 40 lines
-                    if (i + 1) % 40 == 0 and i + 1 < len(lines):
-                        try:
-                            resp = input("\n--- More (Enter=continue, q=quit) ---\n")
-                        except (KeyboardInterrupt, EOFError):
-                            print()
-                            break
-                        if resp.strip().lower() == 'q':
-                            break
-            except Exception as e:
-                print(f"Error generating report: {e}")
+        try:
+            report = generate_report()
+            # Print report, paginated
+            lines = report.split('\n')
+            for i, line in enumerate(lines):
+                print(line)
+                # Pause every 40 lines
+                if (i + 1) % 40 == 0 and i + 1 < len(lines):
+                    try:
+                        resp = input("\n--- More (Enter=continue, q=quit) ---\n")
+                    except (KeyboardInterrupt, EOFError):
+                        print()
+                        break
+                    if resp.strip().lower() == 'q':
+                        break
+        except Exception as e:
+            print(f"Error generating report: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -341,49 +336,46 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Node Inventory ===\n")
 
-        if not _HAS_NODE_INVENTORY:
-            print("Error: Node inventory module not available.")
-        else:
-            try:
-                from utils.paths import get_real_user_home
+        try:
+            from utils.paths import get_real_user_home
 
-                path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
-                inv = NodeInventory(path=path)
+            path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+            inv = NodeInventory(path=path)
 
-                stats = inv.get_stats()
-                print(f"  Total nodes:    {stats['total']}")
-                print(f"  Online:         {stats['online']}")
-                print(f"  Offline:        {stats['offline']}")
-                print(f"  Stale (>7d):    {stats['stale']}")
-                print(f"  With position:  {stats['with_position']}")
+            stats = inv.get_stats()
+            print(f"  Total nodes:    {stats['total']}")
+            print(f"  Online:         {stats['online']}")
+            print(f"  Offline:        {stats['offline']}")
+            print(f"  Stale (>7d):    {stats['stale']}")
+            print(f"  With position:  {stats['with_position']}")
 
-                if stats['total'] > 0:
-                    # Show node list (non-stale only)
-                    nodes = [n for n in inv.get_all_nodes() if not n.is_stale]
-                    if nodes:
-                        print(f"\n  {'ID':<12} {'Name':<20} {'Status':<8} {'SNR':>5}  {'Hardware'}")
-                        print(f"  {'-'*12} {'-'*20} {'-'*8} {'-'*5}  {'-'*12}")
-                        for node in nodes[:25]:  # Cap at 25 for readability
-                            name = node.display_name[:20]
-                            nid = node.node_id[:12]
-                            status = node.status
-                            snr = f"{node.last_snr:.1f}" if node.last_snr is not None else "  -"
-                            hw = node.hardware[:12] if node.hardware else "-"
-                            print(f"  {nid:<12} {name:<20} {status:<8} {snr:>5}  {hw}")
-                        if len(nodes) > 25:
-                            print(f"\n  ... and {len(nodes) - 25} more nodes")
+            if stats['total'] > 0:
+                # Show node list (non-stale only)
+                nodes = [n for n in inv.get_all_nodes() if not n.is_stale]
+                if nodes:
+                    print(f"\n  {'ID':<12} {'Name':<20} {'Status':<8} {'SNR':>5}  {'Hardware'}")
+                    print(f"  {'-'*12} {'-'*20} {'-'*8} {'-'*5}  {'-'*12}")
+                    for node in nodes[:25]:  # Cap at 25 for readability
+                        name = node.display_name[:20]
+                        nid = node.node_id[:12]
+                        status = node.status
+                        snr = f"{node.last_snr:.1f}" if node.last_snr is not None else "  -"
+                        hw = node.hardware[:12] if node.hardware else "-"
+                        print(f"  {nid:<12} {name:<20} {status:<8} {snr:>5}  {hw}")
+                    if len(nodes) > 25:
+                        print(f"\n  ... and {len(nodes) - 25} more nodes")
 
-                    # Role breakdown
-                    if stats['roles']:
-                        roles_str = ", ".join(f"{r}: {c}" for r, c in stats['roles'].items())
-                        print(f"\n  Roles: {roles_str}")
-                else:
-                    print("\n  No nodes tracked yet.")
-                    print("  Nodes are added when received via MQTT or meshtastic CLI.")
+                # Role breakdown
+                if stats['roles']:
+                    roles_str = ", ".join(f"{r}: {c}" for r, c in stats['roles'].items())
+                    print(f"\n  Roles: {roles_str}")
+            else:
+                print("\n  No nodes tracked yet.")
+                print("  Nodes are added when received via MQTT or meshtastic CLI.")
 
-            except Exception as e:
-                logger.debug(f"Node inventory quick action failed: {e}")
-                print(f"Error: {e}")
+        except Exception as e:
+            logger.debug(f"Node inventory quick action failed: {e}")
+            print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -393,48 +385,45 @@ class QuickActionsMixin:
         clear_screen()
         print("=== GPS Position ===\n")
 
-        if not _HAS_GPS_INTEGRATION:
-            print("Error: GPS integration module not available.")
-        else:
+        try:
+            from utils.paths import get_real_user_home
+
+            config_path = get_real_user_home() / ".config" / "meshforge" / "operator_position.json"
+            gps = GPSManager(config_path=config_path)
+
+            # Try to get nodes for distance calculation
+            nodes = []
             try:
-                from utils.paths import get_real_user_home
-
-                config_path = get_real_user_home() / ".config" / "meshforge" / "operator_position.json"
-                gps = GPSManager(config_path=config_path)
-
-                # Try to get nodes for distance calculation
-                nodes = []
-                try:
-                    from utils.node_inventory import NodeInventory as _NodeInv
-                    inv_path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
-                    inv = _NodeInv(path=inv_path)
-                    for node in inv.get_all_nodes():
-                        if node.has_position:
-                            nodes.append({
-                                'id': node.node_id,
-                                'name': node.display_name,
-                                'lat': node.lat,
-                                'lon': node.lon,
-                            })
-                except Exception as e:
-                    logger.debug("Node inventory for GPS report unavailable: %s", e)
-
-                # Display position report
-                report = gps.format_position_report(nodes=nodes if nodes else None)
-                print(f"  {report.replace(chr(10), chr(10) + '  ')}")
-
-                # Show gpsd status
-                print()
-                if gps.gpsd_available:
-                    print("  gpsd: connected")
-                else:
-                    print("  gpsd: not available")
-                    if not gps.has_position:
-                        print("  Tip: Set position manually in Tools > GPS")
-
+                from utils.node_inventory import NodeInventory as _NodeInv
+                inv_path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+                inv = _NodeInv(path=inv_path)
+                for node in inv.get_all_nodes():
+                    if node.has_position:
+                        nodes.append({
+                            'id': node.node_id,
+                            'name': node.display_name,
+                            'lat': node.lat,
+                            'lon': node.lon,
+                        })
             except Exception as e:
-                logger.debug(f"GPS quick action failed: {e}")
-                print(f"Error: {e}")
+                logger.debug("Node inventory for GPS report unavailable: %s", e)
+
+            # Display position report
+            report = gps.format_position_report(nodes=nodes if nodes else None)
+            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+
+            # Show gpsd status
+            print()
+            if gps.gpsd_available:
+                print("  gpsd: connected")
+            else:
+                print("  gpsd: not available")
+                if not gps.has_position:
+                    print("  Tip: Set position manually in Tools > GPS")
+
+        except Exception as e:
+            logger.debug(f"GPS quick action failed: {e}")
+            print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -444,31 +433,28 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Diagnostic Health Check ===\n")
 
-        if not _HAS_DIAGNOSTIC_ENGINE:
-            print("Error: Diagnostic engine not available.")
-        else:
-            try:
-                engine = get_diagnostic_engine()
-                summary = engine.get_health_summary()
+        try:
+            engine = get_diagnostic_engine()
+            summary = engine.get_health_summary()
 
-                print(f"  Overall Health:    {summary['overall_health']}")
-                print(f"  Symptoms (1h):     {summary['symptoms_last_hour']}")
-                print(f"  Total Diagnoses:   {summary['stats'].get('diagnoses_made', 0)}")
-                print(f"  Auto-Recoveries:   {summary['stats'].get('auto_recoveries', 0)}")
-                print(f"  Rules Loaded:      {summary['stats'].get('rules_loaded', 0)}")
+            print(f"  Overall Health:    {summary['overall_health']}")
+            print(f"  Symptoms (1h):     {summary['symptoms_last_hour']}")
+            print(f"  Total Diagnoses:   {summary['stats'].get('diagnoses_made', 0)}")
+            print(f"  Auto-Recoveries:   {summary['stats'].get('auto_recoveries', 0)}")
+            print(f"  Rules Loaded:      {summary['stats'].get('rules_loaded', 0)}")
 
-                # Recent issues
-                recent = engine.get_recent_diagnoses(limit=5)
-                if recent:
-                    print(f"\n  Recent Issues ({len(recent)}):")
-                    for d in recent[-5:]:
-                        cat = d.symptom.category.value
-                        print(f"    [{cat}] {d.likely_cause[:60]}")
-                else:
-                    print("\n  No recent issues detected.")
+            # Recent issues
+            recent = engine.get_recent_diagnoses(limit=5)
+            if recent:
+                print(f"\n  Recent Issues ({len(recent)}):")
+                for d in recent[-5:]:
+                    cat = d.symptom.category.value
+                    print(f"    [{cat}] {d.likely_cause[:60]}")
+            else:
+                print("\n  No recent issues detected.")
 
-            except Exception as e:
-                print(f"Error: {e}")
+        except Exception as e:
+            print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")
@@ -478,26 +464,23 @@ class QuickActionsMixin:
         clear_screen()
         print("=== Channel Activity ===\n")
 
-        if not _HAS_CHANNEL_SCAN:
-            print("Error: Channel scan module not available.")
-        else:
-            try:
-                monitor = ChannelMonitor()
+        try:
+            monitor = ChannelMonitor()
 
-                # Try to query device for channel config
-                channels = monitor.query_device_channels()
-                if not channels:
-                    print("  (Could not query device channels)")
-                    print("  Showing activity from MQTT monitoring only.")
-                    print()
+            # Try to query device for channel config
+            channels = monitor.query_device_channels()
+            if not channels:
+                print("  (Could not query device channels)")
+                print("  Showing activity from MQTT monitoring only.")
+                print()
 
-                # Display activity report
-                report = monitor.get_activity_report()
-                print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+            # Display activity report
+            report = monitor.get_activity_report()
+            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
 
-            except Exception as e:
-                logger.debug(f"Channel scan quick action failed: {e}")
-                print(f"Error: {e}")
+        except Exception as e:
+            logger.debug(f"Channel scan quick action failed: {e}")
+            print(f"Error: {e}")
 
         print()
         self._wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/rns_interfaces_mixin.py
+++ b/src/launcher_tui/rns_interfaces_mixin.py
@@ -13,12 +13,9 @@ import sys
 import subprocess
 import logging
 from backend import clear_screen
-from utils.safe_import import safe_import
+from commands import rns as rns_mod
 
 logger = logging.getLogger(__name__)
-
-# Hoist commands.rns import to module level
-_rns_mod, _HAS_RNS_COMMANDS = safe_import('commands.rns')
 
 
 class RNSInterfacesMixin:
@@ -405,12 +402,5 @@ class RNSInterfacesMixin:
         return result
 
     def _import_rns_commands(self):
-        """Import and return the commands.rns module, or None on failure."""
-        if _HAS_RNS_COMMANDS:
-            return _rns_mod
-        self.dialog.msgbox(
-            "Import Error",
-            "Could not import RNS commands module.\n\n"
-            "Ensure src/commands/rns.py exists.",
-        )
-        return None
+        """Import and return the commands.rns module."""
+        return rns_mod

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -41,11 +41,11 @@ from utils.paths import get_real_user_home
 )
 
 # Import RNS identity helpers
-get_identity_path, _HAS_RNS_IDENTITY = safe_import('commands.rns', 'get_identity_path')
-create_identities, _HAS_RNS_CREATE = safe_import('commands.rns', 'create_identities')
+from commands.rns import get_identity_path
+from commands.rns import create_identities
 
 # Import propagation module
-propagation_mod, _HAS_PROPAGATION = safe_import('commands.propagation')
+from commands import propagation
 
 
 class ServiceMenuMixin:
@@ -155,10 +155,9 @@ class ServiceMenuMixin:
             pass
 
         # 3. Check gateway identity exists
-        if _HAS_RNS_IDENTITY:
-            gw_id = get_identity_path()
-            if not gw_id.exists():
-                issues.append("Gateway identity not created yet")
+        gw_id = get_identity_path()
+        if not gw_id.exists():
+            issues.append("Gateway identity not created yet")
 
         if not issues:
             return True
@@ -217,15 +216,14 @@ class ServiceMenuMixin:
                 print("  Bridge may fail to connect.\n")
 
         # Create gateway identity if missing
-        if _HAS_RNS_IDENTITY and _HAS_RNS_CREATE:
-            gw_id = get_identity_path()
-            if not gw_id.exists():
-                print("[3] Creating gateway identity...")
-                result = create_identities()
-                if result.success:
-                    print(f"  {result.message}\n")
-                else:
-                    print(f"  Warning: {result.message}\n")
+        gw_id = get_identity_path()
+        if not gw_id.exists():
+            print("[3] Creating gateway identity...")
+            result = create_identities()
+            if result.success:
+                print(f"  {result.message}\n")
+            else:
+                print(f"  Warning: {result.message}\n")
 
         # Restart NomadNet as client (if we stopped it)
         if nomadnet_conflict:
@@ -1262,13 +1260,12 @@ WantedBy=multi-user.target
                 )
                 if result.returncode == 0:
                     print("\033[0;32m✓\033[0m OpenHamClock started on port 3000")
-                    if _HAS_PROPAGATION:
-                        print("\nAuto-configuring MeshForge...")
-                        propagation_mod.configure_source(
-                            propagation_mod.DataSource.OPENHAMCLOCK,
-                            host="localhost", port=3000
-                        )
-                        print("\033[0;32m✓\033[0m MeshForge configured for OpenHamClock")
+                    print("\nAuto-configuring MeshForge...")
+                    propagation.configure_source(
+                        propagation.DataSource.OPENHAMCLOCK,
+                        host="localhost", port=3000
+                    )
+                    print("\033[0;32m✓\033[0m MeshForge configured for OpenHamClock")
                 else:
                     print(f"\033[0;31mError:\033[0m {result.stderr}")
 

--- a/src/launcher_tui/settings_menu_mixin.py
+++ b/src/launcher_tui/settings_menu_mixin.py
@@ -9,7 +9,7 @@ from utils.safe_import import safe_import
 MapDataCollector, _HAS_MAP_DATA_COLLECTOR = safe_import(
     'utils.map_data_collector', 'MapDataCollector'
 )
-_propagation, _HAS_PROPAGATION = safe_import('commands.propagation')
+from commands import propagation
 
 
 class SettingsMenuMixin:
@@ -129,14 +129,10 @@ class SettingsMenuMixin:
 
     def _test_noaa_source(self):
         """Test NOAA SWPC connectivity and show current data."""
-        if not _HAS_PROPAGATION:
-            self.dialog.msgbox("Error", "Propagation module not available.")
-            return
-
-        result = _propagation.check_source(_propagation.DataSource.NOAA)
+        result = propagation.check_source(propagation.DataSource.NOAA)
         if result.success:
             # Also get current conditions
-            wx = _propagation.get_space_weather()
+            wx = propagation.get_space_weather()
             if wx.success:
                 d = wx.data
                 lines = [
@@ -160,13 +156,9 @@ class SettingsMenuMixin:
 
     def _configure_pskreporter(self):
         """Configure PSKReporter MQTT as propagation data source."""
-        if not _HAS_PROPAGATION:
-            self.dialog.msgbox("Error", "Propagation module not available.")
-            return
-
         while True:
             # Get current config
-            pskr_cfg = _propagation._sources.get(_propagation.DataSource.PSKREPORTER)
+            pskr_cfg = propagation._sources.get(propagation.DataSource.PSKREPORTER)
             current_call = pskr_cfg.callsign if pskr_cfg else ""
             current_bands = ", ".join(pskr_cfg.bands) if pskr_cfg and pskr_cfg.bands else "all"
             is_enabled = pskr_cfg.enabled if pskr_cfg else False
@@ -194,8 +186,8 @@ class SettingsMenuMixin:
 
             if choice == "enable":
                 new_state = not is_enabled
-                result = _propagation.configure_source(
-                    _propagation.DataSource.PSKREPORTER,
+                result = propagation.configure_source(
+                    propagation.DataSource.PSKREPORTER,
                     enabled=new_state,
                     callsign=current_call,
                     bands=pskr_cfg.bands if pskr_cfg else [],
@@ -217,8 +209,8 @@ class SettingsMenuMixin:
                     current_call,
                 )
                 if call is not None:
-                    _propagation.configure_source(
-                        _propagation.DataSource.PSKREPORTER,
+                    propagation.configure_source(
+                        propagation.DataSource.PSKREPORTER,
                         enabled=is_enabled,
                         callsign=call.strip(),
                         bands=pskr_cfg.bands if pskr_cfg else [],
@@ -235,8 +227,8 @@ class SettingsMenuMixin:
                 )
                 if bands_input is not None:
                     bands = [b.strip() for b in bands_input.split(",") if b.strip()]
-                    _propagation.configure_source(
-                        _propagation.DataSource.PSKREPORTER,
+                    propagation.configure_source(
+                        propagation.DataSource.PSKREPORTER,
                         enabled=is_enabled,
                         callsign=current_call,
                         bands=bands,
@@ -244,7 +236,7 @@ class SettingsMenuMixin:
                     )
 
             elif choice == "test":
-                result = _propagation.check_source(_propagation.DataSource.PSKREPORTER)
+                result = propagation.check_source(propagation.DataSource.PSKREPORTER)
                 if result.success:
                     self.dialog.msgbox(
                         "PSKReporter Connected",
@@ -289,18 +281,14 @@ class SettingsMenuMixin:
             self.dialog.msgbox("Error", "Invalid port number (1-65535).")
             return
 
-        if not _HAS_PROPAGATION:
-            self.dialog.msgbox("Error", "Propagation module not available.")
-            return
-
-        result = _propagation.configure_source(
-            _propagation.DataSource.OPENHAMCLOCK,
+        result = propagation.configure_source(
+            propagation.DataSource.OPENHAMCLOCK,
             host=host,
             port=int(port),
         )
         if result.success:
             # Test connectivity
-            test = _propagation.check_source(_propagation.DataSource.OPENHAMCLOCK)
+            test = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
             if test.success:
                 self.dialog.msgbox(
                     "OpenHamClock Connected",
@@ -347,17 +335,13 @@ class SettingsMenuMixin:
             self.dialog.msgbox("Error", "Invalid port number (1-65535).")
             return
 
-        if not _HAS_PROPAGATION:
-            self.dialog.msgbox("Error", "Propagation module not available.")
-            return
-
-        result = _propagation.configure_source(
-            _propagation.DataSource.HAMCLOCK,
+        result = propagation.configure_source(
+            propagation.DataSource.HAMCLOCK,
             host=host,
             port=int(port),
         )
         if result.success:
-            test = _propagation.check_source(_propagation.DataSource.HAMCLOCK)
+            test = propagation.check_source(propagation.DataSource.HAMCLOCK)
             if test.success:
                 self.dialog.msgbox(
                     "HamClock Connected",
@@ -380,49 +364,46 @@ class SettingsMenuMixin:
         """Test all configured propagation data sources."""
         lines = ["Propagation Source Status", "=" * 35, ""]
 
-        if not _HAS_PROPAGATION:
-            lines.append("Propagation module not available.")
+        # NOAA (always)
+        noaa = propagation.check_source(propagation.DataSource.NOAA)
+        status = "Connected" if noaa.success else "Unreachable"
+        lines.append(f"NOAA SWPC (primary): {status}")
+
+        # PSKReporter
+        pskr = propagation.check_source(propagation.DataSource.PSKREPORTER)
+        if pskr.success:
+            spots = pskr.data.get('spots_received', 0)
+            lines.append(f"PSKReporter MQTT: Connected ({spots} spots)")
         else:
-            # NOAA (always)
-            noaa = _propagation.check_source(_propagation.DataSource.NOAA)
-            status = "Connected" if noaa.success else "Unreachable"
-            lines.append(f"NOAA SWPC (primary): {status}")
+            lines.append(f"PSKReporter MQTT: Not configured")
 
-            # PSKReporter
-            pskr = _propagation.check_source(_propagation.DataSource.PSKREPORTER)
-            if pskr.success:
-                spots = pskr.data.get('spots_received', 0)
-                lines.append(f"PSKReporter MQTT: Connected ({spots} spots)")
-            else:
-                lines.append(f"PSKReporter MQTT: Not configured")
+        # OpenHamClock
+        ohc = propagation.check_source(propagation.DataSource.OPENHAMCLOCK)
+        if ohc.success:
+            lines.append(f"OpenHamClock: Connected")
+        else:
+            lines.append(f"OpenHamClock: Not configured")
 
-            # OpenHamClock
-            ohc = _propagation.check_source(_propagation.DataSource.OPENHAMCLOCK)
-            if ohc.success:
-                lines.append(f"OpenHamClock: Connected")
-            else:
-                lines.append(f"OpenHamClock: Not configured")
+        # HamClock
+        hc = propagation.check_source(propagation.DataSource.HAMCLOCK)
+        if hc.success:
+            lines.append(f"HamClock (legacy): Connected")
+        else:
+            lines.append(f"HamClock (legacy): Not configured")
 
-            # HamClock
-            hc = _propagation.check_source(_propagation.DataSource.HAMCLOCK)
-            if hc.success:
-                lines.append(f"HamClock (legacy): Connected")
-            else:
-                lines.append(f"HamClock (legacy): Not configured")
-
-            # Current data
-            wx = _propagation.get_space_weather()
-            if wx.success:
-                d = wx.data
-                lines.append("")
-                lines.append("-" * 35)
-                lines.append("Current Conditions:")
-                sfi = d.get('solar_flux')
-                kp = d.get('k_index')
-                if sfi:
-                    lines.append(f"  SFI: {int(sfi)}")
-                if kp is not None:
-                    lines.append(f"  Kp: {kp}")
-                lines.append(f"  {d.get('geomag_storm', '')}")
+        # Current data
+        wx = propagation.get_space_weather()
+        if wx.success:
+            d = wx.data
+            lines.append("")
+            lines.append("-" * 35)
+            lines.append("Current Conditions:")
+            sfi = d.get('solar_flux')
+            kp = d.get('k_index')
+            if sfi:
+                lines.append(f"  SFI: {int(sfi)}")
+            if kp is not None:
+                lines.append(f"  Kp: {kp}")
+            lines.append(f"  {d.get('geomag_storm', '')}")
 
         self.dialog.msgbox("Source Status", "\n".join(lines))

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -41,26 +41,17 @@ check_service, ServiceState, ServiceStatus, _check_udp_port_fn, _HAS_SERVICE_CHE
     'utils.service_check', 'check_service', 'ServiceState', 'ServiceStatus', 'check_udp_port'
 )
 
-_ports_mod, _HAS_PORTS = safe_import('utils.ports')
-if _HAS_PORTS:
-    MESHTASTICD_PORT = _ports_mod.MESHTASTICD_PORT
-    MESHTASTICD_WEB_PORT = _ports_mod.MESHTASTICD_WEB_PORT
-    RNS_SHARED_INSTANCE_PORT = _ports_mod.RNS_SHARED_INSTANCE_PORT
-    RNS_TCP_SERVER_PORT = _ports_mod.RNS_TCP_SERVER_PORT
-    MQTT_PORT = _ports_mod.MQTT_PORT
-else:
-    # Fallback constants if utils not available
-    MESHTASTICD_PORT = 4403
-    MESHTASTICD_WEB_PORT = 9443
-    RNS_SHARED_INSTANCE_PORT = 37428
-    RNS_TCP_SERVER_PORT = 4242
-    MQTT_PORT = 1883
+from utils import ports
+MESHTASTICD_PORT = ports.MESHTASTICD_PORT
+MESHTASTICD_WEB_PORT = ports.MESHTASTICD_WEB_PORT
+RNS_SHARED_INSTANCE_PORT = ports.RNS_SHARED_INSTANCE_PORT
+RNS_TCP_SERVER_PORT = ports.RNS_TCP_SERVER_PORT
+MQTT_PORT = ports.MQTT_PORT
 
 # Sudo-safe home directory — first-party, always available (MF001)
 from utils.paths import get_real_user_home
 
-# Import ReticulumPaths for _heal_rns_storage_dirs (directory creation only)
-_ReticulumPaths, _HAS_RETICULUM_PATHS = safe_import('utils.paths', 'ReticulumPaths')
+from utils.paths import ReticulumPaths
 
 
 class ServiceRunState(Enum):
@@ -287,10 +278,7 @@ class StartupChecker:
         context, regenerating shared_instance auth tokens and breaking
         RNS connectivity for the normal user.
         """
-        if not _HAS_RETICULUM_PATHS:
-            return
-
-        if not _ReticulumPaths.ensure_system_dirs():
+        if not ReticulumPaths.ensure_system_dirs():
             logger.debug("Could not create /etc/reticulum directories")
             return
 

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -25,26 +25,21 @@ from typing import Dict, Optional, List
 
 logger = logging.getLogger(__name__)
 
-from utils.safe_import import safe_import
-
 # Import centralized service checking
-check_systemd_service, check_process_running, _check_udp_port, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_udp_port'
-)
+from utils.service_check import check_systemd_service, check_process_running, check_udp_port
 
 # Import startup checker for enhanced status
-StartupChecker, EnvironmentState, ServiceRunState, HAS_STARTUP_CHECKER = safe_import(
-    'startup_checks', 'StartupChecker', 'EnvironmentState', 'ServiceRunState'
-)
+from startup_checks import StartupChecker, EnvironmentState, ServiceRunState
+HAS_STARTUP_CHECKER = True
 
 # Space weather API
-_SpaceWeatherAPI, _HAS_SPACE_WEATHER = safe_import('utils.space_weather', 'SpaceWeatherAPI')
+from utils.space_weather import SpaceWeatherAPI
 
 # EventBus for push-based updates
-_event_bus, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'event_bus')
+from utils.event_bus import event_bus
 
 # Node tracker for initial node count seeding
-_get_node_tracker, _HAS_NODE_TRACKER = safe_import('gateway.node_tracker', 'get_node_tracker')
+from gateway.node_tracker import get_node_tracker
 
 # RNS shared instance port (UDP) — rnsd must bind this to be functional
 _RNS_PORT = 37428
@@ -186,28 +181,15 @@ class StatusBar:
             Status symbol character.
         """
         try:
-            if _HAS_SERVICE_CHECK:
-                is_running, _ = check_systemd_service(service)
-                if not is_running:
+            is_running, _ = check_systemd_service(service)
+            if not is_running:
+                return SYM_STOPPED
+            # rnsd zombie detection: systemd active but port not bound
+            if service == 'rnsd':
+                if not check_udp_port(_RNS_PORT):
+                    logger.debug("rnsd active but port %d not bound", _RNS_PORT)
                     return SYM_STOPPED
-                # rnsd zombie detection: systemd active but port not bound
-                if service == 'rnsd' and _check_udp_port is not None:
-                    if not _check_udp_port(_RNS_PORT):
-                        logger.debug("rnsd active but port %d not bound", _RNS_PORT)
-                        return SYM_STOPPED
-                return SYM_RUNNING
-
-            # Fallback to direct systemctl call
-            result = subprocess.run(
-                ['systemctl', 'is-active', service],
-                capture_output=True, text=True, timeout=3
-            )
-            if result.stdout.strip() == 'active':
-                if service == 'rnsd' and _check_udp_port is not None:
-                    if not _check_udp_port(_RNS_PORT):
-                        return SYM_STOPPED
-                return SYM_RUNNING
-            return SYM_STOPPED
+            return SYM_RUNNING
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             return SYM_UNKNOWN
 
@@ -217,16 +199,7 @@ class StatusBar:
         Uses centralized service_check module when available.
         """
         try:
-            if _HAS_SERVICE_CHECK:
-                self._bridge_running = check_process_running('rns_bridge')
-                return
-
-            # Fallback to direct pgrep call
-            result = subprocess.run(
-                ['pgrep', '-f', 'rns_bridge'],
-                capture_output=True, timeout=3
-            )
-            self._bridge_running = result.returncode == 0
+            self._bridge_running = check_process_running('rns_bridge')
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             self._bridge_running = None
 
@@ -237,13 +210,8 @@ class StatusBar:
         is already called infrequently (5-min TTL). Falls back gracefully
         if network is unavailable.
         """
-        if not _HAS_SPACE_WEATHER:
-            logger.debug("Space weather module not available")
-            self._space_weather = None
-            return
-
         try:
-            api = _SpaceWeatherAPI(timeout=5)  # Short timeout for TUI
+            api = SpaceWeatherAPI(timeout=5)  # Short timeout for TUI
             data = api.get_current_conditions()
 
             # Build compact status: "SFI:125 K:2"
@@ -347,14 +315,11 @@ class StatusBar:
         """
         if self._event_subscribed:
             return
-        if _HAS_EVENT_BUS:
-            _event_bus.subscribe('service', self._on_service_event)
-            _event_bus.subscribe('message', self._on_message_event)
-            _event_bus.subscribe('node', self._on_node_event)
-            self._event_subscribed = True
-            logger.debug("StatusBar subscribed to EventBus service+message+node events")
-        else:
-            logger.debug("EventBus not available — StatusBar will poll only")
+        event_bus.subscribe('service', self._on_service_event)
+        event_bus.subscribe('message', self._on_message_event)
+        event_bus.subscribe('node', self._on_node_event)
+        self._event_subscribed = True
+        logger.debug("StatusBar subscribed to EventBus service+message+node events")
 
     def _seed_node_count(self) -> None:
         """Pull initial node count from the node tracker singleton.
@@ -362,11 +327,8 @@ class StatusBar:
         Without this, the status bar shows no node count until a new
         'discovered' event arrives from the EventBus.
         """
-        if not _HAS_NODE_TRACKER:
-            logger.debug("Node tracker not available for initial count")
-            return
         try:
-            tracker = _get_node_tracker()
+            tracker = get_node_tracker()
             nodes = tracker.get_all_nodes()
             if nodes:
                 self._node_count = len(nodes)

--- a/src/launcher_tui/web_client_mixin.py
+++ b/src/launcher_tui/web_client_mixin.py
@@ -17,10 +17,8 @@ import socket
 import subprocess
 import threading
 
-from utils.safe_import import safe_import
-
 # Import _sudo_cmd for privileged systemctl calls
-_sudo_cmd, _HAS_SERVICE_CHECK = safe_import('utils.service_check', '_sudo_cmd')
+from utils.service_check import _sudo_cmd
 
 logger = logging.getLogger(__name__)
 

--- a/src/monitor.py
+++ b/src/monitor.py
@@ -39,12 +39,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from utils.safe_import import safe_import
-
-# Module-level safe imports
+# Module-level imports
 from utils.paths import get_real_user_home
-_NodeMonitor_src, _HAS_MONITOR_SRC = safe_import('src.monitoring', 'NodeMonitor')
-_NodeMonitor_rel, _HAS_MONITOR_REL = safe_import('monitoring', 'NodeMonitor')
+from monitoring import NodeMonitor
 
 # Config file location
 CONFIG_DIR = get_real_user_home() / '.config' / 'meshtastic-monitor'
@@ -166,15 +163,6 @@ def print_node_table(nodes: list, my_node_id: Optional[str] = None):
 def run_monitor(host: str, port: int, json_output: bool, watch: bool, interval: int):
     """Main monitoring function"""
     global _running
-
-    if _HAS_MONITOR_SRC:
-        NodeMonitor = _NodeMonitor_src
-    elif _HAS_MONITOR_REL:
-        NodeMonitor = _NodeMonitor_rel
-    else:
-        print("Error: Could not import NodeMonitor. Make sure you're running from the project root.")
-        print("Usage: python3 -m src.monitor")
-        sys.exit(1)
 
     if not json_output:
         print_banner()

--- a/src/plugins/meshcore.py
+++ b/src/plugins/meshcore.py
@@ -37,8 +37,8 @@ _MeshCoreHandler, _HAS_HANDLER = safe_import(
 _detect_devices, _HAS_DETECT = safe_import(
     'gateway.meshcore_handler', 'detect_meshcore_devices'
 )
-_GatewayConfig, _HAS_CONFIG = safe_import('gateway.config', 'GatewayConfig')
-_MeshCoreConfig, _HAS_MC_CONFIG = safe_import('gateway.config', 'MeshCoreConfig')
+from gateway.config import GatewayConfig
+from gateway.config import MeshCoreConfig
 _BridgeHealthMonitor, _HAS_HEALTH = safe_import(
     'gateway.bridge_health', 'BridgeHealthMonitor'
 )
@@ -105,7 +105,7 @@ class MeshCorePlugin(ProtocolPlugin):
         Returns:
             True if handler started successfully.
         """
-        if not _HAS_HANDLER or not _HAS_CONFIG:
+        if not _HAS_HANDLER:
             logger.error("MeshCore handler or config not available")
             return False
 
@@ -116,7 +116,7 @@ class MeshCorePlugin(ProtocolPlugin):
         try:
             # Build gateway config from kwargs
             conn_type = kwargs.get("type", "serial")
-            mc_config = _MeshCoreConfig(
+            mc_config = MeshCoreConfig(
                 enabled=True,
                 device_path=kwargs.get("port", "/dev/ttyUSB1"),
                 baud_rate=kwargs.get("baud_rate", 115200),
@@ -129,7 +129,7 @@ class MeshCorePlugin(ProtocolPlugin):
                 ),
             )
 
-            gw_config = _GatewayConfig()
+            gw_config = GatewayConfig()
             gw_config.meshcore = mc_config
 
             # Create minimal supporting objects

--- a/src/setup_wizard.py
+++ b/src/setup_wizard.py
@@ -23,8 +23,6 @@ from enum import Enum
 # Setup logging
 logger = logging.getLogger(__name__)
 
-from utils.safe_import import safe_import
-
 # Service management — first-party, direct import per CLAUDE.md
 from utils.service_check import (
     check_service as _check_service_central,
@@ -36,9 +34,7 @@ from utils.service_check import (
     _sudo_write,
 )
 
-_get_real_user_home_mod, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-_ReticulumPaths, _HAS_RETICULUM_PATHS = safe_import('utils.paths', 'ReticulumPaths')
+from utils.paths import get_real_user_home, ReticulumPaths
 
 
 class WizardServiceState(Enum):
@@ -144,15 +140,7 @@ class SetupWizard:
 
     def _get_real_home(self) -> Path:
         """Get real user home even when running as sudo"""
-        if _HAS_PATHS:
-            return _get_real_user_home_mod()
-        sudo_user = os.environ.get('SUDO_USER', '')
-        if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-            return Path(f"/home/{sudo_user}")
-        logname = os.environ.get('LOGNAME', '')
-        if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-            return Path(f"/home/{logname}")
-        return Path('/root')
+        return get_real_user_home()
 
     def _setup_logging(self):
         """Setup file logging for the wizard"""
@@ -425,10 +413,7 @@ class SetupWizard:
         if (rns_status and rns_status.state == WizardServiceState.RUNNING and
             nomad_status and nomad_status.state == WizardServiceState.RUNNING):
             # Both running - check if nomadnet is configured to use shared instance
-            if _HAS_RETICULUM_PATHS:
-                config_path = _ReticulumPaths.get_config_file()
-            else:
-                config_path = self._get_real_home() / ".reticulum" / "config"
+            config_path = ReticulumPaths.get_config_file()
             if config_path.exists():
                 try:
                     config_text = config_path.read_text()

--- a/src/updates/version_checker.py
+++ b/src/updates/version_checker.py
@@ -24,7 +24,7 @@ from utils.safe_import import safe_import
 
 # Module-level safe imports
 _version_mod, _HAS_VERSION = safe_import('__version__', '__version__')
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 # Cache for version checks to avoid hitting APIs too frequently
 _version_cache: Dict[str, Any] = {}
@@ -167,11 +167,7 @@ def get_meshtastic_cli_version() -> Optional[str]:
     """Get installed meshtastic CLI version"""
     try:
         # Find meshtastic CLI using centralized function
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             return None
@@ -213,11 +209,7 @@ def get_node_firmware_version() -> Optional[str]:
                     pass
 
         # Find CLI using centralized function
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             return None

--- a/src/utils/active_health_probe.py
+++ b/src/utils/active_health_probe.py
@@ -38,10 +38,8 @@ from dataclasses import dataclass, field
 from typing import Callable, Dict, Optional, List
 from enum import Enum
 
-from utils.safe_import import safe_import
-
-_emit_service_status, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'emit_service_status')
-_check_udp_port_fn, _HAS_UDP_CHECK = safe_import('utils.service_check', 'check_udp_port')
+from utils.event_bus import emit_service_status
+from utils.service_check import check_udp_port
 
 logger = logging.getLogger(__name__)
 
@@ -411,40 +409,19 @@ class ActiveHealthProbe:
         """
         Probe RNS shared instance port.
 
-        Primary: uses check_udp_port() from service_check which reads
-        /proc/net/udp for reliable detection. Falls back to bind test
-        if service_check is unavailable.
+        Uses check_udp_port() from service_check which reads
+        /proc/net/udp for reliable detection.
 
         Args:
             port: RNS shared instance port (default: 37428)
             host: Host to check (default: 127.0.0.1)
         """
-        # Primary: /proc/net/udp-based check (reliable)
-        if _HAS_UDP_CHECK:
-            try:
-                if _check_udp_port_fn(port, host):
-                    return HealthResult(healthy=True, reason="port_bound")
-                return HealthResult(healthy=False, reason="port_not_bound")
-            except Exception as e:
-                return HealthResult(healthy=False, reason=f"check_error: {e}")
-
-        # Fallback: bind test (unreliable with SO_REUSEADDR)
-        sock = None
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.settimeout(2)
-            sock.bind((host, port))
-            return HealthResult(healthy=False, reason="port_not_bound")
-        except OSError as e:
-            if e.errno in (98, 48, 10048):  # EADDRINUSE
+            if check_udp_port(port, host):
                 return HealthResult(healthy=True, reason="port_bound")
-            return HealthResult(healthy=False, reason=f"socket_error: {e}")
-        finally:
-            if sock:
-                try:
-                    sock.close()
-                except Exception:
-                    pass
+            return HealthResult(healthy=False, reason="port_not_bound")
+        except Exception as e:
+            return HealthResult(healthy=False, reason=f"check_error: {e}")
 
     def check_systemd_service(self, service_name: str) -> HealthResult:
         """
@@ -511,15 +488,12 @@ def _emit_state_change(service_name: str, new_state: HealthState) -> None:
     Emits a ServiceEvent whenever a service transitions between states,
     enabling the status bar and other subscribers to react without polling.
     """
-    if _HAS_EVENT_BUS:
-        available = new_state == HealthState.HEALTHY
-        _emit_service_status(
-            service_name=service_name,
-            available=available,
-            message=f"{service_name}: {new_state.value}",
-        )
-    else:
-        logger.debug("event_bus not available for health probe callback")
+    available = new_state == HealthState.HEALTHY
+    emit_service_status(
+        service_name=service_name,
+        available=available,
+        message=f"{service_name}: {new_state.value}",
+    )
 
 
 # Module-level singleton so all callers share one probe instance

--- a/src/utils/claude_assistant.py
+++ b/src/utils/claude_assistant.py
@@ -45,8 +45,8 @@ from enum import Enum
 from utils.safe_import import safe_import
 
 _anthropic_mod, _HAS_ANTHROPIC = safe_import('anthropic')
-_get_latency_monitor, _HAS_LATENCY = safe_import('utils.latency_monitor', 'get_latency_monitor')
-_get_diag_engine, _HAS_DIAG_ENGINE = safe_import('utils.diagnostic_engine', 'get_diagnostic_engine')
+from utils.latency_monitor import get_latency_monitor
+from utils.diagnostic_engine import get_diagnostic_engine
 
 # Import standalone components
 from utils.diagnostic_engine import (
@@ -357,39 +357,37 @@ Always prioritize safety - never suggest actions that could damage hardware
                     parts.append(f"{len(events)} recent events")
 
         # Live service latency from NOC monitor
-        if _HAS_LATENCY:
-            try:
-                monitor = _get_latency_monitor(auto_start=False)
-                if monitor._services:
-                    svc_parts = []
-                    for svc in monitor._services.values():
-                        if svc.samples:
-                            svc_parts.append(
-                                f"{svc.name}:{svc.status}"
-                                f"({svc.avg_rtt_ms:.0f}ms)"
-                            )
-                    if svc_parts:
-                        parts.append(f"services=[{', '.join(svc_parts)}]")
+        try:
+            monitor = get_latency_monitor(auto_start=False)
+            if monitor._services:
+                svc_parts = []
+                for svc in monitor._services.values():
+                    if svc.samples:
+                        svc_parts.append(
+                            f"{svc.name}:{svc.status}"
+                            f"({svc.avg_rtt_ms:.0f}ms)"
+                        )
+                if svc_parts:
+                    parts.append(f"services=[{', '.join(svc_parts)}]")
 
-                    degraded = monitor.get_degraded()
-                    if degraded:
-                        parts.append(f"DEGRADED: {', '.join(degraded)}")
-            except Exception as e:
-                logger.debug(f"Failed to get latency context: {e}")
+                degraded = monitor.get_degraded()
+                if degraded:
+                    parts.append(f"DEGRADED: {', '.join(degraded)}")
+        except Exception as e:
+            logger.debug(f"Failed to get latency context: {e}")
 
         # Recent diagnostics
-        if _HAS_DIAG_ENGINE:
-            try:
-                engine = _get_diag_engine()
-                recent = engine.get_recent_diagnoses(limit=3)
-                if recent:
-                    diag_parts = [
-                        f"{d.symptom.category.name}:{d.symptom.message[:40]}"
-                        for d in recent
-                    ]
-                    parts.append(f"recent_diag=[{'; '.join(diag_parts)}]")
-            except Exception as e:
-                logger.debug(f"Failed to get diagnostic context: {e}")
+        try:
+            engine = get_diagnostic_engine()
+            recent = engine.get_recent_diagnoses(limit=3)
+            if recent:
+                diag_parts = [
+                    f"{d.symptom.category.name}:{d.symptom.message[:40]}"
+                    for d in recent
+                ]
+                parts.append(f"recent_diag=[{'; '.join(diag_parts)}]")
+        except Exception as e:
+            logger.debug(f"Failed to get diagnostic context: {e}")
 
         return ", ".join(parts)
 

--- a/src/utils/cli.py
+++ b/src/utils/cli.py
@@ -5,17 +5,19 @@ import shutil
 import subprocess
 import time
 from pathlib import Path
-from rich.console import Console
-from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
-from rich.prompt import Prompt, Confirm
-from rich.table import Table
-from rich.panel import Panel
 
-from utils.safe_import import safe_import
-
-_run_cli_async_gtk, _HAS_COMMON_GTK = safe_import('utils.common', 'run_cli_async_gtk')
-
-console = Console()
+# rich is an external/optional dependency — guard the import
+try:
+    from rich.console import Console
+    from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
+    from rich.prompt import Prompt, Confirm
+    from rich.table import Table
+    from rich.panel import Panel
+    console = Console()
+except ImportError:
+    Console = Progress = SpinnerColumn = TextColumn = BarColumn = None
+    Prompt = Confirm = Table = Panel = None
+    console = None
 
 
 def find_meshtastic_cli():
@@ -193,9 +195,6 @@ def show_panel(content, title=None, style="cyan"):
 def run_meshtastic_async(args, callback, host='localhost', timeout=30):
     """Run meshtastic CLI command asynchronously with callback.
 
-    Designed for GTK applications where CLI commands should run in
-    background threads. Uses common.run_cli_async_gtk if available.
-
     Args:
         args: Command arguments (without meshtastic prefix)
         callback: Function called with (success: bool, stdout: str, stderr: str)
@@ -205,28 +204,23 @@ def run_meshtastic_async(args, callback, host='localhost', timeout=30):
     Returns:
         The started thread
     """
-    if _HAS_COMMON_GTK:
+    import threading
+
+    def do_run():
         cli_path = find_meshtastic_cli()
-        return _run_cli_async_gtk(args, callback, cli_path=cli_path, host=host, timeout=timeout)
-    else:
-        # Fallback implementation
-        import threading
+        if not cli_path:
+            callback(False, "", "Meshtastic CLI not found")
+            return
 
-        def do_run():
-            cli_path = find_meshtastic_cli()
-            if not cli_path:
-                callback(False, "", "Meshtastic CLI not found")
-                return
+        cmd = [cli_path, '--host', host] + args
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+            callback(result.returncode == 0, result.stdout, result.stderr)
+        except subprocess.TimeoutExpired:
+            callback(False, "", f"Command timed out after {timeout}s")
+        except Exception as e:
+            callback(False, "", str(e))
 
-            cmd = [cli_path, '--host', host] + args
-            try:
-                result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
-                callback(result.returncode == 0, result.stdout, result.stderr)
-            except subprocess.TimeoutExpired:
-                callback(False, "", f"Command timed out after {timeout}s")
-            except Exception as e:
-                callback(False, "", str(e))
-
-        thread = threading.Thread(target=do_run, daemon=True)
-        thread.start()
-        return thread
+    thread = threading.Thread(target=do_run, daemon=True)
+    thread.start()
+    return thread

--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -2,7 +2,7 @@
 
 This module provides:
 - Settings management (save/load JSON with defaults)
-- Async CLI command execution for GTK
+- Async CLI command execution
 - Common path utilities
 - Thread-safe operations
 
@@ -18,10 +18,6 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TypeVar, Union
 
 from utils.cli import find_meshtastic_cli
-from utils.safe_import import safe_import
-
-# gi.repository is an external dependency (PyGObject/GTK) - keep safe_import
-_GLib, _HAS_GLIB = safe_import('gi.repository', 'GLib')
 
 logger = logging.getLogger(__name__)
 
@@ -198,10 +194,7 @@ def run_cli_async(
     host: str = 'localhost',
     timeout: int = 30
 ) -> threading.Thread:
-    """Run meshtastic CLI command asynchronously with callback.
-
-    Designed for GTK applications where CLI commands should run in
-    background threads with results delivered via GLib.idle_add.
+    """Run CLI commands in background threads with callback.
 
     Args:
         args: Command arguments (without meshtastic prefix)
@@ -255,38 +248,6 @@ def run_cli_async(
     thread = threading.Thread(target=do_run, daemon=True)
     thread.start()
     return thread
-
-
-def run_cli_async_gtk(
-    args: List[str],
-    callback: Callable[[bool, str, str], None],
-    cli_path: Optional[str] = None,
-    host: str = 'localhost',
-    timeout: int = 30
-) -> threading.Thread:
-    """Run meshtastic CLI command asynchronously with GTK-safe callback.
-
-    Same as run_cli_async but wraps callback in GLib.idle_add for
-    thread-safe GTK UI updates.
-
-    Args:
-        args: Command arguments (without meshtastic prefix)
-        callback: Function called with (success, stdout, stderr)
-        cli_path: Optional explicit CLI path
-        host: Meshtastic host
-        timeout: Command timeout
-
-    Returns:
-        The started thread
-    """
-    if _HAS_GLIB:
-        def gtk_callback(success: bool, stdout: str, stderr: str):
-            _GLib.idle_add(callback, success, stdout, stderr)
-
-        return run_cli_async(args, gtk_callback, cli_path, host, timeout)
-    else:
-        # GTK not available, fall back to direct callback
-        return run_cli_async(args, callback, cli_path, host, timeout)
 
 
 def ensure_config_dir(subdir: Optional[str] = None) -> Path:

--- a/src/utils/device_backup.py
+++ b/src/utils/device_backup.py
@@ -12,30 +12,10 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional, Dict, Any, List
 
-from utils.safe_import import safe_import
-
 logger = logging.getLogger(__name__)
 
-# Import path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-# Import CLI utility
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
-
-def get_real_user_home():
-    """Get real user home, with fallback for sudo-safe home directory."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f"/home/{sudo_user}")
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f"/home/{logname}")
-        return candidate
-        return Path('/root')
+from utils.paths import get_real_user_home
+from utils.cli import find_meshtastic_cli
 
 
 class DeviceBackupManager:
@@ -255,11 +235,7 @@ class DeviceBackupManager:
 
     def _run_meshtastic_cmd(self, args: List[str], host: str, port: int) -> str:
         """Run meshtastic CLI command and return output."""
-        if _HAS_CLI:
-            cli_path = _find_meshtastic_cli()
-        else:
-            import shutil
-            cli_path = shutil.which('meshtastic')
+        cli_path = find_meshtastic_cli()
 
         if not cli_path:
             logger.error("[Backup] meshtastic CLI not found")

--- a/src/utils/device_persistence.py
+++ b/src/utils/device_persistence.py
@@ -34,7 +34,6 @@ Usage:
         controller.connect()
 """
 
-import copy
 import logging
 import time
 from dataclasses import dataclass
@@ -42,13 +41,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from utils.safe_import import safe_import
+from utils.common import SettingsManager
 
 logger = logging.getLogger(__name__)
-
-# Import SettingsManager for persistence
-_SettingsManager, _HAS_COMMON = safe_import('utils.common', 'SettingsManager')
-SettingsManager = _SettingsManager  # None if not available (fallback for testing)
 
 
 @dataclass
@@ -117,34 +112,22 @@ class DevicePersistence:
 
     def __init__(self):
         """Initialize device persistence (use get_instance() instead)."""
-        if SettingsManager is not None:
-            self._settings = SettingsManager(
-                "device_connection",
-                defaults=DEVICE_PERSISTENCE_DEFAULTS
-            )
-        else:
-            # Fallback for testing without full utils
-            self._settings = None
-            self._memory_store = copy.deepcopy(DEVICE_PERSISTENCE_DEFAULTS)
-            logger.warning("SettingsManager not available, using memory storage")
+        self._settings = SettingsManager(
+            "device_connection",
+            defaults=DEVICE_PERSISTENCE_DEFAULTS
+        )
 
     def _get(self, key: str, default: Any = None) -> Any:
         """Get a setting value."""
-        if self._settings:
-            return self._settings.get(key, default)
-        return self._memory_store.get(key, default)
+        return self._settings.get(key, default)
 
     def _set(self, key: str, value: Any) -> None:
         """Set a setting value."""
-        if self._settings:
-            self._settings.set(key, value)
-        else:
-            self._memory_store[key] = value
+        self._settings.set(key, value)
 
     def _save(self) -> None:
         """Save settings to disk."""
-        if self._settings:
-            self._settings.save()
+        self._settings.save()
 
     # --- Last Device API ---
 

--- a/src/utils/firmware_flasher.py
+++ b/src/utils/firmware_flasher.py
@@ -24,17 +24,16 @@ FirmwareDownloader, FirmwareAsset, _HAS_DOWNLOADER = safe_import(
 EsptoolWrapper, FlashResult, FlashProgress, FlashStage, _HAS_ESPTOOL = safe_import(
     'utils.esptool_wrapper', 'EsptoolWrapper', 'FlashResult', 'FlashProgress', 'FlashStage'
 )
-DeviceScanner, _HAS_SCANNER = safe_import('utils.device_scanner', 'DeviceScanner')
-DeviceBackupManager, _HAS_BACKUP = safe_import('utils.device_backup', 'DeviceBackupManager')
+from utils.device_scanner import DeviceScanner
+from utils.device_backup import DeviceBackupManager
 _check_esptool_available, _HAS_ESPTOOL_CHECK = safe_import(
     'utils.esptool_wrapper', 'check_esptool_available'
 )
 
 # Log any missing components
-if not _HAS_DOWNLOADER or not _HAS_ESPTOOL or not _HAS_SCANNER or not _HAS_BACKUP:
+if not _HAS_DOWNLOADER or not _HAS_ESPTOOL:
     logger.warning("[Flasher] Some components not available: "
-                   f"downloader={_HAS_DOWNLOADER}, esptool={_HAS_ESPTOOL}, "
-                   f"scanner={_HAS_SCANNER}, backup={_HAS_BACKUP}")
+                   f"downloader={_HAS_DOWNLOADER}, esptool={_HAS_ESPTOOL}")
 
 
 class FlasherState(Enum):
@@ -392,17 +391,11 @@ def check_flash_capability() -> dict:
     else:
         result["errors"].append("esptool wrapper not available")
 
-    if _HAS_SCANNER and DeviceScanner:
-        DeviceScanner()
-        result["device_scanner"] = True
-    else:
-        result["errors"].append("Device scanner not available")
+    DeviceScanner()
+    result["device_scanner"] = True
 
-    if _HAS_BACKUP and DeviceBackupManager:
-        DeviceBackupManager()
-        result["backup_manager"] = True
-    else:
-        result["errors"].append("Backup manager not available")
+    DeviceBackupManager()
+    result["backup_manager"] = True
 
     result["available"] = result["esptool"] and result["device_scanner"]
 

--- a/src/utils/gps_integration.py
+++ b/src/utils/gps_integration.py
@@ -30,12 +30,9 @@ from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import List, Optional
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Optional: centralized path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 # gpsd connection settings
 GPSD_HOST = "localhost"
@@ -305,17 +302,7 @@ class GPSManager:
 
     def _get_default_path(self) -> Path:
         """Get default config path."""
-        if _HAS_PATHS:
-            config_dir = _get_real_user_home() / ".config" / "meshforge"
-        else:
-            import os
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
-                config_dir = Path(f'/home/{sudo_user}/.config/meshforge')
-            else:
-                config_dir = Path('/tmp/meshforge')
-                logger.warning(
-                    "Cannot determine real user home; using /tmp/meshforge")
+        config_dir = get_real_user_home() / ".config" / "meshforge"
         return config_dir / "operator_position.json"
 
     def _load_cached(self) -> None:

--- a/src/utils/health_score.py
+++ b/src/utils/health_score.py
@@ -46,10 +46,8 @@ from collections import deque
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-from utils.safe_import import safe_import
-
-# Optional: EventBus for automatic service status updates
-_event_bus, _HAS_EVENT_BUS = safe_import('utils.event_bus', 'event_bus')
+# EventBus for automatic service status updates
+from utils.event_bus import event_bus
 
 
 # Score thresholds
@@ -702,8 +700,7 @@ def get_health_scorer() -> HealthScorer:
     _health_scorer = HealthScorer()
 
     # Subscribe to EventBus service events for automatic scoring
-    if _HAS_EVENT_BUS:
-        _event_bus.subscribe('service', _on_service_event)
+    event_bus.subscribe('service', _on_service_event)
 
     return _health_scorer
 

--- a/src/utils/influxdb_exporter.py
+++ b/src/utils/influxdb_exporter.py
@@ -42,16 +42,14 @@ import threading
 import time
 from typing import Any, Dict, List, Optional, Union
 
-from utils.safe_import import safe_import
-
 logger = logging.getLogger(__name__)
 
-# Optional dependencies — module-level safe_import
-_version_mod, _HAS_VERSION = safe_import('__version__')
-_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
-_MapDataCollector, _HAS_MAP_DATA = safe_import('utils.map_data_collector', 'MapDataCollector')
-_PersistentMessageQueue, _HAS_MESSAGE_QUEUE = safe_import('gateway.message_queue', 'PersistentMessageQueue')
-_get_local_subscriber, _HAS_MQTT = safe_import('monitoring.mqtt_subscriber', 'get_local_subscriber')
+# First-party imports
+import __version__ as version_mod
+from utils.service_check import check_service
+from utils.map_data_collector import MapDataCollector
+from gateway.message_queue import PersistentMessageQueue
+from monitoring.mqtt_subscriber import get_local_subscriber
 
 
 class InfluxDBExporter:
@@ -316,7 +314,7 @@ class InfluxDBExporter:
         success = True
 
         # Version info
-        version = _version_mod.__version__ if _HAS_VERSION else "unknown"
+        version = version_mod.__version__
 
         self.write_point(
             "meshforge_info",
@@ -326,162 +324,154 @@ class InfluxDBExporter:
         )
 
         # Service health
-        if _HAS_SERVICE_CHECK:
-            for service in ["meshtasticd", "rnsd", "mosquitto"]:
-                try:
-                    status = _check_service(service)
-                    self.write_point(
-                        "meshforge_service_healthy",
-                        {
-                            "healthy": 1 if status.available else 0,
-                        },
-                        {"service": service},
-                        timestamp
-                    )
-                except Exception:
-                    pass
+        for service in ["meshtasticd", "rnsd", "mosquitto"]:
+            try:
+                status = check_service(service)
+                self.write_point(
+                    "meshforge_service_healthy",
+                    {
+                        "healthy": 1 if status.available else 0,
+                    },
+                    {"service": service},
+                    timestamp
+                )
+            except Exception:
+                pass
 
         # Node counts
-        if _HAS_MAP_DATA:
-            try:
-                collector = _MapDataCollector(enable_history=False)
-                geojson = collector.collect(max_age_seconds=60)
-                props = geojson.get("properties", {})
+        try:
+            collector = MapDataCollector(enable_history=False)
+            geojson = collector.collect(max_age_seconds=60)
+            props = geojson.get("properties", {})
 
-                self.write_point(
-                    "meshforge_nodes",
-                    {
-                        "total": props.get("total_nodes", 0),
-                        "with_gps": props.get("nodes_with_position", 0),
-                    },
-                    {},
-                    timestamp
-                )
+            self.write_point(
+                "meshforge_nodes",
+                {
+                    "total": props.get("total_nodes", 0),
+                    "with_gps": props.get("nodes_with_position", 0),
+                },
+                {},
+                timestamp
+            )
 
-                # Per-node metrics
-                for feature in geojson.get("features", []):
-                    node_props = feature.get("properties", {})
-                    node_id = node_props.get("id", "")
-                    if not node_id:
-                        continue
+            # Per-node metrics
+            for feature in geojson.get("features", []):
+                node_props = feature.get("properties", {})
+                node_id = node_props.get("id", "")
+                if not node_id:
+                    continue
 
-                    fields = {}
-                    if node_props.get("snr") is not None:
-                        fields["snr"] = float(node_props["snr"])
-                    if node_props.get("rssi") is not None:
-                        fields["rssi"] = int(node_props["rssi"])
-                    if node_props.get("battery") is not None:
-                        fields["battery"] = int(node_props["battery"])
+                fields = {}
+                if node_props.get("snr") is not None:
+                    fields["snr"] = float(node_props["snr"])
+                if node_props.get("rssi") is not None:
+                    fields["rssi"] = int(node_props["rssi"])
+                if node_props.get("battery") is not None:
+                    fields["battery"] = int(node_props["battery"])
 
-                    if fields:
-                        self.write_point(
-                            "meshforge_node",
-                            fields,
-                            {"node_id": node_id, "name": node_props.get("name", "")},
-                            timestamp
-                        )
-            except Exception as e:
-                logger.debug(f"Error collecting node metrics: {e}")
-        else:
-            logger.debug("MapDataCollector not available for InfluxDB export")
-
-        # Message queue stats
-        if _HAS_MESSAGE_QUEUE:
-            try:
-                queue = _PersistentMessageQueue()
-                stats = queue.get_stats()
-
-                self.write_point(
-                    "meshforge_messages",
-                    {
-                        "pending": stats.get("pending", 0),
-                        "delivered": stats.get("delivered", 0),
-                        "failed": stats.get("failed", 0),
-                        "retried": stats.get("retried", 0),
-                    },
-                    {},
-                    timestamp
-                )
-            except Exception as e:
-                logger.debug(f"Error collecting message metrics: {e}")
-
-        # Environment sensor metrics from MQTT subscriber
-        if _HAS_MQTT:
-            try:
-                subscriber = _get_local_subscriber()
-                if subscriber.is_connected():
-                    # MQTT stats
-                    mqtt_stats = subscriber.get_stats()
+                if fields:
                     self.write_point(
-                        "meshforge_mqtt",
-                        {
-                            "nodes_total": mqtt_stats.get("node_count", 0),
-                            "nodes_online": mqtt_stats.get("online_count", 0),
-                            "mesh_size_24h": mqtt_stats.get("mesh_size_24h", 0),
-                            "messages": mqtt_stats.get("message_count", 0),
-                        },
-                        {},
+                        "meshforge_node",
+                        fields,
+                        {"node_id": node_id, "name": node_props.get("name", "")},
                         timestamp
                     )
+        except Exception as e:
+            logger.debug(f"Error collecting node metrics: {e}")
 
-                    # Environment sensors per node
-                    for node in subscriber.get_nodes_with_environment_metrics():
-                        fields = {}
-                        if node.temperature is not None:
-                            fields["temperature"] = float(node.temperature)
-                        if node.humidity is not None:
-                            fields["humidity"] = float(node.humidity)
-                        if node.pressure is not None:
-                            fields["pressure"] = float(node.pressure)
-                        if node.gas_resistance is not None:
-                            fields["gas_resistance"] = float(node.gas_resistance)
-                        if fields:
-                            self.write_point(
-                                "meshforge_environment",
-                                fields,
-                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
-                                timestamp
-                            )
+        # Message queue stats
+        try:
+            queue = PersistentMessageQueue()
+            stats = queue.get_stats()
 
-                    # Air quality sensors per node
-                    for node in subscriber.get_nodes_with_air_quality():
-                        fields = {}
-                        if node.pm25_standard is not None:
-                            fields["pm25"] = int(node.pm25_standard)
-                        if node.pm10_standard is not None:
-                            fields["pm10"] = int(node.pm10_standard)
-                        if node.co2 is not None:
-                            fields["co2"] = int(node.co2)
-                        if node.iaq is not None:
-                            fields["iaq"] = int(node.iaq)
-                        if fields:
-                            self.write_point(
-                                "meshforge_air_quality",
-                                fields,
-                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
-                                timestamp
-                            )
+            self.write_point(
+                "meshforge_messages",
+                {
+                    "pending": stats.get("pending", 0),
+                    "delivered": stats.get("delivered", 0),
+                    "failed": stats.get("failed", 0),
+                    "retried": stats.get("retried", 0),
+                },
+                {},
+                timestamp
+            )
+        except Exception as e:
+            logger.debug(f"Error collecting message metrics: {e}")
 
-                    # Health metrics per node
-                    for node in subscriber.get_nodes():
-                        fields = {}
-                        if node.heart_bpm is not None:
-                            fields["heart_bpm"] = int(node.heart_bpm)
-                        if node.spo2 is not None:
-                            fields["spo2"] = int(node.spo2)
-                        if node.body_temperature is not None:
-                            fields["body_temperature"] = float(node.body_temperature)
-                        if fields:
-                            self.write_point(
-                                "meshforge_health",
-                                fields,
-                                {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
-                                timestamp
-                            )
-            except Exception as e:
-                logger.debug(f"Error collecting MQTT/environment metrics: {e}")
-        else:
-            logger.debug("MQTT subscriber not available for InfluxDB export")
+        # Environment sensor metrics from MQTT subscriber
+        try:
+            subscriber = get_local_subscriber()
+            if subscriber.is_connected():
+                # MQTT stats
+                mqtt_stats = subscriber.get_stats()
+                self.write_point(
+                    "meshforge_mqtt",
+                    {
+                        "nodes_total": mqtt_stats.get("node_count", 0),
+                        "nodes_online": mqtt_stats.get("online_count", 0),
+                        "mesh_size_24h": mqtt_stats.get("mesh_size_24h", 0),
+                        "messages": mqtt_stats.get("message_count", 0),
+                    },
+                    {},
+                    timestamp
+                )
+
+                # Environment sensors per node
+                for node in subscriber.get_nodes_with_environment_metrics():
+                    fields = {}
+                    if node.temperature is not None:
+                        fields["temperature"] = float(node.temperature)
+                    if node.humidity is not None:
+                        fields["humidity"] = float(node.humidity)
+                    if node.pressure is not None:
+                        fields["pressure"] = float(node.pressure)
+                    if node.gas_resistance is not None:
+                        fields["gas_resistance"] = float(node.gas_resistance)
+                    if fields:
+                        self.write_point(
+                            "meshforge_environment",
+                            fields,
+                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                            timestamp
+                        )
+
+                # Air quality sensors per node
+                for node in subscriber.get_nodes_with_air_quality():
+                    fields = {}
+                    if node.pm25_standard is not None:
+                        fields["pm25"] = int(node.pm25_standard)
+                    if node.pm10_standard is not None:
+                        fields["pm10"] = int(node.pm10_standard)
+                    if node.co2 is not None:
+                        fields["co2"] = int(node.co2)
+                    if node.iaq is not None:
+                        fields["iaq"] = int(node.iaq)
+                    if fields:
+                        self.write_point(
+                            "meshforge_air_quality",
+                            fields,
+                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                            timestamp
+                        )
+
+                # Health metrics per node
+                for node in subscriber.get_nodes():
+                    fields = {}
+                    if node.heart_bpm is not None:
+                        fields["heart_bpm"] = int(node.heart_bpm)
+                    if node.spo2 is not None:
+                        fields["spo2"] = int(node.spo2)
+                    if node.body_temperature is not None:
+                        fields["body_temperature"] = float(node.body_temperature)
+                    if fields:
+                        self.write_point(
+                            "meshforge_health",
+                            fields,
+                            {"node_id": node.node_id, "name": node.long_name or node.short_name or ""},
+                            timestamp
+                        )
+        except Exception as e:
+            logger.debug(f"Error collecting MQTT/environment metrics: {e}")
 
         # Flush remaining batch
         if not self._flush_batch():
@@ -550,44 +540,42 @@ class InfluxDBExporter:
         timestamp = self._get_timestamp()
 
         # Build same metrics as write_metrics but return as string
-        version = _version_mod.__version__ if _HAS_VERSION else "unknown"
+        version = version_mod.__version__
 
         lines.append(self._format_line_protocol(
             "meshforge_info", {"value": 1}, {"version": version}, timestamp
         ))
 
         # Service health
-        if _HAS_SERVICE_CHECK:
-            for service in ["meshtasticd", "rnsd", "mosquitto"]:
-                try:
-                    status = _check_service(service)
-                    lines.append(self._format_line_protocol(
-                        "meshforge_service_healthy",
-                        {"healthy": 1 if status.available else 0},
-                        {"service": service},
-                        timestamp
-                    ))
-                except Exception:
-                    pass
-
-        # Node counts
-        if _HAS_MAP_DATA:
+        for service in ["meshtasticd", "rnsd", "mosquitto"]:
             try:
-                collector = _MapDataCollector(enable_history=False)
-                geojson = collector.collect(max_age_seconds=60)
-                props = geojson.get("properties", {})
-
+                status = check_service(service)
                 lines.append(self._format_line_protocol(
-                    "meshforge_nodes",
-                    {
-                        "total": props.get("total_nodes", 0),
-                        "with_gps": props.get("nodes_with_position", 0),
-                    },
-                    {},
+                    "meshforge_service_healthy",
+                    {"healthy": 1 if status.available else 0},
+                    {"service": service},
                     timestamp
                 ))
             except Exception:
                 pass
+
+        # Node counts
+        try:
+            collector = MapDataCollector(enable_history=False)
+            geojson = collector.collect(max_age_seconds=60)
+            props = geojson.get("properties", {})
+
+            lines.append(self._format_line_protocol(
+                "meshforge_nodes",
+                {
+                    "total": props.get("total_nodes", 0),
+                    "with_gps": props.get("nodes_with_position", 0),
+                },
+                {},
+                timestamp
+            ))
+        except Exception:
+            pass
 
         return "\n".join(lines)
 

--- a/src/utils/logging_structured.py
+++ b/src/utils/logging_structured.py
@@ -41,10 +41,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-from utils.safe_import import safe_import
-
-# Optional: centralized path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
+from utils.paths import get_real_user_home
 
 
 class StructuredFormatter(logging.Formatter):
@@ -93,16 +90,7 @@ def setup_structured_logging(
         The configured handler (for testing/removal)
     """
     if log_dir is None:
-        if _HAS_PATHS:
-            log_dir = _get_real_user_home() / ".config" / "meshforge" / "logs"
-        else:
-            import os as _os
-            sudo_user = _os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
-                log_dir = Path(f'/home/{sudo_user}/.config/meshforge/logs')
-            else:
-                # Avoid Path.home() which returns /root under sudo (MF001)
-                log_dir = Path('/tmp/meshforge/logs')
+        log_dir = get_real_user_home() / ".config" / "meshforge" / "logs"
 
     log_dir.mkdir(parents=True, exist_ok=True)
     log_file = log_dir / "meshforge_structured.jsonl"

--- a/src/utils/lora_presets.py
+++ b/src/utils/lora_presets.py
@@ -37,7 +37,7 @@ if _HAS_SERVICE_CHECK:
     check_systemd_service = _check_systemd_service
     ServiceState = _ServiceState
 
-_find_meshtastic_cli, _HAS_CLI = safe_import('utils.cli', 'find_meshtastic_cli')
+from utils.cli import find_meshtastic_cli
 
 
 class MeshtasticPreset(Enum):
@@ -484,11 +484,7 @@ def detect_meshtastic_settings(verbose: bool = False) -> Optional[Dict]:
         log_attempt("meshtasticd systemd service", False, str(e))
 
     # Check if meshtastic CLI is available using centralized finder
-    if _HAS_CLI:
-        _meshtastic_cli_path = _find_meshtastic_cli()
-    else:
-        import shutil
-        _meshtastic_cli_path = shutil.which('meshtastic')
+    _meshtastic_cli_path = find_meshtastic_cli()
     meshtastic_cli_available = _meshtastic_cli_path is not None
 
     def run_meshtastic_cmd(args: list, timeout: int = 10) -> tuple:

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -26,21 +26,21 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
-# --- Optional dependency imports via safe_import ---
+# --- Imports ---
 from utils.safe_import import safe_import
 
-get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-SettingsManager, _HAS_SETTINGS = safe_import('utils.common', 'SettingsManager')
-_get_node_tracker, _HAS_NODE_TRACKER = safe_import('gateway.node_tracker', 'get_node_tracker')
-_get_http_client, _HAS_MESHTASTIC_HTTP = safe_import('utils.meshtastic_http', 'get_http_client')
-(_get_connection_manager, _safe_close_interface, _ConnectionMode,
- _reset_connection_manager, _HAS_MESHTASTIC_CONN) = safe_import(
-    'utils.meshtastic_connection',
-    'get_connection_manager', 'safe_close_interface',
-    'ConnectionMode', 'reset_connection_manager',
+from utils.paths import get_real_user_home
+from utils.common import SettingsManager
+from gateway.node_tracker import get_node_tracker
+from utils.meshtastic_http import get_http_client
+from utils.meshtastic_connection import (
+    get_connection_manager, safe_close_interface,
+    ConnectionMode, reset_connection_manager,
 )
-_get_local_subscriber, _HAS_MQTT = safe_import('monitoring.mqtt_subscriber', 'get_local_subscriber')
-_AREDNScanner, _AREDNClient, _HAS_AREDN = safe_import('utils.aredn', 'AREDNScanner', 'AREDNClient')
+from monitoring.mqtt_subscriber import get_local_subscriber
+from utils.aredn import AREDNScanner, AREDNClient
+
+# External/optional dependencies
 _RNS, _HAS_RNS = safe_import('RNS')
 _msgpack, _HAS_MSGPACK = safe_import('msgpack')
 
@@ -71,10 +71,8 @@ class MapDataCollector:
     def __init__(self, cache_dir: Optional[Path] = None, enable_history: bool = True):
         if cache_dir:
             self._cache_dir = cache_dir
-        elif _HAS_PATHS:
-            self._cache_dir = get_real_user_home() / ".local" / "share" / "meshforge"
         else:
-            self._cache_dir = Path("/tmp/meshforge")
+            self._cache_dir = get_real_user_home() / ".local" / "share" / "meshforge"
 
         self._cache_dir.mkdir(parents=True, exist_ok=True)
         self._cache_file = self._cache_dir / "map_nodes.geojson"
@@ -82,20 +80,17 @@ class MapDataCollector:
         self._cached_geojson: Optional[Dict] = None
 
         # User-configurable cache age settings
-        if _HAS_SETTINGS:
-            self._settings = SettingsManager(
-                "map_settings",
-                defaults={
-                    "node_cache_max_age_hours": self.DEFAULT_NODE_CACHE_MAX_AGE_HOURS,
-                    "rns_cache_max_age_hours": self.DEFAULT_RNS_CACHE_MAX_AGE_HOURS,
-                    "online_status_threshold_minutes": self.DEFAULT_ONLINE_THRESHOLD_MINUTES,
-                    "meshtasticd_host": self.DEFAULT_MESHTASTICD_HOST,
-                    "meshtasticd_port": self.DEFAULT_MESHTASTICD_PORT,
-                    "aredn_node_ips": [],  # e.g. ["10.54.25.1", "10.1.0.1"]
-                }
-            )
-        else:
-            self._settings = None
+        self._settings = SettingsManager(
+            "map_settings",
+            defaults={
+                "node_cache_max_age_hours": self.DEFAULT_NODE_CACHE_MAX_AGE_HOURS,
+                "rns_cache_max_age_hours": self.DEFAULT_RNS_CACHE_MAX_AGE_HOURS,
+                "online_status_threshold_minutes": self.DEFAULT_ONLINE_THRESHOLD_MINUTES,
+                "meshtasticd_host": self.DEFAULT_MESHTASTICD_HOST,
+                "meshtasticd_port": self.DEFAULT_MESHTASTICD_PORT,
+                "aredn_node_ips": [],  # e.g. ["10.54.25.1", "10.1.0.1"]
+            }
+        )
 
         # Track nodes without GPS for reporting
         self._nodes_without_position: List[Dict] = []
@@ -364,12 +359,8 @@ class MapDataCollector:
         Returns:
             List of GeoJSON features for nodes with valid positions.
         """
-        if not _HAS_NODE_TRACKER:
-            logger.debug("UnifiedNodeTracker not available")
-            return []
-
         try:
-            tracker = _get_node_tracker()
+            tracker = get_node_tracker()
             geojson = tracker.to_geojson()
             features = geojson.get("features", [])
 
@@ -447,11 +438,8 @@ class MapDataCollector:
         needing the TCP connection lock. This is the preferred collection
         method because it doesn't conflict with the gateway bridge.
         """
-        if not _HAS_MESHTASTIC_HTTP:
-            return []
-
         try:
-            client = _get_http_client(host=host)
+            client = get_http_client(host=host)
             if not client.is_available:
                 logger.debug("meshtasticd HTTP API not available")
                 return []
@@ -524,15 +512,11 @@ class MapDataCollector:
         Returns list of GeoJSON features for nodes with valid positions.
         Also populates self._nodes_without_position for nodes lacking GPS.
         """
-        if not _HAS_MESHTASTIC_CONN:
-            logger.debug("meshtastic_connection module not available")
-            return []
-
         features = []
         no_position_nodes = []
         host = self.get_meshtasticd_host()
         port = self.get_meshtasticd_port()
-        manager = _get_connection_manager(host=host, port=port)
+        manager = get_connection_manager(host=host, port=port)
 
         # Don't block if someone else holds the connection
         if not manager.acquire_lock(timeout=5.0):
@@ -570,7 +554,7 @@ class MapDataCollector:
                         f"{len(no_position_nodes)} without GPS (total: {total_nodes})"
                     )
             finally:
-                _safe_close_interface(interface)
+                safe_close_interface(interface)
 
         except Exception as e:
             logger.debug(f"TCP interface collection error: {e}")
@@ -587,10 +571,6 @@ class MapDataCollector:
 
         Returns list of GeoJSON features for nodes with valid positions.
         """
-        if not _HAS_MESHTASTIC_CONN:
-            logger.debug("meshtastic_connection module not available")
-            return []
-
         # Check if USB device is available
         import glob
         usb_devices = glob.glob('/dev/ttyUSB*') + glob.glob('/dev/ttyACM*')
@@ -603,8 +583,8 @@ class MapDataCollector:
 
         # Reset manager to ensure we get SERIAL mode
         # (in case a previous TCP connection left it in TCP mode)
-        _reset_connection_manager()
-        manager = _get_connection_manager(mode=_ConnectionMode.SERIAL)
+        reset_connection_manager()
+        manager = get_connection_manager(mode=ConnectionMode.SERIAL)
 
         # Don't block if someone else holds the connection
         if not manager.acquire_lock(timeout=5.0):
@@ -645,7 +625,7 @@ class MapDataCollector:
                         f"{len(no_position_nodes)} without GPS (total: {total_nodes})"
                     )
             finally:
-                _safe_close_interface(interface)
+                safe_close_interface(interface)
 
         except Exception as e:
             logger.debug(f"Direct radio collection error: {e}")
@@ -878,17 +858,16 @@ class MapDataCollector:
         then falls back to cached GeoJSON file.
         """
         # Try live subscriber first (has real-time sensor data)
-        if _HAS_MQTT:
-            try:
-                subscriber = _get_local_subscriber()
-                if subscriber.is_connected():
-                    geojson = subscriber.get_geojson()
-                    features = geojson.get("features", [])
-                    if features:
-                        logger.debug(f"MQTT live: {len(features)} nodes with position")
-                        return features
-            except Exception as e:
-                logger.debug(f"MQTT live collection error: {e}")
+        try:
+            subscriber = get_local_subscriber()
+            if subscriber.is_connected():
+                geojson = subscriber.get_geojson()
+                features = geojson.get("features", [])
+                if features:
+                    logger.debug(f"MQTT live: {len(features)} nodes with position")
+                    return features
+        except Exception as e:
+            logger.debug(f"MQTT live collection error: {e}")
 
         # Fallback: cached MQTT node file
         try:
@@ -910,16 +889,7 @@ class MapDataCollector:
         features = []
 
         # Check node_cache.json
-        if _HAS_PATHS:
-            cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
-        else:
-            sudo_user = os.environ.get('SUDO_USER', '')
-            # Path traversal protection (security)
-            if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-                cache_path = Path(f'/home/{sudo_user}/.config/meshforge/node_cache.json')
-            else:
-                # Avoid Path.home() which returns /root under sudo (MF001)
-                cache_path = Path('/tmp/meshforge/node_cache.json')
+        cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
 
         if cache_path.exists():
             try:
@@ -1006,10 +976,6 @@ class MapDataCollector:
         """
         features = []
 
-        if not _HAS_AREDN:
-            logger.debug("AREDN module not available")
-            return []
-
         # First try to connect to the local AREDN node
         local_node_ip = self._get_aredn_node_ip()
         if not local_node_ip:
@@ -1018,7 +984,7 @@ class MapDataCollector:
 
         try:
             # Get the local node info (may have location)
-            client = _AREDNClient(local_node_ip, timeout=5)
+            client = AREDNClient(local_node_ip, timeout=5)
             local_node = client.get_node_info()
 
             if local_node:
@@ -1030,7 +996,7 @@ class MapDataCollector:
                 for link in local_node.links:
                     if link.ip:
                         try:
-                            neighbor_client = _AREDNClient(link.ip, timeout=3)
+                            neighbor_client = AREDNClient(link.ip, timeout=3)
                             neighbor_node = neighbor_client.get_node_info()
                             if neighbor_node:
                                 neighbor_feature = self._aredn_node_to_feature(neighbor_node)
@@ -1285,10 +1251,7 @@ class MapDataCollector:
                 logger.debug(f"RNS position cache load error: {e}")
 
         # Source 2: Node tracker cache (RNS entries)
-        if _HAS_PATHS:
-            cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
-        else:
-            cache_path = Path("/tmp/meshforge/node_cache.json")
+        cache_path = get_real_user_home() / ".config" / "meshforge" / "node_cache.json"
 
         if cache_path.exists():
             try:
@@ -1315,9 +1278,8 @@ class MapDataCollector:
     def _load_nomadnet_peers(self) -> List[Dict]:
         """Load known peers from NomadNet cache if available."""
         peers = []
-        if not _HAS_PATHS or not _HAS_MSGPACK:
-            if not _HAS_MSGPACK:
-                logger.debug("msgpack not available for NomadNet peer reading")
+        if not _HAS_MSGPACK:
+            logger.debug("msgpack not available for NomadNet peer reading")
             return peers
         try:
             nomadnet_dir = get_real_user_home() / '.nomadnetwork'

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -62,7 +62,7 @@ _SRTMProvider, _LOSAnalyzer, _HAS_TERRAIN = safe_import(
 _MessageQueue, _HAS_MSG_QUEUE = safe_import(
     'gateway.message_queue', 'MessageQueue'
 )
-_messaging_mod, _HAS_MESSAGING = safe_import('commands.messaging')
+from commands import messaging
 _get_listener_status, _HAS_MSG_LISTENER = safe_import(
     'utils.message_listener', 'get_listener_status'
 )
@@ -726,32 +726,29 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
 
         messages = []
 
-        if not _HAS_MESSAGING:
-            logger.debug("Messaging module not available")
-        else:
-            try:
-                result = _messaging_mod.get_messages(limit=limit, network=network)
+        try:
+            result = messaging.get_messages(limit=limit, network=network)
 
-                if result.success and result.data:
-                    all_messages = result.data.get('messages', [])
+            if result.success and result.data:
+                all_messages = result.data.get('messages', [])
 
-                    # Filter by timestamp if 'since' is provided
-                    if since:
-                        try:
-                            since_dt = datetime.fromisoformat(since.replace('Z', '+00:00'))
-                            all_messages = [
-                                m for m in all_messages
-                                if m.get('timestamp') and
-                                datetime.fromisoformat(m['timestamp']) > since_dt
-                            ]
-                        except (ValueError, TypeError):
-                            pass  # Invalid timestamp, skip filtering
+                # Filter by timestamp if 'since' is provided
+                if since:
+                    try:
+                        since_dt = datetime.fromisoformat(since.replace('Z', '+00:00'))
+                        all_messages = [
+                            m for m in all_messages
+                            if m.get('timestamp') and
+                            datetime.fromisoformat(m['timestamp']) > since_dt
+                        ]
+                    except (ValueError, TypeError):
+                        pass  # Invalid timestamp, skip filtering
 
-                    # Filter to show only received messages (from_id != 'local')
-                    messages = [m for m in all_messages if m.get('from_id') != 'local']
+                # Filter to show only received messages (from_id != 'local')
+                messages = [m for m in all_messages if m.get('from_id') != 'local']
 
-            except Exception as e:
-                logger.debug(f"Error getting received messages: {e}")
+        except Exception as e:
+            logger.debug(f"Error getting received messages: {e}")
 
         self._serve_json({
             "messages": messages,

--- a/src/utils/metrics_common.py
+++ b/src/utils/metrics_common.py
@@ -12,29 +12,13 @@ Usage:
 """
 
 import logging
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        return Path(f'/home/{logname}')
-    return Path('/root')
 
 
 # Metric type constants (Prometheus types)

--- a/src/utils/network_diag.py
+++ b/src/utils/network_diag.py
@@ -15,35 +15,8 @@ import socket
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from utils.safe_import import safe_import
-
 # Import canonical check_port from service_check
-_check_port, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_port')
-
-if _HAS_SERVICE_CHECK:
-    check_port = _check_port
-else:
-    # Fallback: try src-prefixed path
-    _check_port2, _HAS_SRC_CHECK = safe_import('src.utils.service_check', 'check_port')
-    if _HAS_SRC_CHECK:
-        check_port = _check_port2
-    else:
-        # Fallback implementation
-        def check_port(port: int, host: str = 'localhost') -> bool:
-            sock = None
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-                sock.settimeout(1)
-                result = sock.connect_ex((host, port))
-                return result == 0
-            except (socket.error, OSError):
-                return False
-            finally:
-                if sock:
-                    try:
-                        sock.close()
-                    except Exception:
-                        pass
+from utils.service_check import check_port
 
 # TCP state mapping (hex to name)
 TCP_STATES = {

--- a/src/utils/node_inventory.py
+++ b/src/utils/node_inventory.py
@@ -25,17 +25,14 @@ Persistence:
 
 import json
 import logging
-import os
 import time
 from dataclasses import dataclass, field, asdict
 from pathlib import Path
 from typing import Dict, List, Optional
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 # Node is "online" if seen within this window
 ONLINE_TIMEOUT_SEC = 900  # 15 minutes
@@ -141,15 +138,7 @@ class NodeInventory:
 
     def _get_default_path(self) -> Path:
         """Get default persistence path."""
-        if _HAS_PATHS:
-            config_dir = _get_real_user_home() / ".config" / "meshforge"
-        else:
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
-                config_dir = Path(f'/home/{sudo_user}/.config/meshforge')
-            else:
-                # Avoid Path.home() which returns /root under sudo (MF001)
-                config_dir = Path('/tmp/meshforge')
+        config_dir = get_real_user_home() / ".config" / "meshforge"
         return config_dir / "node_inventory.json"
 
     def _load(self) -> None:

--- a/src/utils/offline_sync.py
+++ b/src/utils/offline_sync.py
@@ -36,11 +36,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 
 class SyncCategory(Enum):
@@ -186,16 +184,7 @@ class OfflineSyncQueue:
 
     def _get_default_path(self) -> Path:
         """Get default database path."""
-        if _HAS_PATHS:
-            data_dir = _get_real_user_home() / ".local" / "share" / "meshforge"
-        else:
-            sudo_user = os.environ.get('SUDO_USER')
-            if sudo_user and sudo_user != 'root':
-                data_dir = Path(f'/home/{sudo_user}/.local/share/meshforge')
-            else:
-                data_dir = Path('/tmp/meshforge')
-                logger.warning(
-                    "Cannot determine real user home; using /tmp/meshforge")
+        data_dir = get_real_user_home() / ".local" / "share" / "meshforge"
         return data_dir / "offline_sync.db"
 
     def _init_db(self) -> None:

--- a/src/utils/quick_start.py
+++ b/src/utils/quick_start.py
@@ -21,11 +21,9 @@ from dataclasses import dataclass
 from typing import List, Dict, Any, Optional
 from pathlib import Path
 
-from utils.safe_import import safe_import
+from utils.service_check import check_service
 
 logger = logging.getLogger(__name__)
-
-_check_service, _HAS_SERVICE_CHECK = safe_import('utils.service_check', 'check_service')
 
 
 @dataclass
@@ -139,10 +137,6 @@ def get_available_modes() -> List[QuickStartMode]:
 
     Returns all modes but marks which ones are ready vs need setup.
     """
-    # Use centralized service check
-    has_service_check = _HAS_SERVICE_CHECK
-    check_service = _check_service
-
     available = []
 
     for mode in QUICK_START_MODES:
@@ -158,15 +152,14 @@ def get_available_modes() -> List[QuickStartMode]:
         )
 
         # Check if required services are available
-        if has_service_check and check_service:
-            missing = []
-            for svc in mode.services_required:
-                status = check_service(svc)
-                if not status.available:
-                    missing.append(svc)
+        missing = []
+        for svc in mode.services_required:
+            status = check_service(svc)
+            if not status.available:
+                missing.append(svc)
 
-            if missing:
-                mode_copy.description += f" (needs: {', '.join(missing)})"
+        if missing:
+            mode_copy.description += f" (needs: {', '.join(missing)})"
 
         available.append(mode_copy)
 
@@ -269,13 +262,12 @@ def apply_mode(mode_id: str) -> Dict[str, Any]:
     services_to_start = mode.services_required.copy()
 
     # Check which optional services are available
-    if _HAS_SERVICE_CHECK:
-        for svc in mode.services_optional:
-            # Check if service is installed (even if not running)
-            status = _check_service(svc)
-            # Add if it's installed and would be useful
-            if status.state.value != "not_installed":
-                services_to_start.append(svc)
+    for svc in mode.services_optional:
+        # Check if service is installed (even if not running)
+        status = check_service(svc)
+        # Add if it's installed and would be useful
+        if status.state.value != "not_installed":
+            services_to_start.append(svc)
 
     return {
         'success': True,

--- a/src/utils/shared_health_state.py
+++ b/src/utils/shared_health_state.py
@@ -39,24 +39,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        return Path(f'/home/{logname}')
-    return Path('/root')
 
 
 class HealthState(Enum):

--- a/src/utils/system.py
+++ b/src/utils/system.py
@@ -20,12 +20,9 @@ from utils.safe_import import safe_import
 
 # Module-level safe imports
 distro, _HAS_DISTRO = safe_import('distro')
-check_service, check_systemd_service, ServiceState, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'check_systemd_service', 'ServiceState'
-)
+from utils.service_check import check_service, check_systemd_service, ServiceState
 _psutil, _HAS_PSUTIL = safe_import('psutil')
 _serial_list_ports, _HAS_SERIAL = safe_import('serial.tools.list_ports')
-GLib, _HAS_GLIB = safe_import('gi.repository', 'GLib')
 
 
 def check_root() -> bool:
@@ -250,11 +247,7 @@ def run_admin_command_async(
 
     def do_run():
         success, stdout, stderr = run_admin_command(cmd, use_gui, timeout)
-        # Use GLib.idle_add if available (GTK apps)
-        if _HAS_GLIB:
-            GLib.idle_add(callback, success, stdout, stderr)
-        else:
-            callback(success, stdout, stderr)
+        callback(success, stdout, stderr)
 
     thread = threading.Thread(target=do_run, daemon=True)
     thread.start()
@@ -277,7 +270,7 @@ def systemctl_admin(action: str, service: str, callback: Callable[[bool, str, st
         # Synchronous
         success, _, err = systemctl_admin('restart', 'meshtasticd')
 
-        # Async for GTK
+        # Async
         systemctl_admin('restart', 'meshtasticd', callback=on_done)
     """
     cmd = ['systemctl', action, service]
@@ -529,30 +522,19 @@ def get_service_status(service_name: str) -> str:
     Args:
         service_name: Name of the systemd service (validated, no shell chars)
     """
-    # Use centralized service checker if available
-    if _HAS_SERVICE_CHECK:
-        is_running, is_enabled = check_systemd_service(service_name)
-        if is_running:
-            return 'active'
-        elif is_running is False:
-            return 'inactive'
-        else:
-            return 'unknown'
+    is_running, is_enabled = check_systemd_service(service_name)
+    if is_running:
+        return 'active'
+    elif is_running is False:
+        return 'inactive'
     else:
-        # Fallback to direct systemctl call using list form to prevent command injection
-        result = run_command(['systemctl', 'is-active', service_name])
-        return result['stdout'].strip() if result['success'] else 'unknown'
+        return 'unknown'
 
 
 def is_service_running(service_name: str) -> bool:
     """Check if a systemd service is running"""
-    # Use centralized service checker if available
-    if _HAS_SERVICE_CHECK:
-        is_running, is_enabled = check_systemd_service(service_name)
-        return is_running
-    else:
-        # Fallback to direct method
-        return get_service_status(service_name) == 'active'
+    is_running, is_enabled = check_systemd_service(service_name)
+    return is_running
 
 
 def enable_service(service_name: str) -> bool:
@@ -795,15 +777,6 @@ def get_dependency_status() -> Dict[str, bool]:
         'rich': check_dependency('rich'),
         'pyserial': check_dependency('serial'),
     }
-
-    # GTK4 requires special handling
-    try:
-        import gi
-        gi.require_version('Gtk', '4.0')
-        from gi.repository import Gtk
-        deps['gtk4'] = True
-    except (ImportError, ValueError):
-        deps['gtk4'] = False
 
     return deps
 

--- a/src/utils/terrain.py
+++ b/src/utils/terrain.py
@@ -31,26 +31,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
 
 # Import existing RF calculations
 (

--- a/src/utils/tile_cache.py
+++ b/src/utils/tile_cache.py
@@ -33,11 +33,9 @@ from pathlib import Path
 from typing import Callable, Dict, List, Optional, Tuple
 from urllib.request import Request, urlopen
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 # User agent for tile requests (be a good citizen)
 USER_AGENT = 'MeshForge/0.4.7 (mesh network operations; offline caching)'
@@ -290,12 +288,7 @@ class TileCache:
     @staticmethod
     def _get_default_dir() -> Path:
         """Get default cache directory with sudo awareness."""
-        if _HAS_PATHS:
-            data_dir = _get_real_user_home() / ".local" / "share" / "meshforge"
-        else:
-            data_dir = Path('/tmp/meshforge')
-            logger.warning(
-                "Cannot determine real user home; using /tmp/meshforge")
+        data_dir = get_real_user_home() / ".local" / "share" / "meshforge"
         return data_dir / "tiles"
 
     def _download_tile(self, z: int, x: int, y: int) -> bool:

--- a/src/utils/topology_snapshot.py
+++ b/src/utils/topology_snapshot.py
@@ -39,11 +39,9 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import centralized path utility for sudo compatibility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 
 # Optional dependencies for topology capture
 _get_global_node_tracker, _HAS_GLOBAL_TRACKER = safe_import(
@@ -52,16 +50,6 @@ _get_global_node_tracker, _HAS_GLOBAL_TRACKER = safe_import(
 _MapDataCollector, _HAS_MAP_COLLECTOR = safe_import(
     'utils.map_data_collector', 'MapDataCollector'
 )
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        return Path(f'/home/{sudo_user}')
-    return Path('/root')
-
 
 @dataclass
 class TopologySnapshot:

--- a/src/utils/webhooks.py
+++ b/src/utils/webhooks.py
@@ -20,27 +20,9 @@ from typing import Callable, Dict, List, Optional, Any
 import urllib.request
 import urllib.error
 
-from utils.safe_import import safe_import
+from utils.paths import get_real_user_home
 
 logger = logging.getLogger(__name__)
-
-# Import path utility
-_get_real_user_home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
-
-def get_real_user_home() -> Path:
-    """Get real user home, with fallback for sudo compatibility."""
-    if _HAS_PATHS:
-        return _get_real_user_home()
-    import os
-    sudo_user = os.environ.get('SUDO_USER', '')
-    if sudo_user and sudo_user != 'root' and '/' not in sudo_user and '..' not in sudo_user:
-        candidate = Path(f'/home/{sudo_user}')
-        return candidate
-    logname = os.environ.get('LOGNAME', '')
-    if logname and logname != 'root' and '/' not in logname and '..' not in logname:
-        candidate = Path(f'/home/{logname}')
-        return candidate
-    return Path('/root')
 
 
 class EventType(Enum):

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -127,27 +127,24 @@ class TestRnsdZombieDetection:
         """rnsd active in systemd but port 37428 not bound → stopped."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar._check_udp_port', return_value=False):
-                with patch('status_bar._HAS_SERVICE_CHECK', True):
-                    result = bar._check_systemd_active('rnsd')
+            with patch('status_bar.check_udp_port', return_value=False):
+                result = bar._check_systemd_active('rnsd')
         assert result == SYM_STOPPED
 
     def test_rnsd_healthy_shows_running(self):
         """rnsd active in systemd and port 37428 bound → running."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar._check_udp_port', return_value=True):
-                with patch('status_bar._HAS_SERVICE_CHECK', True):
-                    result = bar._check_systemd_active('rnsd')
+            with patch('status_bar.check_udp_port', return_value=True):
+                result = bar._check_systemd_active('rnsd')
         assert result == SYM_RUNNING
 
     def test_rnsd_systemd_inactive_skips_port_check(self):
         """rnsd not active in systemd → stopped without port check."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(False, False)):
-            with patch('status_bar._check_udp_port') as mock_udp:
-                with patch('status_bar._HAS_SERVICE_CHECK', True):
-                    result = bar._check_systemd_active('rnsd')
+            with patch('status_bar.check_udp_port') as mock_udp:
+                result = bar._check_systemd_active('rnsd')
         mock_udp.assert_not_called()
         assert result == SYM_STOPPED
 
@@ -155,20 +152,19 @@ class TestRnsdZombieDetection:
         """meshtasticd should not trigger UDP port check."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar._check_udp_port') as mock_udp:
-                with patch('status_bar._HAS_SERVICE_CHECK', True):
-                    result = bar._check_systemd_active('meshtasticd')
+            with patch('status_bar.check_udp_port') as mock_udp:
+                result = bar._check_systemd_active('meshtasticd')
         mock_udp.assert_not_called()
         assert result == SYM_RUNNING
 
     def test_udp_check_unavailable_falls_through(self):
-        """When check_udp_port is None (import failed), trust systemd only."""
+        """When check_udp_port raises OSError, exception is caught gracefully."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar._check_udp_port', None):
-                with patch('status_bar._HAS_SERVICE_CHECK', True):
-                    result = bar._check_systemd_active('rnsd')
-        assert result == SYM_RUNNING
+            with patch('status_bar.check_udp_port', side_effect=OSError("unavailable")):
+                result = bar._check_systemd_active('rnsd')
+        # OSError caught by the try/except → SYM_UNKNOWN
+        assert result in (SYM_UNKNOWN, SYM_STOPPED)
 
 
 class TestBridgeCheck:
@@ -437,9 +433,8 @@ class TestSpaceWeather:
         MockAPI = MagicMock()
         MockAPI.return_value.get_current_conditions.return_value = mock_data
 
-        with patch('status_bar._SpaceWeatherAPI', MockAPI):
-            with patch('status_bar._HAS_SPACE_WEATHER', True):
-                bar._check_space_weather()
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            bar._check_space_weather()
 
         assert bar._space_weather == "SFI:145 K:3"
 
@@ -451,18 +446,17 @@ class TestSpaceWeather:
         MockAPI = MagicMock()
         MockAPI.return_value.get_current_conditions.side_effect = Exception("Network error")
 
-        with patch('status_bar._SpaceWeatherAPI', MockAPI):
-            with patch('status_bar._HAS_SPACE_WEATHER', True):
-                bar._check_space_weather()
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            bar._check_space_weather()
 
         # Should be cleared on failure
         assert bar._space_weather is None
 
     def test_space_weather_import_error(self):
-        """Missing space_weather module should not crash."""
+        """SpaceWeatherAPI raising should not crash."""
         bar = StatusBar(version="1.0")
 
-        with patch('status_bar._HAS_SPACE_WEATHER', False):
+        with patch('status_bar.SpaceWeatherAPI', side_effect=Exception("import error")):
             bar._check_space_weather()
             assert bar._space_weather is None
 
@@ -477,9 +471,8 @@ class TestSpaceWeather:
         MockAPI = MagicMock()
         MockAPI.return_value.get_current_conditions.return_value = mock_data
 
-        with patch('status_bar._SpaceWeatherAPI', MockAPI):
-            with patch('status_bar._HAS_SPACE_WEATHER', True):
-                bar._check_space_weather()
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            bar._check_space_weather()
 
         assert bar._space_weather == "SFI:120"
         assert "K:" not in bar._space_weather
@@ -617,9 +610,8 @@ class TestSeedNodeCount:
         mock_tracker = MagicMock()
         mock_tracker.get_all_nodes.return_value = [MagicMock()] * 5
 
-        with patch('status_bar._get_node_tracker', return_value=mock_tracker):
-            with patch('status_bar._HAS_NODE_TRACKER', True):
-                bar._seed_node_count()
+        with patch('status_bar.get_node_tracker', return_value=mock_tracker):
+            bar._seed_node_count()
 
         assert bar._node_count == 5
 
@@ -631,18 +623,17 @@ class TestSeedNodeCount:
         mock_tracker = MagicMock()
         mock_tracker.get_all_nodes.return_value = []
 
-        with patch('status_bar._get_node_tracker', return_value=mock_tracker):
-            with patch('status_bar._HAS_NODE_TRACKER', True):
-                bar._seed_node_count()
+        with patch('status_bar.get_node_tracker', return_value=mock_tracker):
+            bar._seed_node_count()
 
         assert bar._node_count is None
 
     def test_seed_import_failure(self):
-        """Missing node tracker should not crash."""
+        """get_node_tracker raising should not crash."""
         bar = StatusBar(version="1.0")
         bar._node_count = None
 
-        with patch('status_bar._HAS_NODE_TRACKER', False):
+        with patch('status_bar.get_node_tracker', side_effect=Exception("import error")):
             bar._seed_node_count()
 
         assert bar._node_count is None


### PR DESCRIPTION
Security audit found strong posture (zero critical/high findings) but ~80 instances of safe_import wrapping first-party modules, violating CLAUDE.md rules and masking an import chain bug that broke test collection.

Root cause: utils/cli.py imported rich unconditionally, cascading through utils/common.py → commands/propagation.py → test collection failure.

Changes:
- Guard rich imports in utils/cli.py with try/except (external dep)
- Convert ~80 safe_import calls for first-party modules to direct imports across 65 source files (utils.paths, service_check, cli, event_bus, common, and all other first-party modules)
- Remove all associated _HAS_* guard flags and fallback code paths
- Remove GTK4 dead code from utils/common.py, utils/system.py, utils/cli.py
- Add linter rule MF006 to prevent future safe_import misuse on first-party modules
- Update tests to match new clean import names (no underscore prefixes)
- Net reduction: -814 lines of dead/redundant code

Lint: 0 errors | Tests: 1598 passed, 14 skipped, 0 failed

https://claude.ai/code/session_01Lyqb1WrNQy9cvTEpYfrBFt