### PR TITLE
Add automated MeshChat install/uninstall and LXMF exclusivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 
 Plug in a LoRa radio, run the installer, and you get:
 - A **gateway** bridging Meshtastic and Reticulum via MQTT (zero interference)
+- **MeshChat** LXMF messaging with web UI — automated install from the TUI
 - **Live NOC maps** showing Meshtastic AND RNS nodes on one map
 - **Coverage maps** with SNR-based link quality
 - **Wireshark-grade packet inspection** for both networks
@@ -107,13 +108,14 @@ The alpha branch (`0.6.0-alpha`) includes:
 
 ### Deployment Profiles
 
-MeshForge supports 5 deployment profiles. Install only the dependencies you need:
+MeshForge supports 6 deployment profiles. Install only the dependencies you need:
 
 | Profile | Services Needed | Install | Use Case |
 |---------|----------------|---------|----------|
 | `radio_maps` | meshtasticd | `pip install -r requirements/core.txt -r requirements/maps.txt` | Radio config + coverage maps |
 | `monitor` | (none) | `pip install -r requirements/core.txt -r requirements/mqtt.txt` | MQTT packet analysis |
 | `meshcore` | (none) | `pip install -r requirements/core.txt` + meshcore | MeshCore companion radio |
+| `meshchat` | meshtasticd, rnsd | `pip install -r requirements/core.txt -r requirements/rns.txt` + MeshChat | LXMF messaging with web UI |
 | `gateway` | meshtasticd, rnsd | `pip install -r requirements/core.txt -r requirements/rns.txt -r requirements/mqtt.txt` | Meshtastic <> RNS bridge |
 | `full` | meshtasticd, rnsd, mosquitto | `pip install -r requirements.txt` | Everything |
 
@@ -170,6 +172,7 @@ headless operation. Navigation is keyboard-driven with max 10 items per menu lev
 Main Menu (MeshForge NOC)
 ├── 1. Dashboard             Service status, health, alerts, data path check
 ├── 2. Mesh Networks         Meshtastic, RNS, MeshCore, AREDN, MQTT, Gateway
+│       └── RNS submenu      NomadNet Client, MeshChat Client (install/manage)
 ├── 3. RF & SDR              Link budget, site planner, frequency slots, SDR
 ├── 4. Maps & Viz            Live NOC map, coverage, topology, traffic inspector
 ├── 5. Configuration         Radio, channels, RNS config, services, backup
@@ -219,6 +222,7 @@ Main Menu (MeshForge NOC)
 | **RNS Packet Sniffer** | Live RNS capture, announce tracking, destination filtering, path discovery | Beta |
 | **Device Backup** | Configuration backup/restore, versioned snapshots, scheduled backups | Beta |
 | **First-Run Wizard** | Hardware auto-detect templates, region selection, service verification | Stable |
+| **MeshChat** | Automated install, LXMF messaging, web UI (:8000), HTTP API, peer discovery, LXMF announce, systemd service | Beta |
 | **Messaging** | Broadcast/direct messaging, LXMF routing, message history | Beta |
 | **Amateur Radio** | Callsign management, Part 97 reference, ARES/RACES info | Beta |
 | **Webhooks** | Event routing, external system integration | Beta |
@@ -315,6 +319,7 @@ graph TB
     subgraph External Services
         MESHTASTICD[meshtasticd<br>LoRa radio daemon]
         RNSD[rnsd<br>Reticulum transport]
+        MESHCHAT[MeshChat<br>LXMF messaging :8000]
         AREDN_NET[AREDN<br>IP mesh network]
         MQTT[MQTT Broker<br>Node telemetry]
         NOAA[NOAA SWPC<br>Space weather]
@@ -338,6 +343,7 @@ graph TB
 
     GATEWAY --> MQTT
     GATEWAY --> RNSD
+    MESHCHAT --> RNSD
     MONITOR --> MQTT
     MQTT --> MESHTASTICD
     TRAFFIC --> GATEWAY
@@ -354,6 +360,7 @@ graph TB
     style BROWSER fill:#2d5016,color:#fff
     style CLI fill:#2d5016,color:#fff
     style GATEWAY fill:#1a3a5c,color:#fff
+    style MESHCHAT fill:#1a5c3a,color:#fff
     style TRAFFIC fill:#3a1a5c,color:#fff
     style AI fill:#5c1a3a,color:#fff
     style UCONSOLE fill:#5c4a1a,color:#fff
@@ -415,6 +422,29 @@ sudo apt install mosquitto                     # MQTT broker
 - Gateway Bridge: `Mesh Networks → Gateway Config → Templates → mqtt_bridge`
 - MQTT Monitor: `Mesh Networks → MQTT Monitor → Configure → Use Local Broker`
 - MQTT Settings: `Gateway Config → MQTT Bridge Settings → Run Setup Guide`
+
+### MeshChat (LXMF Messaging)
+
+MeshChat provides LXMF encrypted messaging with a web UI at `http://127.0.0.1:8000`.
+MeshForge automates the full installation and manages MeshChat as a systemd service.
+
+**Install from TUI:**
+```
+Mesh Networks → RNS → MeshChat Client → Install MeshChat
+```
+
+The installer handles everything: Node.js/npm prerequisites, git clone, Python
+dependencies, frontend build, and systemd service creation. MeshChat connects
+to rnsd as a shared instance client for Meshtastic bridging.
+
+**LXMF app exclusivity:** MeshChat and NomadNet are both LXMF clients. Only one
+should run at a time to avoid port conflicts. MeshForge enforces this — starting
+one will offer to stop the other.
+
+**Data flow:**
+```
+Meshtastic Node → meshtasticd → MeshForge Gateway → LXMF → rnsd → MeshChat (:8000)
+```
 
 ### Design Principles
 
@@ -582,6 +612,8 @@ src/
 │   ├── backend.py         # whiptail/dialog abstraction
 │   ├── startup_checks.py  # Environment checks + conflict resolution
 │   ├── status_bar.py      # Service status bar
+│   ├── meshchat_client_mixin.py  # MeshChat install/manage/monitor (automated)
+│   ├── nomadnet_client_mixin.py # NomadNet install/launch/configure
 │   └── *_mixin.py         # 47 feature modules (RF, channels, AI, MeshCore, topology, emergency, etc.)
 ├── commands/              # Command modules
 │   ├── propagation.py     # Space weather & HF propagation (NOAA primary)
@@ -705,6 +737,7 @@ See `dashboards/README.md` and `docs/METRICS.md` for full setup instructions.
 | 1883 | mosquitto MQTT | mosquitto | Multi-consumer (optional) |
 | 5000 | MeshForge Map Server | **MeshForge** | Live NOC map + REST API (20 endpoints) |
 | 5001 | MeshForge WebSocket | **MeshForge** | Real-time message broadcast |
+| 8000 | MeshChat Web UI | MeshChat | LXMF messaging + HTTP API |
 | 8081 | MeshForge Config API | **MeshForge** | RESTful config management |
 | 9090 | Prometheus metrics | **MeshForge** | Prometheus + Grafana JSON API |
 | 9443 | meshtasticd Web UI | meshtasticd | Protobuf + JSON endpoints |
@@ -1069,6 +1102,7 @@ Full research library: [`.claude/research/`](.claude/research/README.md)
 | Development Blog | [nursedude.substack.com](https://nursedude.substack.com) | Project updates |
 | Meshtastic Docs | [meshtastic.org/docs](https://meshtastic.org/docs/) | Primary radio network |
 | Reticulum Network | [reticulum.network](https://reticulum.network/) | Bridge target (encrypted transport) |
+| MeshChat | [github.com/liamcottle/reticulum-meshchat](https://github.com/liamcottle/reticulum-meshchat) | LXMF messaging client (automated install) |
 | AREDN Mesh | [arednmesh.org](https://www.arednmesh.org/) | Monitoring integration |
 | RTL-SDR | [rtl-sdr.com](https://www.rtl-sdr.com/) | Spectrum analysis (planned) |
 | uConsole AIO V2 | [hackergadgets.com](https://hackergadgets.com/products/uconsole-aio-v2) | Field hardware (Q2 2026) |

--- a/src/launcher_tui/meshchat_client_mixin.py
+++ b/src/launcher_tui/meshchat_client_mixin.py
@@ -12,7 +12,13 @@ Data flow:
   Meshtastic (Short Turbo) <> meshtasticd <> MeshForge Gateway
   <> LXMF <> rnsd <> LXMF <> MeshChat
 
-Requires:  git clone + pip install (see INSTALL_HINT)
+Install:  Automated via TUI (git clone + npm + pip + systemd service)
+          Or manually: see plugins/meshchat/service.py INSTALL_HINT
+
+LXMF exclusivity:
+  MeshChat and NomadNet are both LXMF clients. Only one should run
+  at a time to avoid port 37428 conflicts. The _ensure_lxmf_exclusive()
+  helper enforces this by offering to stop the other app before starting.
 """
 
 import logging
@@ -142,6 +148,7 @@ class MeshChatClientMixin:
                 else:
                     choices.append(("start", "Start MeshChat"))
                 choices.append(("logs", "View Logs"))
+                choices.append(("uninstall", "Disable MeshChat"))
             else:
                 choices.append(("install", "Install MeshChat"))
 
@@ -167,6 +174,7 @@ class MeshChatClientMixin:
                 "web": ("MeshChat Web UI", self._meshchat_web_ui),
                 "logs": ("View MeshChat Logs", self._meshchat_logs),
                 "install": ("Install MeshChat", self._install_meshchat),
+                "uninstall": ("Disable MeshChat", self._uninstall_meshchat),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -248,6 +256,10 @@ class MeshChatClientMixin:
 
     def _launch_meshchat(self):
         """Start MeshChat service."""
+        # Preflight: ensure NomadNet is not running (one LXMF app at a time)
+        if not self._ensure_lxmf_exclusive("meshchat"):
+            return
+
         # Preflight: check RNS availability
         if not self._check_rns_for_meshchat():
             return
@@ -504,7 +516,7 @@ class MeshChatClientMixin:
                         for line in result.stdout.strip().split('\n'):
                             print(f"  {line}")
                         shown = True
-            except (subprocess.SubprocessError, OSError, Exception) as e:
+            except (subprocess.SubprocessError, OSError) as e:
                 logger.debug("MeshChat journal read failed: %s", e)
 
         # Try log file paths
@@ -548,25 +560,469 @@ class MeshChatClientMixin:
         self._wait_for_enter()
 
     # ------------------------------------------------------------------
-    # Install
+    # Install (fully automated)
     # ------------------------------------------------------------------
 
+    MESHCHAT_REPO = "https://github.com/liamcottle/reticulum-meshchat"
+    MESHCHAT_SERVICE_NAME = "reticulum-meshchat"
+
+    def _get_meshchat_install_dir(self) -> Path:
+        """Return the MeshChat install directory under user home."""
+        return get_real_user_home() / 'reticulum-meshchat'
+
+    def _get_pip_command(self) -> list:
+        """Return the pip command appropriate for this install.
+
+        Prefers MeshForge's venv pip, falls back to system pip3
+        with --break-system-packages for PEP 668 compatibility.
+        """
+        venv_pip = Path('/opt/meshforge/venv/bin/pip')
+        if venv_pip.exists():
+            return [str(venv_pip)]
+
+        # Check for PEP 668 (externally-managed Python)
+        import glob
+        if glob.glob('/usr/lib/python3*/EXTERNALLY-MANAGED'):
+            return ['pip3', 'install', '--break-system-packages']
+
+        return ['pip3']
+
     def _install_meshchat(self):
-        """Show MeshChat installation instructions."""
-        self.dialog.msgbox(
+        """Automated MeshChat installation.
+
+        Steps:
+        1. Confirm with user
+        2. Check/install prerequisites (git, nodejs, npm)
+        3. git clone reticulum-meshchat
+        4. pip install -r requirements.txt
+        5. npm install && npm run build-frontend
+        6. Create systemd service
+        7. Enable + start service
+        """
+        if self._is_meshchat_installed():
+            self.dialog.msgbox(
+                "Already Installed",
+                "MeshChat is already installed.\n\n"
+                "Use Start/Stop from the menu to manage it.",
+            )
+            return
+
+        if not self.dialog.yesno(
             "Install MeshChat",
-            "MeshChat (Reticulum MeshChat) provides LXMF messaging\n"
-            "with a web UI at http://127.0.0.1:8000.\n\n"
-            "Install:\n"
-            "  git clone https://github.com/liamcottle/reticulum-meshchat\n"
-            "  cd reticulum-meshchat\n"
-            "  pip install -r requirements.txt\n"
-            "  npm install --omit=dev && npm run build-frontend\n"
-            "  python meshchat.py\n\n"
-            "For systemd service (auto-start on boot):\n"
-            "  Create /etc/systemd/system/reticulum-meshchat.service\n"
-            "  with ExecStart pointing to meshchat.py",
+            "Install MeshChat (Reticulum MeshChat)?\n\n"
+            "This will:\n"
+            "  1. Install Node.js/npm (if needed)\n"
+            "  2. Clone the MeshChat repository\n"
+            "  3. Install Python dependencies\n"
+            "  4. Build the web frontend (npm)\n"
+            "  5. Create a systemd service\n\n"
+            "MeshChat provides LXMF messaging with a\n"
+            "web UI at http://127.0.0.1:8000\n\n"
+            "Source: github.com/liamcottle/reticulum-meshchat\n\n"
+            "Install now?",
+        ):
+            return
+
+        # LXMF exclusivity check — stop NomadNet if running
+        if not self._ensure_lxmf_exclusive("meshchat"):
+            return
+
+        clear_screen()
+        print("=== Installing MeshChat ===\n")
+
+        install_dir = self._get_meshchat_install_dir()
+        sudo_user = os.environ.get('SUDO_USER')
+        run_as_user = sudo_user if sudo_user and sudo_user != 'root' else None
+
+        try:
+            # Step 1: Prerequisites
+            if not self._install_meshchat_prerequisites():
+                self._wait_for_enter()
+                return
+
+            # Step 2: Git clone
+            if not self._install_meshchat_clone(install_dir, run_as_user):
+                self._wait_for_enter()
+                return
+
+            # Step 3: pip install
+            if not self._install_meshchat_pip(install_dir, run_as_user):
+                self._wait_for_enter()
+                return
+
+            # Step 4: npm build
+            if not self._install_meshchat_npm(install_dir, run_as_user):
+                self._wait_for_enter()
+                return
+
+            # Step 5: systemd service
+            if not self._install_meshchat_service(install_dir, run_as_user):
+                print("\nSystemd service creation failed.")
+                print("You can still run MeshChat manually:")
+                print(f"  cd {install_dir} && python3 meshchat.py")
+
+            # Step 6: Start service
+            print("\nStarting MeshChat service...")
+            try:
+                subprocess.run(
+                    ['systemctl', 'start', self.MESHCHAT_SERVICE_NAME],
+                    capture_output=True, timeout=15,
+                )
+                time.sleep(3)
+            except (subprocess.SubprocessError, OSError) as e:
+                logger.debug("Service start failed: %s", e)
+
+            # Verify
+            if self._is_meshchat_running():
+                print("\nMeshChat is running!")
+                print("Web UI: http://127.0.0.1:8000")
+            else:
+                print("\nMeshChat installed but may not be running yet.")
+                print(f"Check: systemctl status {self.MESHCHAT_SERVICE_NAME}")
+
+            print("\nInstallation complete.")
+
+        except KeyboardInterrupt:
+            print("\n\nInstallation cancelled.")
+        except Exception as e:
+            print(f"\nInstallation error: {e}")
+            logger.exception("MeshChat install failed")
+
+        try:
+            self._wait_for_enter()
+        except (EOFError, KeyboardInterrupt):
+            pass
+
+    def _install_meshchat_prerequisites(self) -> bool:
+        """Check and install git, nodejs, npm. Returns True on success."""
+        # git
+        if not shutil.which('git'):
+            print("Installing git...")
+            result = subprocess.run(
+                ['apt-get', 'install', '-y', '-qq', 'git'],
+                capture_output=True, timeout=120,
+            )
+            if result.returncode != 0:
+                print("Failed to install git.")
+                print("Try: sudo apt install git")
+                return False
+
+        # Node.js + npm
+        if not shutil.which('node') or not shutil.which('npm'):
+            print("Installing Node.js and npm...")
+            result = subprocess.run(
+                ['apt-get', 'install', '-y', '-qq', 'nodejs', 'npm'],
+                capture_output=True, timeout=180,
+            )
+            if result.returncode != 0:
+                print("Failed to install Node.js/npm.")
+                print("Try: sudo apt install nodejs npm")
+                return False
+            print("Node.js and npm installed.")
+
+        # Verify
+        for tool in ['git', 'node', 'npm']:
+            if not shutil.which(tool):
+                print(f"Error: {tool} not found after install.")
+                return False
+
+        print("Prerequisites OK (git, node, npm)\n")
+        return True
+
+    def _install_meshchat_clone(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Clone the MeshChat repository. Returns True on success."""
+        if install_dir.exists():
+            print(f"Directory exists: {install_dir}")
+            # Pull latest instead of clone
+            print("Pulling latest changes...")
+            cmd = ['git', '-C', str(install_dir), 'pull', '--ff-only']
+            if run_as_user:
+                cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                print(f"Git pull failed: {result.stderr.strip()}")
+                print("Continuing with existing checkout.")
+            else:
+                print("Repository updated.")
+            return True
+
+        print(f"Cloning MeshChat to {install_dir}...")
+        cmd = ['git', 'clone', self.MESHCHAT_REPO, str(install_dir)]
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, timeout=120)
+        if result.returncode != 0:
+            print("Git clone failed.")
+            print(f"Try: git clone {self.MESHCHAT_REPO} {install_dir}")
+            return False
+
+        print("Repository cloned.\n")
+        return True
+
+    def _install_meshchat_pip(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Install MeshChat Python dependencies. Returns True on success."""
+        req_file = install_dir / 'requirements.txt'
+        if not req_file.exists():
+            print("No requirements.txt found — skipping pip install.")
+            return True
+
+        print("Installing Python dependencies...")
+        pip_cmd = self._get_pip_command()
+
+        # Build install command
+        if len(pip_cmd) > 1 and pip_cmd[1] == 'install':
+            # pip3 install --break-system-packages case
+            cmd = pip_cmd + ['--timeout', '60', '-r', str(req_file)]
+        else:
+            cmd = pip_cmd + ['install', '--timeout', '60', '-r', str(req_file)]
+
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, timeout=300)
+        if result.returncode != 0:
+            print("pip install failed.")
+            print(f"Try: pip3 install -r {req_file}")
+            return False
+
+        print("Python dependencies installed.\n")
+        return True
+
+    def _install_meshchat_npm(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Build MeshChat web frontend with npm. Returns True on success."""
+        pkg_json = install_dir / 'package.json'
+        if not pkg_json.exists():
+            print("No package.json found — skipping npm build.")
+            return True
+
+        print("Installing npm dependencies...")
+        cmd = ['npm', 'install', '--omit=dev']
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, cwd=str(install_dir), timeout=300)
+        if result.returncode != 0:
+            print("npm install failed.")
+            print(f"Try: cd {install_dir} && npm install --omit=dev")
+            return False
+
+        print("Building web frontend...")
+        cmd = ['npm', 'run', 'build-frontend']
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, cwd=str(install_dir), timeout=300)
+        if result.returncode != 0:
+            print("npm build failed.")
+            print(f"Try: cd {install_dir} && npm run build-frontend")
+            return False
+
+        print("Web frontend built.\n")
+        return True
+
+    def _install_meshchat_service(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Create systemd service for MeshChat. Returns True on success."""
+        service_user = run_as_user or 'root'
+        user_home = get_real_user_home()
+        python_path = shutil.which('python3') or '/usr/bin/python3'
+        meshchat_py = install_dir / 'meshchat.py'
+
+        service_content = (
+            f"[Unit]\n"
+            f"Description=Reticulum MeshChat LXMF Client\n"
+            f"After=network.target rnsd.service\n"
+            f"Wants=rnsd.service\n"
+            f"\n"
+            f"[Service]\n"
+            f"Type=simple\n"
+            f"User={service_user}\n"
+            f"WorkingDirectory={install_dir}\n"
+            f"ExecStart={python_path} {meshchat_py}\n"
+            f"Restart=on-failure\n"
+            f"RestartSec=5\n"
+            f"StartLimitBurst=5\n"
+            f"StartLimitIntervalSec=60\n"
+            f"Environment=HOME={user_home}\n"
+            f"\n"
+            f"[Install]\n"
+            f"WantedBy=multi-user.target\n"
         )
+
+        service_path = f"/etc/systemd/system/{self.MESHCHAT_SERVICE_NAME}.service"
+        print(f"Creating systemd service: {service_path}")
+
+        try:
+            # Write service file
+            with open(service_path, 'w') as f:
+                f.write(service_content)
+
+            # Reload systemd and enable
+            subprocess.run(
+                ['systemctl', 'daemon-reload'],
+                capture_output=True, timeout=15,
+            )
+            subprocess.run(
+                ['systemctl', 'enable', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+            print("Service created and enabled.\n")
+            return True
+
+        except (IOError, OSError, subprocess.SubprocessError) as e:
+            print(f"Failed to create service: {e}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Uninstall (stop + disable)
+    # ------------------------------------------------------------------
+
+    def _uninstall_meshchat(self):
+        """Stop and disable MeshChat service.
+
+        Leaves files in place for easy re-enable. Does not delete
+        the cloned repository or configuration.
+        """
+        if not self.dialog.yesno(
+            "Disable MeshChat",
+            "Stop and disable the MeshChat service?\n\n"
+            "This will:\n"
+            "  - Stop MeshChat if running\n"
+            "  - Disable auto-start on boot\n\n"
+            "Files remain at ~/reticulum-meshchat\n"
+            "for easy re-enable later.\n\n"
+            "Disable now?",
+        ):
+            return
+
+        clear_screen()
+        print("=== Disabling MeshChat ===\n")
+
+        # Stop service
+        try:
+            print("Stopping MeshChat...")
+            subprocess.run(
+                ['systemctl', 'stop', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Service stop: %s", e)
+
+        # Kill any running process
+        try:
+            subprocess.run(
+                ['pkill', '-f', 'meshchat.py'],
+                capture_output=True, timeout=5,
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        time.sleep(1)
+
+        # Disable service
+        try:
+            print("Disabling auto-start...")
+            subprocess.run(
+                ['systemctl', 'disable', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Service disable: %s", e)
+
+        install_dir = self._get_meshchat_install_dir()
+        if self._is_meshchat_running():
+            print("\nMeshChat may still be running.")
+            print("Try: sudo pkill -f meshchat.py")
+        else:
+            print("\nMeshChat stopped and disabled.")
+
+        print(f"\nFiles remain at: {install_dir}")
+        print("To re-enable: systemctl enable --now reticulum-meshchat")
+
+        self._wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # LXMF exclusivity (one app at a time)
+    # ------------------------------------------------------------------
+
+    def _ensure_lxmf_exclusive(self, starting_app: str) -> bool:
+        """Ensure only one LXMF app runs at a time.
+
+        MeshChat and NomadNet both use LXMF and can conflict on
+        port 37428 when connecting to rnsd. Only one should run.
+
+        Args:
+            starting_app: "meshchat" or "nomadnet"
+
+        Returns:
+            True if OK to proceed, False if user cancelled.
+        """
+        if starting_app == "meshchat":
+            # Check if NomadNet is running
+            nomadnet_running = False
+            if _HAS_SERVICE_CHECK and check_process_running:
+                nomadnet_running = check_process_running('nomadnet')
+            if not nomadnet_running:
+                try:
+                    result = subprocess.run(
+                        ['pgrep', '-f', 'bin/nomadnet'],
+                        capture_output=True, text=True, timeout=5,
+                    )
+                    nomadnet_running = (
+                        result.returncode == 0 and
+                        bool(result.stdout.strip())
+                    )
+                except (subprocess.SubprocessError, OSError):
+                    pass
+
+            if nomadnet_running:
+                if not self.dialog.yesno(
+                    "NomadNet Running",
+                    "NomadNet is currently running.\n\n"
+                    "Only one LXMF app should run at a time\n"
+                    "to avoid port 37428 conflicts.\n\n"
+                    "Stop NomadNet and start MeshChat?",
+                ):
+                    return False
+                # Stop NomadNet
+                try:
+                    subprocess.run(
+                        ['pkill', '-f', 'bin/nomadnet'],
+                        capture_output=True, timeout=10,
+                    )
+                    time.sleep(2)
+                except (subprocess.SubprocessError, OSError):
+                    pass
+
+        elif starting_app == "nomadnet":
+            # Check if MeshChat is running
+            if self._is_meshchat_running():
+                if not self.dialog.yesno(
+                    "MeshChat Running",
+                    "MeshChat is currently running.\n\n"
+                    "Only one LXMF app should run at a time\n"
+                    "to avoid port 37428 conflicts.\n\n"
+                    "Stop MeshChat and start NomadNet?",
+                ):
+                    return False
+                # Stop MeshChat
+                try:
+                    subprocess.run(
+                        ['systemctl', 'stop', self.MESHCHAT_SERVICE_NAME],
+                        capture_output=True, timeout=15,
+                    )
+                except (subprocess.SubprocessError, OSError):
+                    pass
+                try:
+                    subprocess.run(
+                        ['pkill', '-f', 'meshchat.py'],
+                        capture_output=True, timeout=5,
+                    )
+                except (subprocess.SubprocessError, OSError):
+                    pass
+                time.sleep(2)
+
+        return True
 
     # ------------------------------------------------------------------
     # Preflight: RNS check

--- a/src/launcher_tui/nomadnet_client_mixin.py
+++ b/src/launcher_tui/nomadnet_client_mixin.py
@@ -230,6 +230,7 @@ class NomadNetClientMixin:
                 choices.append(("logs", "View NomadNet Logs"))
                 choices.append(("config", "View NomadNet Config"))
                 choices.append(("edit", "Edit NomadNet Config"))
+                choices.append(("uninstall", "Disable NomadNet"))
             else:
                 choices.append(("install", "Install NomadNet"))
 
@@ -254,6 +255,7 @@ class NomadNetClientMixin:
                 "config": ("View NomadNet Config", self._view_nomadnet_config),
                 "edit": ("Edit NomadNet Config", self._edit_nomadnet_config),
                 "install": ("Install NomadNet", self._install_nomadnet),
+                "uninstall": ("Disable NomadNet", self._uninstall_nomadnet),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -379,6 +381,11 @@ class NomadNetClientMixin:
         nn_path = self._find_nomadnet_binary()
         if not nn_path:
             return
+
+        # LXMF exclusivity: stop MeshChat if running (one at a time)
+        if hasattr(self, '_ensure_lxmf_exclusive'):
+            if not self._ensure_lxmf_exclusive("nomadnet"):
+                return
 
         # Fix ownership of user directories if they were created by root
         # This is a common issue when MeshForge runs with sudo
@@ -675,6 +682,11 @@ class NomadNetClientMixin:
             self.dialog.msgbox("Already Running", "NomadNet is already running.")
             return
 
+        # LXMF exclusivity: stop MeshChat if running (one at a time)
+        if hasattr(self, '_ensure_lxmf_exclusive'):
+            if not self._ensure_lxmf_exclusive("nomadnet"):
+                return
+
         # Fix ownership of user directories if they were created by root
         if not self._fix_user_directory_ownership():
             return
@@ -782,6 +794,64 @@ class NomadNetClientMixin:
                 self.dialog.msgbox("Warning", "NomadNet may still be running.\nTry: sudo pkill -9 -f nomadnet")
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to stop NomadNet:\n{e}")
+
+    # ------------------------------------------------------------------
+    # Uninstall (stop + disable)
+    # ------------------------------------------------------------------
+
+    def _uninstall_nomadnet(self):
+        """Stop NomadNet and leave it disabled.
+
+        Does not remove files — just stops the process and shows how
+        to reinstall later if desired.
+        """
+        if not self.dialog.yesno(
+            "Disable NomadNet",
+            "Stop NomadNet and disable it?\n\n"
+            "This will:\n"
+            "  - Stop NomadNet if running\n"
+            "  - Leave files in place\n\n"
+            "Reinstall later with: pipx install nomadnet\n\n"
+            "Disable now?",
+        ):
+            return
+
+        clear_screen()
+        print("=== Disabling NomadNet ===\n")
+
+        # Stop running processes
+        if self._is_nomadnet_running():
+            print("Stopping NomadNet...")
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'bin/nomadnet'],
+                    capture_output=True, timeout=10,
+                )
+                time.sleep(2)
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+            if self._is_nomadnet_running():
+                try:
+                    subprocess.run(
+                        ['pkill', '-9', '-f', 'bin/nomadnet'],
+                        capture_output=True, timeout=10,
+                    )
+                    time.sleep(1)
+                except (subprocess.SubprocessError, OSError):
+                    pass
+
+        if self._is_nomadnet_running():
+            print("NomadNet may still be running.")
+            print("Try: sudo pkill -9 -f nomadnet")
+        else:
+            print("NomadNet stopped.")
+
+        user_home = get_real_user_home()
+        print(f"\nConfig remains at: {user_home}/.nomadnetwork/")
+        print("Reinstall: pipx install nomadnet")
+
+        self._wait_for_enter()
 
     # ------------------------------------------------------------------
     # Config management
@@ -1413,7 +1483,6 @@ hide_guide = no
             # Fix ownership if running via sudo
             sudo_user = os.environ.get('SUDO_USER')
             if sudo_user and sudo_user != 'root':
-                import subprocess
                 subprocess.run(
                     ['chown', f'{sudo_user}:{sudo_user}', str(config_path)],
                     capture_output=True, timeout=10

--- a/src/plugins/meshchat/service.py
+++ b/src/plugins/meshchat/service.py
@@ -78,7 +78,10 @@ class MeshChatService:
     # Installation hints
     INSTALL_URL = "https://github.com/liamcottle/reticulum-meshchat"
     INSTALL_HINT = (
-        "Install MeshChat:\n"
+        "Install MeshChat from TUI:\n"
+        "  Mesh Networks > RNS > MeshChat Client > Install MeshChat\n\n"
+        "Or manually:\n"
+        "  sudo apt install nodejs npm\n"
         "  git clone https://github.com/liamcottle/reticulum-meshchat\n"
         "  cd reticulum-meshchat\n"
         "  pip install -r requirements.txt\n"

--- a/tests/test_meshchat_mixin.py
+++ b/tests/test_meshchat_mixin.py
@@ -288,3 +288,342 @@ class TestMeshChatGatewayDiagnostic:
         diag = GatewayDiagnostic()
         result = diag.check_meshchat_rns_integration()
         assert result.status == CheckStatus.FAIL
+
+
+# ============================================================================
+# Automated Installer Tests
+# ============================================================================
+
+class TestMeshChatInstaller:
+    """Test the automated MeshChat installation methods."""
+
+    def _make_mixin(self):
+        """Create a mixin instance with mocked dialog."""
+        from launcher_tui.meshchat_client_mixin import MeshChatClientMixin
+
+        class TestClass(MeshChatClientMixin):
+            def __init__(self):
+                self.dialog = MagicMock()
+                self._feature_flags = {}
+
+            def _safe_call(self, name, method, *a, **kw):
+                return method(*a, **kw)
+
+            def _wait_for_enter(self, msg=""):
+                pass
+
+            def _feature_enabled(self, f):
+                return True
+
+            def _get_rnsd_user(self):
+                return None
+
+        return TestClass()
+
+    def test_has_install_method(self):
+        """Mixin has automated _install_meshchat method."""
+        mixin = self._make_mixin()
+        assert hasattr(mixin, '_install_meshchat')
+        assert callable(mixin._install_meshchat)
+
+    def test_has_uninstall_method(self):
+        """Mixin has _uninstall_meshchat method."""
+        mixin = self._make_mixin()
+        assert hasattr(mixin, '_uninstall_meshchat')
+        assert callable(mixin._uninstall_meshchat)
+
+    def test_has_lxmf_exclusive_method(self):
+        """Mixin has _ensure_lxmf_exclusive method."""
+        mixin = self._make_mixin()
+        assert hasattr(mixin, '_ensure_lxmf_exclusive')
+        assert callable(mixin._ensure_lxmf_exclusive)
+
+    def test_get_meshchat_install_dir(self):
+        """Install dir is under user home, not /root."""
+        mixin = self._make_mixin()
+        with patch('launcher_tui.meshchat_client_mixin.get_real_user_home') as mock_home:
+            mock_home.return_value = __import__('pathlib').Path('/home/testuser')
+            result = mixin._get_meshchat_install_dir()
+            assert str(result) == '/home/testuser/reticulum-meshchat'
+
+    @patch('shutil.which', return_value='/usr/bin/meshchat')
+    def test_install_skips_if_already_installed(self, mock_which):
+        """Install shows 'already installed' if MeshChat is present."""
+        mixin = self._make_mixin()
+        mixin._install_meshchat()
+        mixin.dialog.msgbox.assert_called_once()
+        assert "Already Installed" in str(mixin.dialog.msgbox.call_args)
+
+    def test_install_cancelled_by_user(self):
+        """Install returns when user declines."""
+        mixin = self._make_mixin()
+        with patch.object(mixin, '_is_meshchat_installed', return_value=False):
+            mixin.dialog.yesno.return_value = False
+            mixin._install_meshchat()
+            # Should not proceed to prerequisites
+            assert mixin.dialog.yesno.called
+
+    @patch('shutil.which')
+    def test_install_prerequisites_checks_git_node_npm(self, mock_which):
+        """Prerequisites checker verifies git, node, npm."""
+        mixin = self._make_mixin()
+
+        # All tools available
+        mock_which.return_value = '/usr/bin/git'
+        result = mixin._install_meshchat_prerequisites()
+        assert result is True
+
+    @patch('shutil.which', return_value=None)
+    @patch('subprocess.run')
+    def test_install_prerequisites_installs_nodejs(self, mock_run, mock_which):
+        """Prerequisites installs nodejs when not found."""
+        mixin = self._make_mixin()
+
+        # First call: git not found, then found after install
+        call_count = [0]
+        def which_side_effect(tool):
+            call_count[0] += 1
+            # After apt install, tools are "found"
+            if call_count[0] > 3:
+                return f'/usr/bin/{tool}'
+            return None
+
+        mock_which.side_effect = which_side_effect
+        mock_run.return_value = MagicMock(returncode=0)
+        result = mixin._install_meshchat_prerequisites()
+        assert mock_run.called
+
+    @patch('subprocess.run')
+    def test_install_clone_new_repo(self, mock_run):
+        """Clone creates new repo when dir doesn't exist."""
+        mixin = self._make_mixin()
+        mock_run.return_value = MagicMock(returncode=0)
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = __import__('pathlib').Path(tmpdir) / 'reticulum-meshchat'
+            result = mixin._install_meshchat_clone(install_dir, None)
+            assert result is True
+            # Verify git clone was called
+            clone_call = mock_run.call_args_list[0]
+            assert 'git' in clone_call[0][0]
+            assert 'clone' in clone_call[0][0]
+
+    @patch('subprocess.run')
+    def test_install_clone_pulls_existing(self, mock_run):
+        """Clone pulls latest when dir already exists."""
+        mixin = self._make_mixin()
+        mock_run.return_value = MagicMock(returncode=0, stderr='')
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = __import__('pathlib').Path(tmpdir)
+            result = mixin._install_meshchat_clone(install_dir, None)
+            assert result is True
+            pull_call = mock_run.call_args_list[0]
+            assert 'pull' in pull_call[0][0]
+
+    def test_install_service_creates_unit_file(self):
+        """Service creation writes a valid systemd unit file."""
+        mixin = self._make_mixin()
+
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            install_dir = __import__('pathlib').Path(tmpdir)
+            service_path = install_dir / 'test.service'
+
+            with patch('launcher_tui.meshchat_client_mixin.get_real_user_home',
+                       return_value=__import__('pathlib').Path('/home/testuser')):
+                with patch('subprocess.run', return_value=MagicMock(returncode=0)):
+                    with patch('builtins.open', create=True) as mock_open:
+                        mock_open.return_value.__enter__ = lambda s: s
+                        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+                        mock_open.return_value.write = MagicMock()
+
+                        result = mixin._install_meshchat_service(install_dir, 'testuser')
+                        # Verify write was called with unit file content
+                        if mock_open.return_value.write.called:
+                            content = mock_open.return_value.write.call_args[0][0]
+                            assert 'User=testuser' in content
+                            assert 'meshchat.py' in content
+                            assert 'rnsd.service' in content
+
+    def test_meshchat_repo_url(self):
+        """MESHCHAT_REPO constant points to correct URL."""
+        from launcher_tui.meshchat_client_mixin import MeshChatClientMixin
+        assert 'liamcottle/reticulum-meshchat' in MeshChatClientMixin.MESHCHAT_REPO
+
+    def test_meshchat_service_name(self):
+        """MESHCHAT_SERVICE_NAME is correct."""
+        from launcher_tui.meshchat_client_mixin import MeshChatClientMixin
+        assert MeshChatClientMixin.MESHCHAT_SERVICE_NAME == "reticulum-meshchat"
+
+
+# ============================================================================
+# Uninstall (Stop + Disable) Tests
+# ============================================================================
+
+class TestMeshChatUninstall:
+    """Test MeshChat and NomadNet uninstall functionality."""
+
+    def _make_meshchat_mixin(self):
+        """Create MeshChat mixin for testing."""
+        from launcher_tui.meshchat_client_mixin import MeshChatClientMixin
+
+        class TestClass(MeshChatClientMixin):
+            def __init__(self):
+                self.dialog = MagicMock()
+
+            def _wait_for_enter(self, msg=""):
+                pass
+
+            def _is_meshchat_running(self):
+                return False
+
+        return TestClass()
+
+    def test_uninstall_cancelled(self):
+        """Uninstall does nothing when user cancels."""
+        mixin = self._make_meshchat_mixin()
+        mixin.dialog.yesno.return_value = False
+        mixin._uninstall_meshchat()
+        # Should only call yesno (confirmation), nothing else
+
+    @patch('subprocess.run')
+    def test_uninstall_stops_and_disables(self, mock_run):
+        """Uninstall calls systemctl stop and disable."""
+        mixin = self._make_meshchat_mixin()
+        mixin.dialog.yesno.return_value = True
+        mock_run.return_value = MagicMock(returncode=0)
+
+        mixin._uninstall_meshchat()
+
+        # Verify systemctl calls
+        calls = [str(c) for c in mock_run.call_args_list]
+        stop_called = any('stop' in c and 'reticulum-meshchat' in c for c in calls)
+        disable_called = any('disable' in c and 'reticulum-meshchat' in c for c in calls)
+        assert stop_called, "systemctl stop not called"
+        assert disable_called, "systemctl disable not called"
+
+
+# ============================================================================
+# LXMF Exclusive Toggle Tests
+# ============================================================================
+
+class TestLXMFExclusiveToggle:
+    """Test _ensure_lxmf_exclusive() one-app-at-a-time enforcement."""
+
+    def _make_mixin(self):
+        """Create mixin for testing."""
+        from launcher_tui.meshchat_client_mixin import MeshChatClientMixin
+
+        class TestClass(MeshChatClientMixin):
+            def __init__(self):
+                self.dialog = MagicMock()
+
+            def _is_meshchat_running(self):
+                return False
+
+        return TestClass()
+
+    @patch('subprocess.run')
+    def test_meshchat_start_no_conflict(self, mock_run):
+        """Starting MeshChat succeeds when NomadNet not running."""
+        mixin = self._make_mixin()
+        mock_run.return_value = MagicMock(returncode=1, stdout='')
+
+        with patch('launcher_tui.meshchat_client_mixin._HAS_SERVICE_CHECK', False):
+            result = mixin._ensure_lxmf_exclusive("meshchat")
+            assert result is True
+
+    @patch('subprocess.run')
+    def test_meshchat_start_stops_nomadnet(self, mock_run):
+        """Starting MeshChat offers to stop NomadNet."""
+        mixin = self._make_mixin()
+        mixin.dialog.yesno.return_value = True
+
+        # First pgrep finds NomadNet, second pkill succeeds
+        call_count = [0]
+        def run_side_effect(cmd, **kwargs):
+            call_count[0] += 1
+            result = MagicMock()
+            if call_count[0] == 1:  # pgrep for nomadnet
+                result.returncode = 0
+                result.stdout = "1234\n"
+            else:
+                result.returncode = 0
+                result.stdout = ""
+            return result
+
+        mock_run.side_effect = run_side_effect
+
+        with patch('launcher_tui.meshchat_client_mixin._HAS_SERVICE_CHECK', False):
+            result = mixin._ensure_lxmf_exclusive("meshchat")
+            assert result is True
+            mixin.dialog.yesno.assert_called_once()
+
+    @patch('subprocess.run')
+    def test_meshchat_start_user_declines(self, mock_run):
+        """User declines to stop NomadNet, MeshChat start cancelled."""
+        mixin = self._make_mixin()
+        mixin.dialog.yesno.return_value = False
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="1234\n")
+
+        with patch('launcher_tui.meshchat_client_mixin._HAS_SERVICE_CHECK', False):
+            result = mixin._ensure_lxmf_exclusive("meshchat")
+            assert result is False
+
+    @patch('subprocess.run')
+    def test_nomadnet_start_stops_meshchat(self, mock_run):
+        """Starting NomadNet offers to stop MeshChat."""
+        mixin = self._make_mixin()
+        mixin._is_meshchat_running = lambda: True
+        mixin.dialog.yesno.return_value = True
+        mock_run.return_value = MagicMock(returncode=0)
+
+        result = mixin._ensure_lxmf_exclusive("nomadnet")
+        assert result is True
+        mixin.dialog.yesno.assert_called_once()
+        assert "MeshChat" in str(mixin.dialog.yesno.call_args)
+
+    def test_nomadnet_start_no_conflict(self):
+        """Starting NomadNet succeeds when MeshChat not running."""
+        mixin = self._make_mixin()
+        mixin._is_meshchat_running = lambda: False
+
+        result = mixin._ensure_lxmf_exclusive("nomadnet")
+        assert result is True
+
+    @patch('subprocess.run')
+    def test_nomadnet_start_user_declines(self, mock_run):
+        """User declines to stop MeshChat, NomadNet start cancelled."""
+        mixin = self._make_mixin()
+        mixin._is_meshchat_running = lambda: True
+        mixin.dialog.yesno.return_value = False
+
+        result = mixin._ensure_lxmf_exclusive("nomadnet")
+        assert result is False
+
+
+# ============================================================================
+# Service INSTALL_HINT Tests
+# ============================================================================
+
+class TestMeshChatServiceHint:
+    """Test that service.py INSTALL_HINT references TUI install."""
+
+    def test_install_hint_mentions_tui(self):
+        """INSTALL_HINT references TUI automated install path."""
+        from plugins.meshchat.service import MeshChatService
+        assert "TUI" in MeshChatService.INSTALL_HINT
+
+    def test_install_hint_mentions_npm(self):
+        """INSTALL_HINT mentions npm for manual install."""
+        from plugins.meshchat.service import MeshChatService
+        assert "npm" in MeshChatService.INSTALL_HINT
+
+    def test_install_hint_mentions_nodejs(self):
+        """INSTALL_HINT mentions nodejs prerequisite."""
+        from plugins.meshchat.service import MeshChatService
+        assert "nodejs" in MeshChatService.INSTALL_HINT


### PR DESCRIPTION
## Summary

This PR adds fully automated MeshChat installation and uninstall capabilities to the TUI, along with LXMF port exclusivity enforcement to prevent conflicts between MeshChat and NomadNet.

## Key Changes

**MeshChat Installation (Automated)**
- Implemented `_install_meshchat()` with step-by-step guided installation:
  - Prerequisite checking and installation (git, Node.js, npm)
  - Repository cloning with git pull support for existing installs
  - Python dependency installation via pip (with PEP 668 compatibility)
  - Web frontend build via npm
  - Systemd service creation and enablement
- Added helper methods: `_install_meshchat_prerequisites()`, `_install_meshchat_clone()`, `_install_meshchat_pip()`, `_install_meshchat_npm()`, `_install_meshchat_service()`
- Added `_get_meshchat_install_dir()` and `_get_pip_command()` utilities
- Replaced static installation instructions with interactive, fully-automated workflow

**MeshChat Uninstall**
- Implemented `_uninstall_meshchat()` to stop and disable the systemd service
- Leaves files in place for easy re-enablement
- Added "Disable MeshChat" menu option

**NomadNet Uninstall**
- Implemented `_uninstall_nomadnet()` with similar stop/disable pattern
- Added "Disable NomadNet" menu option

**LXMF Exclusivity Enforcement**
- Implemented `_ensure_lxmf_exclusive(app_name)` to prevent port 37428 conflicts
- When starting MeshChat: checks if NomadNet is running and offers to stop it
- When starting NomadNet: checks if MeshChat is running and offers to stop it
- Integrated into both `_launch_meshchat()` and NomadNet launch methods
- User can decline, cancelling the app start

**Menu Updates**
- Added "Disable MeshChat" and "Disable NomadNet" options to respective menus
- Updated dispatch tables to route uninstall actions

**Documentation & Tests**
- Updated module docstring with installation and LXMF exclusivity notes
- Updated `service.py` INSTALL_HINT to reference TUI automated install
- Updated README.md to mention MeshChat and new `meshchat` deployment profile
- Added comprehensive test suite covering installer, uninstaller, and LXMF exclusivity logic

## Implementation Details

- Installation runs with appropriate user context (respects `SUDO_USER` environment variable)
- Pip command detection handles both venv and system pip with PEP 668 compatibility
- Systemd service includes proper dependencies (`After=network.target rnsd.service`)
- Exception handling distinguishes between `SubprocessError` and `OSError` (removed bare `Exception` catch)
- LXMF exclusivity uses both service check API (if available) and `pgrep` fallback
- All subprocess calls include appropriate timeouts and error handling

https://claude.ai/code/session_01K4kmXPzAzrE5BuN9VvvRHq