### PR TITLE
Add comprehensive radio hardware templates for 19 supported devices

### DIFF
--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -60,16 +60,177 @@ class RadioConfig:
     config_file: Optional[str] = None
 
 
-# Default config templates for common radios
+# Default config templates for all supported radios
+# GPIO pins sourced from src/config/hardware.py KNOWN_SPI_HATS / KNOWN_USB_MODULES
 RADIO_TEMPLATES = {
+    # ─────────────────────────────────────────────
+    # USB Radios (run own firmware, managed via serial)
+    # ─────────────────────────────────────────────
+    "heltec-usb": {
+        "name": "heltec-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "Heltec V3/V4 USB (ESP32-S3, 28dBm TX, gateway)",
+        "config": """\
+# Heltec V3/V4 USB Radio Configuration
+# Chipset: ESP32-S3 (USB CDC)
+# V4 supports 28dBm TX power. Gateway capable.
+# Power: 500mA typical, 1A peak (V4 at max TX)
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "station-g2-usb": {
+        "name": "station-g2-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "Station G2 USB (CP2102, gateway, PoE)",
+        "config": """\
+# Station G2 USB Radio Configuration
+# Chipset: CP2102 USB-Serial
+# Gateway capable. PoE option available.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "tbeam-usb": {
+        "name": "tbeam-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "LILYGO T-Beam S3 USB (CH9102, GPS, gateway)",
+        "config": """\
+# LILYGO T-Beam S3 USB Radio Configuration
+# Chipset: CH9102 USB-Serial
+# Built-in GPS. Gateway capable.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "rak4631-usb": {
+        "name": "rak4631-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "RAK4631 USB (nRF52840 + SX1262, ultra-low power)",
+        "config": """\
+# RAK4631 USB Radio Configuration
+# Chipset: nRF52840 + SX1262
+# Ultra-low power. Flash via UF2.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "meshtoad-usb": {
+        "name": "meshtoad-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "MeshToad/MeshTadpole USB (CH340, MtnMesh)",
+        "config": """\
+# MeshToad / MeshTadpole USB Radio Configuration
+# Chipset: CH340/CH341 USB-Serial
+# MtnMesh devices. 900mA peak power draw.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "meshstick-usb": {
+        "name": "meshstick-usb",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "MeshStick USB (official Meshtastic device)",
+        "config": """\
+# MeshStick USB Radio Configuration
+# Official Meshtastic USB device.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "usb-serial-generic": {
+        "name": "usb-serial-generic",
+        "radio_type": RadioType.USB_SERIAL,
+        "description": "Generic USB Serial Radio (FTDI/FT232, fallback)",
+        "config": """\
+# Generic USB Serial Radio Configuration
+# For FTDI (FT232) and other USB-serial LoRa boards.
+# Use as fallback when your specific device is not listed.
+
+Serial:
+  Device: auto
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    # ─────────────────────────────────────────────
+    # SPI HATs (GPIO-connected, native meshtasticd)
+    # ─────────────────────────────────────────────
     "meshtoad-spi": {
         "name": "meshtoad-spi",
         "radio_type": RadioType.NATIVE_SPI,
         "chip": "sx1262",
         "description": "Meshtoad/MeshStick SPI Radio (SX1262 via CH341)",
-        "config": """# Meshtoad / MeshStick SPI Radio Configuration
+        "config": """\
+# Meshtoad / MeshStick SPI Radio Configuration
 # Uses CH341 USB-to-SPI adapter with SX1262
-# Reference: https://github.com/markbirss/MESHSTICK
 
 Lora:
   Module: sx1262
@@ -80,39 +241,315 @@ Lora:
   Busy: 4
   DIO2_AS_RF_SWITCH: true
   DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "meshadv-pi-hat": {
+        "name": "meshadv-pi-hat",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshAdv-Pi-Hat 1W (SX1262, GPS, high-power)",
+        "config": """\
+# MeshAdv-Pi-Hat SPI Configuration (1W High-Power)
+# Hardware: E22-900M30S/33S (SX1262), +33dBm (1W)
+# Features: GPS (ATGM336H), I2C/Qwiic, PPS
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+GPS:
+  SerialPath: /dev/ttyS0
+
+I2C:
+  I2CDevice: /dev/i2c-1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "meshadv-mini": {
+        "name": "meshadv-mini",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshAdv-Mini (SX1262, GPS, +22dBm)",
+        "config": """\
+# MeshAdv-Mini SPI Configuration
+# Hardware: SX1262/SX1268, +22dBm
+# Features: GPS, Temperature Sensor, PWM Fan, I2C/Qwiic
+
+Lora:
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  RXen: 12
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+GPS:
+  SerialPath: /dev/ttyS0
+
+I2C:
+  I2CDevice: /dev/i2c-1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "meshadv-pi-v1.1": {
+        "name": "meshadv-pi-v1.1",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshAdv-Pi v1.1 (SX1262)",
+        "config": """\
+# MeshAdv-Pi v1.1 SPI Configuration
+# Hardware: SX1262
+
+Lora:
+  CS: 8
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "waveshare-sx1262": {
+        "name": "waveshare-sx1262",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Waveshare SX1262 LoRa HAT",
+        "config": """\
+# Waveshare SX1262 LoRa HAT SPI Configuration
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
 """
     },
     "rak-hat-spi": {
         "name": "rak-hat-spi",
         "radio_type": RadioType.NATIVE_SPI,
         "chip": "sx1262",
-        "description": "RAK WisLink SPI HAT (SX1262)",
-        "config": """# RAK WisLink SPI HAT Configuration
-# Direct GPIO connection on Raspberry Pi
+        "description": "RAK WisLink / RAK2287 SPI HAT (SX1262)",
+        "config": """\
+# RAK WisLink / RAK2287 SPI HAT Configuration
 
 Lora:
-  Module: sx1262
-  CS: 0
-  IRQ: 22
-  Busy: 23
-  Reset: 24
+  CS: 8
+  IRQ: 25
+  Busy: 24
+  Reset: 17
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
 
 Logging:
   LogLevel: info
 """
     },
-    "usb-serial": {
-        "name": "usb-serial",
-        "radio_type": RadioType.USB_SERIAL,
-        "description": "USB Serial Radio (T-Beam, Heltec, etc.)",
-        "config": """# USB Serial Radio Configuration
-# For radios connected via USB (T-Beam, Heltec, RAK USB)
+    "adafruit-rfm9x": {
+        "name": "adafruit-rfm9x",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1276",
+        "description": "Adafruit RFM9x LoRa Radio Bonnet (SX1276)",
+        "config": """\
+# Adafruit RFM9x LoRa Radio Bonnet SPI Configuration
+# Hardware: SX1276 (RFM95/RFM96) — no Busy pin
 
-# Serial device will be auto-detected
-# Common paths: /dev/ttyUSB0, /dev/ttyACM0
+Lora:
+  Module: sx1276
+  CS: 7
+  IRQ: 25
+  Reset: 17
 
-Serial:
-  Device: auto  # or specify: /dev/ttyUSB0
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "femtofox": {
+        "name": "femtofox",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "FemtoFox LoRa Board (compact SX1262)",
+        "config": """\
+# FemtoFox LoRa Board SPI Configuration
+
+Lora:
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "ebyte-e22-900m30s": {
+        "name": "ebyte-e22-900m30s",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Ebyte E22-900M30S 1W (SX1262, 915MHz)",
+        "config": """\
+# Ebyte E22-900M30S SPI Configuration (1W, 915MHz)
+# WARNING: High-power module — requires adequate power supply.
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "ebyte-e22-400m30s": {
+        "name": "ebyte-e22-400m30s",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1268",
+        "description": "Ebyte E22-400M30S 1W (SX1268, 433MHz EU/Asia)",
+        "config": """\
+# Ebyte E22-400M30S SPI Configuration (1W, 433MHz EU/Asia)
+# WARNING: High-power module — requires adequate power supply.
+
+Lora:
+  Module: sx1268
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "elecrow-rfm95": {
+        "name": "elecrow-rfm95",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1276",
+        "description": "Elecrow RFM95 LoRa HAT (SX1276)",
+        "config": """\
+# Elecrow RFM95 LoRa HAT SPI Configuration
+# Hardware: SX1276 (RFM95) — no Busy pin
+
+Lora:
+  Module: sx1276
+  CS: 25
+  IRQ: 5
+  Reset: 17
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "seeed-sensecap": {
+        "name": "seeed-sensecap",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Seeed SenseCAP E5 LoRa HAT (SX1262)",
+        "config": """\
+# Seeed SenseCAP E5 LoRa HAT SPI Configuration
+
+Lora:
+  CS: 8
+  IRQ: 25
+  Reset: 22
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
 
 Logging:
   LogLevel: info
@@ -127,10 +564,9 @@ class MeshtasticdConfig:
 
     Directory structure:
         /etc/meshtasticd/
-        ├── available.d/     # Available radio configs
-        │   ├── meshtoad-spi.yaml
-        │   ├── rak-hat-spi.yaml
-        │   └── usb-serial.yaml
+        ├── available.d/     # Available radio configs (19 templates)
+        │   ├── heltec-usb.yaml, tbeam-usb.yaml, ...  (7 USB)
+        │   └── meshtoad-spi.yaml, rak-hat-spi.yaml, ... (12 SPI)
         ├── config.d/        # Enabled configs (symlinks to available.d)
         │   └── active.yaml -> ../available.d/meshtoad-spi.yaml
         ├── config.yaml      # Main config (merged from config.d)

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -413,6 +413,16 @@ Press Cancel to keep current values."""
 
     def _hardware_config_menu(self):
         """Hardware configuration selection."""
+        # Auto-create directory structure and templates if missing
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            config_mgr = MeshtasticdConfig()
+            config_mgr.ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create templates (no root), using existing")
+        except Exception as e:
+            logger.debug("Template auto-creation failed: %s", e)
+
         available_dir = Path('/etc/meshtasticd/available.d')
         config_d = Path('/etc/meshtasticd/config.d')
 
@@ -420,13 +430,15 @@ Press Cancel to keep current values."""
             self.dialog.msgbox("Error",
                 "Hardware templates not found.\n\n"
                 f"Expected: {available_dir}\n\n"
-                "Run the installer to set up templates.")
+                "Run with sudo to auto-create, or run the installer.")
             return
 
         # List available hardware configs
         available = list(available_dir.glob('*.yaml'))
         if not available:
-            self.dialog.msgbox("Error", "No hardware templates found.")
+            self.dialog.msgbox("Error",
+                "No hardware templates found.\n\n"
+                "Run with sudo to auto-create, or run the installer.")
             return
 
         # Get currently active configs
@@ -893,8 +905,17 @@ Press Cancel to keep current values."""
     def _edit_file(self, path: str):
         """Edit a file with nano."""
         if not Path(path).exists():
-            self.dialog.msgbox("Error", f"File not found:\n{path}")
-            return
+            # Try to auto-create meshtasticd config structure
+            if '/etc/meshtasticd/' in path:
+                try:
+                    from core.meshtasticd_config import MeshtasticdConfig
+                    config_mgr = MeshtasticdConfig()
+                    config_mgr.ensure_structure()
+                except Exception as e:
+                    logger.debug("Auto-create config failed: %s", e)
+            if not Path(path).exists():
+                self.dialog.msgbox("Error", f"File not found:\n{path}")
+                return
 
         # Clear screen and run nano
         clear_screen()

--- a/templates/available.d/adafruit-rfm9x.yaml
+++ b/templates/available.d/adafruit-rfm9x.yaml
@@ -1,0 +1,26 @@
+# Adafruit RFM9x LoRa Radio Bonnet SPI Configuration
+# Hardware: SX1276 (RFM95/RFM96)
+# Manufacturer: Adafruit
+#
+# Note: SX1276 does NOT have a Busy pin.
+#
+# Copy to: /etc/meshtasticd/config.d/adafruit-rfm9x.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1276
+  CS: 7
+  IRQ: 25
+  Reset: 17
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/ebyte-e22-400m30s.yaml
+++ b/templates/available.d/ebyte-e22-400m30s.yaml
@@ -1,0 +1,32 @@
+# Ebyte E22-400M30S SPI Configuration (1W High-Power, 433MHz)
+# Hardware: SX1268 at +30dBm (1W)
+# Manufacturer: Ebyte
+# Region: 433MHz for EU/Asia
+#
+# WARNING: High-power module — requires adequate power supply.
+#
+# Copy to: /etc/meshtasticd/config.d/ebyte-e22-400m30s.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1268
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/ebyte-e22-900m30s.yaml
+++ b/templates/available.d/ebyte-e22-900m30s.yaml
@@ -1,0 +1,31 @@
+# Ebyte E22-900M30S SPI Configuration (1W High-Power, 915MHz)
+# Hardware: SX1262 at +30dBm (1W)
+# Manufacturer: Ebyte
+#
+# WARNING: High-power module — requires adequate power supply.
+# Used in MeshAdv-Pi-Hat and similar high-power setups.
+#
+# Copy to: /etc/meshtasticd/config.d/ebyte-e22-900m30s.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/elecrow-rfm95.yaml
+++ b/templates/available.d/elecrow-rfm95.yaml
@@ -1,0 +1,26 @@
+# Elecrow RFM95 LoRa HAT SPI Configuration
+# Hardware: SX1276 (RFM95)
+# Manufacturer: Elecrow
+#
+# Note: SX1276 does NOT have a Busy pin.
+#
+# Copy to: /etc/meshtasticd/config.d/elecrow-rfm95.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1276
+  CS: 25
+  IRQ: 5
+  Reset: 17
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/femtofox.yaml
+++ b/templates/available.d/femtofox.yaml
@@ -1,0 +1,26 @@
+# FemtoFox LoRa Board SPI Configuration
+# Hardware: Compact SX1262 module
+# Manufacturer: FemtoFox
+#
+# Copy to: /etc/meshtasticd/config.d/femtofox.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/heltec-usb.yaml
+++ b/templates/available.d/heltec-usb.yaml
@@ -1,0 +1,26 @@
+# Heltec V3/V4 USB Radio Configuration
+# Chipset: ESP32-S3 (USB CDC)
+# USB ID: 303a:1001 (CDC), 303a:4001 (JTAG)
+#
+# V4 supports 28dBm TX power. Gateway capable.
+# Flash method: esptool
+# Power: 500mA typical, 1A peak (V4 at max TX)
+#
+# Copy to: /etc/meshtasticd/config.d/heltec-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: auto          # /dev/ttyACM0 typical for ESP32-S3 CDC
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshadv-mini.yaml
+++ b/templates/available.d/meshadv-mini.yaml
@@ -1,0 +1,37 @@
+# MeshAdv-Mini SPI Configuration
+# Hardware: SX1262/SX1268 LoRa/GPS Raspberry Pi HAT
+# Manufacturer: chrismyers2000
+# Power: +22dBm
+# Features: GPS (ATGM336H-5NR32), Temperature Sensor, PWM Fan, I2C/Qwiic
+# Compatible: Pi 2/3/4/5, Zero, Zero W, Zero 2 W
+#
+# Copy to: /etc/meshtasticd/config.d/meshadv-mini.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  RXen: 12
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+GPS:
+  SerialPath: /dev/ttyS0
+  # PPSGpio: 17              # Uncomment for PPS timing
+
+I2C:
+  I2CDevice: /dev/i2c-1      # TMP102 temp sensor at 0x48
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshadv-pi-hat.yaml
+++ b/templates/available.d/meshadv-pi-hat.yaml
@@ -1,0 +1,38 @@
+# MeshAdv-Pi-Hat SPI Configuration (1W High-Power)
+# Hardware: E22-900M30S/33S (SX1262) or E22-400M30S/33S (SX1268)
+# Manufacturer: chrismyers2000
+# Power: +33dBm (1W) — requires adequate power supply
+# Features: GPS (ATGM336H), I2C/Qwiic, PPS
+# Compatible: Pi 2/3/4/5, Zero, Zero W, Zero 2 W, Pi 400
+#
+# Copy to: /etc/meshtasticd/config.d/meshadv-pi-hat.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  RXen: 12
+  TXen: 13
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+GPS:
+  SerialPath: /dev/ttyS0
+  # PPSGpio: 23              # Uncomment for PPS timing
+
+I2C:
+  I2CDevice: /dev/i2c-1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshadv-pi-v1.1.yaml
+++ b/templates/available.d/meshadv-pi-v1.1.yaml
@@ -1,0 +1,25 @@
+# MeshAdv-Pi v1.1 SPI Configuration
+# Hardware: SX1262
+# Manufacturer: MeshAdv
+#
+# Copy to: /etc/meshtasticd/config.d/meshadv-pi-v1.1.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 8
+  IRQ: 22
+  Busy: 23
+  Reset: 24
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshstick-usb.yaml
+++ b/templates/available.d/meshstick-usb.yaml
@@ -1,0 +1,25 @@
+# MeshStick USB Radio Configuration
+# Chipset: Native USB
+# USB ID: 1209:0000
+#
+# Official Meshtastic USB device.
+# Power: Standard USB
+#
+# Copy to: /etc/meshtasticd/config.d/meshstick-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: auto          # /dev/ttyACM0 typical
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshtoad-spi.yaml
+++ b/templates/available.d/meshtoad-spi.yaml
@@ -1,0 +1,26 @@
+# Meshtoad / MeshStick SPI Radio Configuration
+# Hardware: SX1262 via CH341 USB-to-SPI adapter
+# Reference: https://github.com/markbirss/MESHSTICK
+#
+# Copy to: /etc/meshtasticd/config.d/meshtoad-spi.yaml
+#
+# The Meshtoad uses a CH341 chip as USB-to-SPI bridge.
+# Ensure the ch341 kernel module is loaded:
+#   sudo modprobe ch341
+#   lsmod | grep ch341
+
+Lora:
+  Module: sx1262
+  spidev: ch341
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/meshtoad-usb.yaml
+++ b/templates/available.d/meshtoad-usb.yaml
@@ -1,0 +1,27 @@
+# MeshToad / MeshTadpole USB Radio Configuration
+# Chipset: CH340/CH341 USB-Serial
+# USB ID: 1a86:7523 (CH340), 1a86:55d4 (CH341 alternate)
+#
+# MtnMesh devices. 900mA peak power draw.
+# Note: Some MeshToad variants use CH341 in SPI mode — use
+# meshtoad-spi.yaml for those (USB-to-SPI bridge).
+#
+# Copy to: /etc/meshtasticd/config.d/meshtoad-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset MEDIUM_FAST
+#   (MediumFast preset recommended for MtnMesh compatibility)
+
+Serial:
+  Device: auto          # /dev/ttyUSB0 typical for CH340
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/rak-hat-spi.yaml
+++ b/templates/available.d/rak-hat-spi.yaml
@@ -1,0 +1,25 @@
+# RAK WisLink / RAK2287 SPI HAT Configuration
+# Hardware: SX1262
+# Manufacturer: RAKwireless
+#
+# Copy to: /etc/meshtasticd/config.d/rak-hat-spi.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 8
+  IRQ: 25
+  Busy: 24
+  Reset: 17
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/rak4631-usb.yaml
+++ b/templates/available.d/rak4631-usb.yaml
@@ -1,0 +1,26 @@
+# RAK4631 USB Radio Configuration
+# Chipset: nRF52840 + SX1262
+# USB ID: 239a:8029 (runtime), 239a:0029 (bootloader/UF2)
+#
+# Ultra-low power. Excellent for solar nodes. Gateway capable.
+# Flash method: UF2 (double-tap reset to enter bootloader)
+# Power: 100mA typical
+#
+# Copy to: /etc/meshtasticd/config.d/rak4631-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: auto          # /dev/ttyACM0 typical for nRF52840
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/seeed-sensecap.yaml
+++ b/templates/available.d/seeed-sensecap.yaml
@@ -1,0 +1,24 @@
+# Seeed SenseCAP E5 LoRa HAT SPI Configuration
+# Hardware: SX1262
+# Manufacturer: Seeed Studio
+#
+# Copy to: /etc/meshtasticd/config.d/seeed-sensecap.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 8
+  IRQ: 25
+  Reset: 22
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/station-g2-usb.yaml
+++ b/templates/available.d/station-g2-usb.yaml
@@ -1,0 +1,26 @@
+# Station G2 USB Radio Configuration
+# Chipset: CP2102 USB-Serial
+# USB ID: 10c4:ea60
+#
+# Gateway capable. PoE option available.
+# Flash method: esptool
+# Power: 5V DC or PoE (for Ethernet variant)
+#
+# Copy to: /etc/meshtasticd/config.d/station-g2-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: auto          # /dev/ttyUSB0 typical for CP2102
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/tbeam-usb.yaml
+++ b/templates/available.d/tbeam-usb.yaml
@@ -1,0 +1,26 @@
+# LILYGO T-Beam S3 USB Radio Configuration
+# Chipset: CH9102 USB-Serial
+# USB ID: 1a86:55d3
+#
+# Built-in GPS. Gateway capable.
+# Flash method: esptool
+# Power: 500mA typical
+#
+# Copy to: /etc/meshtasticd/config.d/tbeam-usb.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: auto          # /dev/ttyUSB0 typical for CH9102
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/usb-serial-generic.yaml
+++ b/templates/available.d/usb-serial-generic.yaml
@@ -1,0 +1,29 @@
+# Generic USB Serial Radio Configuration
+# For FTDI (FT232) and other USB-serial LoRa boards
+# USB ID: 0403:6001 (FTDI), or other serial adapters
+#
+# Use this template as a fallback when your specific device
+# is not listed in the other USB templates.
+# Power: Standard USB
+#
+# Copy to: /etc/meshtasticd/config.d/usb-serial-generic.yaml
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+#
+# To find your device path:
+#   ls /dev/ttyUSB* /dev/ttyACM* 2>/dev/null
+
+Serial:
+  Device: auto          # /dev/ttyUSB0 or /dev/ttyACM0
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/waveshare-sx1262.yaml
+++ b/templates/available.d/waveshare-sx1262.yaml
@@ -1,0 +1,25 @@
+# Waveshare SX1262 LoRa HAT SPI Configuration
+# Hardware: SX1262
+# Manufacturer: Waveshare
+#
+# Copy to: /etc/meshtasticd/config.d/waveshare-sx1262.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  DIO2_AS_RF_SWITCH: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info


### PR DESCRIPTION
## Summary
Expanded the radio hardware configuration system from 2 generic templates to 19 device-specific templates covering both USB serial and SPI HAT radios. This provides users with pre-configured GPIO pins, chipset details, and device-specific settings for popular Meshtastic hardware.

## Key Changes

- **USB Serial Radios (7 templates)**: Added dedicated configs for Heltec V3/V4, Station G2, T-Beam S3, RAK4631, MeshToad/MeshTadpole, MeshStick, and generic FTDI fallback
  - Each includes USB chipset info, power specs, and gateway capabilities
  - Auto device detection via `Device: auto`

- **SPI HAT Radios (12 templates)**: Added configs for MeshAdv-Pi-Hat (1W), MeshAdv-Mini, MeshAdv-Pi v1.1, Waveshare SX1262, RAK WisLink/RAK2287, Adafruit RFM9x, FemtoFox, Ebyte E22-900M30S/400M30S, Elecrow RFM95, and Seeed SenseCAP E5
  - Includes accurate GPIO pin mappings sourced from `src/config/hardware.py`
  - Specifies chipset (SX1262, SX1268, SX1276) and power levels
  - High-power modules (Ebyte 1W) include power supply warnings

- **Template Organization**: Reorganized `RADIO_TEMPLATES` dict with clear section headers separating USB and SPI categories

- **Configuration Files**: Created 19 YAML template files in `templates/available.d/` with:
  - Device-specific GPIO pin configurations
  - Chipset and USB ID information
  - Power requirements and capabilities
  - Setup instructions (e.g., SPI enablement via `raspi-config`)
  - Meshtastic CLI examples for radio configuration

- **UI Enhancement**: Updated `meshtasticd_config_mixin.py` to auto-create template directory structure when running with elevated privileges, with graceful fallback for non-root execution

- **Documentation**: Added inline comments referencing GPIO source and clarifying USB vs. SPI device categories

## Implementation Details

- GPIO pins are sourced from existing `src/config/hardware.py` KNOWN_SPI_HATS and KNOWN_USB_MODULES
- Each template includes TCP port (4403), webserver port (443), and logging configuration
- USB templates use `Device: auto` for cross-platform compatibility
- SPI templates include DIO2_AS_RF_SWITCH and DIO3_TCXO_VOLTAGE settings where applicable
- High-power modules (Ebyte E22 series) include explicit power supply warnings
- Templates support both runtime configuration via Meshtastic CLI and static YAML setup

https://claude.ai/code/session_01XZaSjBwijhsXFcKt3fZbcV