### PR TITLE
Improve service startup reliability with crash detection and diagnostics

### DIFF
--- a/scripts/verify_post_install.sh
+++ b/scripts/verify_post_install.sh
@@ -275,8 +275,8 @@ PORT_4403_OK=false
 if ss -tlnp 2>/dev/null | grep -q ":4403 "; then
     PORT_4403_OK=true
 elif $MESHTASTICD_RUNNING; then
-    for _attempt in 1 2 3; do
-        sleep 1
+    for _attempt in 1 2 3 4 5; do
+        sleep 2
         if ss -tlnp 2>/dev/null | grep -q ":4403 "; then
             PORT_4403_OK=true
             break

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -41,6 +41,7 @@ from utils.service_check import (
     check_port as _centralized_check_port,
     check_service,
     _detect_radio_hardware,
+    ServiceState as _CheckState,
 )
 
 # Setup logging
@@ -496,6 +497,24 @@ class ServiceOrchestrator:
         except (subprocess.TimeoutExpired, FileNotFoundError):
             return False
 
+    def _log_journal_tail(self, service_name: str, lines: int = 8):
+        """Log recent journal entries for a failed service to aid debugging."""
+        config = self.SERVICES.get(service_name)
+        if not config:
+            return
+        try:
+            result = subprocess.run(
+                ['journalctl', '-u', config.systemd_name, '-n', str(lines),
+                 '--no-pager', '-o', 'short-iso'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.stdout.strip():
+                logger.error(f"Recent {service_name} logs:")
+                for line in result.stdout.strip().splitlines():
+                    logger.error(f"  {line}")
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            pass
+
     def get_status(self, service_name: str) -> ServiceStatus:
         """Get detailed status of a service."""
         config = self.SERVICES.get(service_name)
@@ -623,26 +642,73 @@ class ServiceOrchestrator:
             return False
 
         if wait:
-            # Wait for startup delay
-            time.sleep(config.startup_delay)
+            # Poll service status with crash detection instead of blind sleep
+            max_wait = config.startup_delay + 5  # e.g., 10s for meshtasticd
+            service_up = False
 
-            # Verify service stayed running (systemctl only — not port)
-            if not self.is_running(service_name):
-                logger.warning(f"{service_name} started but not running, retrying...")
-                time.sleep(2)
-                if not self.is_running(service_name):
-                    logger.error(f"{service_name} failed to stay running")
-                    self._emit('service_failed', service_name)
-                    return False
+            for elapsed in range(1, max_wait + 1):
+                time.sleep(1)
+                status = check_service(config.systemd_name)
 
-            # Log port readiness as informational (not a gate)
+                if status.available:
+                    service_up = True
+                    break
+
+                if status.state == _CheckState.FAILED:
+                    # Service crashed — log diagnostics immediately
+                    logger.warning(
+                        f"{service_name} crashed during startup (after {elapsed}s)"
+                    )
+                    self._log_journal_tail(service_name, lines=8)
+
+                    # One restart attempt (device node may now be ready)
+                    logger.info(f"Restarting {service_name}...")
+                    subprocess.run(
+                        ['systemctl', 'restart', config.systemd_name],
+                        capture_output=True, text=True, timeout=30
+                    )
+                    # Wait for second attempt
+                    for _ in range(config.startup_delay):
+                        time.sleep(1)
+                        status = check_service(config.systemd_name)
+                        if status.available:
+                            service_up = True
+                            break
+                    if not service_up:
+                        logger.error(
+                            f"{service_name} failed to start after restart"
+                        )
+                        self._log_journal_tail(service_name, lines=8)
+                        self._emit('service_failed', service_name)
+                        return False
+                    break
+
+            if not service_up:
+                # Timed out — never became available or crashed
+                logger.error(
+                    f"{service_name} did not start within {max_wait}s"
+                )
+                self._log_journal_tail(service_name, lines=8)
+                self._emit('service_failed', service_name)
+                return False
+
+            # Port readiness check with retries (non-blocking, per SSOT)
             if config.check_port:
-                if self._check_port(config.check_port):
-                    logger.info(f"{service_name} port {config.check_port} ready")
-                else:
-                    logger.info(
-                        f"{service_name} running (port {config.check_port} not yet "
-                        f"bound — configure radio via web UI at port 9443)"
+                port_ready = False
+                for _ in range(5):
+                    if self._check_port(config.check_port):
+                        port_ready = True
+                        logger.info(
+                            f"{service_name} port {config.check_port} ready"
+                        )
+                        break
+                    time.sleep(1)
+
+                if not port_ready:
+                    logger.warning(
+                        f"{service_name} running but port {config.check_port} "
+                        f"not yet bound — may need more startup time or "
+                        f"radio configuration"
                     )
 
         logger.info(f"{service_name} started successfully")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,229 @@
+"""
+Tests for ServiceOrchestrator startup logic.
+
+Covers:
+- Polling retry with crash detection
+- Journalctl diagnostics on failure
+- Port readiness waiting
+- Service already running
+
+Run: python3 -m pytest tests/test_orchestrator.py -v
+"""
+
+import subprocess
+import pytest
+from unittest.mock import patch, MagicMock, call
+from dataclasses import dataclass
+from pathlib import Path
+
+from utils.service_check import (
+    ServiceState as _CheckState,
+    ServiceStatus as _CheckStatus,
+)
+
+
+def _make_status(available, state, name='meshtasticd', message=''):
+    """Helper to build a service_check.ServiceStatus."""
+    return _CheckStatus(
+        name=name,
+        available=available,
+        state=state,
+        message=message,
+    )
+
+
+def _available():
+    return _make_status(True, _CheckState.AVAILABLE, message='running')
+
+
+def _not_running():
+    return _make_status(False, _CheckState.NOT_RUNNING, message='not running')
+
+
+def _failed():
+    return _make_status(False, _CheckState.FAILED, message='has failed')
+
+
+@pytest.fixture
+def orchestrator():
+    """Create a ServiceOrchestrator with mocked config loading."""
+    with patch('core.orchestrator.Path.exists', return_value=False), \
+         patch('core.orchestrator._detect_radio_hardware', return_value={
+             'has_spi': False, 'has_usb': True,
+             'spi_devices': [], 'usb_devices': ['/dev/ttyUSB0'],
+             'usb_device': '/dev/ttyUSB0', 'hardware_type': 'usb',
+         }):
+        from core.orchestrator import ServiceOrchestrator
+        orch = ServiceOrchestrator(config_path=Path('/nonexistent'))
+        return orch
+
+
+class TestStartServiceCrashDetection:
+    """Test crash detection and restart logic in start_service()."""
+
+    def test_crash_detected_and_restarted_successfully(self, orchestrator):
+        """When service crashes, orchestrator restarts it once and succeeds."""
+        # check_service returns: FAILED on first poll, AVAILABLE after restart
+        check_responses = [_failed(), _available()]
+        check_iter = iter(check_responses)
+
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', side_effect=lambda _: next(check_iter)), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_check_port', return_value=True), \
+             patch.object(orchestrator, '_log_journal_tail') as mock_journal, \
+             patch.object(orchestrator, '_emit'):
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is True
+            # Journal should have been logged on crash detection
+            mock_journal.assert_called()
+
+    def test_crash_permanent_failure(self, orchestrator):
+        """When service crashes and restart also fails, return False with diagnostics."""
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', return_value=_failed()), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_log_journal_tail') as mock_journal, \
+             patch.object(orchestrator, '_emit') as mock_emit:
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is False
+            # Journal diagnostics should be logged (at least once for crash, once for final failure)
+            assert mock_journal.call_count >= 2
+            mock_emit.assert_called_with('service_failed', 'meshtasticd')
+
+
+class TestStartServiceSlowStartup:
+    """Test polling handles slow service startups."""
+
+    def test_service_available_after_several_polls(self, orchestrator):
+        """Service takes a few seconds to start — polling waits for it."""
+        # NOT_RUNNING for 3 polls, then AVAILABLE
+        responses = [_not_running(), _not_running(), _not_running(), _available()]
+        response_iter = iter(responses)
+
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', side_effect=lambda _: next(response_iter)), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_check_port', return_value=True), \
+             patch.object(orchestrator, '_emit'):
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is True
+
+    def test_service_timeout(self, orchestrator):
+        """Service never starts within max_wait — timeout with diagnostics."""
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', return_value=_not_running()), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_log_journal_tail') as mock_journal, \
+             patch.object(orchestrator, '_emit') as mock_emit:
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is False
+            mock_journal.assert_called()
+            mock_emit.assert_called_with('service_failed', 'meshtasticd')
+
+
+class TestStartServicePortReadiness:
+    """Test port readiness retry logic."""
+
+    def test_port_ready_after_retries(self, orchestrator):
+        """Port comes up after a few retries — logged as ready."""
+        port_responses = [False, False, True]
+        port_iter = iter(port_responses)
+
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', return_value=_available()), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_check_port', side_effect=lambda _: next(port_iter)), \
+             patch.object(orchestrator, '_emit'):
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is True
+
+    def test_port_never_ready_still_succeeds(self, orchestrator):
+        """Port never binds — service still reports success (warning only)."""
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=False), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True), \
+             patch('core.orchestrator.check_service', return_value=_available()), \
+             patch('subprocess.run', return_value=MagicMock(returncode=0, stdout='', stderr='')), \
+             patch('time.sleep'), \
+             patch.object(orchestrator, '_check_port', return_value=False), \
+             patch.object(orchestrator, '_emit'):
+
+            result = orchestrator.start_service('meshtasticd')
+
+            # Service is up, port not bound is just a warning
+            assert result is True
+
+
+class TestStartServiceAlreadyRunning:
+    """Test early return when service is already running."""
+
+    def test_already_running(self, orchestrator):
+        """Service already running — return True immediately."""
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=True), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True):
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is True
+
+
+class TestLogJournalTail:
+    """Test _log_journal_tail helper."""
+
+    def test_logs_journal_output(self, orchestrator):
+        """Journal tail is logged for known service."""
+        mock_result = MagicMock()
+        mock_result.stdout = "2026-02-24 line1\n2026-02-24 line2"
+        mock_result.returncode = 0
+
+        with patch('subprocess.run', return_value=mock_result) as mock_run:
+            orchestrator._log_journal_tail('meshtasticd', lines=5)
+
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert 'journalctl' in args
+            assert '-n' in args
+            assert '5' in args
+
+    def test_handles_missing_journalctl(self, orchestrator):
+        """No crash when journalctl not available."""
+        with patch('subprocess.run', side_effect=FileNotFoundError):
+            # Should not raise
+            orchestrator._log_journal_tail('meshtasticd')
+
+    def test_handles_timeout(self, orchestrator):
+        """No crash when journalctl times out."""
+        with patch('subprocess.run', side_effect=subprocess.TimeoutExpired(cmd='', timeout=5)):
+            # Should not raise
+            orchestrator._log_journal_tail('meshtasticd')
+
+    def test_unknown_service(self, orchestrator):
+        """No crash for unknown service name."""
+        orchestrator._log_journal_tail('nonexistent')


### PR DESCRIPTION
## Summary
Enhanced the `ServiceOrchestrator.start_service()` method to detect service crashes during startup, automatically restart failed services, and provide detailed diagnostics via journalctl logs. This replaces the previous blind sleep approach with active polling and crash detection.

## Key Changes

- **Crash Detection & Recovery**: Added polling loop that monitors service state during startup. When a service enters FAILED state, the orchestrator now:
  - Logs diagnostic information immediately via journalctl
  - Attempts one automatic restart
  - Waits for the restarted service to become available
  - Returns failure only after both attempts fail

- **New `_log_journal_tail()` Helper**: Extracts recent systemd journal entries for a failed service to aid debugging. Safely handles missing journalctl, timeouts, and unknown services without crashing.

- **Improved Port Readiness Logic**: 
  - Port binding is now checked with retries (up to 5 attempts) rather than a single check
  - Port unavailability is logged as a warning but does not block success (non-blocking per SSOT principle)
  - Provides clearer messaging about radio configuration via web UI

- **Better Timeout Handling**: Replaced fixed startup delay with a configurable max_wait window (startup_delay + 5s) and per-second polling, allowing faster detection of failures.

- **Enhanced Logging**: Added contextual error messages indicating elapsed time, crash detection, and restart attempts to improve troubleshooting.

## Implementation Details

- Uses `check_service()` to poll systemd unit state instead of just `is_running()` check
- Detects `ServiceState.FAILED` to distinguish crashes from slow startups
- Maintains backward compatibility: services that start normally are unaffected
- Port check retries use 1-second intervals to balance responsiveness and system load
- All subprocess calls include proper timeout handling and error suppression

## Testing
Comprehensive test suite added covering:
- Crash detection and successful restart
- Permanent failures with diagnostics
- Slow startup scenarios
- Port readiness retry logic
- Already-running service early return
- Journal logging edge cases (missing journalctl, timeouts, unknown services)

## Additional Changes
- Updated `verify_post_install.sh` to increase port readiness wait attempts (1→5) and interval (1s→2s) for more reliable post-install verification

https://claude.ai/code/session_01UCHfAGwtwF8cKyeWmDUg4U