### PR TITLE
Fix fullscreen layout by ensuring html and body fill viewport

### DIFF
--- a/web/node_map.html
+++ b/web/node_map.html
@@ -17,11 +17,18 @@
             padding: 0;
             box-sizing: border-box;
         }
+        html {
+            overflow: hidden;
+            height: 100%;
+            width: 100%;
+        }
         body {
             font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
             background: #0a0e1a;
             color: #e0e0e0;
             overflow: hidden;
+            height: 100%;
+            width: 100%;
         }
         #map {
             width: 100%;


### PR DESCRIPTION
## Summary
This change fixes the fullscreen layout of the node map by explicitly setting the html and body elements to fill the entire viewport height and width, and ensuring they don't overflow.

## Key Changes
- Added `overflow: hidden`, `height: 100%`, and `width: 100%` to the `html` element
- Added `height: 100%` and `width: 100%` to the `body` element (which already had `overflow: hidden`)

## Implementation Details
These CSS properties ensure that:
- The html and body elements properly constrain to the viewport dimensions
- No scrollbars appear due to content overflow
- Child elements (like the #map) can properly use percentage-based sizing relative to the full viewport
- The layout remains fixed and fullscreen without unwanted scrolling behavior

https://claude.ai/code/session_0142K3ZvB5mziGy6MSRyXViN