### PR TITLE
Refactor hardware config to use template-based system

### DIFF
--- a/src/launcher_tui/first_run_mixin.py
+++ b/src/launcher_tui/first_run_mixin.py
@@ -43,32 +43,34 @@ StartupChecker, _HAS_STARTUP_CHECKER = safe_import('startup_checks', 'StartupChe
 # =========================================================================
 
 # SPI HAT configurations with their config file names
+# Legacy fallback — used only when /etc/meshtasticd/available.d/ is empty.
+# Filenames must match actual templates in templates/available.d/.
 SPI_HARDWARE_CONFIGS = {
     'meshadv-mini': {
         'name': 'MeshAdv-Mini',
         'description': 'MeshAdv-Mini Pi HAT (recommended for Raspberry Pi)',
-        'config_file': 'lora-meshadv-mini.yaml',
+        'config_file': 'meshadv-mini.yaml',
         'requires_spi': True,
         'requires_overlay': 'spi0-0cs',
     },
     'waveshare-sx1262': {
         'name': 'Waveshare SX1262 HAT',
         'description': 'Waveshare SX1262 868/915M LoRa HAT',
-        'config_file': 'lora-waveshare-sx1262.yaml',
+        'config_file': 'waveshare-sx1262.yaml',
         'requires_spi': True,
         'requires_overlay': None,
     },
     'rak-hat': {
         'name': 'RAK WisLink HAT',
         'description': 'RAKwireless WisLink LoRa HAT',
-        'config_file': 'lora-rak-hat.yaml',
+        'config_file': 'rak-hat-spi.yaml',
         'requires_spi': True,
         'requires_overlay': None,
     },
     'ebyte-e22': {
         'name': 'Ebyte E22 Module',
         'description': 'Ebyte E22-900M/E22-400M LoRa Module',
-        'config_file': 'lora-ebyte-e22.yaml',
+        'config_file': 'ebyte-e22-900m30s.yaml',
         'requires_spi': True,
         'requires_overlay': None,
     },
@@ -109,6 +111,84 @@ class FirstRunMixin:
     """Mixin for first-run wizard in launcher TUI"""
 
     FIRST_RUN_FLAG = ".meshforge_setup_complete"
+
+    def _classify_templates(self, available_d: Path) -> Tuple[List[Path], List[Path]]:
+        """Classify available.d templates into USB and SPI categories.
+
+        Classification uses filename convention:
+          - USB: filename contains '-usb' or starts with 'usb-'
+          - SPI: everything else
+
+        Returns:
+            Tuple of (usb_templates, spi_templates), each a sorted list of Paths
+        """
+        usb_templates = []
+        spi_templates = []
+
+        if not available_d.exists():
+            return usb_templates, spi_templates
+
+        for tmpl in sorted(available_d.glob('*.yaml')):
+            name = tmpl.stem.lower()
+            if '-usb' in name or name.startswith('usb-'):
+                usb_templates.append(tmpl)
+            else:
+                spi_templates.append(tmpl)
+
+        return usb_templates, spi_templates
+
+    def _check_existing_configs(self, config_d: Path, config_type: str) -> bool:
+        """Check for existing configs in config.d and ask user if they want to change.
+
+        Args:
+            config_d: Path to /etc/meshtasticd/config.d
+            config_type: 'USB' or 'SPI HAT' for display purposes
+
+        Returns:
+            True if we should proceed with template selection,
+            False if user wants to keep existing config.
+        """
+        if not config_d.exists():
+            return True
+
+        existing_configs = list(config_d.glob('*.yaml'))
+        if not existing_configs:
+            return True
+
+        config_names = ", ".join(f.name for f in existing_configs)
+        change = self.dialog.yesno(
+            f"Existing {config_type} Config Found",
+            f"You already have hardware configured:\n\n"
+            f"  {config_names}\n\n"
+            f"Location: {config_d}\n\n"
+            "Do you want to change it?",
+            default_no=True
+        )
+
+        if not change:
+            self.dialog.msgbox(
+                "Keeping Existing Config",
+                f"Your current config will be kept:\n\n"
+                f"  {config_names}\n\n"
+                "You can change this later from:\n"
+                "  Configuration > meshtasticd Config > Hardware"
+            )
+            return False
+
+        return True
+
+    def _ensure_template_structure(self):
+        """Ensure /etc/meshtasticd directory structure and templates exist."""
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            config_mgr = MeshtasticdConfig()
+            config_mgr.ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create templates (no root), using existing")
+        except ImportError:
+            logger.warning("core.meshtasticd_config not available, skipping template setup")
+        except (OSError, ValueError) as e:
+            logger.warning("Template auto-creation failed: %s", e)
 
     def _check_first_run(self) -> bool:
         """Check if this is a first run (no setup flag exists)"""
@@ -254,48 +334,29 @@ class FirstRunMixin:
                 )
                 return
 
-        # Check for existing config in config.d
+        self._ensure_template_structure()
+
         config_d = Path('/etc/meshtasticd/config.d')
         available_d = Path('/etc/meshtasticd/available.d')
-        existing_configs = []
-        if config_d.exists():
-            existing_configs = [f for f in config_d.glob('lora-*.yaml')]
 
-        if existing_configs:
-            # Show existing config and ask if user wants to change
-            config_names = ", ".join(f.name for f in existing_configs)
-            change = self.dialog.yesno(
-                "Existing HAT Config Found",
-                f"You already have a HAT configured:\n\n"
-                f"  {config_names}\n\n"
-                f"Location: {config_d}\n\n"
-                "Do you want to change it?",
-                default_no=True
-            )
-            if not change:
-                self.dialog.msgbox(
-                    "Keeping Existing Config",
-                    f"Your current HAT config will be kept:\n\n"
-                    f"  {config_names}\n\n"
-                    "You can change this later from:\n"
-                    "  Configuration > meshtasticd Config > Hardware"
-                )
-                return
+        # Check for existing config (uses *.yaml, not broken lora-*.yaml)
+        if not self._check_existing_configs(config_d, 'SPI HAT'):
+            return
 
-        # Build choices from available.d (dynamic) + fallback to hardcoded
+        # Build choices from available.d SPI templates
         choices = []
+        _, spi_templates = self._classify_templates(available_d)
 
-        # First, use templates from available.d if it exists
-        if available_d.exists():
-            templates = sorted(available_d.glob('lora-*.yaml'))
-            if templates:
-                for tmpl in templates:
-                    # Mark if currently active
-                    is_active = config_d.exists() and (config_d / tmpl.name).exists()
-                    status = " [ACTIVE]" if is_active else ""
-                    # Create readable name from filename
-                    display_name = tmpl.stem.replace('lora-', '').replace('-', ' ').title()
-                    choices.append((tmpl.name, f"{display_name}{status}"))
+        if spi_templates:
+            active_configs = set()
+            if config_d.exists():
+                active_configs = {f.name for f in config_d.glob('*.yaml')}
+
+            for tmpl in spi_templates:
+                is_active = tmpl.name in active_configs
+                status = " [ACTIVE]" if is_active else ""
+                display_name = tmpl.stem.replace('-', ' ').title()
+                choices.append((tmpl.name, f"{display_name}{status}"))
 
         # If no templates found in available.d, fall back to hardcoded list
         if not choices:
@@ -359,7 +420,62 @@ class FirstRunMixin:
             self.dialog.msgbox("Error", f"Failed to apply config: {e}")
 
     def _wizard_step_usb_config(self):
-        """Configure USB serial connection."""
+        """Configure USB serial connection using templates from available.d."""
+        self._ensure_template_structure()
+
+        config_d = Path('/etc/meshtasticd/config.d')
+        available_d = Path('/etc/meshtasticd/available.d')
+
+        # Check for existing configuration first
+        if not self._check_existing_configs(config_d, 'USB'):
+            return
+
+        # Get USB templates from available.d
+        usb_templates, _ = self._classify_templates(available_d)
+
+        if usb_templates:
+            # Build menu from USB templates
+            choices = []
+            active_configs = set()
+            if config_d.exists():
+                active_configs = {f.name for f in config_d.glob('*.yaml')}
+
+            for tmpl in usb_templates:
+                is_active = tmpl.name in active_configs
+                status = " [ACTIVE]" if is_active else ""
+                # Create readable name: "heltec-usb" -> "Heltec Usb"
+                display_name = tmpl.stem.replace('-', ' ').title()
+                choices.append((tmpl.name, f"{display_name}{status}"))
+
+            choices.append(("custom", "Custom USB Device (manual path)"))
+
+            choice = self.dialog.menu(
+                "Step 2: Select USB Hardware",
+                "Select your USB radio from meshtasticd templates:\n\n"
+                f"Templates: {available_d}",
+                choices
+            )
+
+            if choice is None:
+                return
+
+            if choice == "custom":
+                # Fall back to manual USB device selection
+                self._wizard_step_usb_manual()
+                return
+
+            # Apply template from available.d
+            src = available_d / choice
+            if src.exists():
+                self._apply_hardware_config_from_file(src, config_d)
+            else:
+                self.dialog.msgbox("Error", f"Template not found: {src}")
+        else:
+            # No templates available -- fall back to manual selection
+            self._wizard_step_usb_manual()
+
+    def _wizard_step_usb_manual(self):
+        """Fallback: manually select USB device when no templates available."""
         devices = self._find_usb_serial_devices()
 
         if not devices:
@@ -368,10 +484,10 @@ class FirstRunMixin:
                 "No USB serial devices detected.\n\n"
                 "Connect your Meshtastic device via USB and try again.\n\n"
                 "Supported devices:\n"
-                "  • T-Beam (CP2102 or CH340)\n"
-                "  • Heltec LoRa\n"
-                "  • RAK WisBlock\n"
-                "  • LilyGo T-Deck"
+                "  - T-Beam (CP2102 or CH340)\n"
+                "  - Heltec LoRa\n"
+                "  - RAK WisBlock\n"
+                "  - LilyGo T-Deck"
             )
             return
 
@@ -386,20 +502,28 @@ class FirstRunMixin:
         choices.append(("rescan", "Rescan        Detect devices again"))
 
         choice = self.dialog.menu(
-            "Step 2: Select USB Device",
-            "Select your Meshtastic device:\n(* = likely Meshtastic)",
+            "Select USB Device",
+            "No hardware templates found. Select device manually:\n"
+            "(* = likely Meshtastic)",
             choices
         )
 
         if choice == "rescan":
-            self._wizard_step_usb_config()
+            self._wizard_step_usb_manual()
             return
 
         if choice is None:
             return
 
-        # Create USB serial config
-        self._create_usb_config(choice)
+        # Use the generic USB template if available, else create minimal config
+        available_d = Path('/etc/meshtasticd/available.d')
+        generic_template = available_d / 'usb-serial-generic.yaml'
+        config_d = Path('/etc/meshtasticd/config.d')
+
+        if generic_template.exists():
+            self._apply_hardware_config_from_file(generic_template, config_d)
+        else:
+            self._create_usb_config(choice)
 
     def _wizard_step_network_config(self):
         """Configure network connection to remote meshtasticd."""
@@ -559,17 +683,23 @@ class FirstRunMixin:
 
             config_content = f"""# USB Serial Configuration
 # Generated by MeshForge Setup Wizard
-
-Lora:
-  Module: sx1262  # Adjust if your device uses different chip
-  CS: 0
-  IRQ: 0
-  Busy: 0
-  Reset: 0
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
 
 Serial:
-  Enabled: true
   Device: {device_path}
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
 """
             config_file.write_text(config_content)
 


### PR DESCRIPTION
## Summary
Refactored the hardware configuration system to use a template-based approach from `/etc/meshtasticd/available.d/` instead of hardcoded configurations. This makes the system more flexible and maintainable while providing fallback support for legacy setups.

## Key Changes

- **Updated SPI HAT config filenames** to match actual template names:
  - `lora-meshadv-mini.yaml` → `meshadv-mini.yaml`
  - `lora-waveshare-sx1262.yaml` → `waveshare-sx1262.yaml`
  - `lora-rak-hat.yaml` → `rak-hat-spi.yaml`
  - `lora-ebyte-e22.yaml` → `ebyte-e22-900m30s.yaml`

- **Added template classification system** (`_classify_templates`):
  - Automatically categorizes templates as USB or SPI based on filename convention
  - USB templates: contain `-usb` or start with `usb-`
  - SPI templates: everything else

- **Extracted common config checking logic** (`_check_existing_configs`):
  - Unified handling of existing configurations for both USB and SPI
  - Prompts user before overwriting existing hardware configs
  - Provides clear feedback about current configuration location

- **Added template structure initialization** (`_ensure_template_structure`):
  - Ensures `/etc/meshtasticd/` directory structure exists
  - Gracefully handles permission errors and missing dependencies

- **Refactored USB configuration** (`_wizard_step_usb_config`):
  - Now uses templates from `available.d/` when available
  - Falls back to manual device selection if no templates found
  - Extracted manual selection logic to `_wizard_step_usb_manual()`

- **Improved USB config generation** (`_create_usb_config`):
  - Simplified generated config to focus on serial device path
  - Added comments directing users to use Meshtastic CLI for radio settings
  - Includes TCP, webserver, and logging configuration sections

- **Enhanced SPI configuration** (`_wizard_step_spi_config`):
  - Uses dynamic templates from `available.d/` with fallback to hardcoded list
  - Fixed glob pattern from `lora-*.yaml` to `*.yaml` for consistency
  - Shows active configuration status in menu

## Implementation Details

- Template discovery is now dynamic, allowing new hardware support without code changes
- Fallback to hardcoded `SPI_HARDWARE_CONFIGS` ensures backward compatibility
- Configuration checking uses generic `*.yaml` pattern instead of `lora-*` prefix
- USB manual fallback includes generic template support (`usb-serial-generic.yaml`)
- All user-facing messages updated to reflect template-based approach

https://claude.ai/code/session_01NdEQcAcu5XFHkQrCvAwCmS