### PR TITLE
Auto-detect and deploy meshtasticd radio configs

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -916,19 +916,66 @@ NATIVE_SERVICE
                 done
 
                 if [[ ${#USB_TEMPLATES[@]} -gt 0 ]]; then
-                    echo ""
-                    echo -e "  ${CYAN}Available USB hardware templates:${NC}"
-                    for i in "${!USB_TEMPLATES[@]}"; do
-                        echo -e "    $((i+1)). $(basename "${USB_TEMPLATES[$i]}" .yaml)"
-                    done
+                    # Check if a USB config is already in config.d/
+                    EXISTING_USB=""
+                    if [[ -d "$MESHTASTICD_CONFIG_DIR/config.d" ]]; then
+                        EXISTING_USB=$(ls -1 "$MESHTASTICD_CONFIG_DIR/config.d/"*.yaml 2>/dev/null | head -1)
+                    fi
 
-                    # Auto-select if only config.d is empty
-                    EXISTING_CONFIGS=$(ls "$MESHTASTICD_CONFIG_DIR/config.d/"*.yaml 2>/dev/null | wc -l)
-                    if [[ "$EXISTING_CONFIGS" -eq 0 ]]; then
-                        echo -e "  ${YELLOW}  Select your USB radio in the MeshForge TUI:${NC}"
-                        echo -e "  ${YELLOW}    Configuration > Hardware Config${NC}"
+                    if [[ -n "$EXISTING_USB" ]]; then
+                        USB_NAME=$(basename "$EXISTING_USB")
+                        echo -e "  ${GREEN}✓ USB config already active: ${USB_NAME}${NC}"
                     else
-                        echo -e "  ${GREEN}✓ Existing config in config.d/ — keeping current selection${NC}"
+                        # Build USB menu from available.d/ (mirrors SPI HAT selection)
+                        AVAIL_DIR="$MESHTASTICD_CONFIG_DIR/available.d"
+                        declare -a USB_OPTIONS=()
+                        for tmpl in "${USB_TEMPLATES[@]}"; do
+                            usb_base=$(basename "$tmpl" .yaml)
+                            usb_desc=$(grep "^#" "$tmpl" 2>/dev/null | head -1 | sed 's/^# *//' || echo "$usb_base")
+                            [[ -z "$usb_desc" ]] && usb_desc="$usb_base"
+                            USB_OPTIONS+=("$usb_base" "$usb_desc")
+                        done
+
+                        if [[ ${#USB_OPTIONS[@]} -gt 0 ]]; then
+                            USB_COUNT=$((${#USB_OPTIONS[@]} / 2))
+
+                            if command -v whiptail &>/dev/null; then
+                                MENU_H=$((USB_COUNT + 7))
+                                [[ $MENU_H -lt 12 ]] && MENU_H=12
+                                [[ $MENU_H -gt 22 ]] && MENU_H=22
+
+                                SELECTED_USB=$(whiptail --title "USB Radio Selection" --menu \
+                                    "Which USB radio is connected?\n\nConfigs from: ${AVAIL_DIR}/" \
+                                    $MENU_H 70 $USB_COUNT \
+                                    "${USB_OPTIONS[@]}" \
+                                    3>&1 1>&2 2>&3) || SELECTED_USB=""
+                            else
+                                # Fallback: numbered text menu
+                                echo "" >&2
+                                echo -e "  ${BOLD}Select your USB radio:${NC}" >&2
+                                i=1
+                                for ((idx=0; idx<${#USB_OPTIONS[@]}; idx+=2)); do
+                                    echo "    $i) ${USB_OPTIONS[$idx]} - ${USB_OPTIONS[$((idx+1))]}" >&2
+                                    ((i++))
+                                done
+                                echo "" >&2
+                                read -rp "  Select [1-${USB_COUNT}]: " usb_choice
+                                if [[ "$usb_choice" =~ ^[0-9]+$ ]] && [[ "$usb_choice" -ge 1 ]] && [[ "$usb_choice" -le "$USB_COUNT" ]]; then
+                                    idx=$(( (usb_choice - 1) * 2 ))
+                                    SELECTED_USB="${USB_OPTIONS[$idx]}"
+                                fi
+                            fi
+
+                            if [[ -n "$SELECTED_USB" ]]; then
+                                # Copy selected USB config to config.d/
+                                mkdir -p "$MESHTASTICD_CONFIG_DIR/config.d"
+                                cp "$AVAIL_DIR/${SELECTED_USB}.yaml" "$MESHTASTICD_CONFIG_DIR/config.d/"
+                                echo -e "  ${GREEN}✓ USB config installed: ${SELECTED_USB}.yaml${NC}"
+                            else
+                                echo -e "  ${YELLOW}⚠ No USB radio selected — meshtasticd may not start correctly${NC}"
+                                echo -e "  ${YELLOW}  Fix: cp /etc/meshtasticd/available.d/<your-radio>.yaml /etc/meshtasticd/config.d/${NC}"
+                            fi
+                        fi
                     fi
                 fi
 

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -37,7 +37,11 @@ from utils.safe_import import safe_import
 _yaml, _HAS_YAML = safe_import('yaml')
 # Import centralized port checker for consistency across MeshForge
 # See: utils/service_check.py - SINGLE SOURCE OF TRUTH
-from utils.service_check import check_port as _centralized_check_port, check_service
+from utils.service_check import (
+    check_port as _centralized_check_port,
+    check_service,
+    _detect_radio_hardware,
+)
 
 # Setup logging
 logger = logging.getLogger(__name__)
@@ -281,6 +285,111 @@ class ServiceOrchestrator:
             )
             logger.info("Configured for Python meshtastic CLI (USB radio)")
 
+    def _check_meshtasticd_config(self) -> bool:
+        """Check that meshtasticd has a radio config in config.d/.
+
+        Without a radio config template, meshtasticd starts but never binds
+        TCP port 4403 — causing health checks to fail.
+
+        If config.d/ is empty, attempts auto-detection of connected hardware
+        and deploys the matching template.
+
+        Returns:
+            True if config.d/ has at least one config (or was auto-populated).
+        """
+        config_d = MESHTASTICD_CONFIG_DIR / "config.d"
+        available_d = MESHTASTICD_CONFIG_DIR / "available.d"
+
+        # Check if config.d/ already has configs
+        if config_d.exists():
+            existing = list(config_d.glob("*.yaml"))
+            if existing:
+                return True
+
+        logger.warning("No radio config in /etc/meshtasticd/config.d/")
+        logger.info("Attempting auto-detection of radio hardware...")
+
+        # Detect hardware
+        hw = _detect_radio_hardware()
+
+        if not available_d.exists():
+            logger.error(
+                "No templates in /etc/meshtasticd/available.d/ — "
+                "reinstall meshtasticd or run install_noc.sh"
+            )
+            return False
+
+        template_name = None
+
+        # USB auto-detection via vendor:product ID → template mapping
+        if hw['has_usb']:
+            try:
+                from config.hardware import HardwareDetector
+                # Get USB vendor:product ID for first device
+                usb_dev = Path(hw['usb_device'])
+                usb_id_result = subprocess.run(
+                    ['udevadm', 'info', '--query=property', str(usb_dev)],
+                    capture_output=True, text=True, timeout=5
+                )
+                vendor = product = None
+                for line in usb_id_result.stdout.splitlines():
+                    if line.startswith('ID_VENDOR_ID='):
+                        vendor = line.split('=', 1)[1].strip()
+                    elif line.startswith('ID_MODEL_ID='):
+                        product = line.split('=', 1)[1].strip()
+
+                if vendor and product:
+                    usb_id = f"{vendor}:{product}"
+                    template_name = HardwareDetector.match_usb_to_template(usb_id)
+                    if template_name:
+                        device_name = HardwareDetector.get_device_name_for_usb_id(usb_id) or usb_id
+                        logger.info(f"Detected USB radio: {device_name} → {template_name}")
+            except (ImportError, subprocess.SubprocessError, OSError) as e:
+                logger.debug(f"USB auto-detection failed: {e}")
+
+            # Fallback: use usb-serial-generic.yaml
+            if not template_name:
+                template_name = 'usb-serial-generic.yaml'
+                logger.info(f"USB device found at {hw['usb_device']} — using {template_name}")
+
+        # SPI auto-detection: look for first matching SPI template
+        elif hw['has_spi']:
+            spi_templates = list(available_d.glob("*-spi.yaml")) + list(available_d.glob("*-hat*.yaml"))
+            if spi_templates:
+                template_name = spi_templates[0].name
+                logger.info(f"SPI device detected — using {template_name}")
+
+        if not template_name:
+            logger.error(
+                "No radio hardware detected (no SPI or USB devices). "
+                "meshtasticd cannot bind port 4403 without a radio config."
+            )
+            logger.error(
+                "Fix: cp /etc/meshtasticd/available.d/<your-radio>.yaml "
+                "/etc/meshtasticd/config.d/"
+            )
+            return False
+
+        # Deploy the template
+        template_path = available_d / template_name
+        if not template_path.exists():
+            logger.error(f"Template not found: {template_path}")
+            return False
+
+        try:
+            config_d.mkdir(parents=True, exist_ok=True)
+            import shutil
+            shutil.copy2(str(template_path), str(config_d / template_name))
+            logger.info(f"Auto-deployed radio config: {template_name} → config.d/")
+            return True
+        except (OSError, PermissionError) as e:
+            logger.error(f"Failed to deploy config: {e}")
+            logger.error(
+                "Fix: sudo cp /etc/meshtasticd/available.d/"
+                f"{template_name} /etc/meshtasticd/config.d/"
+            )
+            return False
+
     def get_config_info(self) -> Dict[str, Any]:
         """Get current configuration information."""
         return {
@@ -477,6 +586,12 @@ class ServiceOrchestrator:
         if not self.is_installed(service_name):
             logger.error(f"{service_name} is not installed")
             return False
+
+        # Pre-start: ensure meshtasticd has a radio config in config.d/
+        if service_name == 'meshtasticd' and config.check_port:
+            if not self._check_meshtasticd_config():
+                logger.error("meshtasticd cannot start without a radio config")
+                return False
 
         if self.is_healthy(service_name):
             logger.info(f"{service_name} is already running and healthy")


### PR DESCRIPTION
## Summary
This PR adds automatic detection and deployment of meshtasticd radio hardware configurations, ensuring the service can bind to port 4403 on startup. It includes both runtime auto-detection in the orchestrator and improved interactive selection during installation.

## Key Changes

- **New `_check_meshtasticd_config()` method** in orchestrator: Validates that meshtasticd has a radio config in `config.d/`. If missing, attempts automatic hardware detection and deploys the matching template from `available.d/`.
  - Detects USB devices via `udevadm` and matches to templates using `HardwareDetector`
  - Falls back to `usb-serial-generic.yaml` for unrecognized USB devices
  - Detects SPI devices and selects first matching SPI/HAT template
  - Provides clear error messages with remediation steps

- **Pre-start validation** in `start_service()`: Calls `_check_meshtasticd_config()` before starting meshtasticd to prevent service startup failures due to missing radio configs.

- **Enhanced installation script** (`install_noc.sh`): Replaces passive notification with interactive USB radio selection during setup
  - Uses `whiptail` menu when available, falls back to numbered text menu
  - Automatically copies selected USB config to `config.d/` during installation
  - Checks for existing configs and skips selection if already configured
  - Provides consistent UX with existing SPI HAT selection flow

- **Import addition**: Exports `_detect_radio_hardware` from `utils/service_check.py` for use in orchestrator.

## Implementation Details

- Hardware detection leverages existing `_detect_radio_hardware()` utility for consistency
- USB device matching uses vendor:product IDs via `udevadm` for reliable identification
- Graceful fallbacks ensure service can start even if auto-detection fails
- All operations include appropriate logging and user-facing error messages with fix instructions

https://claude.ai/code/session_01SgpoKGTCXjqHrmskQtBvxf