### PR TITLE
fix: Scope log viewer to mesh services only, stop surfacing OS errors

### DIFF
--- a/src/launcher_tui/logs_menu_mixin.py
+++ b/src/launcher_tui/logs_menu_mixin.py
@@ -14,6 +14,10 @@ from utils.paths import get_real_user_home
 class LogsMenuMixin:
     """Mixin providing log viewing functionality."""
 
+    # Systemd units MeshForge monitors — used to scope journalctl queries
+    # so we never surface unrelated OS errors (bluetooth, NFS, etc.)
+    MESH_UNITS = ['meshtasticd', 'rnsd', 'mosquitto', 'nomadnet']
+
     def _logs_menu(self):
         """Log viewer - all terminal-native."""
         while True:
@@ -79,25 +83,25 @@ class LogsMenuMixin:
             pass
 
     def _view_live_all(self):
-        """View live log stream for all services."""
+        """View live log stream for all mesh services."""
         clear_screen()
-        print("=== All services live log (Ctrl+C to stop) ===\n")
+        print("=== Mesh services live log (Ctrl+C to stop) ===\n")
+        cmd = ['journalctl', '-f', '-n', '30', '--no-pager']
+        for unit in self.MESH_UNITS:
+            cmd.extend(['-u', unit])
         try:
-            subprocess.run(
-                ['journalctl', '-f', '-n', '30', '--no-pager'],
-                timeout=None
-            )
+            subprocess.run(cmd, timeout=None)
         except KeyboardInterrupt:
             pass
 
     def _view_error_logs(self):
-        """View error-level logs from the last hour."""
+        """View error-level logs from mesh services in the last hour."""
         clear_screen()
-        print("=== Errors (last hour, priority err+) ===\n")
-        subprocess.run(
-            ['journalctl', '-p', 'err', '--since', '1 hour ago', '--no-pager'],
-            timeout=30
-        )
+        print("=== Mesh Service Errors (last hour, priority err+) ===\n")
+        cmd = ['journalctl', '-p', 'err', '--since', '1 hour ago', '--no-pager']
+        for unit in self.MESH_UNITS:
+            cmd.extend(['-u', unit])
+        subprocess.run(cmd, timeout=30)
         self._wait_for_enter()
 
     def _view_meshtasticd_recent(self):
@@ -121,13 +125,13 @@ class LogsMenuMixin:
         self._wait_for_enter()
 
     def _view_boot_messages(self):
-        """View boot messages from this boot."""
+        """View mesh service boot messages from this boot."""
         clear_screen()
-        print("=== Boot messages (this boot) ===\n")
-        subprocess.run(
-            ['journalctl', '-b', '-n', '100', '--no-pager'],
-            timeout=15
-        )
+        print("=== Mesh Service Boot Messages (this boot) ===\n")
+        cmd = ['journalctl', '-b', '-n', '100', '--no-pager']
+        for unit in self.MESH_UNITS:
+            cmd.extend(['-u', unit])
+        subprocess.run(cmd, timeout=15)
         self._wait_for_enter()
 
     def _view_kernel_messages(self):


### PR DESCRIPTION
The error log viewer was running unfiltered `journalctl -p err` which dumped every system error (bluetooth, NFS, wpa_supplicant, rpi-connect) that has nothing to do with MeshForge. A NOC tool should only surface errors from services it manages.

Scoped _view_error_logs, _view_live_all, and _view_boot_messages to MESH_UNITS (meshtasticd, rnsd, mosquitto, nomadnet) via journalctl -u flags. Added MESH_UNITS class constant for easy extension.

https://claude.ai/code/session_018RT3WzDXzFPBm2tNW9RVzU