### PR TITLE
fix: Move reinstall backup from /tmp to user home for persistence

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -40,7 +40,14 @@ NC='\033[0m'
 
 # Defaults
 INSTALL_DIR="/opt/meshforge"
-BACKUP_DIR="/tmp/meshforge-reinstall-$$"
+BACKUP_TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+# Use persistent location — /tmp gets wiped on reboot and could lose RNS identity
+if [[ -n "$SUDO_USER" ]]; then
+    BACKUP_BASE=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+else
+    BACKUP_BASE="$HOME"
+fi
+BACKUP_DIR="${BACKUP_BASE}/meshforge-backup-${BACKUP_TIMESTAMP}"
 REPO_URL="https://github.com/Nursedude/meshforge.git"
 BRANCH="main"
 NO_CONFIRM=false
@@ -391,8 +398,9 @@ echo "  meshforge-status        Quick health check"
 echo "  meshforge-web           Open radio web client"
 echo ""
 
-# Clean up backup (configs are restored)
-rm -rf "$BACKUP_DIR"
-
+# Keep backup for safety — user can delete manually once verified
+echo -e "${CYAN}Backup preserved at: ${BOLD}${BACKUP_DIR}${NC}"
+echo -e "${CYAN}  Delete after verifying: rm -rf ${BACKUP_DIR}${NC}"
+echo ""
 echo -e "${CYAN}Made with aloha for the mesh community${NC}"
 echo ""


### PR DESCRIPTION
/tmp gets wiped on reboot — if Pi reboots mid-reinstall, RNS identity and radio configs would be lost. Now backs up to ~/meshforge-backup-<timestamp> and preserves backup after restore for manual verification.

https://claude.ai/code/session_01Lyqb1WrNQy9cvTEpYfrBFt