### PR TITLE
fix: Change rnsd port_type from 'udp' to 'unix_socket' in startup_checks

### DIFF
--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -201,7 +201,7 @@ class StartupChecker:
     # Services to check with their expected ports
     SERVICES_TO_CHECK = {
         'meshtasticd': {'port': MESHTASTICD_PORT, 'port_type': 'tcp', 'systemd': True},
-        'rnsd': {'port': RNS_SHARED_INSTANCE_PORT, 'port_type': 'udp', 'systemd': True},
+        'rnsd': {'port': RNS_SHARED_INSTANCE_PORT, 'port_type': 'unix_socket', 'systemd': True},
     }
 
     # Ports that MeshForge needs

--- a/tests/test_status_consistency.py
+++ b/tests/test_status_consistency.py
@@ -134,6 +134,16 @@ class TestServiceCheckContract:
         assert rnsd_config.get('port_type') == 'unix_socket', \
             "rnsd should be configured with port_type 'unix_socket'"
 
+    def test_startup_checks_rnsd_matches_known_services(self):
+        """Startup checks rnsd port_type must match KNOWN_SERVICES."""
+        from src.launcher_tui.startup_checks import StartupChecker
+        from src.utils.service_check import KNOWN_SERVICES
+
+        startup_rnsd = StartupChecker.SERVICES_TO_CHECK['rnsd']
+        known_rnsd = KNOWN_SERVICES['rnsd']
+        assert startup_rnsd['port_type'] == known_rnsd['port_type'], \
+            f"startup_checks port_type '{startup_rnsd['port_type']}' != KNOWN_SERVICES '{known_rnsd['port_type']}'"
+
 
 class TestRnsdStatusAcrossUIs:
     """Integration test: rnsd status should be consistent across all UIs.


### PR DESCRIPTION
startup_checks.py had its own hardcoded SERVICES_TO_CHECK config with port_type 'udp' for rnsd, separate from KNOWN_SERVICES in service_check.py. This caused the backtitle to show "rnsd: UP(no port)" even when rnsd was running correctly — _check_port routed to check_udp_port(37428) instead of check_rns_shared_instance().

Also adds a cross-check test to prevent this kind of config drift between startup_checks and service_check.

https://claude.ai/code/session_01XbNVM7QT2NqVuS8bmhJx1A