### PR TITLE
Auto-fix stale placeholder systemd services on startup

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -1006,13 +1006,17 @@ NATIVE_USB_SERVICE
 
                 DAEMON_TYPE="native-usb"
             else
-                # Native meshtasticd not available — create placeholder service
-                # User can install later from TUI: Configuration > Setup Wizard
+                # Native meshtasticd not available
                 echo -e "  ${YELLOW}Note: Native meshtasticd not installed${NC}"
                 echo -e "  ${YELLOW}  USB templates are available in ${MESHTASTICD_CONFIG_DIR}/available.d/${NC}"
                 echo -e "  ${YELLOW}  Install meshtasticd later: sudo apt install meshtasticd${NC}"
 
-                cat > /etc/systemd/system/meshtasticd.service << 'USB_PLACEHOLDER'
+                # Don't overwrite a working service with a placeholder
+                if systemctl show meshtasticd --property=ExecStart 2>/dev/null | grep -q meshtasticd; then
+                    echo -e "  ${GREEN}✓ Existing meshtasticd service is valid — keeping it${NC}"
+                    DAEMON_TYPE="native-usb"
+                else
+                    cat > /etc/systemd/system/meshtasticd.service << 'USB_PLACEHOLDER'
 [Unit]
 Description=Meshtastic (pending native install)
 Documentation=https://meshtastic.org
@@ -1026,7 +1030,8 @@ ExecStart=/bin/echo "Install native meshtasticd: sudo apt install meshtasticd �
 WantedBy=multi-user.target
 USB_PLACEHOLDER
 
-                DAEMON_TYPE="usb-pending"
+                    DAEMON_TYPE="usb-pending"
+                fi
             fi
             ;;
 
@@ -1063,10 +1068,14 @@ NATIVE_GENERIC
 
                 DAEMON_TYPE="native"
             else
-                # Create a placeholder service
                 echo -e "  ${YELLOW}  Connect USB radio or configure SPI HAT${NC}"
 
-                cat > /etc/systemd/system/meshtasticd.service << 'NO_RADIO_SERVICE'
+                # Don't overwrite a working service with a placeholder
+                if systemctl show meshtasticd --property=ExecStart 2>/dev/null | grep -q meshtasticd; then
+                    echo -e "  ${GREEN}✓ Existing meshtasticd service is valid — keeping it${NC}"
+                    DAEMON_TYPE="native"
+                else
+                    cat > /etc/systemd/system/meshtasticd.service << 'NO_RADIO_SERVICE'
 [Unit]
 Description=Meshtastic (No Radio Configured)
 Documentation=https://meshtastic.org
@@ -1080,7 +1089,8 @@ ExecStart=/bin/echo "No radio detected. Connect USB radio or configure SPI HAT, 
 WantedBy=multi-user.target
 NO_RADIO_SERVICE
 
-                DAEMON_TYPE="placeholder"
+                    DAEMON_TYPE="placeholder"
+                fi
             fi
             ;;
     esac

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -41,6 +41,8 @@ from utils.service_check import (
     check_port as _centralized_check_port,
     check_service,
     _detect_radio_hardware,
+    _sudo_cmd,
+    _sudo_write,
     ServiceState as _CheckState,
 )
 
@@ -599,6 +601,110 @@ class ServiceOrchestrator:
     # Service Control
     # ─────────────────────────────────────────────────────────────
 
+    def _fix_stale_placeholder(self, service_name: str) -> bool:
+        """
+        Detect and fix stale placeholder service files.
+
+        When a previous install created a placeholder systemd unit (Type=oneshot,
+        ExecStart=/bin/echo ...) but the real binary has since been installed,
+        regenerate the service file from the template and daemon-reload.
+
+        Returns:
+            True if a fix was applied, False if no fix was needed or possible.
+        """
+        config = self.SERVICES.get(service_name)
+        if not config or not config.check_binary:
+            return False
+
+        # Read the current ExecStart from systemd
+        try:
+            result = subprocess.run(
+                ['systemctl', 'show', config.systemd_name, '--property=ExecStart'],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            exec_start = result.stdout.strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
+        # Check if ExecStart is a placeholder (echo command)
+        if '/bin/echo' not in exec_start:
+            return False
+
+        # Placeholder detected — check if real binary exists
+        try:
+            bin_result = subprocess.run(
+                ['which', config.check_binary],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return False
+
+        if bin_result.returncode != 0:
+            logger.error(
+                f"{service_name} service is a placeholder and binary not found. "
+                f"Install: sudo apt install {config.check_binary}"
+            )
+            return False
+
+        binary_path = bin_result.stdout.strip()
+        logger.warning(
+            f"{service_name} service is a stale placeholder — "
+            f"real binary found at {binary_path}"
+        )
+
+        # Regenerate from template (same logic as install_noc.sh)
+        template_path = (
+            Path(__file__).resolve().parent.parent.parent
+            / 'templates' / 'systemd' / 'meshtasticd-native.service'
+        )
+
+        if template_path.exists():
+            template = template_path.read_text()
+            service_content = template.replace('@MESHTASTICD_BIN@', binary_path)
+        else:
+            # Inline fallback (matches install_noc.sh NATIVE_USB_SERVICE)
+            service_content = (
+                "[Unit]\n"
+                "Description=Meshtastic Daemon\n"
+                "Documentation=https://meshtastic.org\n"
+                "After=network.target\n"
+                "\n"
+                "[Service]\n"
+                "Type=simple\n"
+                "User=root\n"
+                "WorkingDirectory=/etc/meshtasticd\n"
+                f"ExecStart={binary_path} -c /etc/meshtasticd/config.yaml\n"
+                "Restart=on-failure\n"
+                "RestartSec=5\n"
+                "\n"
+                "[Install]\n"
+                "WantedBy=multi-user.target\n"
+            )
+
+        service_path = f'/etc/systemd/system/{config.systemd_name}.service'
+        success, msg = _sudo_write(service_path, service_content)
+        if not success:
+            logger.error(f"Failed to fix placeholder service: {msg}")
+            return False
+
+        # Reload systemd so it picks up the new unit file
+        try:
+            subprocess.run(
+                _sudo_cmd(['systemctl', 'daemon-reload']),
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            logger.warning("daemon-reload failed after fixing placeholder")
+
+        logger.info(f"Fixed stale placeholder service for {service_name}")
+        return True
+
     def start_service(self, service_name: str, wait: bool = True) -> bool:
         """
         Start a service with health verification.
@@ -628,6 +734,9 @@ class ServiceOrchestrator:
         if self.is_running(service_name):
             logger.info(f"{service_name} is already running")
             return True
+
+        # Auto-fix stale placeholder service files before starting
+        self._fix_stale_placeholder(service_name)
 
         logger.info(f"Starting {service_name}...")
         result = subprocess.run(

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -695,10 +695,33 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
             # Check for placeholder services (active but exited = not a real daemon)
             if is_active and sub_state == "exited":
                 # This is a placeholder or oneshot that ran and exited
-                # Check if this is a mismatch (SPI HAT but USB placeholder)
                 hardware = _detect_radio_hardware()
 
-                if hardware['has_spi'] and not hardware['has_usb']:
+                # Check if the real binary exists — stale placeholder if so
+                has_binary = False
+                try:
+                    bin_result = subprocess.run(
+                        ['which', 'meshtasticd'],
+                        capture_output=True,
+                        text=True,
+                        timeout=5
+                    )
+                    has_binary = bin_result.returncode == 0
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    pass
+
+                if has_binary:
+                    # Real binary exists but service is a placeholder — stale
+                    return ServiceStatus(
+                        name=name,
+                        available=False,
+                        state=ServiceState.DEGRADED,
+                        message=f"{description}: stale placeholder — meshtasticd binary available",
+                        fix_hint="Restart NOC to auto-fix, or run: sudo bash scripts/install_noc.sh",
+                        port=check_port_num,
+                        detection_method="systemctl (exited) + binary exists"
+                    )
+                elif hardware['has_spi'] and not hardware['has_usb']:
                     # SPI HAT detected but placeholder service - MISMATCH!
                     return ServiceStatus(
                         name=name,
@@ -710,7 +733,7 @@ def check_service(name: str, port: Optional[int] = None, host: str = 'localhost'
                         detection_method="systemctl (exited) + hardware mismatch"
                     )
                 elif hardware['has_usb']:
-                    # USB radio - placeholder is correct
+                    # USB radio, no native binary — placeholder is expected
                     return ServiceStatus(
                         name=name,
                         available=False,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -227,3 +227,119 @@ class TestLogJournalTail:
     def test_unknown_service(self, orchestrator):
         """No crash for unknown service name."""
         orchestrator._log_journal_tail('nonexistent')
+
+
+class TestFixStalePlaceholder:
+    """Test _fix_stale_placeholder() auto-fix for stale placeholder services."""
+
+    def test_regenerates_service_when_placeholder_and_binary_exists(self, orchestrator):
+        """When ExecStart is /bin/echo but real binary exists, regenerate service file."""
+        def mock_run(cmd, **kwargs):
+            result = MagicMock()
+            if cmd[0] == 'systemctl' and '--property=ExecStart' in cmd:
+                result.stdout = 'ExecStart=/bin/echo "Install native meshtasticd"'
+                result.returncode = 0
+            elif cmd[0] == 'which':
+                result.stdout = '/usr/bin/meshtasticd\n'
+                result.returncode = 0
+            else:
+                result.stdout = ''
+                result.returncode = 0
+            return result
+
+        with patch('subprocess.run', side_effect=mock_run), \
+             patch('core.orchestrator._sudo_write', return_value=(True, 'ok')) as mock_write, \
+             patch('core.orchestrator._sudo_cmd', side_effect=lambda c: c), \
+             patch('pathlib.Path.exists', return_value=False), \
+             patch('pathlib.Path.read_text', return_value=''):
+
+            result = orchestrator._fix_stale_placeholder('meshtasticd')
+
+            assert result is True
+            mock_write.assert_called_once()
+            written_path = mock_write.call_args[0][0]
+            written_content = mock_write.call_args[0][1]
+            assert written_path == '/etc/systemd/system/meshtasticd.service'
+            assert '/usr/bin/meshtasticd' in written_content
+            assert 'Type=simple' in written_content
+
+    def test_no_fix_when_binary_not_found(self, orchestrator):
+        """When ExecStart is /bin/echo and binary doesn't exist, log error, return False."""
+        def mock_run(cmd, **kwargs):
+            result = MagicMock()
+            if cmd[0] == 'systemctl' and '--property=ExecStart' in cmd:
+                result.stdout = 'ExecStart=/bin/echo "No radio detected"'
+                result.returncode = 0
+            elif cmd[0] == 'which':
+                result.stdout = ''
+                result.returncode = 1
+            else:
+                result.stdout = ''
+                result.returncode = 0
+            return result
+
+        with patch('subprocess.run', side_effect=mock_run), \
+             patch('core.orchestrator._sudo_write') as mock_write:
+
+            result = orchestrator._fix_stale_placeholder('meshtasticd')
+
+            assert result is False
+            mock_write.assert_not_called()
+
+    def test_real_service_unchanged(self, orchestrator):
+        """When ExecStart points to real binary, no fix needed."""
+        def mock_run(cmd, **kwargs):
+            result = MagicMock()
+            if cmd[0] == 'systemctl' and '--property=ExecStart' in cmd:
+                result.stdout = 'ExecStart=/usr/bin/meshtasticd -c /etc/meshtasticd/config.yaml'
+                result.returncode = 0
+            else:
+                result.stdout = ''
+                result.returncode = 0
+            return result
+
+        with patch('subprocess.run', side_effect=mock_run), \
+             patch('core.orchestrator._sudo_write') as mock_write:
+
+            result = orchestrator._fix_stale_placeholder('meshtasticd')
+
+            assert result is False
+            mock_write.assert_not_called()
+
+    def test_uses_template_when_available(self, orchestrator):
+        """When service template exists, use it instead of inline fallback."""
+        template_content = (
+            "[Unit]\n"
+            "Description=Meshtastic Daemon\n"
+            "[Service]\n"
+            "Type=simple\n"
+            "ExecStart=@MESHTASTICD_BIN@ -c /etc/meshtasticd/config.yaml\n"
+            "[Install]\n"
+            "WantedBy=multi-user.target\n"
+        )
+
+        def mock_run(cmd, **kwargs):
+            result = MagicMock()
+            if cmd[0] == 'systemctl' and '--property=ExecStart' in cmd:
+                result.stdout = 'ExecStart=/bin/echo "placeholder"'
+                result.returncode = 0
+            elif cmd[0] == 'which':
+                result.stdout = '/usr/bin/meshtasticd\n'
+                result.returncode = 0
+            else:
+                result.stdout = ''
+                result.returncode = 0
+            return result
+
+        with patch('subprocess.run', side_effect=mock_run), \
+             patch('core.orchestrator._sudo_write', return_value=(True, 'ok')) as mock_write, \
+             patch('core.orchestrator._sudo_cmd', side_effect=lambda c: c), \
+             patch('pathlib.Path.exists', return_value=True), \
+             patch('pathlib.Path.read_text', return_value=template_content):
+
+            result = orchestrator._fix_stale_placeholder('meshtasticd')
+
+            assert result is True
+            written_content = mock_write.call_args[0][1]
+            assert '/usr/bin/meshtasticd' in written_content
+            assert '@MESHTASTICD_BIN@' not in written_content


### PR DESCRIPTION
## Summary
Add automatic detection and repair of stale placeholder systemd service files when the real binary becomes available. This handles the case where an initial installation creates a placeholder service (with `/bin/echo`), but the actual daemon binary is later installed.

## Key Changes

- **New `_fix_stale_placeholder()` method** in `Orchestrator`: Detects when a service file contains a placeholder ExecStart directive (`/bin/echo`) but the real binary exists, then regenerates the service file from template or inline fallback and reloads systemd.

- **Auto-fix on service start**: Calls `_fix_stale_placeholder()` before starting a service to transparently repair stale placeholders without user intervention.

- **Enhanced service status detection** in `check_service()`: Now distinguishes between:
  - Stale placeholders (binary exists but service is placeholder) → `DEGRADED` state with fix hint
  - Hardware mismatches (SPI HAT but USB placeholder) → `UNAVAILABLE` state
  - Expected placeholders (USB radio, no native binary) → `UNAVAILABLE` state

- **Improved install script logic** in `install_noc.sh`: Prevents overwriting existing valid meshtasticd services with placeholders by checking if a working service already exists before creating a placeholder.

## Implementation Details

- Template-first approach: Uses `/templates/systemd/meshtasticd-native.service` if available, with inline fallback matching the install script's NATIVE_USB_SERVICE format
- Graceful degradation: If daemon-reload fails after fixing, logs a warning but doesn't fail the start operation
- Comprehensive error handling: Catches subprocess timeouts and missing commands
- Logging: Provides clear warning/error messages for troubleshooting

https://claude.ai/code/session_01E4i8e6xEbxTuwcJvmPr4C9