### PR TITLE
fix: Add targeted rnsd connection diagnostics

### DIFF
--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -184,6 +184,17 @@ shared_instance_port = 37428
 instance_control_port = 37429
 """)
 
+                # Pre-flight: check if shared instance port is listening
+                try:
+                    from utils.service_check import check_udp_port
+                    if not check_udp_port(37428):
+                        logger.warning(
+                            "rnsd PID %d found but port 37428 not listening "
+                            "(may be initializing or hung)", rns_pids[0]
+                        )
+                except ImportError:
+                    pass  # service_check not available, proceed anyway
+
                 # Connect using client-only config
                 self._reticulum = RNS.Reticulum(configdir=str(client_config_dir))
                 self._rns_connected = True
@@ -245,7 +256,11 @@ instance_control_port = 37429
 
             except Exception as e:
                 logger.warning(f"Could not connect to rnsd: {e}")
-                logger.info("RNS nodes may not appear on map - ensure rnsd is running properly")
+                try:
+                    from utils.gateway_diagnostic import diagnose_rnsd_connection
+                    diagnose_rnsd_connection(rns_pids, error=e)
+                except Exception:
+                    pass  # diagnostic failure should never block startup
                 self._rns_connected = False
 
         except Exception as e:

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -1108,6 +1108,11 @@ class RNSMeshtasticBridge(MeshCoreBridgeMixin):
                 logger.warning(f"RNS port conflict: {e} (will retry in background)")
             else:
                 logger.warning(f"RNS pre-init failed: {e}")
+                try:
+                    from utils.gateway_diagnostic import diagnose_rnsd_connection
+                    diagnose_rnsd_connection(rns_pids, error=e)
+                except Exception:
+                    pass  # diagnostic failure should never block init
 
     def _connect_rns(self):
         """Initialize RNS and LXMF.
@@ -1177,6 +1182,13 @@ class RNSMeshtasticBridge(MeshCoreBridgeMixin):
 
             except Exception as e:
                 logger.error(f"Failed to connect to RNS: {e}")
+                try:
+                    from utils.gateway_diagnostic import (
+                        diagnose_rnsd_connection, find_rns_processes
+                    )
+                    diagnose_rnsd_connection(find_rns_processes(), error=e)
+                except Exception:
+                    pass  # diagnostic failure should never block bridge
                 self._connected_rns = False
 
     def _setup_lxmf(self, RNS, LXMF):

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -944,6 +944,64 @@ def find_rns_processes() -> List[int]:
     return pids
 
 
+def diagnose_rnsd_connection(rns_pids: List[int], error: Exception = None) -> None:
+    """Log diagnostic info when rnsd connection fails.
+
+    Follows 'Eight Times Blind' principle: check port, check known causes,
+    show the log. POLICY: Diagnose only — never restarts services or
+    modifies configs.
+
+    Args:
+        rns_pids: PIDs returned by find_rns_processes()
+        error: The exception from the failed RNS.Reticulum() call
+    """
+    import logging
+    _log = logging.getLogger(__name__)
+
+    # 1. Check if shared instance port is actually listening
+    try:
+        from utils.service_check import check_udp_port
+        port_listening = check_udp_port(37428)
+    except ImportError:
+        port_listening = None  # Can't check
+
+    if rns_pids and port_listening is False:
+        _log.warning(
+            "rnsd PID %d exists but port 37428 not listening "
+            "(zombie or hung during init)", rns_pids[0]
+        )
+    elif rns_pids and port_listening is True:
+        # Port is listening but connection still failed — likely auth or config issue
+        err_str = str(error).lower() if error else ""
+        if "authentication" in err_str or "digest" in err_str:
+            _log.warning("Cause: RPC auth mismatch (stale shared_instance tokens)")
+            _log.info("Fix: sudo systemctl stop rnsd && "
+                      "sudo rm -f /etc/reticulum/storage/shared_instance_* && "
+                      "sudo systemctl start rnsd")
+        else:
+            _log.warning("rnsd port 37428 listening but connection failed — "
+                         "possible config mismatch")
+
+    # 2. Show recent rnsd journal (the actual diagnostic, per "Eight Times Blind")
+    try:
+        r = subprocess.run(
+            ['journalctl', '-u', 'rnsd', '-n', '15', '--no-pager'],
+            capture_output=True, text=True, timeout=10
+        )
+        if r.stdout and r.stdout.strip():
+            _log.warning("Recent rnsd log:")
+            for line in r.stdout.strip().splitlines():
+                _log.warning("  %s", line.strip())
+        else:
+            _log.info("(no rnsd journal output)")
+    except (subprocess.SubprocessError, OSError, FileNotFoundError):
+        _log.debug("Could not read rnsd journal")
+
+    # 3. Actionable hints
+    _log.info("Restart rnsd: sudo systemctl restart rnsd")
+    _log.info("Full logs: journalctl -u rnsd -n 50")
+
+
 def kill_rns_processes(force: bool = False) -> Dict[str, any]:
     """
     Kill running RNS processes to free up the port.


### PR DESCRIPTION
When rnsd connection fails, the gateway and node tracker now surface actionable diagnostics instead of generic "Could not connect" messages:
- Pre-flight port 37428 check detects zombie/hung rnsd before RNS init
- Zombie detection: PID exists but port not listening
- Auth mismatch detection from error messages
- journalctl tail surfaced directly in log output
- Actionable restart/log hints for the operator

Follows "Eight Times Blind" principle: check the port, show the log.

https://claude.ai/code/session_01REdQca3iGFYF5178pANVb2