### PR TITLE
Refactor rnsd user detection and configuration into shared mixin

### DIFF
--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -1215,15 +1215,8 @@ class NomadNetClientMixin:
                     return False
 
         # Check if rnsd is running and get its user
-        try:
-            result = subprocess.run(
-                ['ps', '-o', 'user=', '-C', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            rnsd_user = result.stdout.strip() if result.returncode == 0 else None
-        except (subprocess.SubprocessError, OSError) as e:
-            logger.debug("rnsd user detection failed: %s", e)
-            rnsd_user = None
+        # Uses shared helper from RNSDiagnosticsMixin (same MRO)
+        rnsd_user = self._get_rnsd_user()
 
         if not rnsd_user:
             # rnsd not running -- warn but allow proceeding
@@ -1361,76 +1354,8 @@ class NomadNetClientMixin:
         # rnsd running as correct user (or no sudo context)
         return True
 
-    def _fix_rnsd_user(self, target_user: str) -> bool:
-        """Configure rnsd systemd service to run as the specified user.
-
-        Creates a systemd override to set User= directive, then restarts rnsd.
-        This is the proper fix for the identity mismatch problem.
-        """
-        override_dir = Path('/etc/systemd/system/rnsd.service.d')
-        override_file = override_dir / 'user.conf'
-
-        self.dialog.infobox("Configuring rnsd", f"Setting rnsd to run as {target_user}...")
-
-        try:
-            # Create override directory
-            override_dir.mkdir(parents=True, exist_ok=True)
-
-            # Write override config
-            override_content = f"""[Service]
-User={target_user}
-Group={target_user}
-"""
-            override_file.write_text(override_content)
-
-            # Reload systemd and restart rnsd
-            stop_service('rnsd')
-            subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
-            time.sleep(1)
-            apply_config_and_restart('rnsd')
-            time.sleep(2)
-
-            # Verify it's running as the right user now
-            result = subprocess.run(
-                ['ps', '-o', 'user=', '-C', 'rnsd'],
-                capture_output=True, text=True, timeout=5
-            )
-            new_user = result.stdout.strip()
-
-            if new_user == target_user:
-                self.dialog.msgbox(
-                    "rnsd Fixed",
-                    f"rnsd is now running as {target_user}.\n\n"
-                    f"Override created: {override_file}\n\n"
-                    "NomadNet will now be able to connect via RPC.",
-                )
-                return True
-            else:
-                self.dialog.msgbox(
-                    "Fix May Have Failed",
-                    f"rnsd is running as '{new_user}' (expected '{target_user}').\n\n"
-                    f"Check: systemctl status rnsd\n"
-                    f"       cat {override_file}",
-                )
-                return True  # Let them try anyway
-
-        except PermissionError:
-            self.dialog.msgbox(
-                "Permission Denied",
-                f"Cannot write to {override_dir}\n\n"
-                "MeshForge needs to run with sudo to fix this.",
-            )
-            return False
-        except Exception as e:
-            self.dialog.msgbox(
-                "Configuration Failed",
-                f"Could not configure rnsd: {e}\n\n"
-                "Manual fix:\n"
-                f"  sudo systemctl edit rnsd\n"
-                f"  Add: [Service]\n"
-                f"       User={target_user}",
-            )
-            return False
+    # _fix_rnsd_user() lives in RNSDiagnosticsMixin (rns_diagnostics_mixin.py)
+    # and is accessible via self through Python MRO.
 
     def _validate_nomadnet_config(self) -> bool:
         """Validate and repair NomadNet config if needed.

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -5,19 +5,22 @@ Extracted from rns_menu_mixin.py to reduce file size per CLAUDE.md guidelines.
 """
 
 import logging
+import os
 import re
 import shutil
 import subprocess
 import time
 from pathlib import Path
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
 from utils.paths import get_real_user_home, ReticulumPaths
 from backend import clear_screen
 from utils.service_check import (
-    check_process_running, check_udp_port, check_rns_shared_instance,
-    get_rns_shared_instance_info, start_service, stop_service, _sudo_cmd,
+    apply_config_and_restart, check_process_running, check_udp_port,
+    check_rns_shared_instance, get_rns_shared_instance_info,
+    start_service, stop_service, _sudo_cmd,
 )
 from commands.rns import (
     get_identity_path, create_identities, list_known_destinations,
@@ -893,6 +896,94 @@ class RNSDiagnosticsMixin:
     # Keep old name as alias for any callers during transition
     _wait_for_rns_port = _wait_for_rns_shared_instance
 
+    def _get_rnsd_user(self) -> Optional[str]:
+        """Get the OS user running the rnsd process, or None if not running."""
+        try:
+            result = subprocess.run(
+                ['ps', '-o', 'user=', '-C', 'rnsd'],
+                capture_output=True, text=True, timeout=5
+            )
+            user = result.stdout.strip() if result.returncode == 0 else ''
+            return user if user else None
+        except (subprocess.SubprocessError, OSError):
+            return None
+
+    def _fix_rnsd_user(self, target_user: str) -> bool:
+        """Configure rnsd systemd service to run as the specified user.
+
+        Creates a systemd override to set User= directive, then restarts rnsd.
+        This is the proper fix for the identity mismatch problem where rnsd
+        runs as root but user tools expect a different RNS identity.
+        """
+        override_dir = Path('/etc/systemd/system/rnsd.service.d')
+        override_file = override_dir / 'user.conf'
+
+        self.dialog.infobox(
+            "Configuring rnsd",
+            f"Setting rnsd to run as {target_user}...",
+        )
+
+        try:
+            # Create override directory
+            override_dir.mkdir(parents=True, exist_ok=True)
+
+            # Write override config
+            override_content = (
+                f"[Service]\n"
+                f"User={target_user}\n"
+                f"Group={target_user}\n"
+            )
+            override_file.write_text(override_content)
+
+            # Reload systemd and restart rnsd
+            stop_service('rnsd')
+            subprocess.run(
+                ['pkill', '-f', 'rnsd'],
+                capture_output=True, timeout=5,
+            )
+            time.sleep(1)
+            apply_config_and_restart('rnsd')
+            time.sleep(2)
+
+            # Verify it's running as the right user now
+            new_user = self._get_rnsd_user()
+
+            if new_user == target_user:
+                self.dialog.msgbox(
+                    "rnsd Fixed",
+                    f"rnsd is now running as {target_user}.\n\n"
+                    f"Override created: {override_file}\n\n"
+                    "RNS tools and NomadNet can now connect via RPC.",
+                )
+                return True
+            else:
+                self.dialog.msgbox(
+                    "Fix May Have Failed",
+                    f"rnsd is running as '{new_user}' "
+                    f"(expected '{target_user}').\n\n"
+                    f"Check: systemctl status rnsd\n"
+                    f"       cat {override_file}",
+                )
+                return True  # Let them try anyway
+
+        except PermissionError:
+            self.dialog.msgbox(
+                "Permission Denied",
+                f"Cannot write to {override_dir}\n\n"
+                "MeshForge needs to run with sudo to fix this.",
+            )
+            return False
+        except Exception as e:
+            self.dialog.msgbox(
+                "Configuration Failed",
+                f"Could not configure rnsd: {e}\n\n"
+                "Manual fix:\n"
+                f"  sudo systemctl edit rnsd\n"
+                f"  Add: [Service]\n"
+                f"       User={target_user}",
+            )
+            return False
+
     def _diagnose_rns_connectivity(self, error_output: str):
         """Show targeted diagnostics when rnsd is running but tools can't connect.
 
@@ -913,6 +1004,61 @@ class RNSDiagnosticsMixin:
             print(f"  rm -f {user_home}/.reticulum/storage/shared_instance_*")
             print("  sudo systemctl start rnsd")
             return
+
+        # Check if rnsd is running as root (causes identity/auth mismatch)
+        rnsd_user = self._get_rnsd_user()
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if rnsd_user == 'root' and sudo_user and sudo_user != 'root':
+            print(
+                f"Cause: rnsd is running as root, but you are "
+                f"'{sudo_user}'\n"
+                f"       Different users = different RNS identities "
+                f"= auth failure\n"
+            )
+            nomadnet_installed = bool(shutil.which('nomadnet'))
+            menu_items = [
+                ("fix", f"Fix rnsd to run as {sudo_user} (recommended)"),
+            ]
+            if nomadnet_installed:
+                menu_items.append(
+                    ("nomadnet",
+                     "Stop rnsd — let NomadNet manage RNS"),
+                )
+            menu_items.append(("skip", "Skip (show diagnostics)"))
+
+            choice = self.dialog.menu(
+                "rnsd Running as Root",
+                "rnsd is running as root, but RNS tools run as\n"
+                f"'{sudo_user}'. Different users = different RNS\n"
+                "identities = RPC authentication failure.\n\n"
+                "How do you want to fix this?",
+                menu_items,
+            )
+            if choice == "fix":
+                if self._fix_rnsd_user(sudo_user):
+                    print("\nRetry: RNS > Status from the menu.")
+                return
+            elif choice == "nomadnet":
+                self.dialog.infobox(
+                    "Stopping rnsd",
+                    "Stopping rnsd service...",
+                )
+                stop_service('rnsd')
+                subprocess.run(
+                    ['pkill', '-f', 'rnsd'],
+                    capture_output=True, timeout=5,
+                )
+                time.sleep(1)
+                self.dialog.msgbox(
+                    "rnsd Stopped",
+                    "rnsd has been stopped.\n\n"
+                    "NomadNet will start its own RNS instance.\n"
+                    "The gateway bridge will connect to NomadNet's\n"
+                    "shared instance as a client.\n\n"
+                    "Note: RNS is only available while NomadNet runs.",
+                )
+                return
+            # "skip" falls through to existing diagnostics
 
         # Check for blocking interfaces (most common root cause)
         blocking = self._find_blocking_interfaces()


### PR DESCRIPTION
## Summary
Consolidate duplicate rnsd user detection and configuration logic by moving `_get_rnsd_user()` and `_fix_rnsd_user()` methods from `nomadnet_client_mixin.py` to the shared `rns_diagnostics_mixin.py`. This eliminates code duplication and enables both mixins to use the same implementation through Python's MRO.

## Key Changes
- **Moved methods to RNSDiagnosticsMixin:**
  - `_get_rnsd_user()`: Detects the OS user running the rnsd process
  - `_fix_rnsd_user()`: Configures rnsd systemd service to run as a specified user via systemd override

- **Enhanced RNS diagnostics:**
  - Added comprehensive root-cause detection for rnsd running as root when user tools expect a different user
  - Integrated interactive menu offering three options: fix rnsd user, stop rnsd for NomadNet management, or skip to detailed diagnostics
  - Improved user feedback with clear explanations of identity/auth mismatch issues

- **Updated imports:**
  - Added `os` and `Optional` type hint imports to `rns_diagnostics_mixin.py`
  - Reorganized service_check imports to include `apply_config_and_restart`

- **Simplified nomadnet_client_mixin:**
  - Replaced inline rnsd user detection with call to shared `_get_rnsd_user()` method
  - Removed duplicate `_fix_rnsd_user()` implementation with comment noting it's inherited via MRO

## Implementation Details
The refactored `_fix_rnsd_user()` method creates a systemd override at `/etc/systemd/system/rnsd.service.d/user.conf` to set the User and Group directives, then restarts the service and verifies the change. The new diagnostic flow in `_diagnose_rns_connectivity()` detects when rnsd runs as root while the user is non-root, explains the identity mismatch problem, and offers targeted fixes.

https://claude.ai/code/session_01BbhoUkLgtQ9Cip66ewgXFD