### PR TITLE
fix: Improve RNS diagnostics with wait-retry, config drift check, and…

### DIFF
--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -5,7 +5,6 @@ Extracted from rns_menu_mixin.py to reduce file size per CLAUDE.md guidelines.
 """
 
 import logging
-import os
 import re
 import shutil
 import subprocess
@@ -16,22 +15,14 @@ logger = logging.getLogger(__name__)
 
 from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
-from utils.safe_import import safe_import
-
-check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running', 'check_udp_port', 'start_service', 'stop_service', '_sudo_cmd'
+from utils.service_check import (
+    check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd,
 )
-
-get_identity_path, create_identities, list_known_destinations, \
-    check_connectivity, get_status, _HAS_RNS_COMMANDS = safe_import(
-    'commands.rns',
-    'get_identity_path', 'create_identities', 'list_known_destinations',
-    'check_connectivity', 'get_status',
+from commands.rns import (
+    get_identity_path, create_identities, list_known_destinations,
+    check_connectivity, get_status,
 )
-
-detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
-    'utils.config_drift', 'detect_rnsd_config_drift'
-)
+from utils.config_drift import detect_rnsd_config_drift
 
 
 class RNSDiagnosticsMixin:
@@ -41,12 +32,6 @@ class RNSDiagnosticsMixin:
         """Run comprehensive RNS diagnostics."""
         clear_screen()
         print("=== RNS Diagnostics ===\n")
-
-        if not _HAS_RNS_COMMANDS:
-            print("RNS commands module not available.")
-            print("Run from MeshForge root: sudo python3 src/launcher_tui/main.py")
-            self._wait_for_enter()
-            return
 
         # Collect issues and warnings throughout diagnostics
         issues = []
@@ -179,71 +164,74 @@ class RNSDiagnosticsMixin:
 
         # Check if shared instance port is actually listening
         # RNS uses UDP port 37428, NOT TCP — must use UDP bind test
+        port_ok = False
         try:
-            if _HAS_SERVICE_CHECK:
-                port_ok = check_udp_port(37428)
-            else:
-                # Fallback: try UDP bind test inline
-                import socket
-                try:
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                    sock.settimeout(1)
-                    sock.bind(('127.0.0.1', 37428))
-                    sock.close()
-                    port_ok = False  # Bind succeeded = port NOT in use
-                except OSError as e:
-                    port_ok = e.errno in (98, 48, 10048)  # EADDRINUSE = port in use
-                finally:
-                    try:
-                        sock.close()
-                    except Exception:
-                        pass
+            port_ok = check_udp_port(37428)
             if running and not port_ok:
-                print("  ! rnsd running but port 37428 NOT listening")
-                # Show who owns the port (if anyone)
-                try:
-                    from utils.service_check import get_udp_port_owner
-                    owner = get_udp_port_owner(37428)
-                    if owner:
-                        proc_name, pid = owner
-                        print(f"    Port held by: {proc_name} "
-                              f"(PID {pid})")
-                except ImportError:
-                    pass
-                # Check if share_instance is enabled in config
-                share_ok = conn_data.get('share_instance', None)
-                if share_ok is False:
-                    print("    Cause: share_instance is not "
-                          "enabled in [reticulum] config")
-                    print("    Fix: Add 'share_instance = Yes' "
-                          "to [reticulum] section,")
-                    print("         then restart: sudo systemctl "
-                          "restart rnsd")
-                    issues.append(
-                        "share_instance not enabled — gateway "
-                        "cannot connect to rnsd")
+                # rnsd may still be initializing — wait before declaring failure
+                print("  rnsd running but port 37428 not yet listening...")
+                print("  Waiting for rnsd to finish initializing...")
+                port_ok = self._wait_for_rns_port(max_wait=10)
+                if port_ok:
+                    print("  Shared instance port 37428: listening (slow startup)")
                 else:
-                    # Surface recent journal errors to explain WHY
+                    print("  ! rnsd running but port 37428 NOT listening after 10s wait")
+                    # Show who owns the port (if anyone)
                     try:
-                        r = subprocess.run(
-                            ['journalctl', '-u', 'rnsd', '-n', '10',
-                             '--no-pager', '-p', 'warning', '-q',
-                             '--no-hostname'],
-                            capture_output=True, text=True, timeout=10
-                        )
-                        if r.stdout and r.stdout.strip():
-                            print("    Recent rnsd errors:")
-                            for line in r.stdout.strip().splitlines()[-5:]:
-                                print(f"      {line.strip()[:100]}")
-                    except (subprocess.SubprocessError, OSError):
+                        from utils.service_check import get_udp_port_owner
+                        owner = get_udp_port_owner(37428)
+                        if owner:
+                            proc_name, pid = owner
+                            print(f"    Port held by: {proc_name} "
+                                  f"(PID {pid})")
+                    except ImportError:
                         pass
-                    warnings.append(
-                        "rnsd active but shared instance port "
-                        "not bound")
+                    # Check if share_instance is enabled in config
+                    share_ok = conn_data.get('share_instance', None)
+                    if share_ok is False:
+                        print("    Cause: share_instance is not "
+                              "enabled in [reticulum] config")
+                        print("    Fix: Add 'share_instance = Yes' "
+                              "to [reticulum] section,")
+                        print("         then restart: sudo systemctl "
+                              "restart rnsd")
+                        issues.append(
+                            "share_instance not enabled — gateway "
+                            "cannot connect to rnsd")
+                    else:
+                        # Check for config drift as potential root cause
+                        try:
+                            drift = detect_rnsd_config_drift()
+                            if drift.drifted:
+                                print(f"    Config drift: gateway reads {drift.gateway_config_dir}")
+                                print(f"                  rnsd reads    {drift.rnsd_config_dir}")
+                                print(f"    Fix: {drift.fix_hint}")
+                                issues.append(
+                                    "Config drift — rnsd and gateway "
+                                    "use different config paths")
+                        except Exception as e:
+                            logger.debug("Config drift check failed: %s", e)
+                        # Surface recent journal errors to explain WHY
+                        try:
+                            r = subprocess.run(
+                                ['journalctl', '-u', 'rnsd', '-n', '10',
+                                 '--no-pager', '-p', 'warning', '-q',
+                                 '--no-hostname'],
+                                capture_output=True, text=True, timeout=10
+                            )
+                            if r.stdout and r.stdout.strip():
+                                print("    Recent rnsd errors:")
+                                for line in r.stdout.strip().splitlines()[-5:]:
+                                    print(f"      {line.strip()[:100]}")
+                        except (subprocess.SubprocessError, OSError):
+                            pass
+                        warnings.append(
+                            "rnsd active but shared instance port "
+                            "not bound")
             elif running and port_ok:
                 print(f"  Shared instance port 37428: listening")
-        except Exception:
-            pass
+        except Exception as e:
+            logger.debug("Port check failed: %s", e)
 
         # 6. Interface TX/RX health
         print("\n[6/6] Checking interface traffic...")
@@ -265,9 +253,14 @@ class RNSDiagnosticsMixin:
                     print("  Common cause: shared instance port "
                           "37428 not bound.")
             else:
-                print("  Could not retrieve interface traffic "
-                      "(rnstatus not available or rnsd not "
-                      "connected)")
+                # Provide specific reason instead of generic message
+                rnstatus_path = shutil.which('rnstatus')
+                if not rnstatus_path:
+                    print("  rnstatus not installed — install RNS tools: pip install rns")
+                elif running and not port_ok:
+                    print("  rnstatus available but cannot connect (port 37428 not bound)")
+                else:
+                    print("  Could not retrieve interface traffic from rnstatus")
         except Exception as e:
             logger.debug("Interface health check failed: %s", e)
             print(f"  Could not check: {e}")
@@ -286,6 +279,22 @@ class RNSDiagnosticsMixin:
             print("\n--- All checks passed ---")
         elif not issues:
             print("\n--- Connectivity OK (with warnings) ---")
+
+        # Offer inline repair if port 37428 is not listening
+        if running and not port_ok:
+            print("\n--- Quick Fix ---")
+            if self.dialog.yesno(
+                "Repair RNS",
+                "Port 37428 is not listening.\n\n"
+                "Run the RNS repair wizard now?\n"
+                "This will clear auth tokens, check dependencies,\n"
+                "and restart rnsd.\n\n"
+                "Repair now?"
+            ):
+                clear_screen()
+                self._repair_rns_shared_instance()
+                self._wait_for_enter()
+                return
 
         # Offer to create missing identities
         if not identity_exists or not rns_identity.exists():
@@ -327,12 +336,6 @@ class RNSDiagnosticsMixin:
         clear_screen()
         print("=== RNS Config Drift Check ===\n")
         print("Comparing gateway config path vs rnsd actual path...\n")
-
-        if not _HAS_CONFIG_DRIFT:
-            print("  Config drift module not available.")
-            print("  File: src/utils/config_drift.py")
-            self._wait_for_enter()
-            return
 
         result = detect_rnsd_config_drift()
 
@@ -502,29 +505,25 @@ class RNSDiagnosticsMixin:
 
         # Step 6: Restart rnsd
         print("\n[6/7] Restarting rnsd...")
-        if _HAS_SERVICE_CHECK:
-            success, msg = stop_service('rnsd')
-            if not success:
-                print(f"  Warning stopping rnsd: {msg}")
-            time.sleep(1)
+        success, msg = stop_service('rnsd')
+        if not success:
+            print(f"  Warning stopping rnsd: {msg}")
+        time.sleep(1)
 
-            # Reset failed state in case rnsd was in a crash loop
-            try:
-                subprocess.run(
-                    _sudo_cmd(['systemctl', 'reset-failed', 'rnsd']),
-                    capture_output=True, timeout=5
-                )
-            except (subprocess.SubprocessError, OSError):
-                pass
+        # Reset failed state in case rnsd was in a crash loop
+        try:
+            subprocess.run(
+                _sudo_cmd(['systemctl', 'reset-failed', 'rnsd']),
+                capture_output=True, timeout=5
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
 
-            success, msg = start_service('rnsd')
-            if success:
-                print("  rnsd started")
-            else:
-                print(f"  Warning: {msg}")
+        success, msg = start_service('rnsd')
+        if success:
+            print("  rnsd started")
         else:
-            print("  Service management not available — restart manually:")
-            print("    sudo systemctl restart rnsd")
+            print(f"  Warning: {msg}")
 
         # Step 7: Wait for port and verify
         print("\n[7/7] Verifying fix...")
@@ -669,12 +668,7 @@ class RNSDiagnosticsMixin:
                     install_cmd = [rnsd_python, '-m', 'pip', 'install',
                                     '--break-system-packages', pip_name,
                                     'cryptography>=45.0.7,<47', 'pyopenssl>=25.3.0']
-                    if _HAS_SERVICE_CHECK:
-                        base_cmd = _sudo_cmd(install_cmd)
-                    elif os.getuid() != 0:
-                        base_cmd = ['sudo'] + install_cmd
-                    else:
-                        base_cmd = install_cmd
+                    base_cmd = _sudo_cmd(install_cmd)
                     result = subprocess.run(
                         base_cmd,
                         capture_output=True, text=True, timeout=120
@@ -688,13 +682,9 @@ class RNSDiagnosticsMixin:
                         err_text = (result.stderr or result.stdout or '').lower()
                         if 'installed by' in err_text or 'externally-managed' in err_text:
                             print(f"  {pip_name}: Debian package conflict, retrying with --ignore-installed...")
-                            retry_cmd = [rnsd_python, '-m', 'pip', 'install',
+                            retry_cmd = _sudo_cmd([rnsd_python, '-m', 'pip', 'install',
                                          '--break-system-packages', '--ignore-installed', pip_name,
-                                         'cryptography>=45.0.7,<47', 'pyopenssl>=25.3.0']
-                            if _HAS_SERVICE_CHECK:
-                                retry_cmd = _sudo_cmd(retry_cmd)
-                            elif os.getuid() != 0:
-                                retry_cmd = ['sudo'] + retry_cmd
+                                         'cryptography>=45.0.7,<47', 'pyopenssl>=25.3.0'])
                             retry = subprocess.run(
                                 retry_cmd,
                                 capture_output=True, text=True, timeout=120
@@ -849,26 +839,8 @@ class RNSDiagnosticsMixin:
         Returns True if port becomes available, False if timeout expires.
         """
         for i in range(max_wait):
-            if _HAS_SERVICE_CHECK:
-                if check_udp_port(37428):
-                    return True
-            else:
-                # Fallback: inline UDP bind test
-                import socket
-                try:
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                    sock.settimeout(1)
-                    sock.bind(('127.0.0.1', 37428))
-                    sock.close()
-                    # Bind succeeded = port NOT in use, keep waiting
-                except OSError as e:
-                    if e.errno in (98, 48, 10048):  # EADDRINUSE
-                        return True
-                finally:
-                    try:
-                        sock.close()
-                    except Exception:
-                        pass
+            if check_udp_port(37428):
+                return True
             time.sleep(1)
         return False
 
@@ -1060,16 +1032,7 @@ class RNSDiagnosticsMixin:
                     print("Done. Startup order: rnsd -> NomadNet -> MeshForge\n")
                 return
 
-            # Use centralized service check when available
-            if _HAS_SERVICE_CHECK:
-                rnsd_running = check_process_running('rnsd')
-            else:
-                # Fallback to direct pgrep
-                result = subprocess.run(
-                    ['pgrep', '-f', 'rnsd'],
-                    capture_output=True, text=True, timeout=5
-                )
-                rnsd_running = result.returncode == 0
+            rnsd_running = check_process_running('rnsd')
 
             if rnsd_running:
                 # Get PID for diagnostic message
@@ -1086,7 +1049,7 @@ class RNSDiagnosticsMixin:
                 print("  sudo systemctl restart rnsd")
             else:
                 print("No rnsd found. A stale process may be holding the port.")
-                print("  Find it:    sudo lsof -i UDP:29716")
+                print("  Find it:    sudo lsof -i UDP:37428")
                 print("  Kill stale: pkill -f rnsd")
                 print("  Or wait ~30s for the socket to timeout")
         except (subprocess.SubprocessError, OSError) as e:

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -28,25 +28,15 @@ from rns_monitor_mixin import RNSMonitorMixin
 from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 
-# --- Optional dependency imports via safe_import ---
-from utils.safe_import import safe_import
-
-check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd, \
-    daemon_reload, _sudo_write, enable_service, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_process_running', 'check_udp_port', 'start_service', 'stop_service', '_sudo_cmd',
-    'daemon_reload', '_sudo_write', 'enable_service',
+from utils.service_check import (
+    check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd,
+    daemon_reload, _sudo_write, enable_service,
 )
-
-get_identity_path, create_identities, list_known_destinations, \
-    check_connectivity, get_status, _HAS_RNS_COMMANDS = safe_import(
-    'commands.rns',
-    'get_identity_path', 'create_identities', 'list_known_destinations',
-    'check_connectivity', 'get_status',
+from commands.rns import (
+    get_identity_path, create_identities, list_known_destinations,
+    check_connectivity, get_status,
 )
-
-detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
-    'utils.config_drift', 'detect_rnsd_config_drift'
-)
+from utils.config_drift import detect_rnsd_config_drift
 
 
 class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMonitorMixin):
@@ -173,10 +163,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
             # Check identity status for menu hints
             config_dir = ReticulumPaths.get_config_dir()
             rnsd_exists = (config_dir / 'identity').exists()
-            if _HAS_RNS_COMMANDS:
-                gw_exists = get_identity_path().exists()
-            else:
-                gw_exists = False
+            gw_exists = get_identity_path().exists()
 
             choices = [
                 ("show", "Show local identity"),
@@ -217,16 +204,15 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         print(f"rnsd identity: {rnsd_identity}")
                         print("  Not found — use 'Create identities' to generate.\n")
 
-                    if _HAS_RNS_COMMANDS:
-                        gw_id = get_identity_path()
-                        print(f"\nMeshForge gateway identity: {gw_id}")
-                        if gw_id.exists():
-                            self._run_rns_tool(
-                                ['rnid', '-i', str(gw_id), '-p'],
-                                'rnid'
-                            )
-                        else:
-                            print("  Not created — use 'Create identities' to generate.")
+                    gw_id = get_identity_path()
+                    print(f"\nMeshForge gateway identity: {gw_id}")
+                    if gw_id.exists():
+                        self._run_rns_tool(
+                            ['rnid', '-i', str(gw_id), '-p'],
+                            'rnid'
+                        )
+                    else:
+                        print("  Not created — use 'Create identities' to generate.")
                     self._wait_for_enter()
 
                 elif choice == "path":
@@ -245,14 +231,13 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                     else:
                         print("  Not found (created on first rnsd start)")
 
-                    if _HAS_RNS_COMMANDS:
-                        gw_id = get_identity_path()
-                        print(f"\nMeshForge gateway:  {gw_id}")
-                        if gw_id.exists():
-                            stat = gw_id.stat()
-                            print(f"  Size: {stat.st_size} bytes")
-                        else:
-                            print("  Not created yet")
+                    gw_id = get_identity_path()
+                    print(f"\nMeshForge gateway:  {gw_id}")
+                    if gw_id.exists():
+                        stat = gw_id.stat()
+                        print(f"  Size: {stat.st_size} bytes")
+                    else:
+                        print("  Not created yet")
                     self._wait_for_enter()
 
                 elif choice == "recall":
@@ -287,12 +272,6 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         """
         clear_screen()
         print("=== Create RNS Identities ===\n")
-
-        if not _HAS_RNS_COMMANDS:
-            print("ERROR: RNS module not installed.")
-            print("  Install: pip install rns")
-            self._wait_for_enter()
-            return
 
         try:
             config_dir = ReticulumPaths.get_config_dir()
@@ -331,37 +310,32 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         clear_screen()
         print("=== Known RNS Destinations ===\n")
 
-        if not _HAS_RNS_COMMANDS:
-            # Fallback: use rnstatus which also shows some destination info
-            print("Commands module not available, falling back to rnstatus...\n")
-            self._run_rns_tool(['rnstatus', '-a'], 'rnstatus')
-        else:
-            result = list_known_destinations()
+        result = list_known_destinations()
 
-            if result.success:
-                nodes = result.data.get('nodes', [])
-                count = result.data.get('count', 0)
+        if result.success:
+            nodes = result.data.get('nodes', [])
+            count = result.data.get('count', 0)
 
-                if count == 0:
-                    print("No known destinations yet.")
-                    print("\nNodes appear when they announce or when you request paths.")
-                    print("Make sure rnsd is running: sudo systemctl start rnsd")
-                else:
-                    print(f"Found {count} destination(s):\n")
-                    print(f"{'Hash':>10}  {'Hops':>5}  {'Source':<20}  {'Name'}")
-                    print("-" * 60)
-                    for node in nodes:
-                        short = node.get('short_hash', '?')
-                        hops = node.get('hops', -1)
-                        hops_str = str(hops) if hops >= 0 else '?'
-                        source = node.get('source', 'unknown')
-                        name = node.get('name', '')
-                        print(f"{short:>10}  {hops_str:>5}  {source:<20}  {name}")
+            if count == 0:
+                print("No known destinations yet.")
+                print("\nNodes appear when they announce or when you request paths.")
+                print("Make sure rnsd is running: sudo systemctl start rnsd")
             else:
-                print(f"Error: {result.message}")
-                fix_hint = (result.data or {}).get('fix_hint', '')
-                if fix_hint:
-                    print(f"Fix: {fix_hint}")
+                print(f"Found {count} destination(s):\n")
+                print(f"{'Hash':>10}  {'Hops':>5}  {'Source':<20}  {'Name'}")
+                print("-" * 60)
+                for node in nodes:
+                    short = node.get('short_hash', '?')
+                    hops = node.get('hops', -1)
+                    hops_str = str(hops) if hops >= 0 else '?'
+                    source = node.get('source', 'unknown')
+                    name = node.get('name', '')
+                    print(f"{short:>10}  {hops_str:>5}  {source:<20}  {name}")
+        else:
+            print(f"Error: {result.message}")
+            fix_hint = (result.data or {}).get('fix_hint', '')
+            if fix_hint:
+                print(f"Fix: {fix_hint}")
 
         self._wait_for_enter()
 
@@ -724,17 +698,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         rnsd_crashed = False
         for i in range(15):
             # Check if port is up
-            if _HAS_SERVICE_CHECK and check_udp_port:
-                port_ok = check_udp_port(37428)
-            else:
-                try:
-                    result = subprocess.run(
-                        ['ss', '-ulnp'],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    port_ok = '37428' in result.stdout
-                except (subprocess.SubprocessError, OSError):
-                    pass
+            port_ok = check_udp_port(37428)
             if port_ok:
                 break
 
@@ -834,13 +798,12 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         )
                         start_service('rnsd')
                         time.sleep(3)
-                        if _HAS_SERVICE_CHECK and check_udp_port:
-                            if check_udp_port(37428):
-                                print("  SUCCESS: rnsd is now listening on port 37428")
-                                print("\n" + "=" * 50)
-                                print("RNS shared instance is now available!")
-                                print("=" * 50 + "\n")
-                                return True
+                        if check_udp_port(37428):
+                            print("  SUCCESS: rnsd is now listening on port 37428")
+                            print("\n" + "=" * 50)
+                            print("RNS shared instance is now available!")
+                            print("=" * 50 + "\n")
+                            return True
                         print("  rnsd restarted — check with RNS > Diagnostics")
                     else:
                         print(f"  pip install failed: {pip_r.stderr.strip()[:200]}")
@@ -887,31 +850,30 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         else:
                             fixed = '[reticulum]\n  share_instance = Yes\n\n' + config_content
 
-                        if _HAS_SERVICE_CHECK and _sudo_write:
-                            ok, msg = _sudo_write(str(config_path), fixed)
-                            if ok:
-                                # Verify the write took effect
-                                verify = config_path.read_text()
-                                if not _parse_share_instance(verify):
-                                    print("  WARNING: Config write did not take effect")
-                                    return False
-                                print("  Fixed: share_instance = Yes")
-                                # Restart and re-check
-                                stop_service('rnsd')
+                        ok, msg = _sudo_write(str(config_path), fixed)
+                        if ok:
+                            # Verify the write took effect
+                            verify = config_path.read_text()
+                            if not _parse_share_instance(verify):
+                                print("  WARNING: Config write did not take effect")
+                                return False
+                            print("  Fixed: share_instance = Yes")
+                            # Restart and re-check
+                            stop_service('rnsd')
+                            time.sleep(1)
+                            start_service('rnsd')
+                            print("  Waiting for port 37428...")
+                            for _ in range(10):
                                 time.sleep(1)
-                                start_service('rnsd')
-                                print("  Waiting for port 37428...")
-                                for _ in range(10):
-                                    time.sleep(1)
-                                    if check_udp_port and check_udp_port(37428):
-                                        print("  SUCCESS: rnsd is now listening on port 37428")
-                                        print("\n" + "=" * 50)
-                                        print("RNS shared instance is now available!")
-                                        print("=" * 50 + "\n")
-                                        return True
-                                print("  Port still not bound after config fix")
-                            else:
-                                print(f"  Could not write config: {msg}")
+                                if check_udp_port(37428):
+                                    print("  SUCCESS: rnsd is now listening on port 37428")
+                                    print("\n" + "=" * 50)
+                                    print("RNS shared instance is now available!")
+                                    print("=" * 50 + "\n")
+                                    return True
+                            print("  Port still not bound after config fix")
+                        else:
+                            print(f"  Could not write config: {msg}")
                     else:
                         return False
         except Exception as e:
@@ -1055,31 +1017,25 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 '''
-        if _HAS_SERVICE_CHECK and _sudo_write:
-            write_ok, write_msg = _sudo_write(str(service_path), service_content)
-            if write_ok:
-                print("  Fixed: rnsd.service regenerated")
-                # daemon-reload so systemd picks up the change
-                if daemon_reload:
-                    ok, msg = daemon_reload()
-                    if ok:
-                        print("  Reloaded: systemd daemon-reload complete")
-                    else:
-                        print(f"  Warning: daemon-reload failed: {msg}")
-                # Re-enable so rnsd starts on boot (regenerating the
-                # service file can drop the symlink)
-                if enable_service:
-                    ok, msg = enable_service('rnsd')
-                    if ok:
-                        print("  Enabled: rnsd will start on boot")
-                    else:
-                        print(f"  Warning: could not enable rnsd: {msg}")
-                return True
+        write_ok, write_msg = _sudo_write(str(service_path), service_content)
+        if write_ok:
+            print("  Fixed: rnsd.service regenerated")
+            # daemon-reload so systemd picks up the change
+            ok, msg = daemon_reload()
+            if ok:
+                print("  Reloaded: systemd daemon-reload complete")
             else:
-                print(f"  Warning: Could not write service file: {write_msg}")
-                return False
+                print(f"  Warning: daemon-reload failed: {msg}")
+            # Re-enable so rnsd starts on boot (regenerating the
+            # service file can drop the symlink)
+            ok, msg = enable_service('rnsd')
+            if ok:
+                print("  Enabled: rnsd will start on boot")
+            else:
+                print(f"  Warning: could not enable rnsd: {msg}")
+            return True
         else:
-            print("  Warning: service_check not available, cannot write service file")
+            print(f"  Warning: Could not write service file: {write_msg}")
             return False
 
     def _check_meshtastic_plugin(self) -> bool:


### PR DESCRIPTION
… inline repair

- Replace safe_import with direct imports for first-party modules (utils.service_check, commands.rns, utils.config_drift) per CLAUDE.md rules
- Add 10s wait-and-retry when rnsd is running but port 37428 not yet bound, handling slow startup gracefully instead of immediately reporting failure
- Integrate config drift detection into diagnostics flow when port not listening, identifying when rnsd reads a different config than gateway
- Improve step 6 error messaging: distinguish "rnstatus not installed" from "port 37428 not bound" instead of vague generic message
- Offer inline repair wizard from diagnostics when port issue detected, eliminating need to navigate to separate Repair menu
- Fix wrong port number in _diagnose_rns_port_conflict (29716 -> 37428)
- Remove all _HAS_SERVICE_CHECK/_HAS_RNS_COMMANDS/_HAS_CONFIG_DRIFT guards and fallback branches (net -81 lines)

https://claude.ai/code/session_01EtSkVBukctc2o17EUgeFMY