### PR TITLE
Fix reinstall script to escape CWD before removing install directory

### DIFF
--- a/scripts/reinstall.sh
+++ b/scripts/reinstall.sh
@@ -262,6 +262,7 @@ if [[ -z "$INSTALL_DIR" ]] || [[ "$INSTALL_DIR" == "/" ]]; then
     exit 1
 fi
 if [[ -d "$INSTALL_DIR" ]]; then
+    cd /  # Escape CWD before removing it (script runs from inside INSTALL_DIR)
     rm -rf "$INSTALL_DIR"
     echo -e "  ${GREEN}✓${NC} Removed $INSTALL_DIR"
 else


### PR DESCRIPTION
## Summary
Fixed a potential issue in the reinstall script where the current working directory (CWD) could be inside the directory being removed, causing the removal operation to fail or behave unexpectedly.

## Key Changes
- Added `cd /` command before removing `$INSTALL_DIR` to ensure the script is not executing from within the directory being deleted
- This prevents the `rm -rf` command from operating on a directory that contains its own execution context

## Implementation Details
The script runs from inside `INSTALL_DIR`, so when attempting to remove that directory with `rm -rf`, the operation could fail or produce unexpected results if the shell is still using that directory as its working directory. By changing to the root directory first, we ensure a clean removal of the target installation directory.

https://claude.ai/code/session_01J4STsKj466b8dsdttz9PYk