### PR TITLE
Deploy hardware templates and improve meshtasticd config management

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -480,12 +480,27 @@ UDEV_RULES
     mkdir -p "$MESHTASTICD_CONFIG_DIR"/{available.d,config.d,ssl}
     chmod 700 "$MESHTASTICD_CONFIG_DIR/ssl"
 
-    # NOTE: We do NOT create HAT templates here!
-    # meshtasticd already ships with proper templates in available.d/
-    # See: /etc/meshtasticd/available.d/ after installing meshtasticd
-    # Users select their HAT via 'meshforge' menu which copies from available.d/ to config.d/
+    # Deploy MeshForge hardware templates (USB + SPI HATs) to available.d/
+    # Templates ship with MeshForge, not the meshtasticd Debian package
+    if [[ -d "$INSTALL_DIR/templates/available.d" ]]; then
+        cp -n "$INSTALL_DIR/templates/available.d/"*.yaml "$MESHTASTICD_CONFIG_DIR/available.d/" 2>/dev/null
+        DEPLOYED=$(ls -1 "$MESHTASTICD_CONFIG_DIR/available.d/"*.yaml 2>/dev/null | wc -l)
+        echo -e "  ${GREEN}✓ Deployed ${DEPLOYED} hardware templates to available.d/${NC}"
+    else
+        echo -e "  ${YELLOW}⚠ templates/available.d/ not found in $INSTALL_DIR${NC}"
+    fi
 
-    echo -e "  ${CYAN}Available configs (from meshtasticd):${NC}"
+    # Deploy config.yaml if missing
+    if [[ ! -f "$MESHTASTICD_CONFIG_DIR/config.yaml" ]]; then
+        if [[ -f "$INSTALL_DIR/templates/config.yaml" ]]; then
+            cp "$INSTALL_DIR/templates/config.yaml" "$MESHTASTICD_CONFIG_DIR/config.yaml"
+            echo -e "  ${GREEN}✓ Created config.yaml${NC}"
+        fi
+    else
+        echo -e "  ${GREEN}✓ config.yaml already exists${NC}"
+    fi
+
+    echo -e "  ${CYAN}Available hardware configs:${NC}"
     if ls "$MESHTASTICD_CONFIG_DIR/available.d/"*.yaml 2>/dev/null | head -5 >/dev/null; then
         ls -1 "$MESHTASTICD_CONFIG_DIR/available.d/"*.yaml 2>/dev/null | head -10 | xargs -I {} basename {} | sed 's/^/    - /'
         AVAIL_COUNT=$(ls -1 "$MESHTASTICD_CONFIG_DIR/available.d/"*.yaml 2>/dev/null | wc -l)
@@ -493,7 +508,7 @@ UDEV_RULES
             echo "    ... and $((AVAIL_COUNT - 10)) more"
         fi
     else
-        echo "    (will be populated when meshtasticd is installed)"
+        echo -e "  ${YELLOW}⚠ No templates deployed — TUI will generate from built-in list${NC}"
     fi
 
     # Install appropriate daemon based on radio type
@@ -780,7 +795,12 @@ SPI_CONFIG
                     fi
 
                     # ── Step 4: Create systemd service ──
-                    cat > /etc/systemd/system/meshtasticd.service << NATIVE_SERVICE
+                    if [[ -f "$INSTALL_DIR/templates/systemd/meshtasticd-native.service" ]]; then
+                        sed "s|@MESHTASTICD_BIN@|${MESHTASTICD_BIN}|g" \
+                            "$INSTALL_DIR/templates/systemd/meshtasticd-native.service" \
+                            > /etc/systemd/system/meshtasticd.service
+                    else
+                        cat > /etc/systemd/system/meshtasticd.service << NATIVE_SERVICE
 [Unit]
 Description=Meshtastic Daemon (Native SPI)
 Documentation=https://meshtastic.org
@@ -797,6 +817,7 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 NATIVE_SERVICE
+                    fi
 
                     systemctl daemon-reload
 
@@ -858,33 +879,66 @@ NATIVE_SERVICE
                 echo -e "  ${GREEN}  USB device: $USB_DEV${NC}"
             fi
 
-            # Enable USB config if meshtasticd provides one
-            if [[ -f "$MESHTASTICD_CONFIG_DIR/available.d/usb-serial.yaml" ]]; then
-                cp "$MESHTASTICD_CONFIG_DIR/available.d/usb-serial.yaml" "$MESHTASTICD_CONFIG_DIR/config.d/"
+            NATIVE_INSTALLED=false
+
+            # Check if native meshtasticd is already installed
+            if command -v meshtasticd &>/dev/null; then
+                INSTALLED_VERSION=$(meshtasticd --version 2>/dev/null || echo "unknown")
+                echo -e "  ${GREEN}✓ Native meshtasticd already installed (${INSTALLED_VERSION})${NC}"
+                NATIVE_INSTALLED=true
+            else
+                # Install native meshtasticd via apt (same as SPI path)
+                if add_meshtastic_repo; then
+                    echo -e "  ${CYAN}Installing meshtasticd via apt...${NC}"
+                    if apt-get install -y -qq meshtasticd >/dev/null 2>&1; then
+                        if command -v meshtasticd &>/dev/null; then
+                            INSTALLED_VERSION=$(meshtasticd --version 2>/dev/null || echo "unknown")
+                            echo -e "  ${GREEN}✓ Native meshtasticd installed (${INSTALLED_VERSION})${NC}"
+                            NATIVE_INSTALLED=true
+                        else
+                            echo -e "  ${RED}Package installed but binary not found${NC}"
+                        fi
+                    else
+                        echo -e "  ${YELLOW}⚠ apt install meshtasticd failed — will use USB templates only${NC}"
+                    fi
+                else
+                    echo -e "  ${YELLOW}⚠ Could not add Meshtastic repo — will use USB templates only${NC}"
+                fi
             fi
 
-            # Check if native meshtasticd is available (can work with USB serial too)
-            if command -v meshtasticd &> /dev/null; then
+            if $NATIVE_INSTALLED; then
                 MESHTASTICD_BIN=$(command -v meshtasticd)
-                echo -e "  ${GREEN}✓ Native meshtasticd available: ${MESHTASTICD_BIN}${NC}"
 
-                # Only create USB config if config.d/ is empty (no existing HAT config)
-                if [[ -n "$USB_DEV" ]]; then
+                # Let user select their USB hardware template from available.d
+                USB_TEMPLATES=()
+                for tmpl in "$MESHTASTICD_CONFIG_DIR/available.d/"*-usb.yaml "$MESHTASTICD_CONFIG_DIR/available.d/usb-"*.yaml; do
+                    [[ -f "$tmpl" ]] && USB_TEMPLATES+=("$tmpl")
+                done
+
+                if [[ ${#USB_TEMPLATES[@]} -gt 0 ]]; then
+                    echo ""
+                    echo -e "  ${CYAN}Available USB hardware templates:${NC}"
+                    for i in "${!USB_TEMPLATES[@]}"; do
+                        echo -e "    $((i+1)). $(basename "${USB_TEMPLATES[$i]}" .yaml)"
+                    done
+
+                    # Auto-select if only config.d is empty
                     EXISTING_CONFIGS=$(ls "$MESHTASTICD_CONFIG_DIR/config.d/"*.yaml 2>/dev/null | wc -l)
                     if [[ "$EXISTING_CONFIGS" -eq 0 ]]; then
-                        cat > "$MESHTASTICD_CONFIG_DIR/config.d/usb-device.yaml" << USB_CONFIG
-# USB Serial Radio Configuration (auto-generated by MeshForge)
-Lora:
-  SerialPath: ${USB_DEV}
-USB_CONFIG
-                        echo -e "  ${GREEN}✓ Created USB device config${NC}"
+                        echo -e "  ${YELLOW}  Select your USB radio in the MeshForge TUI:${NC}"
+                        echo -e "  ${YELLOW}    Configuration > Hardware Config${NC}"
                     else
-                        echo -e "  ${GREEN}✓ Existing config in config.d/ - skipping USB auto-config${NC}"
+                        echo -e "  ${GREEN}✓ Existing config in config.d/ — keeping current selection${NC}"
                     fi
                 fi
 
-                # Create service using native meshtasticd
-                cat > /etc/systemd/system/meshtasticd.service << NATIVE_USB_SERVICE
+                # Deploy systemd service from template or create inline
+                if [[ -f "$INSTALL_DIR/templates/systemd/meshtasticd-native.service" ]]; then
+                    sed "s|@MESHTASTICD_BIN@|${MESHTASTICD_BIN}|g" \
+                        "$INSTALL_DIR/templates/systemd/meshtasticd-native.service" \
+                        > /etc/systemd/system/meshtasticd.service
+                else
+                    cat > /etc/systemd/system/meshtasticd.service << NATIVE_USB_SERVICE
 [Unit]
 Description=Meshtastic Daemon (USB Serial)
 Documentation=https://meshtastic.org
@@ -901,30 +955,31 @@ RestartSec=5
 [Install]
 WantedBy=multi-user.target
 NATIVE_USB_SERVICE
+                fi
 
                 DAEMON_TYPE="native-usb"
             else
-                # No native daemon - USB radios work directly without a service
-                # The firmware handles mesh networking; CLI connects on demand
-                echo -e "  ${YELLOW}Note: USB radios don't require a daemon service${NC}"
-                echo -e "  ${YELLOW}  Use CLI: meshtastic --port ${USB_DEV:-/dev/ttyUSB0} --info${NC}"
+                # Native meshtasticd not available — create placeholder service
+                # User can install later from TUI: Configuration > Setup Wizard
+                echo -e "  ${YELLOW}Note: Native meshtasticd not installed${NC}"
+                echo -e "  ${YELLOW}  USB templates are available in ${MESHTASTICD_CONFIG_DIR}/available.d/${NC}"
+                echo -e "  ${YELLOW}  Install meshtasticd later: sudo apt install meshtasticd${NC}"
 
-                # Create a placeholder service that explains the situation
                 cat > /etc/systemd/system/meshtasticd.service << 'USB_PLACEHOLDER'
 [Unit]
-Description=Meshtastic USB Radio (No Daemon Needed)
+Description=Meshtastic (pending native install)
 Documentation=https://meshtastic.org
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/bin/echo "USB radios work directly - use: meshtastic --port /dev/ttyUSB0 --info"
+ExecStart=/bin/echo "Install native meshtasticd: sudo apt install meshtasticd — then select hardware in MeshForge TUI"
 
 [Install]
 WantedBy=multi-user.target
 USB_PLACEHOLDER
 
-                DAEMON_TYPE="usb-direct"
+                DAEMON_TYPE="usb-pending"
             fi
             ;;
 

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -622,7 +622,26 @@ class MeshtasticdConfig:
             return False
 
     def _create_default_templates(self):
-        """Create default radio configuration templates."""
+        """Create default radio configuration templates.
+
+        Prefers repo templates from templates/available.d/ (richer content
+        with comments) over the inline RADIO_TEMPLATES dict.
+        """
+        # Try repo templates first (ship with MeshForge, have full comments)
+        repo_templates = Path(__file__).parent.parent.parent / 'templates' / 'available.d'
+        if repo_templates.exists():
+            deployed = 0
+            for tmpl in repo_templates.glob('*.yaml'):
+                dest = self.available_dir / tmpl.name
+                if not dest.exists():
+                    shutil.copy2(tmpl, dest)
+                    deployed += 1
+                    logger.debug(f"Deployed repo template: {dest}")
+            if deployed:
+                logger.info(f"Deployed {deployed} templates from {repo_templates}")
+            return
+
+        # Fallback: generate from built-in RADIO_TEMPLATES dict
         for name, template in RADIO_TEMPLATES.items():
             config_file = self.available_dir / f"{name}.yaml"
             if not config_file.exists():
@@ -630,9 +649,19 @@ class MeshtasticdConfig:
                 logger.debug(f"Created template: {config_file}")
 
     def _create_main_config(self):
-        """Create main config.yaml file."""
+        """Create main config.yaml file.
+
+        Prefers repo template from templates/config.yaml over inline fallback.
+        """
+        # Try repo template first
+        repo_config = Path(__file__).parent.parent.parent / 'templates' / 'config.yaml'
+        if repo_config.exists():
+            shutil.copy2(repo_config, self.main_config)
+            logger.info(f"Deployed config.yaml from {repo_config}")
+            return
+
+        # Fallback: generate inline
         config_content = """# Meshtasticd Configuration (fallback)
-# Normally provided by the meshtasticd package.
 # Individual radio configs are in config.d/
 
 Lora:

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1126,13 +1126,26 @@ SUPPORT:
 
     # --- Config Menu - meshtasticd config.d/ management ---
 
+    def _ensure_meshtasticd_config(self):
+        """Auto-create /etc/meshtasticd structure and templates if missing."""
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            MeshtasticdConfig().ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create meshtasticd config (no root)")
+        except Exception as e:
+            logger.debug("meshtasticd config auto-create failed: %s", e)
+
     def _config_menu(self):
         """Configuration management for meshtasticd."""
+        # Auto-create /etc/meshtasticd structure if missing
+        self._ensure_meshtasticd_config()
+
         while True:
             choices = [
                 ("view", "View Active Config"),
                 ("overlays", "View config.d/ Overlays"),
-                ("available", "Available HAT Configs"),
+                ("available", "Available Hardware Configs"),
                 ("presets", "LoRa Presets"),
                 ("channels", "Channel Configuration"),
                 ("meshtasticd", "Advanced meshtasticd Config"),
@@ -1153,7 +1166,7 @@ SUPPORT:
             dispatch = {
                 "view": ("View Active Config", self._view_active_config),
                 "overlays": ("Config Overlays", self._view_config_overlays),
-                "available": ("Available HAT Configs", self._view_available_hats),
+                "available": ("Available Hardware Configs", self._view_available_configs),
                 "presets": ("LoRa Presets", self._radio_presets_menu),
                 "channels": ("Channel Config", self._channel_config_menu),
                 "meshtasticd": ("Advanced Config", self._meshtasticd_menu),
@@ -1170,6 +1183,11 @@ SUPPORT:
         print("=== meshtasticd config.yaml ===\n")
 
         config_path = Path('/etc/meshtasticd/config.yaml')
+
+        # Auto-create if missing
+        if not config_path.exists():
+            self._ensure_meshtasticd_config()
+
         if config_path.exists():
             print(f"File: {config_path}\n")
             try:
@@ -1177,32 +1195,42 @@ SUPPORT:
             except PermissionError:
                 print("Permission denied. Try: sudo cat /etc/meshtasticd/config.yaml")
         else:
-            print("config.yaml not found!")
-            print("\nInstall meshtasticd:")
-            print("  sudo apt install meshtasticd")
-            print("  # or run the MeshForge installer")
+            print("config.yaml not found!\n")
+            print("Run MeshForge with sudo to auto-create:")
+            print("  sudo python3 src/launcher_tui/main.py")
+            print("\nOr create manually:")
+            print("  sudo mkdir -p /etc/meshtasticd/{available.d,config.d}")
+            print("  sudo cp templates/config.yaml /etc/meshtasticd/")
+            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
 
         self._wait_for_enter()
 
     def _view_config_overlays(self):
-        """Show config.d/ overlay files."""
+        """Show config.d/ overlay files (active hardware configs)."""
         clear_screen()
-        print("=== config.d/ Overlays ===\n")
+        print("=== config.d/ Active Hardware Configs ===\n")
 
         config_d = Path('/etc/meshtasticd/config.d')
+
+        # Auto-create if missing
+        if not config_d.exists():
+            self._ensure_meshtasticd_config()
+
         if not config_d.exists():
             print("config.d/ directory not found.")
-            print("Create it: sudo mkdir -p /etc/meshtasticd/config.d")
+            print("\nRun with sudo to auto-create, or:")
+            print("  sudo mkdir -p /etc/meshtasticd/config.d")
             self._wait_for_enter()
             return
 
         overlays = sorted(config_d.glob('*.yaml'))
         if not overlays:
-            print("No overlay files in config.d/")
-            print("\nOverlays override sections from config.yaml")
-            print("MeshForge writes here instead of touching config.yaml")
+            print("No active hardware configs in config.d/\n")
+            print("Select your hardware from:")
+            print("  Configuration > Available Hardware Configs")
+            print("  Configuration > Advanced meshtasticd Config > Hardware Config")
         else:
-            print(f"Found {len(overlays)} overlay(s):\n")
+            print(f"Found {len(overlays)} active config(s):\n")
             for f in overlays:
                 size = f.stat().st_size
                 print(f"  {f.name} ({size} bytes)")
@@ -1218,32 +1246,54 @@ SUPPORT:
 
         self._wait_for_enter()
 
-    def _view_available_hats(self):
-        """Show available HAT configurations from meshtasticd package."""
+    def _view_available_configs(self):
+        """Show available hardware configs (USB + SPI HATs)."""
         clear_screen()
-        print("=== Available HAT Configs ===\n")
+        print("=== Available Hardware Configs ===\n")
 
         available_d = Path('/etc/meshtasticd/available.d')
+
+        # Auto-create if missing
         if not available_d.exists():
-            print("available.d/ not found.")
-            print("meshtasticd package should provide this.")
-            print("\nInstall: sudo apt install meshtasticd")
+            self._ensure_meshtasticd_config()
+
+        if not available_d.exists():
+            print("available.d/ not found.\n")
+            print("Run with sudo to auto-create, or:")
+            print("  sudo mkdir -p /etc/meshtasticd/available.d")
+            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
             self._wait_for_enter()
             return
 
         configs = sorted(available_d.glob('*.yaml'))
         if not configs:
-            print("No HAT configs available.")
+            print("No hardware configs available.")
         else:
-            print(f"Found {len(configs)} HAT config(s):\n")
-            for i, f in enumerate(configs, 1):
-                print(f"  {i:2d}. {f.name}")
+            # Categorize USB vs SPI
+            usb_configs = [f for f in configs if '-usb' in f.stem or f.stem.startswith('usb-')]
+            spi_configs = [f for f in configs if f not in usb_configs]
 
-            print("\nTo activate a HAT config:")
-            print("  sudo cp /etc/meshtasticd/available.d/<file>.yaml \\")
-            print("         /etc/meshtasticd/config.d/")
-            print("  sudo systemctl restart meshtasticd")
-            print("\nWARNING: Only ONE Lora config should be in config.d/")
+            if usb_configs:
+                print(f"USB Radios ({len(usb_configs)}):")
+                for i, f in enumerate(usb_configs, 1):
+                    print(f"  {i:2d}. {f.stem}")
+
+            if spi_configs:
+                if usb_configs:
+                    print()
+                print(f"SPI HATs ({len(spi_configs)}):")
+                for i, f in enumerate(spi_configs, 1):
+                    print(f"  {i:2d}. {f.stem}")
+
+            # Show active
+            config_d = Path('/etc/meshtasticd/config.d')
+            if config_d.exists():
+                active = list(config_d.glob('*.yaml'))
+                if active:
+                    print(f"\nActive: {', '.join(f.stem for f in active)}")
+
+            print(f"\nTotal: {len(configs)} templates")
+            print("\nActivate via: Configuration > Advanced meshtasticd Config > Hardware Config")
 
         self._wait_for_enter()
 

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -29,8 +29,21 @@ from utils.broker_profiles import get_active_profile
 class MeshtasticdConfigMixin:
     """Mixin providing meshtasticd configuration methods for the launcher."""
 
+    def _ensure_meshtasticd_config(self):
+        """Auto-create /etc/meshtasticd structure and templates if missing."""
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            MeshtasticdConfig().ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create meshtasticd config (no root)")
+        except Exception as e:
+            logger.debug("meshtasticd config auto-create failed: %s", e)
+
     def _meshtasticd_menu(self):
         """Meshtasticd configuration menu."""
+        # Auto-create config structure if missing
+        self._ensure_meshtasticd_config()
+
         while True:
             choices = [
                 ("web", "Web Client (Full Config)"),
@@ -146,8 +159,16 @@ class MeshtasticdConfigMixin:
             config_path = Path('/etc/meshtasticd/config.yaml')
             config_exists = config_path.exists()
 
+            # Auto-create if missing
+            if not config_exists:
+                self._ensure_meshtasticd_config()
+                config_exists = config_path.exists()
+
             config_d = Path('/etc/meshtasticd/config.d')
             active_configs = list(config_d.glob('*.yaml')) if config_d.exists() else []
+
+            available_d = Path('/etc/meshtasticd/available.d')
+            available_count = len(list(available_d.glob('*.yaml'))) if available_d.exists() else 0
 
             # ---- Build display (Issue #20 Phase 2: service state and
             #      detection shown separately with actionable hints) ----
@@ -167,7 +188,8 @@ class MeshtasticdConfigMixin:
             elif is_running and preset_display.startswith("Unknown"):
                 text += "\n  (CLI detection unavailable — select preset manually)"
             text += f"\n\nConfig File: {config_path}"
-            text += f"\nConfig Exists: {'Yes' if config_exists else 'No'}"
+            text += f"\nConfig Exists: {'Yes' if config_exists else 'No — run with sudo to create'}"
+            text += f"\nAvailable Templates: {available_count}"
             text += f"\n\nActive Hardware Configs: {len(active_configs)}"
 
             for cfg in active_configs[:5]:
@@ -175,6 +197,9 @@ class MeshtasticdConfigMixin:
 
             if len(active_configs) > 5:
                 text += f"\n  ... and {len(active_configs) - 5} more"
+
+            if not active_configs and available_count > 0:
+                text += "\n  (none — select hardware from Hardware Config)"
 
             self.dialog.msgbox("Meshtasticd Status", text)
 

--- a/templates/systemd/meshtasticd-native.service
+++ b/templates/systemd/meshtasticd-native.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Meshtastic Daemon
+Documentation=https://meshtastic.org
+After=network.target
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/etc/meshtasticd
+ExecStart=@MESHTASTICD_BIN@ -c /etc/meshtasticd/config.yaml
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
This PR refactors the meshtasticd configuration deployment strategy to use MeshForge-provided hardware templates instead of relying solely on the meshtasticd Debian package. It also improves the TUI to auto-create configuration structures and provides better guidance for hardware selection.

## Key Changes

### Installation Script (`scripts/install_noc.sh`)
- **Template Deployment**: Now copies hardware templates from `templates/available.d/` to `/etc/meshtasticd/available.d/` during installation, with deployment status feedback
- **Config.yaml Deployment**: Deploys `templates/config.yaml` if missing, rather than waiting for meshtasticd package
- **Systemd Service Template**: Uses `templates/systemd/meshtasticd-native.service` template with variable substitution (`@MESHTASTICD_BIN@`) instead of inline heredocs
- **USB Hardware Selection**: Improved USB radio setup to:
  - Detect and list available USB hardware templates
  - Prompt user to select via TUI instead of auto-generating device config
  - Install native meshtasticd via apt if not already present
  - Provide fallback placeholder service if native daemon unavailable
- **Better User Messaging**: Updated console output to distinguish between USB and SPI hardware, with actionable next steps

### Core Configuration (`src/core/meshtasticd_config.py`)
- **Template Priority**: `_create_default_templates()` now prefers repo templates from `templates/available.d/` (richer with comments) over built-in `RADIO_TEMPLATES` dict
- **Config.yaml Priority**: `_create_main_config()` prefers `templates/config.yaml` from repo over inline fallback
- **Fallback Support**: Maintains backward compatibility with inline templates if repo files unavailable

### TUI Improvements (`src/launcher_tui/main.py` and `meshtasticd_config_mixin.py`)
- **Auto-Create Structure**: New `_ensure_meshtasticd_config()` method auto-creates `/etc/meshtasticd` structure and deploys templates when TUI accesses config menus
- **Improved Messaging**: 
  - Renamed "Available HAT Configs" → "Available Hardware Configs"
  - Categorizes templates as USB vs SPI in display
  - Shows active hardware configs and template count
  - Provides clear instructions for hardware selection via TUI
- **Status Display**: Enhanced meshtasticd status to show available template count and guidance when no hardware is selected
- **Permission Handling**: Gracefully handles permission errors when running without sudo

### New Template File
- **`templates/systemd/meshtasticd-native.service`**: Systemd service template with `@MESHTASTICD_BIN@` placeholder for dynamic binary path substitution

## Implementation Details
- Templates are deployed with `cp -n` (no-clobber) to preserve user modifications
- Fallback mechanisms ensure functionality even if repo templates are missing
- All auto-creation attempts are wrapped in try-except to handle permission errors gracefully
- User guidance directs to TUI for hardware selection rather than manual file copying

https://claude.ai/code/session_01L32K19zMw88YdnWHtY1nkC