### PR TITLE
fix: Eliminate fromradio contention causing message "waiting for deli…

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -494,14 +494,32 @@ def _run(self):
 - `src/utils/message_listener.py` - Check for existing persistent connection
 - `src/utils/meshtastic_connection.py` - Connection manager
 
-### External Interference
-**Meshtastic Web UI** on port 9443 can also cause connection spam:
-```bash
-netstat -tlnp | grep 9443  # Check if Web UI is running
-```
-User should disable Web UI if not needed, or accept that MeshForge will compete for the connection.
+### HTTP fromradio Contention Fix (2026-02-23)
+
+**Additional root cause**: The `/api/v1/fromradio` HTTP endpoint is also single-consumer.
+When the protobuf client calls `connect()`, it drains all fromradio packets (including
+delivery ACKs) during session setup, starving the meshtasticd web client at :9443 and
+causing "waiting for delivery" hangs. The meshtastic CLI fallback also competes via TCP.
+
+**Fix**: `send_text_direct()` — a stateless TX function that POSTs directly to
+`/api/v1/toradio` without ever reading from `/api/v1/fromradio`. meshtasticd fills
+in the source node number automatically, so no session handshake is needed for sending.
+
+All TX paths now use `send_text_direct()` as primary, with session-based send as fallback:
+- `mqtt_bridge_handler.py` — gateway MQTT bridge TX
+- `mesh_bridge.py` — preset bridge TX
+- `commands/meshtastic.py` — TUI/CLI message sending (before CLI subprocess fallback)
+
+### Files Changed
+- `src/gateway/meshtastic_protobuf_client.py` — Added `send_text_direct()` stateless TX
+- `src/gateway/mqtt_bridge_handler.py` — Stateless TX as primary path
+- `src/gateway/mesh_bridge.py` — Stateless TX as primary path
+- `src/commands/meshtastic.py` — HTTP protobuf before CLI subprocess
 
 ### Prevention
+- **NEVER read from `/api/v1/fromradio` during TX operations**
+- Use `send_text_direct()` for all message sending (write-only to toradio)
+- Reserve session-based `connect()` + `start_polling()` for config read operations only
 - Always use `get_connection_manager()` instead of creating `TCPInterface` directly
 - Check `has_persistent()` before creating connections
 - Use `acquire_persistent(owner="component_name")` for long-lived connections

--- a/src/commands/meshtastic.py
+++ b/src/commands/meshtastic.py
@@ -446,12 +446,51 @@ def send_message(
             # Broadcast - lower hop to reduce congestion
             hop_limit = HOP_LIMIT_BROADCAST
 
-    # Note: meshtastic CLI doesn't have a direct --hop-limit flag for sendtext
-    # The hop limit is set at the device level via lora.hop_limit
-    # For per-message control, we'd need to use the Python API directly
-    # For now, log the intended hop limit for debugging
     logger.debug(f"Sending with intended hop_limit={hop_limit} (device setting applies)")
 
+    # Try HTTP protobuf first — no CLI subprocess, no TCP contention,
+    # no fromradio reads. This prevents "waiting for delivery" hangs on
+    # the meshtasticd web client at :9443.
+    try:
+        from gateway.meshtastic_protobuf_client import send_text_direct
+
+        dest_num = None
+        if dest:
+            try:
+                cleaned = dest.lstrip('!')
+                dest_num = int(cleaned, 16)
+            except ValueError:
+                try:
+                    dest_num = int(dest)
+                except ValueError:
+                    dest_num = None
+
+        if send_text_direct(
+            text=text,
+            destination=dest_num,
+            channel_index=channel_index,
+            want_ack=want_ack,
+            hop_limit=hop_limit,
+        ):
+            is_dm = dest and dest != '!ffffffff'
+            routing_note = (
+                'DM: uses next-hop routing (flood then direct)' if is_dm
+                else 'Broadcast: flooded to mesh'
+            )
+            return CommandResult.ok(
+                message="Message sent via HTTP protobuf",
+                data={
+                    'hop_limit_intended': hop_limit,
+                    'destination': dest,
+                    'channel': channel_index,
+                    'routing_note': routing_note,
+                    'tx_method': 'http_protobuf',
+                },
+            )
+    except Exception as e:
+        logger.debug(f"HTTP protobuf TX unavailable, falling back to CLI: {e}")
+
+    # Fallback: meshtastic CLI (creates TCP connection to 4403)
     # Add destination for DMs
     if dest:
         args.extend(["--dest", dest])
@@ -480,6 +519,7 @@ def send_message(
             'DM: uses next-hop routing (flood then direct)' if dest
             else 'Broadcast: flooded to mesh'
         )
+        result.data['tx_method'] = 'cli'
 
     return result
 

--- a/src/gateway/__init__.py
+++ b/src/gateway/__init__.py
@@ -31,6 +31,7 @@ from .meshtastic_protobuf_client import (
     MeshtasticProtobufClient,
     get_protobuf_client,
     reset_protobuf_client,
+    send_text_direct,
 )
 from .meshtastic_protobuf_ops import (
     ProtobufEventType,
@@ -65,6 +66,7 @@ __all__ = [
     'MeshtasticProtobufClient',
     'get_protobuf_client',
     'reset_protobuf_client',
+    'send_text_direct',
     'ProtobufEventType',
     'ProtobufTransportConfig',
     'DeviceConfigSnapshot',

--- a/src/gateway/mesh_bridge.py
+++ b/src/gateway/mesh_bridge.py
@@ -259,9 +259,31 @@ class MQTTMeshInterface:
         """
         Send text message via HTTP protobuf (compatible with TCPInterface API).
 
-        Primary: HTTP protobuf to /api/v1/toradio.
-        Fallback: Returns False (caller should log error).
+        Primary: Stateless direct POST to /api/v1/toradio — NEVER reads
+        from /api/v1/fromradio, so the web client at :9443 is never
+        starved of delivery ACK packets.
+
+        Fallback: Session-based protobuf client (legacy).
         """
+        dest_num = None
+        if destinationId:
+            dest_num = self._node_id_to_num(destinationId)
+
+        # Primary: stateless direct send — zero fromradio contention
+        try:
+            from .meshtastic_protobuf_client import send_text_direct
+            if send_text_direct(
+                text=text,
+                host=self._config.host,
+                port=self._config.http_port,
+                destination=dest_num,
+                channel_index=channelIndex,
+            ):
+                return True
+        except Exception as e:
+            logger.debug(f"[{self._name}] Stateless TX failed: {e}")
+
+        # Fallback: session-based send (reads fromradio during connect)
         if not _HAS_PROTOBUF_CLIENT or not _HAS_PROTOBUF_CONFIG:
             logger.warning(f"[{self._name}] Protobuf client unavailable for TX")
             return False
@@ -279,17 +301,13 @@ class MQTTMeshInterface:
                     logger.debug(f"[{self._name}] Protobuf client connect failed")
                     return False
 
-            dest_num = None
-            if destinationId:
-                dest_num = self._node_id_to_num(destinationId)
-
             return client.send_text(
                 text=text,
                 destination=dest_num,
                 channel_index=channelIndex,
             )
         except Exception as e:
-            logger.error(f"[{self._name}] HTTP protobuf TX failed: {e}")
+            logger.error(f"[{self._name}] Session-based TX failed: {e}")
             return False
 
     @staticmethod

--- a/src/gateway/meshtastic_protobuf_client.py
+++ b/src/gateway/meshtastic_protobuf_client.py
@@ -71,6 +71,120 @@ else:
 
 
 # ---------------------------------------------------------------------------
+# Stateless TX — NEVER reads /api/v1/fromradio (zero contention)
+# ---------------------------------------------------------------------------
+
+_stateless_packet_counter = random.randint(1, 0xFFFFFFFF)
+_stateless_counter_lock = threading.Lock()
+
+# SSL context for self-signed certs (meshtasticd default) — created once
+_stateless_ssl_ctx = ssl.create_default_context()
+_stateless_ssl_ctx.check_hostname = False
+_stateless_ssl_ctx.verify_mode = ssl.CERT_NONE
+
+
+def _next_stateless_packet_id() -> int:
+    """Generate a unique packet ID for stateless sends (thread-safe)."""
+    global _stateless_packet_counter
+    with _stateless_counter_lock:
+        _stateless_packet_counter = (_stateless_packet_counter + 1) & 0xFFFFFFFF
+        if _stateless_packet_counter == 0:
+            _stateless_packet_counter = 1
+        return _stateless_packet_counter
+
+
+def send_text_direct(
+    text: str,
+    host: str = "localhost",
+    port: int = 9443,
+    tls: bool = True,
+    destination: Optional[int] = None,
+    channel_index: int = 0,
+    want_ack: bool = True,
+    hop_limit: Optional[int] = None,
+    timeout: float = 5.0,
+) -> bool:
+    """Send a text message via HTTP protobuf WITHOUT creating a session.
+
+    This is the preferred TX path for all message sending. It PUTs a
+    serialized ToRadio protobuf to /api/v1/toradio and returns immediately.
+
+    **Critical**: This function NEVER reads from /api/v1/fromradio.
+    The fromradio endpoint is single-consumer — if we read from it, we
+    steal packets (including delivery ACKs) from the meshtasticd web
+    client at :9443, causing "waiting for delivery" hangs.
+
+    meshtasticd fills in the source node number automatically, so no
+    session handshake (want_config_id) is needed for sending.
+
+    Args:
+        text: Message text to send
+        host: meshtasticd hostname
+        port: meshtasticd HTTP port (default 9443)
+        tls: Use HTTPS (default True, meshtasticd default)
+        destination: Destination node number (None = broadcast 0xFFFFFFFF)
+        channel_index: Channel to send on (0 = primary)
+        want_ack: Request delivery acknowledgment from recipient
+        hop_limit: LoRa hop limit (1-7). None = use device default.
+        timeout: HTTP request timeout in seconds
+
+    Returns:
+        True if meshtasticd accepted the packet, False on error
+    """
+    if not _pb2_available:
+        logger.debug("send_text_direct: protobuf not available")
+        return False
+
+    dest = destination if destination is not None else 0xFFFFFFFF
+    packet_id = _next_stateless_packet_id()
+
+    # Build MeshPacket
+    mesh_packet = mesh_pb2.MeshPacket()
+    mesh_packet.decoded.payload = text.encode('utf-8')
+    mesh_packet.decoded.portnum = portnums_pb2.PortNum.TEXT_MESSAGE_APP
+    mesh_packet.decoded.want_response = False
+    mesh_packet.id = packet_id
+    setattr(mesh_packet, 'to', dest)
+    mesh_packet.channel = channel_index
+    mesh_packet.want_ack = want_ack
+    if hop_limit is not None:
+        mesh_packet.hop_limit = hop_limit
+
+    # Wrap in ToRadio
+    to_radio = mesh_pb2.ToRadio()
+    to_radio.packet.CopyFrom(mesh_packet)
+
+    # HTTP PUT to /api/v1/toradio — write-only, no fromradio read
+    scheme = "https" if tls else "http"
+    url = f"{scheme}://{host}:{port}/api/v1/toradio"
+
+    try:
+        req = urllib.request.Request(
+            url,
+            data=to_radio.SerializeToString(),
+            method='PUT',
+            headers={'Content-Type': 'application/x-protobuf'},
+        )
+        ctx = _stateless_ssl_ctx if tls else None
+        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+            if resp.status in (200, 204):
+                logger.info(
+                    f"Sent text via stateless HTTP protobuf "
+                    f"(id={packet_id}, dest={'broadcast' if dest == 0xFFFFFFFF else f'!{dest:08x}'})"
+                )
+                logger.debug(f"Message content: {text[:50]}")
+                return True
+            logger.warning(f"send_text_direct: unexpected status {resp.status}")
+            return False
+    except urllib.error.HTTPError as e:
+        logger.warning(f"send_text_direct: HTTP {e.code}: {e.reason}")
+        return False
+    except Exception as e:
+        logger.debug(f"send_text_direct: {e}")
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Singleton
 # ---------------------------------------------------------------------------
 

--- a/src/gateway/mqtt_bridge_handler.py
+++ b/src/gateway/mqtt_bridge_handler.py
@@ -542,10 +542,30 @@ class MQTTBridgeHandler:
     ) -> bool:
         """Send text via HTTP protobuf transport (preferred TX path).
 
-        Uses MeshtasticProtobufClient.send_text() which POSTs a serialized
-        ToRadio protobuf to /api/v1/toradio. Same endpoint the web client
-        uses — zero TCP contention, no subprocess overhead.
+        Primary: Stateless direct POST to /api/v1/toradio — NEVER reads
+        from /api/v1/fromradio, so the web client at :9443 is never
+        starved of delivery ACK packets.
+
+        Fallback: Session-based protobuf client (legacy, only if direct
+        send fails).
         """
+        # Convert hex node ID string to int (e.g. "!aabbccdd" -> 0xaabbccdd)
+        dest_num = None
+        if destination:
+            dest_num = self._node_id_to_num(destination)
+
+        # Primary: stateless direct send — zero fromradio contention
+        try:
+            from .meshtastic_protobuf_client import send_text_direct
+            host = self.config.meshtastic.host
+            http_port = getattr(self.config.meshtastic, 'http_port', 9443) or 9443
+            if send_text_direct(text=message, host=host, port=http_port,
+                                destination=dest_num, channel_index=channel):
+                return True
+        except Exception as e:
+            logger.debug(f"Stateless HTTP protobuf TX failed: {e}")
+
+        # Fallback: session-based send (reads fromradio during connect)
         if not _HAS_PROTOBUF_CLIENT:
             return False
 
@@ -559,18 +579,13 @@ class MQTTBridgeHandler:
                     logger.debug("Protobuf client failed to connect for TX")
                     return False
 
-            # Convert hex node ID string to int (e.g. "!aabbccdd" -> 0xaabbccdd)
-            dest_num = None
-            if destination:
-                dest_num = self._node_id_to_num(destination)
-
             return client.send_text(
                 text=message,
                 destination=dest_num,
                 channel_index=channel,
             )
         except Exception as e:
-            logger.debug(f"HTTP protobuf TX failed: {e}")
+            logger.debug(f"Session-based HTTP protobuf TX failed: {e}")
             return False
 
     @staticmethod


### PR DESCRIPTION
…very" hangs

The meshtasticd web client at :9443 and MeshForge TUI messages hang in "waiting for delivery" because the /api/v1/fromradio endpoint is single- consumer. When MeshForge's protobuf client calls connect() during TX, it drains all fromradio packets (including delivery ACKs), starving the web client. The CLI fallback also competes via TCP port 4403.

Fix: Add send_text_direct() — a stateless TX function that PUTs directly to /api/v1/toradio without ever reading from /api/v1/fromradio. meshtasticd fills in the source node number automatically, so no session handshake is needed for sending. All TX paths now use this as primary with session-based/CLI as fallback.

https://claude.ai/code/session_01BNSdvJUXECsGf7zpjRjGdA