### PR TITLE
security: Harden rnsd root-detection and fix user-mismatch helpers

### DIFF
--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -479,23 +479,15 @@ class NomadNetClientMixin:
                     if 'AuthenticationError' in line or 'digest sent was rejected' in line:
                         error_hints.append("RPC authentication failed between NomadNet and rnsd")
                         # Check if rnsd is running as root
-                        try:
-                            ps_result = subprocess.run(
-                                ['ps', '-o', 'user=', '-C', 'rnsd'],
-                                capture_output=True, text=True, timeout=5
-                            )
-                            rnsd_user = ps_result.stdout.strip()
-                            if rnsd_user == 'root':
-                                error_hints.append("rnsd is running as root - identities don't match")
-                                error_hints.append("Fix: sudo systemctl stop rnsd")
-                                error_hints.append("     Then run rnsd as your user, or reconfigure")
-                            elif rnsd_user and rnsd_user != sudo_user:
-                                error_hints.append(f"rnsd runs as '{rnsd_user}', you are '{sudo_user}'")
-                            else:
-                                error_hints.append("Check that rnsd uses the same ~/.reticulum/ identity")
-                        except (subprocess.SubprocessError, OSError) as e:
-                            logger.debug("rnsd user lookup failed: %s", e)
-                            error_hints.append("Ensure rnsd and NomadNet use the same RNS identity")
+                        rnsd_user = self._get_rnsd_user()
+                        if rnsd_user == 'root':
+                            error_hints.append("rnsd is running as root - identities don't match")
+                            error_hints.append("Fix: sudo systemctl stop rnsd")
+                            error_hints.append("     Then run rnsd as your user, or reconfigure")
+                        elif rnsd_user and rnsd_user != sudo_user:
+                            error_hints.append(f"rnsd runs as '{rnsd_user}', you are '{sudo_user}'")
+                        else:
+                            error_hints.append("Check that rnsd uses the same ~/.reticulum/ identity")
                         break
                     elif 'KeyError' in line and 'textui' in line.lower():
                         error_hints.append("Config missing [textui] section")

--- a/src/launcher_tui/rns_diagnostics_mixin.py
+++ b/src/launcher_tui/rns_diagnostics_mixin.py
@@ -903,8 +903,11 @@ class RNSDiagnosticsMixin:
                 ['ps', '-o', 'user=', '-C', 'rnsd'],
                 capture_output=True, text=True, timeout=5
             )
-            user = result.stdout.strip() if result.returncode == 0 else ''
-            return user if user else None
+            if result.returncode != 0:
+                return None
+            # Take first line only — multiple rnsd processes may exist
+            lines = result.stdout.strip().splitlines()
+            return lines[0].strip() if lines else None
         except (subprocess.SubprocessError, OSError):
             return None
 
@@ -915,6 +918,14 @@ class RNSDiagnosticsMixin:
         This is the proper fix for the identity mismatch problem where rnsd
         runs as root but user tools expect a different RNS identity.
         """
+        # Validate username to prevent systemd directive injection
+        if not re.match(r'^[a-z_][a-z0-9_.-]{0,31}$', target_user):
+            self.dialog.msgbox(
+                "Invalid Username",
+                f"'{target_user}' is not a valid Linux username.",
+            )
+            return False
+
         override_dir = Path('/etc/systemd/system/rnsd.service.d')
         override_file = override_dir / 'user.conf'
 
@@ -1058,6 +1069,8 @@ class RNSDiagnosticsMixin:
                     "Note: RNS is only available while NomadNet runs.",
                 )
                 return
+            elif choice is None:
+                return  # User cancelled
             # "skip" falls through to existing diagnostics
 
         # Check for blocking interfaces (most common root cause)


### PR DESCRIPTION
- Validate target_user in _fix_rnsd_user() before writing systemd override (defense-in-depth against directive injection via crafted usernames)
- Handle multiple rnsd processes in _get_rnsd_user() by taking first line
- Add explicit Cancel/Escape handling in root-detection menu
- Replace remaining inline ps call in _diagnose_nomadnet_error() with shared _get_rnsd_user() helper to complete deduplication

https://claude.ai/code/session_01BbhoUkLgtQ9Cip66ewgXFD