### PR TITLE
Remove safe_import fallbacks; assume service_check always available

### DIFF
--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -26,11 +26,10 @@ from backend import clear_screen
 
 logger = logging.getLogger(__name__)
 
-from utils.safe_import import safe_import
-
-# Import centralized service checking
-check_systemd_service, check_process_running, _check_port, _check_udp_port, apply_config_and_restart, restart_service, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_systemd_service', 'check_process_running', 'check_port', 'check_udp_port', 'apply_config_and_restart', 'restart_service', '_sudo_cmd'
+# Centralized service checking — first-party, always available
+from utils.service_check import (
+    check_systemd_service, check_process_running, check_port, check_udp_port,
+    apply_config_and_restart, restart_service, _sudo_cmd,
 )
 
 # First-party modules for quick actions
@@ -98,15 +97,8 @@ class QuickActionsMixin:
             if svc == 'meshforge':
                 is_systemd = False
                 try:
-                    if _HAS_SERVICE_CHECK:
-                        is_running, _ = check_systemd_service(svc)
-                        is_systemd = is_running
-                    else:
-                        result = subprocess.run(
-                            ['systemctl', 'is-active', svc],
-                            capture_output=True, text=True, timeout=5
-                        )
-                        is_systemd = result.stdout.strip() == 'active'
+                    is_running, _ = check_systemd_service(svc)
+                    is_systemd = is_running
                 except Exception:
                     pass
                 mode = "service" if is_systemd else "interactive"
@@ -114,22 +106,8 @@ class QuickActionsMixin:
                 continue
 
             try:
-                if _HAS_SERVICE_CHECK:
-                    is_running, is_enabled = check_systemd_service(svc)
-                    status = 'active' if is_running else 'inactive'
-                else:
-                    # Fallback to direct systemctl call
-                    result = subprocess.run(
-                        ['systemctl', 'is-active', svc],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    status = result.stdout.strip()
-                    # Check boot persistence via fallback
-                    enabled_result = subprocess.run(
-                        ['systemctl', 'is-enabled', svc],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    is_enabled = enabled_result.returncode == 0
+                is_running, is_enabled = check_systemd_service(svc)
+                status = 'active' if is_running else 'inactive'
 
                 # Check boot persistence
                 boot_info = ""
@@ -138,7 +116,11 @@ class QuickActionsMixin:
                     warnings.append(svc)
 
                 if status == 'active':
-                    print(f"  * {svc:<18} running{boot_info}")
+                    # rnsd zombie detection: systemd active but port not bound
+                    if svc == 'rnsd' and not check_udp_port(37428):
+                        print(f"  ! {svc:<18} running (port 37428 not bound)")
+                    else:
+                        print(f"  * {svc:<18} running{boot_info}")
                 elif status == 'failed':
                     print(f"  ! {svc:<18} FAILED")
                 else:
@@ -149,16 +131,7 @@ class QuickActionsMixin:
 
         # Bridge process (not a systemd service — no boot persistence check)
         try:
-            if _HAS_SERVICE_CHECK:
-                bridge_running = check_process_running('rns_bridge')
-            else:
-                # Fallback to direct pgrep call
-                result = subprocess.run(
-                    ['pgrep', '-f', 'rns_bridge'],
-                    capture_output=True, timeout=3
-                )
-                bridge_running = result.returncode == 0
-
+            bridge_running = check_process_running('rns_bridge')
             bridge_status = "running" if bridge_running else "not running"
             sym = "*" if bridge_running else "-"
             print(f"  {sym} {'rns_bridge':<18} {bridge_status}")
@@ -254,11 +227,7 @@ class QuickActionsMixin:
         self._wait_for_enter("Press Enter to continue...")
 
     def _qa_port_check(self):
-        """Quick: check network ports.
-
-        Uses centralized service_check module when available.
-        """
-        import socket as sock
+        """Quick: check network ports."""
         clear_screen()
         print("=== Port Check ===\n")
 
@@ -275,24 +244,9 @@ class QuickActionsMixin:
         for port, desc in ports:
             try:
                 if port in _udp_ports:
-                    if _HAS_SERVICE_CHECK:
-                        port_open = _check_udp_port(port)
-                    else:
-                        try:
-                            with sock.socket(sock.AF_INET, sock.SOCK_DGRAM) as s:
-                                s.settimeout(1)
-                                s.bind(('127.0.0.1', port))
-                                port_open = False  # Bind OK = not in use
-                        except OSError as e:
-                            port_open = e.errno in (98, 48, 10048)
-                elif _HAS_SERVICE_CHECK:
-                    port_open = _check_port(port, host='127.0.0.1', timeout=1.0)
+                    port_open = check_udp_port(port)
                 else:
-                    # Fallback to direct TCP socket check
-                    with sock.socket(sock.AF_INET, sock.SOCK_STREAM) as s:
-                        s.settimeout(1)
-                        result = s.connect_ex(('127.0.0.1', port))
-                        port_open = result == 0
+                    port_open = check_port(port, host='127.0.0.1', timeout=1.0)
 
                 if port_open:
                     print(f"  * {port:<6} {desc}")

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -693,10 +693,11 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         print(f"\n[5/5] Verifying shared instance...")
         print("  Waiting for rnsd to bind port 37428...")
 
-        # Poll for port with early crash detection (up to 15 seconds)
+        # Poll for port with early crash detection (up to 30 seconds)
+        # rnsd can take 20-30s to initialize on slower hardware (Pi)
         port_ok = False
         rnsd_crashed = False
-        for i in range(15):
+        for i in range(30):
             # Check if port is up
             port_ok = check_udp_port(37428)
             if port_ok:
@@ -811,7 +812,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
             return False
 
         # Port never came up but rnsd didn't crash — diagnose why
-        print("  WARNING: rnsd not yet listening on port 37428 after 15s")
+        print("  WARNING: rnsd not yet listening on port 37428 after 30s")
 
         # Check if share_instance is disabled in config (most common cause)
         try:

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -12,33 +12,19 @@ import subprocess
 from pathlib import Path
 from typing import Optional
 from backend import clear_screen
-from utils.safe_import import safe_import
-
 logger = logging.getLogger(__name__)
 
-# Import centralized service checking
-(check_systemd_service, check_process_running, check_service,
- apply_config_and_restart, enable_service, start_service, stop_service,
- restart_service, ServiceState, _sudo_cmd,
- _HAS_SERVICE_CHECK) = safe_import(
-    'utils.service_check',
-    'check_systemd_service', 'check_process_running', 'check_service',
-    'apply_config_and_restart', 'enable_service', 'start_service', 'stop_service',
-    'restart_service', 'ServiceState', '_sudo_cmd',
+# Centralized service checking — first-party, always available
+from utils.service_check import (
+    check_systemd_service, check_process_running, check_service,
+    apply_config_and_restart, enable_service, start_service, stop_service,
+    restart_service, ServiceState, _sudo_cmd, check_udp_port,
+    lock_port_external, unlock_port_external,
+    check_port_locked, persist_iptables,
 )
-_HAS_APPLY_RESTART = _HAS_SERVICE_CHECK
 
 # Sudo-safe home directory — first-party, always available (MF001)
 from utils.paths import get_real_user_home
-
-# Import port lockdown helpers
-(lock_port_external, unlock_port_external,
- check_port_locked, persist_iptables,
- _HAS_PORT_LOCKDOWN) = safe_import(
-    'utils.service_check',
-    'lock_port_external', 'unlock_port_external',
-    'check_port_locked', 'persist_iptables',
-)
 
 # Import RNS identity helpers
 from commands.rns import get_identity_path
@@ -99,15 +85,7 @@ class ServiceMenuMixin:
         Uses centralized service_check module when available.
         """
         try:
-            if _HAS_SERVICE_CHECK:
-                return check_process_running('bridge_cli.py')
-
-            # Fallback to direct pgrep call
-            result = subprocess.run(
-                ['pgrep', '-f', 'bridge_cli.py'],
-                capture_output=True, text=True, timeout=5
-            )
-            return result.returncode == 0
+            return check_process_running('bridge_cli.py')
         except (subprocess.SubprocessError, OSError) as e:
             logger.debug("Bridge process check failed: %s", e)
             return False
@@ -125,18 +103,8 @@ class ServiceMenuMixin:
 
         # 1. Check rnsd is running
         rnsd_running = False
-        if _HAS_SERVICE_CHECK:
-            status = check_service('rnsd')
-            rnsd_running = status.available
-        else:
-            try:
-                result = subprocess.run(
-                    ['pgrep', '-f', 'rnsd'],
-                    capture_output=True, text=True, timeout=5
-                )
-                rnsd_running = result.returncode == 0
-            except (subprocess.SubprocessError, OSError):
-                pass
+        status = check_service('rnsd')
+        rnsd_running = status.available
 
         if not rnsd_running:
             issues.append("rnsd is not running (required for RNS connectivity)")
@@ -192,25 +160,19 @@ class ServiceMenuMixin:
         if not rnsd_running:
             print("[2] Starting rnsd (shared instance)...")
             try:
-                if _HAS_SERVICE_CHECK:
-                    success, msg_text = apply_config_and_restart('rnsd')
-                    if success:
-                        print("  rnsd started via systemctl.")
-                    else:
-                        # Try direct start as fallback
-                        start_service('rnsd')
+                success, msg_text = apply_config_and_restart('rnsd')
+                if success:
+                    print("  rnsd started via systemctl.")
                 else:
+                    # Try direct start as fallback
                     start_service('rnsd')
                 time.sleep(2)
                 # Verify
-                if _HAS_SERVICE_CHECK:
-                    status = check_service('rnsd')
-                    if status.available:
-                        print("  rnsd is now running.\n")
-                    else:
-                        print(f"  Warning: {status.message}\n")
+                status = check_service('rnsd')
+                if status.available:
+                    print("  rnsd is now running.\n")
                 else:
-                    print("  rnsd start command sent.\n")
+                    print(f"  Warning: {status.message}\n")
             except (subprocess.SubprocessError, OSError) as e:
                 print(f"  Error starting rnsd: {e}")
                 print("  Bridge may fail to connect.\n")
@@ -462,15 +424,8 @@ class ServiceMenuMixin:
                 # Check systemd first, fall back to interactive detection
                 is_systemd = False
                 try:
-                    if _HAS_SERVICE_CHECK:
-                        svc_status = check_service(svc)
-                        is_systemd = svc_status.available
-                    else:
-                        result = subprocess.run(
-                            ['systemctl', 'is-active', svc],
-                            capture_output=True, text=True, timeout=5
-                        )
-                        is_systemd = result.stdout.strip() == 'active'
+                    svc_status = check_service(svc)
+                    is_systemd = svc_status.available
                 except Exception:
                     pass
 
@@ -489,49 +444,27 @@ class ServiceMenuMixin:
                 continue
 
             try:
-                if _HAS_SERVICE_CHECK:
-                    # Use detailed check_service() as single source of truth
-                    svc_status = check_service(svc)
-                    _, is_enabled = check_systemd_service(svc)
+                svc_status = check_service(svc)
+                _, is_enabled = check_systemd_service(svc)
 
-                    boot_info = ""
-                    if svc_status.available and not is_enabled:
-                        boot_info = "  (not enabled at boot)"
-                        warnings.append(svc)
+                boot_info = ""
+                if svc_status.available and not is_enabled:
+                    boot_info = "  (not enabled at boot)"
+                    warnings.append(svc)
 
-                    if svc_status.available:
-                        print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
-                    elif svc_status.state in (ServiceState.FAILED, ServiceState.DEGRADED):
-                        print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
-                        failed_services.append(svc)
-                    elif svc_status.state == ServiceState.NOT_RUNNING:
-                        print(f"  \033[2m○\033[0m {svc:<18} stopped")
+                if svc_status.available:
+                    # rnsd zombie detection: systemd active but port not bound
+                    if svc == 'rnsd' and not check_udp_port(37428):
+                        print(f"  \033[0;33m●\033[0m {svc:<18} running (port 37428 not bound)")
                     else:
-                        print(f"  \033[2m○\033[0m {svc:<18} {svc_status.state.value}")
+                        print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
+                elif svc_status.state in (ServiceState.FAILED, ServiceState.DEGRADED):
+                    print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
+                    failed_services.append(svc)
+                elif svc_status.state == ServiceState.NOT_RUNNING:
+                    print(f"  \033[2m○\033[0m {svc:<18} stopped")
                 else:
-                    result = subprocess.run(
-                        ['systemctl', 'is-active', svc],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    status = result.stdout.strip()
-                    enabled_result = subprocess.run(
-                        ['systemctl', 'is-enabled', svc],
-                        capture_output=True, text=True, timeout=5
-                    )
-                    is_enabled = enabled_result.returncode == 0
-
-                    boot_info = ""
-                    if status == 'active' and not is_enabled:
-                        boot_info = "  (not enabled at boot)"
-                        warnings.append(svc)
-
-                    if status == 'active':
-                        print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
-                    elif status == 'failed':
-                        print(f"  \033[0;31m●\033[0m {svc:<18} FAILED")
-                        failed_services.append(svc)
-                    else:
-                        print(f"  \033[2m○\033[0m {svc:<18} {status}")
+                    print(f"  \033[2m○\033[0m {svc:<18} {svc_status.state.value}")
             except (subprocess.SubprocessError, OSError) as e:
                 logger.debug("Service status check for %s failed: %s", svc, e)
                 print(f"  ? {svc:<18} unknown")
@@ -556,13 +489,6 @@ class ServiceMenuMixin:
 
     def _manage_port_lockdown(self):
         """Lock/unlock external access to meshtasticd port 9443."""
-        if not _HAS_PORT_LOCKDOWN:
-            self.dialog.msgbox(
-                "Unavailable",
-                "Port lockdown requires utils.service_check module."
-            )
-            return
-
         while True:
             locked = check_port_locked(9443)
             status_str = "\033[0;32mLOCKED\033[0m (localhost only)" if locked else "\033[0;31mOPEN\033[0m (external access allowed)"
@@ -933,21 +859,9 @@ WantedBy=multi-user.target
             return False
 
     def _is_rnsd_running(self) -> bool:
-        """Check if rnsd is running as a process.
-
-        Uses centralized service_check module when available.
-        """
+        """Check if rnsd is running as a process."""
         try:
-            if _HAS_SERVICE_CHECK:
-                return check_process_running('rnsd')
-
-            # Fallback to direct pgrep call
-            result = subprocess.run(
-                ['pgrep', '-x', 'rnsd'],
-                capture_output=True,
-                timeout=5
-            )
-            return result.returncode == 0
+            return check_process_running('rnsd')
         except (subprocess.SubprocessError, OSError) as e:
             logger.debug("rnsd process check failed: %s", e)
             return False

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -14,18 +14,13 @@ from enum import Enum
 from pathlib import Path
 from typing import List, Dict, Optional
 
-# Import centralized path utility
+# First-party imports — always available
 from utils.paths import get_real_user_home
-from utils.safe_import import safe_import
+from utils.service_check import check_service, check_systemd_service, check_process_with_pid, ServiceState
+from utils.config_drift import detect_rnsd_config_drift
 
-# Optional dependencies — module-level safe imports
-check_service, check_systemd_service, check_process_with_pid, ServiceState, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'check_systemd_service',
-    'check_process_with_pid', 'ServiceState'
-)
-detect_rnsd_config_drift, _HAS_CONFIG_DRIFT = safe_import(
-    'utils.config_drift', 'detect_rnsd_config_drift'
-)
+# Optional external dependencies
+from utils.safe_import import safe_import
 _meshtastic_mod, _HAS_MESHTASTIC = safe_import('meshtastic')
 MeshChatService, MeshChatServiceState, _HAS_MESHCHAT = safe_import(
     'plugins.meshchat', 'MeshChatService', 'ServiceState'
@@ -300,13 +295,12 @@ class GatewayDiagnostic:
             has_meshtastic = 'meshtastic' in content.lower()
 
             # Check for config drift between gateway and rnsd
-            if _HAS_CONFIG_DRIFT:
-                drift = detect_rnsd_config_drift()
-                if drift.drifted:
-                    issues.append(
-                        f"Config drift: gateway uses {drift.gateway_config_dir} "
-                        f"but rnsd uses {drift.rnsd_config_dir}"
-                    )
+            drift = detect_rnsd_config_drift()
+            if drift.drifted:
+                issues.append(
+                    f"Config drift: gateway uses {drift.gateway_config_dir} "
+                    f"but rnsd uses {drift.rnsd_config_dir}"
+                )
 
             if issues:
                 return CheckResult(
@@ -336,18 +330,7 @@ class GatewayDiagnostic:
     def check_rnsd_running(self) -> CheckResult:
         """Check if rnsd daemon is running."""
         try:
-            # Use centralized service check when available
-            if _HAS_SERVICE_CHECK:
-                running, pid = check_process_with_pid('rnsd')
-            else:
-                # Fallback to direct pgrep
-                result = subprocess.run(
-                    ['pgrep', '-f', 'rnsd'],
-                    capture_output=True, text=True, timeout=5
-                )
-                running = result.returncode == 0 and result.stdout.strip()
-                pid = result.stdout.strip().split('\n')[0] if running else None
-
+            running, pid = check_process_with_pid('rnsd')
             if running:
                 return CheckResult(
                     name="RNS Daemon (rnsd)",
@@ -498,17 +481,7 @@ class GatewayDiagnostic:
     def check_meshtasticd(self) -> CheckResult:
         """Check if meshtasticd service is running."""
         try:
-            # Use centralized service check when available
-            if _HAS_SERVICE_CHECK:
-                running, _ = check_process_with_pid('meshtasticd')
-            else:
-                # Fallback to direct pgrep
-                result = subprocess.run(
-                    ['pgrep', '-f', 'meshtasticd'],
-                    capture_output=True, text=True, timeout=5
-                )
-                running = result.returncode == 0 and result.stdout.strip()
-
+            running, _ = check_process_with_pid('meshtasticd')
             if running:
                 # Also check TCP port
                 if self.check_tcp_port('localhost', 4403):
@@ -707,19 +680,9 @@ class GatewayDiagnostic:
     def _check_ble_available(self) -> bool:
         """Check if Bluetooth LE is available."""
         try:
-            # Use centralized service checker if available
-            if _HAS_SERVICE_CHECK:
-                is_running, is_enabled = check_systemd_service('bluetooth')
-                if is_running:
-                    return True
-            else:
-                # Fallback to direct systemctl call
-                result = subprocess.run(
-                    ['systemctl', 'is-active', 'bluetooth'],
-                    capture_output=True, text=True, timeout=5
-                )
-                if result.stdout.strip() == 'active':
-                    return True
+            is_running, is_enabled = check_systemd_service('bluetooth')
+            if is_running:
+                return True
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
This PR removes all conditional imports and fallback code paths that were guarded by `_HAS_SERVICE_CHECK` and `_HAS_PORT_LOCKDOWN` flags. The `utils.service_check` module is now treated as a first-party, always-available dependency, eliminating the need for safe_import wrappers and subprocess fallbacks throughout the codebase.

## Key Changes

- **Removed safe_import usage**: Replaced all `safe_import()` calls for `utils.service_check` with direct imports in:
  - `src/launcher_tui/service_menu_mixin.py`
  - `src/launcher_tui/quick_actions_mixin.py`
  - `src/utils/gateway_diagnostic.py`

- **Eliminated conditional code paths**: Removed all `if _HAS_SERVICE_CHECK:` and `if _HAS_PORT_LOCKDOWN:` guards, keeping only the centralized service_check code paths and removing subprocess fallbacks (pgrep, systemctl direct calls, socket checks)

- **Added new imports**: Imported additional service_check utilities that were previously conditionally imported:
  - `check_udp_port`, `lock_port_external`, `unlock_port_external`, `check_port_locked`, `persist_iptables` in service_menu_mixin
  - `check_port` in quick_actions_mixin

- **Enhanced rnsd zombie detection**: Added explicit checks for rnsd port binding (37428) in service status displays to detect zombie processes where systemd reports active but the port isn't bound

- **Increased rnsd startup timeout**: Extended the port polling timeout from 15 to 30 seconds in `_repair_rns_shared_instance()` to accommodate slower hardware (Raspberry Pi) initialization times

## Implementation Details

- All direct subprocess calls (`pgrep`, `systemctl`, socket operations) have been removed in favor of centralized service_check functions
- The code now assumes `utils.service_check` is always available, simplifying logic flow and reducing maintenance burden
- Error handling remains in place for subprocess operations that still occur within the service_check module itself
- The rnsd zombie detection uses `check_udp_port(37428)` to verify actual port binding, providing better visibility into service health

https://claude.ai/code/session_016HxL2uhm2dwHyYaHGXs8rj