### PR TITLE
Improve RNS diagnostics and TUI crash handling

### DIFF
--- a/src/cli/diagnose.py
+++ b/src/cli/diagnose.py
@@ -100,16 +100,29 @@ def check_rns_port():
     """Check if RNS port is available."""
     print_header("RNS NETWORK")
 
+    # Check if rnsd is running (via service_check single source of truth)
+    rnsd_running = False
+    if SERVICE_CHECK_AVAILABLE:
+        rnsd_status = _check_service('rnsd')
+        rnsd_running = rnsd_status.available
+
     # Check port 29716 (RNS AutoInterface)
+    port_available = True
     try:
         sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
         sock.bind(('::', 29716))
         sock.close()
-        print_status("RNS port 29716", True, "available")
     except OSError as e:
-        print_status("RNS port 29716", False, f"in use ({e})")
+        port_available = False
+        if rnsd_running:
+            # Port in use BY rnsd — this is correct and expected
+            print_status("RNS port 29716", True,
+                         "in use by rnsd (expected)")
+        else:
+            # Port in use but rnsd not running — real conflict
+            print_status("RNS port 29716", False, f"in use ({e})")
 
-        # Try to find what's using it
+        # Show process info either way for diagnostics
         try:
             result = subprocess.run(
                 ['lsof', '-i', ':29716'],
@@ -117,10 +130,13 @@ def check_rns_port():
             )
             if result.stdout:
                 print(f"    Process using port:")
-                for line in result.stdout.strip().split('\n')[1:2]:  # First result only
+                for line in result.stdout.strip().split('\n')[1:2]:
                     print(f"      {line}")
         except Exception:
             pass
+
+    if port_available:
+        print_status("RNS port 29716", True, "available")
 
     # Check shared instance (RNS uses abstract domain sockets on Linux)
     try:
@@ -322,6 +338,24 @@ def check_rns_interfaces():
                 or 'could not' in combined.lower()):
             print_status("RNS shared instance", False,
                          "cannot connect to rnsd")
+            # Check if port 37428 appears bound (contradictory state)
+            try:
+                from utils.service_check import (
+                    check_rns_shared_instance, get_udp_port_owner
+                )
+                if check_rns_shared_instance():
+                    print("    Note: Port 37428 appears bound but "
+                          "rnstatus cannot connect.")
+                    print("    This may indicate rnsd is initializing "
+                          "or in a degraded state.")
+                    print("    Try: sudo systemctl restart rnsd")
+                    owner = get_udp_port_owner(37428)
+                    if owner:
+                        proc_name, pid = owner
+                        print(f"    Port owner: {proc_name} "
+                              f"(PID {pid})")
+            except ImportError:
+                pass
             return
 
         # Parse interface lines from rnstatus output

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1429,6 +1429,29 @@ def main():
 
     stderr_log = log_dir / "tui_errors.log"
     _original_stderr = sys.stderr
+
+    # Last-resort exception hook — catches crashes that bypass try/except
+    _original_excepthook = sys.excepthook
+
+    def _crash_hook(exc_type, exc_value, exc_tb):
+        try:
+            with open(stderr_log, 'a') as f:
+                f.write(f"\n{'='*60}\n")
+                f.write(f"[{datetime.datetime.now().isoformat()}] "
+                        f"UNHANDLED {exc_type.__name__}\n")
+                traceback.print_exception(
+                    exc_type, exc_value, exc_tb, file=f)
+                f.write(f"{'='*60}\n")
+                f.flush()
+        except Exception:
+            pass
+        _original_excepthook(exc_type, exc_value, exc_tb)
+
+    sys.excepthook = _crash_hook
+
+    # Show log path before stderr redirect so user knows where to look
+    print(f"  Log: {stderr_log}", file=_original_stderr)
+
     _stderr_file = None
     try:
         _stderr_file = open(stderr_log, 'a')  # noqa: SIM115 — long-lived redirect
@@ -1499,9 +1522,11 @@ def main():
         try:
             sys.stderr = _original_stderr
             if _stderr_file is not None:
+                _stderr_file.flush()
                 _stderr_file.close()
         except Exception:
             pass
+        sys.excepthook = _original_excepthook
         sys.exit(exit_code)
 
 


### PR DESCRIPTION
## Summary
This PR enhances diagnostic reporting for RNS network issues and adds robust crash logging to the TUI launcher to help with debugging production issues.

## Key Changes

### RNS Diagnostics (`src/cli/diagnose.py`)
- **Smarter port status reporting**: The RNS port 29716 check now distinguishes between:
  - Port in use by rnsd (expected, reported as success)
  - Port in use by another process (reported as failure)
  - Port available (reported as success)
  - Uses `service_check` as single source of truth for rnsd status
  
- **Enhanced interface diagnostics**: When `rnstatus` cannot connect to rnsd, the diagnostic now:
  - Checks if port 37428 appears bound (indicating contradictory state)
  - Provides helpful context about rnsd initialization or degraded states
  - Shows the process owner of the port for further investigation
  - Suggests restart command to user

### TUI Crash Handling (`src/launcher_tui/main.py`)
- **Last-resort exception hook**: Captures unhandled exceptions that bypass try/except blocks
  - Logs full traceback with timestamp to stderr log file
  - Preserves original exception hook behavior
  - Ensures crash information is captured even if normal error handling fails

- **Improved logging visibility**: 
  - Displays log file path to user before stderr redirection
  - Ensures stderr file is flushed before closing
  - Properly restores exception hook on exit

## Implementation Details
- The RNS port check now uses conditional logic to provide context-aware status messages rather than treating all "in use" states as failures
- The crash hook wraps exception logging in try/except to prevent logging failures from masking the original crash
- Log path is printed to original stderr before redirection so users can locate logs even if the TUI fails to start

https://claude.ai/code/session_01WpXf1bgYH2f9Tf18FPrr94