### PR TITLE
Replace safe_import fallback with direct imports in startup_checks

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -159,6 +159,9 @@ _home, _HAS_PATHS = safe_import('utils.paths', 'get_real_user_home')
 ### Resolution (2026-02-20)
 Consolidated 20 files from `safe_import('utils.paths', ...)` fallback patterns to direct `from utils.paths import get_real_user_home`. Net -220 lines removed.
 
+### Follow-up (2026-02-23)
+Review found `startup_checks.py` still used `safe_import('utils.service_check', ...)` with `_HAS_SERVICE_CHECK` guard — converted to direct import. The guard created a dead fallback path that would silently revert RNS socket detection to broken UDP-only behavior.
+
 ---
 
 ## Development Checklist
@@ -773,9 +776,20 @@ def _on_message(self, event):
 - `src/utils/websocket_server.py` — Subscribes to event_bus, broadcasts to WebSocket clients
 - `src/launcher_tui/messaging_mixin.py` — TUI live feed subscribes to message events
 
+### RNS Socket Detection Enhancement (2026-02-22, PRs #920-922)
+RNS uses abstract Unix domain sockets (`\0rns/{instance_name}`), not UDP port 37428.
+All 20+ `check_udp_port(37428)` calls replaced with `check_rns_shared_instance()` which
+uses 3-tier detection: abstract Unix socket -> TCP -> UDP fallback. KNOWN_SERVICES rnsd
+`port_type` changed from `'udp'` to `'unix_socket'`. 18 unit tests added; consistency
+test prevents drift between `startup_checks.SERVICES_TO_CHECK` and `KNOWN_SERVICES`.
+
+Stale docstring in `status_bar.py` (said "UDP port 37428") and `safe_import` for
+first-party `utils.service_check` in `startup_checks.py` cleaned up 2026-02-23.
+
 ### Prevention
 - Don't add more detection fallback methods - simplify instead
 - UI should always distinguish "service state" from "detection capability"
+- Use `check_rns_shared_instance()` for all rnsd reachability checks (never raw UDP)
 
 ---
 

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -32,13 +32,12 @@ from pathlib import Path
 from typing import List, Dict, Optional, Tuple
 from enum import Enum
 
-from utils.safe_import import safe_import
-
 logger = logging.getLogger(__name__)
 
-# Import service check utilities
-check_service, ServiceState, ServiceStatus, _check_udp_port_fn, _check_rns_shared_instance_fn, _HAS_SERVICE_CHECK = safe_import(
-    'utils.service_check', 'check_service', 'ServiceState', 'ServiceStatus', 'check_udp_port', 'check_rns_shared_instance'
+# Service check utilities — first-party, always available (direct import per Issue #5)
+from utils.service_check import (
+    check_service, ServiceState, ServiceStatus,
+    check_udp_port, check_rns_shared_instance,
 )
 
 from utils import ports
@@ -433,10 +432,10 @@ class StartupChecker:
         For UDP ports, uses centralized check_udp_port().
         """
         try:
-            if port_type == 'unix_socket' and _HAS_SERVICE_CHECK:
-                return _check_rns_shared_instance_fn()
-            if port_type == 'udp' and _HAS_SERVICE_CHECK:
-                return _check_udp_port_fn(port)
+            if port_type == 'unix_socket':
+                return check_rns_shared_instance()
+            if port_type == 'udp':
+                return check_udp_port(port)
 
             sock_type = socket.SOCK_STREAM if port_type == 'tcp' else socket.SOCK_DGRAM
             with socket.socket(socket.AF_INET, sock_type) as sock:

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -171,8 +171,9 @@ class StatusBar:
         """Check if a systemd service is active.
 
         Uses centralized service_check module when available.
-        For rnsd, also verifies UDP port 37428 is bound — systemd can
-        report "active" while the service fails to bind its port (zombie).
+        For rnsd, also verifies the RNS shared instance is reachable —
+        systemd can report "active" while the service fails to bind its
+        socket (zombie).
 
         Args:
             service: Service unit name.


### PR DESCRIPTION
## Summary
Removes the `safe_import()` fallback pattern from `startup_checks.py` for the first-party `utils.service_check` module, converting to direct imports. This eliminates a dead code path that would silently degrade RNS socket detection to broken UDP-only behavior if the import failed.

## Changes
- **startup_checks.py**: 
  - Replaced `safe_import('utils.service_check', ...)` with direct `from utils.service_check import ...`
  - Removed `_HAS_SERVICE_CHECK` guard checks in `_check_port()` method
  - Updated function calls from `_check_udp_port_fn()` and `_check_rns_shared_instance_fn()` to direct calls `check_udp_port()` and `check_rns_shared_instance()`
  - Added clarifying comment that service_check is first-party and always available

- **status_bar.py**: 
  - Updated docstring to reference "RNS shared instance" instead of "UDP port 37428" for accuracy

- **persistent_issues.md**: 
  - Documented this follow-up fix to the earlier `safe_import` consolidation work

## Implementation Details
The `_HAS_SERVICE_CHECK` guard was a vestigial safety check that would cause the code to fall back to raw socket checks if the service_check module failed to import. Since `utils.service_check` is a first-party module that's always available in the codebase, this guard created an unnecessary fallback path. Removing it simplifies the code and ensures RNS socket detection always uses the proper `check_rns_shared_instance()` method rather than potentially degrading to UDP-only checks.

https://claude.ai/code/session_01VoDLzX3jBcBNLKunncsr9y