### PR TITLE
Add retry logic with stabilization delays for RNS shared instance

### DIFF
--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -25,6 +25,13 @@ from commands.rns import (
 )
 from utils.config_drift import detect_rnsd_config_drift
 
+# Error patterns indicating RNS shared instance connectivity failure.
+# Used in _run_rns_tool() for both initial detection and retry validation.
+_RNS_SHARED_ERRORS = (
+    "no shared", "could not connect", "could not get",
+    "shared instance", "authenticationerror", "digest",
+)
+
 
 class RNSDiagnosticsMixin:
     """Mixin providing RNS diagnostics and tool execution functionality."""
@@ -737,10 +744,7 @@ class RNSDiagnosticsMixin:
             # Check for error patterns BEFORE returncode — rnstatus returns
             # exit code 0 even when the shared instance is unreachable.
             lower_combined = combined.lower()
-            has_shared_error = any(p in lower_combined for p in (
-                "no shared", "could not connect", "could not get",
-                "shared instance", "authenticationerror", "digest",
-            ))
+            has_shared_error = any(p in lower_combined for p in _RNS_SHARED_ERRORS)
 
             if "address already in use" in lower_combined:
                 # Suppress noisy traceback, show actionable diagnostics
@@ -779,14 +783,33 @@ class RNSDiagnosticsMixin:
                             print("Starting rnsd...")
                             if self._wait_for_rns_shared_instance(max_wait=10):
                                 print(f"rnsd started. Retrying {tool_name}...\n")
-                                retry_result = subprocess.run(
-                                    cmd, capture_output=True, text=True, timeout=15
-                                )
-                                if retry_result.returncode == 0 and retry_result.stdout:
-                                    print(retry_result.stdout, end='')
+                                # rnsd creates the socket before fully
+                                # initializing. Retry with stabilization
+                                # delays to handle the startup race.
+                                retry_combined = ""
+                                for attempt in range(3):
+                                    if attempt > 0:
+                                        time.sleep(2)
+                                    retry_result = subprocess.run(
+                                        cmd, capture_output=True,
+                                        text=True, timeout=15,
+                                    )
+                                    retry_combined = (
+                                        (retry_result.stdout or "")
+                                        + (retry_result.stderr or "")
+                                    )
+                                    retry_has_error = any(
+                                        p in retry_combined.lower()
+                                        for p in _RNS_SHARED_ERRORS
+                                    )
+                                    if (retry_result.returncode == 0
+                                            and retry_result.stdout
+                                            and not retry_has_error):
+                                        print(retry_result.stdout, end='')
+                                        break
                                 else:
                                     self._diagnose_rns_connectivity(
-                                        (retry_result.stdout or "") + (retry_result.stderr or "")
+                                        retry_combined
                                     )
                             else:
                                 print("rnsd started but shared instance not available.")
@@ -803,18 +826,33 @@ class RNSDiagnosticsMixin:
                     print("rnsd is running — waiting for shared instance...")
                     port_ready = self._wait_for_rns_shared_instance()
                     if port_ready:
-                        # Shared instance came up — retry the tool
+                        # Shared instance socket detected — but rnsd may still
+                        # be initializing (crypto, interfaces). Retry with
+                        # stabilization delays to handle the startup race.
                         print(f"Shared instance ready. Retrying {tool_name}...\n")
-                        retry_result = subprocess.run(
-                            cmd, capture_output=True, text=True, timeout=15
-                        )
-                        if retry_result.returncode == 0 and retry_result.stdout:
-                            print(retry_result.stdout, end='')
-                        else:
-                            # Port is up but tool still fails — auth or config issue
-                            self._diagnose_rns_connectivity(
-                                (retry_result.stdout or "") + (retry_result.stderr or "")
+                        retry_combined = ""
+                        for attempt in range(3):
+                            if attempt > 0:
+                                time.sleep(2)
+                            retry_result = subprocess.run(
+                                cmd, capture_output=True, text=True, timeout=15
                             )
+                            retry_combined = (
+                                (retry_result.stdout or "")
+                                + (retry_result.stderr or "")
+                            )
+                            retry_has_error = any(
+                                p in retry_combined.lower()
+                                for p in _RNS_SHARED_ERRORS
+                            )
+                            if (retry_result.returncode == 0
+                                    and retry_result.stdout
+                                    and not retry_has_error):
+                                print(retry_result.stdout, end='')
+                                break
+                        else:
+                            # All retries exhausted — show diagnostics
+                            self._diagnose_rns_connectivity(retry_combined)
                     else:
                         # Port never came up — show diagnostics
                         self._diagnose_rns_connectivity(combined)


### PR DESCRIPTION
## Summary
This PR improves the reliability of RNS tool execution by adding retry logic with stabilization delays when the RNS shared instance is detected but not yet fully initialized. It also extracts error pattern detection into a reusable constant to reduce code duplication.

## Key Changes
- **Extract error patterns constant**: Moved RNS shared instance error patterns into `_RNS_SHARED_ERRORS` tuple for reuse across the codebase
- **Add retry loop with delays**: When rnsd is started or the shared instance socket is detected, the tool now retries up to 3 times with 2-second stabilization delays between attempts
- **Improve error detection in retries**: Each retry attempt now checks for RNS connectivity errors in addition to return codes, preventing false successes when the shared instance is still initializing
- **Enhanced comments**: Added clarifying comments explaining the startup race condition between socket creation and full rnsd initialization

## Implementation Details
- The retry logic applies to two scenarios:
  1. After starting rnsd from a stopped state
  2. After detecting the shared instance socket is ready but tool still fails
- Each retry collects combined stdout/stderr and validates against `_RNS_SHARED_ERRORS` patterns
- Retries only succeed when: return code is 0, stdout is present, and no RNS error patterns are detected
- If all retries fail, diagnostics are run on the final combined output

https://claude.ai/code/session_01LJ8nzHpoScuXun8eGJPo92