### PR TITLE
Replace UDP port checks with RNS shared instance detection

### DIFF
--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -122,10 +122,10 @@ def check_rns_port():
         except Exception:
             pass
 
-    # Check shared instance port (RNS uses UDP, not TCP)
+    # Check shared instance (RNS uses abstract domain sockets on Linux)
     try:
-        from utils.service_check import check_udp_port
-        port_bound = check_udp_port(37428)
+        from utils.service_check import check_rns_shared_instance
+        port_bound = check_rns_shared_instance()
     except ImportError:
         # Fallback: inline UDP bind test
         port_bound = False

--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -1298,28 +1298,17 @@ def list_known_destinations() -> CommandResult:
     # First check if rnsd is running (using improved detection)
     status = get_status()
     if not status.data.get('rnsd_running'):
-        # Also check UDP port as fallback
-        import socket
+        # Also check shared instance as fallback (domain socket, TCP, or UDP)
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            sock.settimeout(1)
-            try:
-                sock.bind(('127.0.0.1', 37428))
-                sock.close()
-                # If we can bind, rnsd is NOT running
+            from utils.service_check import check_rns_shared_instance
+            if not check_rns_shared_instance():
                 return CommandResult.fail(
                     "rnsd not running",
                     fix_hint="Start with: rnsd or sudo systemctl start rnsd"
                 )
-            except OSError as e:
-                sock.close()
-                if e.errno in (98, 48, 10048):  # EADDRINUSE
-                    pass  # rnsd is running, continue
-                else:
-                    return CommandResult.fail(
-                        "rnsd not running",
-                        fix_hint="Start with: rnsd or sudo systemctl start rnsd"
-                    )
+            # Shared instance is reachable, continue
+        except ImportError:
+            pass  # No service_check available, proceed anyway
         except Exception as e:
             logger.debug(f"RNS availability check error: {e}")
 

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -186,10 +186,10 @@ instance_control_port = 37429
 
                 # Pre-flight: check if shared instance port is listening
                 try:
-                    from utils.service_check import check_udp_port
-                    if not check_udp_port(37428):
+                    from utils.service_check import check_rns_shared_instance
+                    if not check_rns_shared_instance():
                         logger.warning(
-                            "rnsd PID %d found but port 37428 not listening "
+                            "rnsd PID %d found but shared instance not available "
                             "(may be initializing or hung)", rns_pids[0]
                         )
                 except ImportError:

--- a/src/launcher_tui/quick_actions_mixin.py
+++ b/src/launcher_tui/quick_actions_mixin.py
@@ -29,6 +29,7 @@ logger = logging.getLogger(__name__)
 # Centralized service checking — first-party, always available
 from utils.service_check import (
     check_systemd_service, check_process_running, check_port, check_udp_port,
+    check_rns_shared_instance,
     apply_config_and_restart, restart_service, _sudo_cmd,
 )
 
@@ -116,9 +117,9 @@ class QuickActionsMixin:
                     warnings.append(svc)
 
                 if status == 'active':
-                    # rnsd zombie detection: systemd active but port not bound
-                    if svc == 'rnsd' and not check_udp_port(37428):
-                        print(f"  ! {svc:<18} running (port 37428 not bound)")
+                    # rnsd zombie detection: systemd active but shared instance not available
+                    if svc == 'rnsd' and not check_rns_shared_instance():
+                        print(f"  ! {svc:<18} running (shared instance not available)")
                     else:
                         print(f"  * {svc:<18} running{boot_info}")
                 elif status == 'failed':
@@ -238,13 +239,13 @@ class QuickActionsMixin:
             (1883, 'MQTT broker'),
         ]
 
-        # RNS uses UDP port 37428, all others are TCP
-        _udp_ports = {37428}
+        # RNS uses abstract domain sockets on Linux (not UDP/TCP port)
+        _rns_port = 37428
 
         for port, desc in ports:
             try:
-                if port in _udp_ports:
-                    port_open = check_udp_port(port)
+                if port == _rns_port:
+                    port_open = check_rns_shared_instance()
                 else:
                     port_open = check_port(port, host='127.0.0.1', timeout=1.0)
 

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -16,7 +16,8 @@ logger = logging.getLogger(__name__)
 from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 from utils.service_check import (
-    check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd,
+    check_process_running, check_udp_port, check_rns_shared_instance,
+    get_rns_shared_instance_info, start_service, stop_service, _sudo_cmd,
 )
 from commands.rns import (
     get_identity_path, create_identities, list_known_destinations,
@@ -162,27 +163,33 @@ class RNSDiagnosticsMixin:
             logger.debug("Interface dependency check failed: %s", e)
             print(f"  Could not check: {e}")
 
-        # Check if shared instance port is actually listening
-        # RNS uses UDP port 37428, NOT TCP — must use UDP bind test
-        port_ok = False
+        # Check if shared instance is actually reachable.
+        # RNS uses abstract Unix domain sockets on Linux (\0rns/default),
+        # NOT UDP port 37428. check_rns_shared_instance() checks both.
+        instance_ok = False
         try:
-            port_ok = check_udp_port(37428)
-            if running and not port_ok:
+            si_info = get_rns_shared_instance_info()
+            instance_ok = si_info['available']
+            if running and not instance_ok:
                 # rnsd may still be initializing — wait before declaring failure
-                print("  rnsd running but port 37428 not yet listening...")
+                print("  rnsd running but shared instance not yet available...")
                 print("  Waiting for rnsd to finish initializing...")
-                port_ok = self._wait_for_rns_port(max_wait=10)
-                if port_ok:
-                    print("  Shared instance port 37428: listening (slow startup)")
+                instance_ok = self._wait_for_rns_shared_instance(max_wait=10)
+                if instance_ok:
+                    si_info = get_rns_shared_instance_info()
+                    print(f"  Shared instance: available (slow startup)")
+                    print(f"    Method: {si_info['detail']}")
                 else:
-                    print("  ! rnsd running but port 37428 NOT listening after 10s wait")
-                    # Show who owns the port (if anyone)
+                    print("  ! rnsd running but shared instance NOT "
+                          "available after 10s wait")
+                    print(f"    {si_info['detail']}")
+                    # Show who owns port 37428 (if anyone, for TCP/UDP mode)
                     try:
                         from utils.service_check import get_udp_port_owner
                         owner = get_udp_port_owner(37428)
                         if owner:
                             proc_name, pid = owner
-                            print(f"    Port held by: {proc_name} "
+                            print(f"    Port 37428 held by: {proc_name} "
                                   f"(PID {pid})")
                     except ImportError:
                         pass
@@ -211,25 +218,24 @@ class RNSDiagnosticsMixin:
                                     "use different config paths")
                         except Exception as e:
                             logger.debug("Config drift check failed: %s", e)
-                        # Surface recent journal errors to explain WHY
+                        # Surface recent journal errors (unfiltered)
                         try:
                             r = subprocess.run(
                                 ['journalctl', '-u', 'rnsd', '-n', '10',
-                                 '--no-pager', '-p', 'warning', '-q',
-                                 '--no-hostname'],
+                                 '--no-pager', '-q', '--no-hostname'],
                                 capture_output=True, text=True, timeout=10
                             )
                             if r.stdout and r.stdout.strip():
-                                print("    Recent rnsd errors:")
+                                print("    Recent rnsd log:")
                                 for line in r.stdout.strip().splitlines()[-5:]:
                                     print(f"      {line.strip()[:100]}")
                         except (subprocess.SubprocessError, OSError):
                             pass
                         warnings.append(
-                            "rnsd active but shared instance port "
-                            "not bound")
-            elif running and port_ok:
-                print(f"  Shared instance port 37428: listening")
+                            "rnsd active but shared instance "
+                            "not available")
+            elif running and instance_ok:
+                print(f"  Shared instance: available ({si_info['method']})")
         except Exception as e:
             logger.debug("Port check failed: %s", e)
 
@@ -257,8 +263,8 @@ class RNSDiagnosticsMixin:
                 rnstatus_path = shutil.which('rnstatus')
                 if not rnstatus_path:
                     print("  rnstatus not installed — install RNS tools: pip install rns")
-                elif running and not port_ok:
-                    print("  rnstatus available but cannot connect (port 37428 not bound)")
+                elif running and not instance_ok:
+                    print("  rnstatus available but cannot connect (shared instance not available)")
                 else:
                     print("  Could not retrieve interface traffic from rnstatus")
         except Exception as e:
@@ -280,14 +286,14 @@ class RNSDiagnosticsMixin:
         elif not issues:
             print("\n--- Connectivity OK (with warnings) ---")
 
-        # Offer inline repair if port 37428 is not listening
-        if running and not port_ok:
+        # Offer inline repair if shared instance is not available
+        if running and not instance_ok:
             print("\n--- Quick Fix ---")
             if self.dialog.yesno(
                 "Repair RNS",
-                "Port 37428 is not listening.\n\n"
+                "RNS shared instance is not available.\n\n"
                 "Run the RNS repair wizard now?\n"
-                "This will clear auth tokens, check dependencies,\n"
+                "This will validate config, check dependencies,\n"
                 "and restart rnsd.\n\n"
                 "Repair now?"
             ):
@@ -525,13 +531,14 @@ class RNSDiagnosticsMixin:
         else:
             print(f"  Warning: {msg}")
 
-        # Step 7: Wait for port and verify
+        # Step 7: Wait for shared instance and verify
         print("\n[7/7] Verifying fix...")
-        print("  Waiting for port 37428...")
-        port_ok = self._wait_for_rns_port(max_wait=15)
+        print("  Waiting for shared instance...")
+        instance_ready = self._wait_for_rns_shared_instance(max_wait=15)
 
-        if port_ok:
-            print("  Port 37428: listening")
+        if instance_ready:
+            si_info = get_rns_shared_instance_info()
+            print(f"  Shared instance: available ({si_info['detail']})")
 
             # Re-run drift detection to confirm fix
             verify = detect_rnsd_config_drift()
@@ -544,7 +551,7 @@ class RNSDiagnosticsMixin:
                 print(f"  rnsd:    {verify.rnsd_config_dir}")
                 print("  You may need to restart MeshForge for path resolution to update.")
         else:
-            print("  Port 37428 not listening after 15s.")
+            print("  Shared instance not available after 15s.")
             print("  rnsd may be slow to initialize or may have crashed.")
             print("  Check: sudo journalctl -u rnsd -n 20")
 
@@ -770,7 +777,7 @@ class RNSDiagnosticsMixin:
                         try:
                             start_service('rnsd')
                             print("Starting rnsd...")
-                            if self._wait_for_rns_port(max_wait=10):
+                            if self._wait_for_rns_shared_instance(max_wait=10):
                                 print(f"rnsd started. Retrying {tool_name}...\n")
                                 retry_result = subprocess.run(
                                     cmd, capture_output=True, text=True, timeout=15
@@ -782,7 +789,7 @@ class RNSDiagnosticsMixin:
                                         (retry_result.stdout or "") + (retry_result.stderr or "")
                                     )
                             else:
-                                print("rnsd started but port 37428 not listening.")
+                                print("rnsd started but shared instance not available.")
                                 print("Check: sudo journalctl -u rnsd -n 20")
                                 print("Or run: RNS > Diagnostics from the menu.")
                         except (subprocess.SubprocessError, OSError) as e:
@@ -792,12 +799,12 @@ class RNSDiagnosticsMixin:
                 else:
                     # rnsd IS running but tools can't connect.
                     # Most common cause: rnsd still initializing (crypto, interfaces).
-                    # Wait for port 37428 before showing diagnostics.
-                    print("rnsd is running — waiting for port 37428...")
-                    port_ready = self._wait_for_rns_port()
+                    # Wait for shared instance before showing diagnostics.
+                    print("rnsd is running — waiting for shared instance...")
+                    port_ready = self._wait_for_rns_shared_instance()
                     if port_ready:
-                        # Port came up — retry the tool
-                        print(f"Port ready. Retrying {tool_name}...\n")
+                        # Shared instance came up — retry the tool
+                        print(f"Shared instance ready. Retrying {tool_name}...\n")
                         retry_result = subprocess.run(
                             cmd, capture_output=True, text=True, timeout=15
                         )
@@ -832,17 +839,21 @@ class RNSDiagnosticsMixin:
             print(f"\n{tool_name} timed out. RNS may be unresponsive.")
             print("Try restarting rnsd: sudo systemctl restart rnsd")
 
-    def _wait_for_rns_port(self, max_wait: int = 10) -> bool:
-        """Wait for rnsd to start listening on UDP port 37428.
+    def _wait_for_rns_shared_instance(self, max_wait: int = 10) -> bool:
+        """Wait for rnsd shared instance to become available.
 
-        Polls the port with 1-second intervals using UDP bind test.
-        Returns True if port becomes available, False if timeout expires.
+        Checks abstract Unix domain socket (Linux default), TCP, and UDP
+        with 1-second intervals. Returns True if shared instance becomes
+        reachable, False if timeout expires.
         """
         for i in range(max_wait):
-            if check_udp_port(37428):
+            if check_rns_shared_instance():
                 return True
             time.sleep(1)
         return False
+
+    # Keep old name as alias for any callers during transition
+    _wait_for_rns_port = _wait_for_rns_shared_instance
 
     def _diagnose_rns_connectivity(self, error_output: str):
         """Show targeted diagnostics when rnsd is running but tools can't connect.

--- a/src/launcher_tui/rns_menu_mixin.py
+++ b/src/launcher_tui/rns_menu_mixin.py
@@ -29,7 +29,9 @@ from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 
 from utils.service_check import (
-    check_process_running, check_udp_port, start_service, stop_service, _sudo_cmd,
+    check_process_running, check_udp_port, check_rns_shared_instance,
+    get_rns_shared_instance_info, get_udp_port_owner,
+    start_service, stop_service, _sudo_cmd,
     daemon_reload, _sudo_write, enable_service,
 )
 from commands.rns import (
@@ -636,9 +638,110 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         if files_cleared == 0:
             print("    No stale auth files found")
 
+        # Pre-flight 4a: Validate share_instance = Yes BEFORE restart.
+        # Without this, rnsd won't expose the shared instance at all.
+        # Previously this was only checked POST-failure after 30s timeout.
+        try:
+            from commands.rns import _parse_share_instance
+            config_path = ReticulumPaths.get_config_file()
+            if config_path.exists():
+                config_content = config_path.read_text()
+                share_ok = _parse_share_instance(config_content)
+                if share_ok:
+                    print("  share_instance: Yes (OK)")
+                else:
+                    print("  share_instance: DISABLED")
+                    print("  Without share_instance = Yes, rnsd won't accept")
+                    print("  connections from gateway, rnstatus, or other tools.")
+                    if self.dialog.yesno(
+                        "Fix share_instance",
+                        "share_instance is disabled in the RNS config.\n\n"
+                        "Without it, rnsd won't expose the shared instance\n"
+                        "and no client apps (gateway, rnstatus) can connect.\n\n"
+                        f"Config: {config_path}\n\n"
+                        "Set share_instance = Yes?"
+                    ):
+                        import re as _re
+                        if _re.search(r'^\s*share_instance\s*=',
+                                      config_content, _re.MULTILINE):
+                            fixed = _re.sub(
+                                r'^(\s*share_instance\s*=\s*).*$',
+                                r'\1Yes',
+                                config_content,
+                                count=1,
+                                flags=_re.MULTILINE
+                            )
+                        elif '[reticulum]' in config_content.lower():
+                            fixed = config_content.replace(
+                                '[reticulum]',
+                                '[reticulum]\n  share_instance = Yes',
+                                1
+                            )
+                        else:
+                            fixed = ('[reticulum]\n  share_instance = Yes\n\n'
+                                     + config_content)
+                        ok, msg = _sudo_write(str(config_path), fixed)
+                        if ok:
+                            verify = config_path.read_text()
+                            if _parse_share_instance(verify):
+                                print("  Fixed: share_instance = Yes")
+                            else:
+                                print("  WARNING: Config write did not take effect")
+                        else:
+                            print(f"  Could not write config: {msg}")
+            else:
+                print(f"  Config not found at {config_path}")
+        except Exception as e:
+            logger.debug("Pre-flight share_instance check failed: %s", e)
+
+        # Pre-flight 4b: Check config drift (gateway vs rnsd config paths).
+        # If rnsd reads a different config file, the repair may fix the wrong one.
+        try:
+            drift = detect_rnsd_config_drift()
+            if drift.drifted:
+                print(f"\n  WARNING: Config drift detected!")
+                print(f"    Gateway reads: {drift.gateway_config_dir}")
+                print(f"    rnsd reads:    {drift.rnsd_config_dir}")
+                print(f"    Fix: {drift.fix_hint}")
+                print("    The checks above may have validated the wrong config.")
+        except Exception as e:
+            logger.debug("Pre-flight config drift check failed: %s", e)
+
+        # Pre-flight 4c: Check NomadNet conflict.
+        # NomadNet can hold the shared instance, preventing rnsd from binding.
+        try:
+            if self._check_nomadnet_conflict():
+                print("\n  WARNING: NomadNet is running!")
+                print("  NomadNet may hold the RNS shared instance,")
+                print("  preventing rnsd from becoming the shared instance.")
+                owner = get_udp_port_owner(37428)
+                if owner:
+                    print(f"  Port 37428 held by: {owner[0]} (PID {owner[1]})")
+                if self.dialog.yesno(
+                    "Stop NomadNet?",
+                    "NomadNet is running and may hold the\n"
+                    "RNS shared instance port.\n\n"
+                    "Stop NomadNet before starting rnsd?\n"
+                    "(NomadNet can be restarted afterward as a client)",
+                ):
+                    try:
+                        subprocess.run(
+                            ['pkill', '-f', 'nomadnet'],
+                            capture_output=True, timeout=5
+                        )
+                        time.sleep(1)
+                        print("  NomadNet stopped")
+                    except (subprocess.SubprocessError, OSError) as e:
+                        print(f"  Could not stop NomadNet: {e}")
+                else:
+                    print("  Proceeding with NomadNet running (rnsd may fail)...")
+        except Exception as e:
+            logger.debug("Pre-flight NomadNet check failed: %s", e)
+
         # Pre-flight: check for blocking interfaces BEFORE starting rnsd.
         # If enabled interfaces have missing dependencies (e.g., meshtasticd
         # not running), rnsd will hang during init and never bind port 37428.
+        user_declined_disable = False
         blocking = self._find_blocking_interfaces()
         if blocking:
             print("\n  WARNING: Enabled interfaces have missing dependencies:")
@@ -667,6 +770,7 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                 else:
                     print("  Could not disable interfaces — rnsd may hang")
             else:
+                user_declined_disable = True
                 print("  Proceeding without disabling (rnsd may hang)...\n")
 
         # Clear any systemd start limit (after 5 crashes, systemd refuses to start)
@@ -689,18 +793,20 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
         except Exception as e:
             print(f"  Warning: {e}")
 
-        # Step 5: Wait for port and verify
+        # Step 5: Wait for shared instance and verify
         print(f"\n[5/5] Verifying shared instance...")
-        print("  Waiting for rnsd to bind port 37428...")
+        print("  Waiting for rnsd shared instance...")
 
-        # Poll for port with early crash detection (up to 30 seconds)
+        # Poll for shared instance with early crash detection (up to 30 seconds)
         # rnsd can take 20-30s to initialize on slower hardware (Pi)
-        port_ok = False
+        # RNS uses abstract Unix domain sockets on Linux (\0rns/default),
+        # NOT UDP port 37428. check_rns_shared_instance() checks both.
+        instance_ok = False
         rnsd_crashed = False
         for i in range(30):
-            # Check if port is up
-            port_ok = check_udp_port(37428)
-            if port_ok:
+            # Check if shared instance is reachable (domain socket, TCP, or UDP)
+            instance_ok = check_rns_shared_instance()
+            if instance_ok:
                 break
 
             # Early exit: check if rnsd has already crashed
@@ -718,8 +824,10 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
 
             time.sleep(1)
 
-        if port_ok:
-            print("  SUCCESS: rnsd is now listening on port 37428")
+        if instance_ok:
+            info = get_rns_shared_instance_info()
+            print(f"  SUCCESS: RNS shared instance is available")
+            print(f"  Method: {info['detail']}")
             print("\n" + "=" * 50)
             print("RNS shared instance is now available!")
             print("=" * 50 + "\n")
@@ -799,8 +907,8 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
                         )
                         start_service('rnsd')
                         time.sleep(3)
-                        if check_udp_port(37428):
-                            print("  SUCCESS: rnsd is now listening on port 37428")
+                        if check_rns_shared_instance():
+                            print("  SUCCESS: RNS shared instance is available")
                             print("\n" + "=" * 50)
                             print("RNS shared instance is now available!")
                             print("=" * 50 + "\n")
@@ -811,91 +919,114 @@ class RNSMenuMixin(RNSSnifferMixin, RNSConfigMixin, RNSDiagnosticsMixin, RNSMoni
 
             return False
 
-        # Port never came up but rnsd didn't crash — diagnose why
-        print("  WARNING: rnsd not yet listening on port 37428 after 30s")
+        # Shared instance not available after 30s but rnsd didn't crash.
+        # Run comprehensive diagnostics to identify the root cause.
+        print("  WARNING: Shared instance not available after 30s")
+        print()
+        print("  --- Diagnosing root cause ---")
 
-        # Check if share_instance is disabled in config (most common cause)
+        # Diagnostic 1: Show shared instance detection details
+        info = get_rns_shared_instance_info()
+        print(f"  Shared instance: {info['detail']}")
+
+        # Diagnostic 2: Check who owns port 37428 (if TCP/UDP mode)
+        try:
+            owner = get_udp_port_owner(37428)
+            if owner:
+                print(f"  Port 37428 owner: {owner[0]} (PID {owner[1]})")
+                if owner[0] in ('nomadnet', 'python', 'python3'):
+                    print("  Likely cause: NomadNet is holding the port")
+        except Exception:
+            pass
+
+        # Diagnostic 3: Re-check share_instance (config drift may mean
+        # rnsd read a different config than pre-flight validated)
         try:
             from commands.rns import _parse_share_instance
             config_path = ReticulumPaths.get_config_file()
             if config_path.exists():
                 config_content = config_path.read_text()
                 if not _parse_share_instance(config_content):
-                    print("  Cause: share_instance not enabled in [reticulum] config")
-                    print("  Port 37428 requires share_instance = Yes")
+                    print("  Cause: share_instance not enabled in config")
+                    print("  (pre-flight fix may not have applied due to config drift)")
+        except Exception:
+            pass
 
+        # Diagnostic 4: Config drift (more accurate now that rnsd is running,
+        # can read /proc/<pid>/cmdline for actual config path)
+        try:
+            drift = detect_rnsd_config_drift()
+            if drift.drifted:
+                print(f"  Config drift: gateway reads {drift.gateway_config_dir}")
+                print(f"                rnsd reads    {drift.rnsd_config_dir}")
+                print(f"  Fix: {drift.fix_hint}")
+        except Exception:
+            pass
+
+        # Diagnostic 5: NomadNet conflict (may have started after pre-flight)
+        try:
+            if self._check_nomadnet_conflict():
+                print("  NomadNet is running (may hold the shared instance)")
+        except Exception:
+            pass
+
+        # Diagnostic 6: Blocking interfaces — offer second chance
+        try:
+            post_blocking = self._find_blocking_interfaces()
+            if post_blocking:
+                print("\n  Blocking interfaces detected:")
+                for iface_name, reason, fix in post_blocking:
+                    print(f"    [{iface_name}] {reason}")
+                if user_declined_disable:
+                    print("\n  These are likely why rnsd is stuck.")
+                    iface_names = [b[0] for b in post_blocking]
+                    names_str = ", ".join(iface_names)
                     if self.dialog.yesno(
-                        "Fix share_instance",
-                        "The shared instance is disabled in the RNS config.\n\n"
-                        "Without it, rnsd won't listen on port 37428\n"
-                        "and no client apps (gateway, rnstatus) can connect.\n\n"
-                        f"Config: {config_path}\n\n"
-                        "Set share_instance = Yes and restart rnsd?"
+                        "Disable Blocking Interfaces?",
+                        f"Blocking interfaces are preventing rnsd\n"
+                        f"from initializing:\n"
+                        f"  {names_str}\n\n"
+                        f"Disable them and restart rnsd?"
                     ):
-                        # Fix the config: replace existing setting or add it
-                        import re as _re
-                        if _re.search(r'^\s*share_instance\s*=', config_content, _re.MULTILINE):
-                            fixed = _re.sub(
-                                r'^(\s*share_instance\s*=\s*).*$',
-                                r'\1Yes',
-                                config_content,
-                                count=1,
-                                flags=_re.MULTILINE
-                            )
-                        elif '[reticulum]' in config_content.lower():
-                            fixed = config_content.replace(
-                                '[reticulum]',
-                                '[reticulum]\n  share_instance = Yes',
-                                1
-                            )
-                        else:
-                            fixed = '[reticulum]\n  share_instance = Yes\n\n' + config_content
-
-                        ok, msg = _sudo_write(str(config_path), fixed)
-                        if ok:
-                            # Verify the write took effect
-                            verify = config_path.read_text()
-                            if not _parse_share_instance(verify):
-                                print("  WARNING: Config write did not take effect")
-                                return False
-                            print("  Fixed: share_instance = Yes")
-                            # Restart and re-check
+                        disabled = self._disable_interfaces_in_config(iface_names)
+                        if disabled:
+                            print(f"  Disabled {len(disabled)} interface(s)")
                             stop_service('rnsd')
                             time.sleep(1)
                             start_service('rnsd')
-                            print("  Waiting for port 37428...")
-                            for _ in range(10):
+                            print("  Waiting for shared instance...")
+                            for _ in range(15):
                                 time.sleep(1)
-                                if check_udp_port(37428):
-                                    print("  SUCCESS: rnsd is now listening on port 37428")
+                                if check_rns_shared_instance():
+                                    si = get_rns_shared_instance_info()
+                                    print(f"  SUCCESS: {si['detail']}")
                                     print("\n" + "=" * 50)
                                     print("RNS shared instance is now available!")
                                     print("=" * 50 + "\n")
                                     return True
-                            print("  Port still not bound after config fix")
-                        else:
-                            print(f"  Could not write config: {msg}")
-                    else:
-                        return False
-        except Exception as e:
-            print(f"  (config check failed: {e})")
+                            print("  Still not available after disabling interfaces")
+        except Exception:
+            pass
 
-        # Fetch recent journal errors to show why port isn't binding
+        # Diagnostic 7: Unfiltered journal (no -p warning filter).
+        # Info-level messages reveal where rnsd is stuck during init.
+        print()
         try:
             r = subprocess.run(
-                ['journalctl', '-u', 'rnsd', '-n', '10', '--no-pager',
-                 '-p', 'warning', '-q', '--no-hostname'],
+                ['journalctl', '-u', 'rnsd', '-n', '15', '--no-pager',
+                 '-q', '--no-hostname'],
                 capture_output=True, text=True, timeout=10
             )
             if r.stdout and r.stdout.strip():
-                print("  Recent rnsd errors:")
-                for line in r.stdout.strip().splitlines()[-5:]:
+                print("  Recent rnsd log:")
+                for line in r.stdout.strip().splitlines()[-10:]:
                     print(f"    {line.strip()[:100]}")
             else:
-                print("  No recent errors in journal")
+                print("  No journal entries for rnsd")
         except (subprocess.SubprocessError, OSError):
             print("  Check logs: sudo journalctl -u rnsd -n 20")
 
+        print("\n  Run RNS > Diagnostics for a full health check.")
         return False
 
     def _validate_rnsd_service_file(self) -> bool:

--- a/src/launcher_tui/rns_monitor_mixin.py
+++ b/src/launcher_tui/rns_monitor_mixin.py
@@ -19,8 +19,8 @@ from utils.rns_status_parser import (
 )
 from utils.safe_import import safe_import
 
-check_service, check_udp_port, start_service, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'check_udp_port', 'start_service',
+check_service, check_udp_port, check_rns_shared_instance, start_service, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'check_udp_port', 'check_rns_shared_instance', 'start_service',
 )
 
 logger = logging.getLogger(__name__)
@@ -168,9 +168,9 @@ class RNSMonitorMixin:
             logger.debug("check_service('rnsd') failed: %s", e)
 
         try:
-            result['port_bound'] = check_udp_port(37428)
+            result['port_bound'] = check_rns_shared_instance()
         except Exception as e:
-            logger.debug("check_udp_port(37428) failed: %s", e)
+            logger.debug("check_rns_shared_instance failed: %s", e)
 
         # Get PID via pgrep
         try:

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -19,6 +19,7 @@ from utils.service_check import (
     check_systemd_service, check_process_running, check_service,
     apply_config_and_restart, enable_service, start_service, stop_service,
     restart_service, ServiceState, _sudo_cmd, check_udp_port,
+    check_rns_shared_instance,
     lock_port_external, unlock_port_external,
     check_port_locked, persist_iptables,
 )
@@ -453,9 +454,9 @@ class ServiceMenuMixin:
                     warnings.append(svc)
 
                 if svc_status.available:
-                    # rnsd zombie detection: systemd active but port not bound
-                    if svc == 'rnsd' and not check_udp_port(37428):
-                        print(f"  \033[0;33m●\033[0m {svc:<18} running (port 37428 not bound)")
+                    # rnsd zombie detection: systemd active but shared instance not available
+                    if svc == 'rnsd' and not check_rns_shared_instance():
+                        print(f"  \033[0;33m●\033[0m {svc:<18} running (shared instance not available)")
                     else:
                         print(f"  \033[0;32m●\033[0m {svc:<18} running{boot_info}")
                 elif svc_status.state in (ServiceState.FAILED, ServiceState.DEGRADED):

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -37,8 +37,8 @@ from utils.safe_import import safe_import
 logger = logging.getLogger(__name__)
 
 # Import service check utilities
-check_service, ServiceState, ServiceStatus, _check_udp_port_fn, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'ServiceState', 'ServiceStatus', 'check_udp_port'
+check_service, ServiceState, ServiceStatus, _check_udp_port_fn, _check_rns_shared_instance_fn, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'ServiceState', 'ServiceStatus', 'check_udp_port', 'check_rns_shared_instance'
 )
 
 from utils import ports
@@ -428,11 +428,13 @@ class StartupChecker:
     def _check_port(self, port: int, port_type: str = 'tcp') -> bool:
         """Check if a port is open.
 
-        For UDP ports, uses centralized check_udp_port() which queries
-        kernel socket state via ss(8) — reliable even when the service
-        sets SO_REUSEADDR.
+        For RNS (unix_socket), uses check_rns_shared_instance() which checks
+        abstract domain sockets (Linux default) and falls back to TCP/UDP.
+        For UDP ports, uses centralized check_udp_port().
         """
         try:
+            if port_type == 'unix_socket' and _HAS_SERVICE_CHECK:
+                return _check_rns_shared_instance_fn()
             if port_type == 'udp' and _HAS_SERVICE_CHECK:
                 return _check_udp_port_fn(port)
 

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -26,7 +26,7 @@ from typing import Dict, Optional, List
 logger = logging.getLogger(__name__)
 
 # Import centralized service checking
-from utils.service_check import check_systemd_service, check_process_running, check_udp_port
+from utils.service_check import check_systemd_service, check_process_running, check_udp_port, check_rns_shared_instance
 
 # Import startup checker for enhanced status
 from startup_checks import StartupChecker, EnvironmentState, ServiceRunState
@@ -184,10 +184,10 @@ class StatusBar:
             is_running, _ = check_systemd_service(service)
             if not is_running:
                 return SYM_STOPPED
-            # rnsd zombie detection: systemd active but port not bound
+            # rnsd zombie detection: systemd active but shared instance not available
             if service == 'rnsd':
-                if not check_udp_port(_RNS_PORT):
-                    logger.debug("rnsd active but port %d not bound", _RNS_PORT)
+                if not check_rns_shared_instance():
+                    logger.debug("rnsd active but shared instance not available")
                     return SYM_STOPPED
             return SYM_RUNNING
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):

--- a/src/utils/active_health_probe.py
+++ b/src/utils/active_health_probe.py
@@ -39,7 +39,7 @@ from typing import Callable, Dict, Optional, List
 from enum import Enum
 
 from utils.event_bus import emit_service_status
-from utils.service_check import check_udp_port
+from utils.service_check import check_udp_port, check_rns_shared_instance
 
 logger = logging.getLogger(__name__)
 
@@ -407,19 +407,19 @@ class ActiveHealthProbe:
 
     def check_rns_port(self, port: int = 37428, host: str = "127.0.0.1") -> HealthResult:
         """
-        Probe RNS shared instance port.
+        Probe RNS shared instance availability.
 
-        Uses check_udp_port() from service_check which reads
-        /proc/net/udp for reliable detection.
+        Uses check_rns_shared_instance() which checks abstract Unix domain
+        sockets (Linux default), TCP, and UDP for reliable detection.
 
         Args:
-            port: RNS shared instance port (default: 37428)
+            port: RNS shared instance port for TCP/UDP fallback (default: 37428)
             host: Host to check (default: 127.0.0.1)
         """
         try:
-            if check_udp_port(port, host):
-                return HealthResult(healthy=True, reason="port_bound")
-            return HealthResult(healthy=False, reason="port_not_bound")
+            if check_rns_shared_instance(port=port):
+                return HealthResult(healthy=True, reason="shared_instance_available")
+            return HealthResult(healthy=False, reason="shared_instance_unavailable")
         except Exception as e:
             return HealthResult(healthy=False, reason=f"check_error: {e}")
 

--- a/src/utils/gateway_diagnostic.py
+++ b/src/utils/gateway_diagnostic.py
@@ -921,16 +921,16 @@ def diagnose_rnsd_connection(rns_pids: List[int], error: Exception = None) -> No
     import logging
     _log = logging.getLogger(__name__)
 
-    # 1. Check if shared instance port is actually listening
+    # 1. Check if shared instance is actually available
     try:
-        from utils.service_check import check_udp_port
-        port_listening = check_udp_port(37428)
+        from utils.service_check import check_rns_shared_instance
+        port_listening = check_rns_shared_instance()
     except ImportError:
         port_listening = None  # Can't check
 
     if rns_pids and port_listening is False:
         _log.warning(
-            "rnsd PID %d exists but port 37428 not listening "
+            "rnsd PID %d exists but shared instance not available "
             "(zombie or hung during init)", rns_pids[0]
         )
     elif rns_pids and port_listening is True:

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -1117,30 +1117,14 @@ class MapDataCollector:
         """
         features = []
 
-        # Quick check if rnsd shared instance is running (UDP port 37428)
+        # Quick check if rnsd shared instance is available
         try:
-            from utils.service_check import check_udp_port
-            if not check_udp_port(37428):
-                logger.debug("rnsd shared instance not available on port 37428")
+            from utils.service_check import check_rns_shared_instance
+            if not check_rns_shared_instance():
+                logger.debug("rnsd shared instance not available")
                 return []
         except ImportError:
-            # Fallback: inline UDP bind test
-            try:
-                sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-                sock.settimeout(2)
-                sock.bind(('127.0.0.1', 37428))
-                sock.close()
-                # Bind succeeded = port NOT in use
-                logger.debug("rnsd shared instance not available on port 37428")
-                return []
-            except OSError as e:
-                if e.errno not in (98, 48, 10048):  # Not EADDRINUSE = real error
-                    return []
-            finally:
-                try:
-                    sock.close()
-                except Exception:
-                    pass
+            pass  # Proceed without pre-check
 
         if not _HAS_RNS:
             logger.debug("RNS module not available for direct query")

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -64,6 +64,8 @@ __all__ = [
     'require_service',      # Check with exception on failure
     'check_port',           # TCP port check (utility)
     'check_udp_port',       # UDP port check (utility)
+    'check_rns_shared_instance',  # RNS shared instance check (domain socket + TCP + UDP)
+    'get_rns_shared_instance_info',  # RNS shared instance diagnostics
     'get_udp_port_owner',   # UDP port owner lookup (process name + PID)
     'check_process_running', # Process check via pgrep (utility)
     'check_systemd_service', # Systemd status check
@@ -130,7 +132,7 @@ KNOWN_SERVICES = {
     },
     'rnsd': {
         'port': RNS_SHARED_INSTANCE_PORT,
-        'port_type': 'udp',
+        'port_type': 'unix_socket',  # RNS uses abstract domain sockets on Linux
         'systemd_name': 'rnsd',
         'is_systemd': True,  # rnsd runs as systemd service (install_noc.sh creates unit)
         'description': 'Reticulum Network Stack daemon',
@@ -400,6 +402,103 @@ def get_udp_port_owner(port: int) -> Optional[Tuple[str, int]]:
             continue
 
     return None
+
+
+def check_rns_shared_instance(instance_name: str = 'default',
+                               port: int = 37428) -> bool:
+    """Check if the RNS shared instance is accepting connections.
+
+    RNS uses abstract Unix domain sockets on Linux by default
+    (``\\0rns/{instance_name}``).  Falls back to TCP port 37428 when
+    ``shared_instance_type = tcp`` is configured or on platforms
+    without AF_UNIX support.
+
+    Checks in priority order:
+        1. Abstract Unix domain socket (Linux default)
+        2. TCP port (fallback)
+        3. UDP port (legacy)
+
+    Args:
+        instance_name: RNS instance name (default: ``'default'``).
+        port: Shared instance port for TCP/UDP fallback (default: 37428).
+
+    Returns:
+        True if the shared instance is reachable via any method.
+    """
+    info = get_rns_shared_instance_info(instance_name, port)
+    return info['available']
+
+
+def get_rns_shared_instance_info(instance_name: str = 'default',
+                                  port: int = 37428) -> dict:
+    """Get detailed shared instance connectivity info for diagnostics.
+
+    Returns a dict with keys:
+        - ``available`` (bool): Whether shared instance is reachable.
+        - ``method`` (str): Detection method that succeeded
+          (``'unix_socket'``, ``'tcp'``, ``'udp'``, or ``'none'``).
+        - ``detail`` (str): Human-readable connection detail.
+
+    Args:
+        instance_name: RNS instance name (default: ``'default'``).
+        port: Shared instance port for TCP/UDP fallback (default: 37428).
+    """
+    # 1. Abstract Unix domain socket (Linux default for RNS)
+    # RNS uses abstract namespace: \0rns/{instance_name}
+    socket_path = f'\0rns/{instance_name}'
+    if hasattr(socket, 'AF_UNIX'):
+        try:
+            sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            sock.settimeout(2)
+            sock.connect(socket_path)
+            sock.close()
+            return {
+                'available': True,
+                'method': 'unix_socket',
+                'detail': f'@rns/{instance_name} (abstract domain socket)',
+            }
+        except (OSError, ConnectionRefusedError):
+            pass
+        finally:
+            try:
+                sock.close()
+            except Exception:
+                pass
+
+    # 2. TCP port (used when shared_instance_type = tcp)
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(2)
+        sock.connect(('127.0.0.1', port))
+        sock.close()
+        return {
+            'available': True,
+            'method': 'tcp',
+            'detail': f'127.0.0.1:{port} (TCP)',
+        }
+    except (OSError, ConnectionRefusedError):
+        pass
+    finally:
+        try:
+            sock.close()
+        except Exception:
+            pass
+
+    # 3. UDP port (legacy fallback)
+    if check_udp_port(port):
+        return {
+            'available': True,
+            'method': 'udp',
+            'detail': f'127.0.0.1:{port} (UDP)',
+        }
+
+    return {
+        'available': False,
+        'method': 'none',
+        'detail': (f'No shared instance found '
+                   f'(checked @rns/{instance_name}, '
+                   f'TCP:{port}, UDP:{port})'),
+    }
 
 
 def check_process_running(process_name: str) -> bool:

--- a/tests/test_service_check.py
+++ b/tests/test_service_check.py
@@ -12,8 +12,10 @@ import subprocess
 from src.utils.service_check import (
     check_port,
     check_process_with_pid,
+    check_rns_shared_instance,
     check_service,
     check_systemd_service,
+    get_rns_shared_instance_info,
     require_service,
     daemon_reload,
     enable_service,
@@ -225,9 +227,9 @@ class TestKnownServices:
         """Test rnsd configuration."""
         assert 'rnsd' in KNOWN_SERVICES
         config = KNOWN_SERVICES['rnsd']
-        # rnsd uses UDP shared instance port (37428)
+        # rnsd uses abstract Unix domain sockets on Linux (port for fallback)
         assert config['port'] == 37428
-        assert config['port_type'] == 'udp'
+        assert config['port_type'] == 'unix_socket'
 
     def test_nomadnet_config(self):
         """Test NomadNet configuration in KNOWN_SERVICES."""
@@ -518,3 +520,242 @@ class TestCheckProcessWithPid:
 
             assert running is False
             assert pid is None
+
+
+class TestCheckRNSSharedInstance:
+    """Tests for check_rns_shared_instance function."""
+
+    def test_detects_unix_domain_socket(self):
+        """Test detection via abstract Unix domain socket (Linux default)."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+            # connect succeeds (no exception)
+
+            result = check_rns_shared_instance()
+
+            assert result is True
+            # Verify AF_UNIX socket was created
+            mock_socket_cls.assert_called_with(socket.AF_UNIX, socket.SOCK_STREAM)
+            mock_sock.connect.assert_called_once_with('\0rns/default')
+
+    def test_falls_back_to_tcp(self):
+        """Test TCP fallback when domain socket fails."""
+        call_count = 0
+
+        def socket_factory(family, sock_type):
+            nonlocal call_count
+            call_count += 1
+            mock_sock = MagicMock()
+            if family == socket.AF_UNIX:
+                # Domain socket fails
+                mock_sock.connect.side_effect = ConnectionRefusedError()
+            elif family == socket.AF_INET:
+                # TCP succeeds
+                pass
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            result = check_rns_shared_instance()
+
+            assert result is True
+            assert call_count >= 2  # AF_UNIX tried, then AF_INET
+
+    def test_falls_back_to_udp(self):
+        """Test UDP fallback when both domain socket and TCP fail."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            # Both AF_UNIX and AF_INET fail
+            mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=True) as mock_udp:
+                result = check_rns_shared_instance()
+
+                assert result is True
+                mock_udp.assert_called_once_with(37428)
+
+    def test_all_methods_fail(self):
+        """Test returns False when no connection method works."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=False):
+                result = check_rns_shared_instance()
+
+                assert result is False
+
+    def test_custom_instance_name(self):
+        """Test custom RNS instance name in socket path."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+
+            result = check_rns_shared_instance(instance_name='myinstance')
+
+            assert result is True
+            mock_sock.connect.assert_called_once_with('\0rns/myinstance')
+
+    def test_custom_port(self):
+        """Test custom port for TCP/UDP fallback."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=False) as mock_udp:
+                check_rns_shared_instance(port=9999)
+
+                mock_udp.assert_called_once_with(9999)
+
+    def test_no_af_unix_support(self):
+        """Test platforms without AF_UNIX (falls through to TCP)."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+            # TCP succeeds
+
+            with patch.object(socket, 'AF_UNIX', create=False):
+                # Remove AF_UNIX attribute to simulate platforms without it
+                with patch('builtins.hasattr', side_effect=lambda obj, name: False if name == 'AF_UNIX' else hasattr(obj, name)):
+                    result = check_rns_shared_instance()
+
+                    assert result is True
+                    # Should have used AF_INET (TCP), not AF_UNIX
+                    mock_socket_cls.assert_called_with(socket.AF_INET, socket.SOCK_STREAM)
+
+    def test_socket_timeout_treated_as_failure(self):
+        """Test that socket timeout is treated as unavailable."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            mock_sock.connect.side_effect = OSError("Connection timed out")
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=False):
+                result = check_rns_shared_instance()
+
+                assert result is False
+
+
+class TestGetRNSSharedInstanceInfo:
+    """Tests for get_rns_shared_instance_info function."""
+
+    def test_unix_socket_info(self):
+        """Test info dict when connected via domain socket."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+
+            info = get_rns_shared_instance_info()
+
+            assert info['available'] is True
+            assert info['method'] == 'unix_socket'
+            assert '@rns/default' in info['detail']
+            assert 'abstract domain socket' in info['detail']
+
+    def test_tcp_info(self):
+        """Test info dict when connected via TCP."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            if family == socket.AF_UNIX:
+                mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            info = get_rns_shared_instance_info()
+
+            assert info['available'] is True
+            assert info['method'] == 'tcp'
+            assert '127.0.0.1:37428' in info['detail']
+            assert 'TCP' in info['detail']
+
+    def test_udp_info(self):
+        """Test info dict when detected via UDP."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=True):
+                info = get_rns_shared_instance_info()
+
+                assert info['available'] is True
+                assert info['method'] == 'udp'
+                assert 'UDP' in info['detail']
+
+    def test_unavailable_info(self):
+        """Test info dict when no method works."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            with patch('src.utils.service_check.check_udp_port', return_value=False):
+                info = get_rns_shared_instance_info()
+
+                assert info['available'] is False
+                assert info['method'] == 'none'
+                assert '@rns/default' in info['detail']
+                assert 'TCP:37428' in info['detail']
+                assert 'UDP:37428' in info['detail']
+
+    def test_info_has_required_keys(self):
+        """Test that info dict always has required keys."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+
+            info = get_rns_shared_instance_info()
+
+            assert 'available' in info
+            assert 'method' in info
+            assert 'detail' in info
+            assert isinstance(info['available'], bool)
+            assert isinstance(info['method'], str)
+            assert isinstance(info['detail'], str)
+
+    def test_custom_instance_name_in_detail(self):
+        """Test custom instance name appears in detail string."""
+        with patch('socket.socket') as mock_socket_cls:
+            mock_sock = MagicMock()
+            mock_socket_cls.return_value = mock_sock
+
+            info = get_rns_shared_instance_info(instance_name='testnet')
+
+            assert '@rns/testnet' in info['detail']
+
+    def test_custom_port_in_tcp_detail(self):
+        """Test custom port appears in TCP fallback detail."""
+        def socket_factory(family, sock_type):
+            mock_sock = MagicMock()
+            if family == socket.AF_UNIX:
+                mock_sock.connect.side_effect = ConnectionRefusedError()
+            return mock_sock
+
+        with patch('socket.socket', side_effect=socket_factory):
+            info = get_rns_shared_instance_info(port=9999)
+
+            assert info['available'] is True
+            assert '127.0.0.1:9999' in info['detail']
+
+
+class TestRNSSharedInstanceExports:
+    """Tests for RNS shared instance function exports."""
+
+    def test_check_rns_shared_instance_exported(self):
+        """Verify check_rns_shared_instance is in __all__."""
+        from src.utils import service_check
+        assert 'check_rns_shared_instance' in service_check.__all__
+
+    def test_get_rns_shared_instance_info_exported(self):
+        """Verify get_rns_shared_instance_info is in __all__."""
+        from src.utils import service_check
+        assert 'get_rns_shared_instance_info' in service_check.__all__

--- a/tests/test_status_bar.py
+++ b/tests/test_status_bar.py
@@ -121,47 +121,47 @@ class TestServiceChecks:
 
 
 class TestRnsdZombieDetection:
-    """Test rnsd zombie detection: systemd active but port not bound."""
+    """Test rnsd zombie detection: systemd active but shared instance not available."""
 
     def test_rnsd_zombie_shows_stopped(self):
-        """rnsd active in systemd but port 37428 not bound → stopped."""
+        """rnsd active in systemd but shared instance not available → stopped."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar.check_udp_port', return_value=False):
+            with patch('status_bar.check_rns_shared_instance', return_value=False):
                 result = bar._check_systemd_active('rnsd')
         assert result == SYM_STOPPED
 
     def test_rnsd_healthy_shows_running(self):
-        """rnsd active in systemd and port 37428 bound → running."""
+        """rnsd active in systemd and shared instance available → running."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar.check_udp_port', return_value=True):
+            with patch('status_bar.check_rns_shared_instance', return_value=True):
                 result = bar._check_systemd_active('rnsd')
         assert result == SYM_RUNNING
 
-    def test_rnsd_systemd_inactive_skips_port_check(self):
-        """rnsd not active in systemd → stopped without port check."""
+    def test_rnsd_systemd_inactive_skips_instance_check(self):
+        """rnsd not active in systemd → stopped without shared instance check."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(False, False)):
-            with patch('status_bar.check_udp_port') as mock_udp:
+            with patch('status_bar.check_rns_shared_instance') as mock_rns:
                 result = bar._check_systemd_active('rnsd')
-        mock_udp.assert_not_called()
+        mock_rns.assert_not_called()
         assert result == SYM_STOPPED
 
-    def test_meshtasticd_no_port_check(self):
-        """meshtasticd should not trigger UDP port check."""
+    def test_meshtasticd_no_instance_check(self):
+        """meshtasticd should not trigger RNS shared instance check."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar.check_udp_port') as mock_udp:
+            with patch('status_bar.check_rns_shared_instance') as mock_rns:
                 result = bar._check_systemd_active('meshtasticd')
-        mock_udp.assert_not_called()
+        mock_rns.assert_not_called()
         assert result == SYM_RUNNING
 
-    def test_udp_check_unavailable_falls_through(self):
-        """When check_udp_port raises OSError, exception is caught gracefully."""
+    def test_instance_check_unavailable_falls_through(self):
+        """When check_rns_shared_instance raises OSError, exception is caught."""
         bar = StatusBar(version="1.0")
         with patch('status_bar.check_systemd_service', return_value=(True, True)):
-            with patch('status_bar.check_udp_port', side_effect=OSError("unavailable")):
+            with patch('status_bar.check_rns_shared_instance', side_effect=OSError("unavailable")):
                 result = bar._check_systemd_active('rnsd')
         # OSError caught by the try/except → SYM_UNKNOWN
         assert result in (SYM_UNKNOWN, SYM_STOPPED)

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -122,17 +122,17 @@ class TestServiceCheckContract:
             assert result is not None, "check_service should never return None"
 
     def test_rnsd_check_uses_udp_port(self):
-        """rnsd status check should include UDP port 37428 check."""
+        """rnsd status check should use shared instance detection."""
         from src.utils.service_check import KNOWN_SERVICES
 
-        # Verify rnsd is configured with UDP port
+        # Verify rnsd is configured with unix_socket (abstract domain socket)
         assert 'rnsd' in KNOWN_SERVICES, "rnsd should be in KNOWN_SERVICES"
         rnsd_config = KNOWN_SERVICES['rnsd']
-        # Port may be the constant value 37428
+        # Port retained for TCP/UDP fallback
         assert rnsd_config.get('port') == 37428, \
-            "rnsd should be configured with UDP port 37428"
-        assert rnsd_config.get('port_type') == 'udp', \
-            "rnsd should be configured with port_type 'udp'"
+            "rnsd should be configured with fallback port 37428"
+        assert rnsd_config.get('port_type') == 'unix_socket', \
+            "rnsd should be configured with port_type 'unix_socket'"
 
 
 class TestRnsdStatusAcrossUIs:


### PR DESCRIPTION
## Summary
This PR replaces direct UDP port 37428 checks with a new `check_rns_shared_instance()` function that properly detects RNS shared instance availability across multiple connection methods. RNS uses abstract Unix domain sockets on Linux by default (not UDP), so the previous port-only checks were incomplete and misleading.

## Key Changes

- **New shared instance detection functions** in `src/utils/service_check.py`:
  - `check_rns_shared_instance(instance_name, port)`: Returns boolean indicating if shared instance is reachable
  - `get_rns_shared_instance_info(instance_name, port)`: Returns detailed diagnostics dict with method (`unix_socket`, `tcp`, `udp`, or `none`) and human-readable detail string
  - Both functions check in priority order: abstract Unix domain socket → TCP → UDP

- **Updated RNS repair flow** in `src/launcher_tui/rns_menu_mixin.py`:
  - Added pre-flight checks for `share_instance = Yes` config setting (required for shared instance to work)
  - Added config drift detection (gateway vs rnsd config paths)
  - Added NomadNet conflict detection (can hold the shared instance port)
  - Replaced port-only checks with `check_rns_shared_instance()` throughout
  - Enhanced diagnostics when shared instance fails to come up (shows which method failed, port owner, config issues, blocking interfaces)
  - Added second-chance interface disabling if user initially declined

- **Updated diagnostics** in `src/launcher_tui/rns_diagnostics_mixin.py`:
  - Replaced `check_udp_port(37428)` with `check_rns_shared_instance()`
  - Shows connection method in output (e.g., "available (unix_socket)")
  - Improved error messages to reference "shared instance" instead of "port 37428"

- **Updated all service checks** across codebase:
  - `src/launcher_tui/status_bar.py`: Zombie detection now uses shared instance check
  - `src/launcher_tui/quick_actions_mixin.py`: Service status display uses shared instance check
  - `src/launcher_tui/startup_checks.py`: Startup validation uses shared instance check
  - `src/launcher_tui/service_menu_mixin.py`: Service menu uses shared instance check
  - `src/launcher_tui/rns_monitor_mixin.py`: Monitor uses shared instance check
  - `src/commands/rns.py`: Known destinations check uses shared instance detection
  - `src/utils/map_data_collector.py`: Map data collection uses shared instance check
  - `src/utils/active_health_probe.py`: Health probe uses shared instance check
  - `src/cli/diagnose.py`: Diagnostics use shared instance check
  - `src/gateway/node_tracker.py`: Node tracker uses shared instance check
  - `src/utils/gateway_diagnostic.py`: Gateway diagnostics use shared instance check

- **Updated KNOWN_SERVICES** configuration:
  - Changed rnsd `port_type` from `'udp'` to `'unix_socket'` to reflect actual implementation

- **Comprehensive test coverage** in `tests/test_service_check.py`:
  - Tests for Unix domain socket detection (Linux default)
  - Tests for TCP fallback when domain socket unavailable
  - Tests for UDP fallback when both socket and TCP fail
  - Tests for custom instance names and ports
  - Tests for platforms without AF_UNIX support
  - Tests for timeout handling
  - Tests for info dict structure and content

## Implementation Details

The new detection strategy properly reflects how RNS actually works:
- **Linux (default)**: Uses abstract Unix domain socket `\0rns/{instance_name}` for zero-copy IPC
- **Fallback (TCP)**: When `shared_instance_type = tcp` is configured
- **Legacy (UDP)**: Last resort for compatibility

The repair flow now validates configuration *before* attempting restart, catching common issues like disabled `share_instance` setting, config drift between gateway and rnsd, and NomadNet conflicts that

https://claude.ai/code/session_01XbNVM7QT2NqVuS8bmhJx1A