### PR TITLE
Fix broken ALSA udev rules on Raspberry Pi OS

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -396,6 +396,35 @@ if ls /usr/lib/python3*/EXTERNALLY-MANAGED 1>/dev/null 2>&1; then
 fi
 
 # ─────────────────────────────────────────────────────────────────
+# Fix known ALSA udev packaging bug (RPi OS)
+# 90-alsa-restore.rules may have GOTO targets with no matching LABEL
+# ─────────────────────────────────────────────────────────────────
+ALSA_RULES="/usr/lib/udev/rules.d/90-alsa-restore.rules"
+if [[ -f "$ALSA_RULES" ]] && [[ ! -f /etc/udev/rules.d/90-alsa-restore.rules ]]; then
+    NEEDS_FIX=false
+    while IFS= read -r goto_label; do
+        if ! grep -q "LABEL=\"$goto_label\"" "$ALSA_RULES"; then
+            NEEDS_FIX=true
+            break
+        fi
+    done < <(grep -oP 'GOTO="\K[^"]+' "$ALSA_RULES" | sort -u)
+
+    if $NEEDS_FIX; then
+        echo -e "  ${YELLOW}Fixing broken ALSA udev rules (RPi OS packaging bug)...${NC}"
+        cp "$ALSA_RULES" /etc/udev/rules.d/90-alsa-restore.rules
+        # Append missing LABEL declarations before EOF
+        while IFS= read -r goto_label; do
+            if ! grep -q "LABEL=\"$goto_label\"" "$ALSA_RULES"; then
+                echo "LABEL=\"$goto_label\"" >> /etc/udev/rules.d/90-alsa-restore.rules
+                echo "    Added missing LABEL=\"$goto_label\""
+            fi
+        done < <(grep -oP 'GOTO="\K[^"]+' "$ALSA_RULES" | sort -u)
+        udevadm control --reload-rules 2>/dev/null || true
+        echo -e "  ${GREEN}ALSA udev rules fixed${NC}"
+    fi
+fi
+
+# ─────────────────────────────────────────────────────────────────
 # Install meshtasticd (auto-detect USB vs SPI)
 # ─────────────────────────────────────────────────────────────────
 if $INSTALL_MESHTASTICD; then

--- a/scripts/verify_post_install.sh
+++ b/scripts/verify_post_install.sh
@@ -319,6 +319,28 @@ else
         "May cause permission issues with USB radios"
 fi
 
+# Check ALSA udev rules for broken GOTO labels (RPi OS packaging bug)
+ALSA_RULES="/usr/lib/udev/rules.d/90-alsa-restore.rules"
+if [[ -f "$ALSA_RULES" ]]; then
+    BROKEN_GOTOS=""
+    while IFS= read -r goto_label; do
+        if ! grep -q "LABEL=\"$goto_label\"" "$ALSA_RULES"; then
+            BROKEN_GOTOS="${BROKEN_GOTOS:+$BROKEN_GOTOS, }$goto_label"
+        fi
+    done < <(grep -oP 'GOTO="\K[^"]+' "$ALSA_RULES" | sort -u)
+
+    if [[ -n "$BROKEN_GOTOS" ]]; then
+        if [[ -f /etc/udev/rules.d/90-alsa-restore.rules ]]; then
+            check_pass "ALSA udev rules" "Override exists in /etc/udev/rules.d/"
+        else
+            check_warn "ALSA udev rules" "Broken GOTO labels: $BROKEN_GOTOS" \
+                "Run installer or: sudo python3 -c \"from utils.udev_fix import fix_broken_udev_rules; print(fix_broken_udev_rules())\""
+        fi
+    else
+        check_pass "ALSA udev rules" "No broken GOTO labels"
+    fi
+fi
+
 log ""
 
 # ─────────────────────────────────────────────────────────────────

--- a/src/launcher_tui/startup_checks.py
+++ b/src/launcher_tui/startup_checks.py
@@ -116,6 +116,9 @@ class EnvironmentState:
     is_first_run: bool = False
     config_exists: bool = False
 
+    # System-level warnings (udev bugs, packaging issues, etc.)
+    system_warnings: List[str] = field(default_factory=list)
+
     @property
     def has_conflicts(self) -> bool:
         """Check if there are any port conflicts."""
@@ -251,6 +254,11 @@ class StartupChecker:
 
         # Check first run status
         env.is_first_run, env.config_exists = self._check_first_run()
+
+        # Detect system-level issues (udev packaging bugs, etc.)
+        alsa_warning = self._check_alsa_udev()
+        if alsa_warning:
+            env.system_warnings.append(alsa_warning)
 
         self._cache = env
         return env
@@ -601,6 +609,33 @@ class StartupChecker:
         config_exists = settings_file.exists()
 
         return is_first_run, config_exists
+
+    def _check_alsa_udev(self) -> Optional[str]:
+        """Detect broken ALSA udev rules (RPi OS packaging bug).
+
+        Returns a warning string if broken, None if OK or not applicable.
+        """
+        override = Path("/etc/udev/rules.d/90-alsa-restore.rules")
+        pkg_rules = Path("/usr/lib/udev/rules.d/90-alsa-restore.rules")
+
+        if override.exists() or not pkg_rules.exists():
+            return None
+
+        try:
+            content = pkg_rules.read_text()
+            gotos = set(re.findall(r'GOTO="([^"]+)"', content))
+            labels = set(re.findall(r'LABEL="([^"]+)"', content))
+            missing = gotos - labels
+            if missing:
+                return (
+                    f"ALSA udev rules have broken GOTO labels: {missing} "
+                    f"(fix: sudo python3 -c "
+                    f"\"from utils.udev_fix import fix_broken_udev_rules; "
+                    f"fix_broken_udev_rules()\")"
+                )
+        except OSError:
+            pass
+        return None
 
 
 def resolve_conflict(conflict: PortConflict, action: str = 'stop') -> bool:

--- a/src/utils/diagnostic_rules.py
+++ b/src/utils/diagnostic_rules.py
@@ -278,6 +278,26 @@ def load_mesh_rules(engine: "DiagnosticEngine") -> None:
     # ===== CONFIGURATION RULES =====
 
     engine.add_rule(DiagnosticRule(
+        name="alsa_udev_broken_goto",
+        pattern=r"(?i)(alsa|udev).*(goto|label).*(missing|broken|no matching|ignoring)",
+        category=Category.CONFIGURATION,
+        cause_template=(
+            "ALSA udev rules have GOTO references to non-existent labels. "
+            "This is a known alsa-utils packaging bug on Raspberry Pi OS. "
+            "Harmless but produces udev errors on every boot."
+        ),
+        suggestions=[
+            "Fix automatically: sudo python3 -c "
+            "\"from utils.udev_fix import fix_broken_udev_rules; "
+            "print(fix_broken_udev_rules())\"",
+            "Or re-run the installer: sudo bash scripts/install_noc.sh",
+            "Manual: copy 90-alsa-restore.rules to /etc/udev/rules.d/ "
+            "and add the missing LABEL line",
+        ],
+        confidence_base=0.95,
+    ))
+
+    engine.add_rule(DiagnosticRule(
         name="config_file_missing",
         pattern=r"(?i)(config|configuration).*(missing|not found|does not exist)",
         category=Category.CONFIGURATION,

--- a/src/utils/udev_fix.py
+++ b/src/utils/udev_fix.py
@@ -1,0 +1,107 @@
+"""
+Fix broken udev rules on Raspberry Pi OS.
+
+Detects and fixes the known alsa-utils packaging bug where
+90-alsa-restore.rules contains GOTO targets without matching LABELs.
+
+Fix creates an override in /etc/udev/rules.d/ (never modifies package files
+in /usr/lib/udev/rules.d/).
+"""
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import List, Tuple
+
+from utils.service_check import _sudo_cmd, _sudo_write
+
+logger = logging.getLogger(__name__)
+
+ALSA_RULES_PKG = Path("/usr/lib/udev/rules.d/90-alsa-restore.rules")
+ALSA_RULES_OVERRIDE = Path("/etc/udev/rules.d/90-alsa-restore.rules")
+
+
+def check_broken_udev_rules() -> List[str]:
+    """Return list of GOTO labels missing a matching LABEL in ALSA udev rules.
+
+    Returns empty list if the file doesn't exist, is already overridden,
+    or has no broken references.
+    """
+    if ALSA_RULES_OVERRIDE.exists():
+        return []  # Already overridden
+
+    if not ALSA_RULES_PKG.exists():
+        return []  # Not applicable (no ALSA rules)
+
+    try:
+        content = ALSA_RULES_PKG.read_text()
+    except OSError as e:
+        logger.warning("Cannot read %s: %s", ALSA_RULES_PKG, e)
+        return []
+
+    gotos = set(re.findall(r'GOTO="([^"]+)"', content))
+    labels = set(re.findall(r'LABEL="([^"]+)"', content))
+    return sorted(gotos - labels)
+
+
+def fix_broken_udev_rules() -> Tuple[bool, str]:
+    """Detect and fix broken GOTO labels in ALSA udev rules.
+
+    Reads the package-provided rules file, identifies any GOTO targets
+    without a matching LABEL, and creates a corrected override in
+    /etc/udev/rules.d/.
+
+    Returns:
+        Tuple of (success, message).
+    """
+    if ALSA_RULES_OVERRIDE.exists():
+        return True, "ALSA udev rules already have an override in /etc/udev/rules.d/"
+
+    missing = check_broken_udev_rules()
+    if not missing:
+        return True, "ALSA udev rules are OK (no broken GOTO labels)"
+
+    logger.info("Broken GOTO labels in %s: %s", ALSA_RULES_PKG, missing)
+
+    try:
+        content = ALSA_RULES_PKG.read_text()
+    except OSError as e:
+        return False, f"Cannot read {ALSA_RULES_PKG}: {e}"
+
+    # Insert missing LABELs before the final LABEL (or at EOF)
+    lines = content.splitlines(keepends=True)
+    insert_lines = [f'LABEL="{label}"\n' for label in missing]
+
+    # Find last LABEL line to insert before it
+    last_label_idx = None
+    for i in range(len(lines) - 1, -1, -1):
+        if re.match(r'^LABEL="', lines[i].strip()):
+            last_label_idx = i
+            break
+
+    if last_label_idx is not None:
+        for offset, line in enumerate(insert_lines):
+            lines.insert(last_label_idx + offset, line)
+    else:
+        lines.extend(insert_lines)
+
+    corrected = "".join(lines)
+
+    success, msg = _sudo_write(str(ALSA_RULES_OVERRIDE), corrected)
+    if not success:
+        return False, f"Failed to write override: {msg}"
+
+    # Reload udev rules
+    try:
+        subprocess.run(
+            _sudo_cmd(["udevadm", "control", "--reload-rules"]),
+            capture_output=True,
+            timeout=10,
+        )
+        logger.info("udev rules reloaded after ALSA fix")
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.warning("udevadm reload failed (non-fatal): %s", e)
+
+    labels_str = ", ".join(missing)
+    return True, f"Fixed ALSA udev rules: added missing LABEL(s) {labels_str}"


### PR DESCRIPTION
## Summary
Adds detection and automatic fixing of a known alsa-utils packaging bug on Raspberry Pi OS where the `90-alsa-restore.rules` file contains GOTO directives that reference non-existent LABEL targets. This causes harmless but noisy udev errors on every boot.

## Key Changes

- **New utility module** (`src/utils/udev_fix.py`): Provides functions to detect and fix broken ALSA udev rules
  - `check_broken_udev_rules()`: Identifies missing LABEL targets for GOTO directives
  - `fix_broken_udev_rules()`: Creates an override in `/etc/udev/rules.d/` with corrected rules and reloads udev

- **Startup checks integration** (`src/launcher_tui/startup_checks.py`): 
  - Added `system_warnings` field to `EnvironmentState` to track system-level issues
  - New `_check_alsa_udev()` method to detect the broken rules condition during startup
  - Displays actionable warning to users if the issue is detected

- **Installation script** (`scripts/install_noc.sh`): 
  - Automatically detects and fixes broken ALSA udev rules during installation
  - Creates override file and reloads udev rules without modifying package files

- **Post-install verification** (`scripts/verify_post_install.sh`): 
  - Checks for broken ALSA udev rules and reports status
  - Distinguishes between fixed (override exists) and unfixed states

- **Diagnostic rules** (`src/utils/diagnostic_rules.py`): 
  - Added diagnostic rule to detect ALSA udev issues in system logs
  - Provides users with multiple fix options

## Implementation Details

- The fix creates an override in `/etc/udev/rules.d/` rather than modifying the package-provided file in `/usr/lib/udev/rules.d/`
- Missing LABEL declarations are inserted before the final LABEL line in the rules file
- udev rules are reloaded after the fix is applied
- Detection is skipped if an override already exists or if ALSA rules are not present on the system

https://claude.ai/code/session_018RT3WzDXzFPBm2tNW9RVzU