### PR TITLE
Centralize config.yaml creation to prevent overwrites

### DIFF
--- a/src/config/config_file_manager.py
+++ b/src/config/config_file_manager.py
@@ -839,7 +839,13 @@ class ConfigFileManager:
             self._apply_changes()
 
     def _create_basic_config(self):
-        """Create a basic config.yaml with all required sections"""
+        """Create a basic config.yaml — only if it doesn't already exist.
+
+        NEVER overwrites the user's config.yaml (MaxNodes, etc.).
+        """
+        if self.MAIN_CONFIG.exists():
+            console.print(f"[yellow]{self.MAIN_CONFIG} already exists — not overwriting.[/yellow]")
+            return
         basic_config = """# Meshtasticd Configuration
 # See: https://meshtastic.org/docs/hardware/devices/linux-native-hardware/
 # Hardware-specific LoRa settings should be in config.d/*.yaml

--- a/src/config/spi_hats.py
+++ b/src/config/spi_hats.py
@@ -344,16 +344,12 @@ class SPIHatConfigurator:
                 check=False, timeout=10
             )
 
-        # Generate config.yaml content
+        # Generate hardware config content
         yaml_content = self.generate_config_yaml(config)
 
-        # Save to config.yaml
-        config_yaml_path = '/etc/meshtasticd/config.yaml'
-        success, msg = _sudo_write(config_yaml_path, yaml_content)
-        if success:
-            saved_files.append(config_yaml_path)
-        else:
-            console.print(f"[red]Failed to write {config_yaml_path}: {msg}[/red]")
+        # NEVER overwrite /etc/meshtasticd/config.yaml — that is the user's
+        # file (MaxNodes, MaxMessageQueue, etc.).  Hardware-specific settings
+        # go to available.d/ with a symlink in config.d/ only.
 
         # Save device-specific config to available.d
         hat_name = config.get('hat', 'unknown').lower().replace(' ', '-')

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -649,10 +649,19 @@ class MeshtasticdConfig:
                 logger.debug(f"Created template: {config_file}")
 
     def _create_main_config(self):
-        """Create main config.yaml file.
+        """Create main config.yaml file ONLY if it does not already exist.
+
+        SAFETY: NEVER overwrites an existing config.yaml. Users hand-edit
+        this file (e.g., MaxNodes: 400). MeshForge runtime changes go to
+        config.d/meshforge-overrides.yaml instead.
 
         Prefers repo template from templates/config.yaml over inline fallback.
         """
+        # Defense-in-depth: NEVER overwrite user's config.yaml
+        if self.main_config.exists():
+            logger.debug("config.yaml already exists, preserving: %s", self.main_config)
+            return
+
         # Try repo template first
         repo_config = Path(__file__).parent.parent.parent / 'templates' / 'config.yaml'
         if repo_config.exists():

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -620,25 +620,12 @@ class ServiceMenuMixin:
                     "Check: cat /etc/meshtasticd/config.yaml"
                 )
 
-            # Only create config.yaml if it doesn't exist or is empty
+            # Only create config.yaml if it doesn't exist or is empty.
+            # Uses centralized ensure_structure() so content stays in sync
+            # with templates/config.yaml.  NEVER overwrites user's config.
             if needs_config:
-                config_yaml.write_text("""---
-Lora:
-  Module: auto
-
-Logging:
-  LogLevel: info
-
-Webserver:
-  Port: 9443
-  RootPath: /usr/share/meshtasticd/web
-
-General:
-  MaxNodes: 200
-  MaxMessageQueue: 100
-  ConfigDirectory: /etc/meshtasticd/config.d/
-  AvailableDirectory: /etc/meshtasticd/available.d/
-""")
+                from core.meshtasticd_config import MeshtasticdConfig
+                MeshtasticdConfig().ensure_structure()
                 self.dialog.infobox("Fixing", "Created minimal config.yaml")
 
             # NOTE: We do NOT create HAT templates - meshtasticd provides them
@@ -741,38 +728,16 @@ General:
             result = subprocess.run(['which', 'meshtasticd'], capture_output=True, text=True, timeout=5)
             meshtasticd_bin = result.stdout.strip() if result.returncode == 0 else '/usr/bin/meshtasticd'
 
-            # Ensure config directories exist (meshtasticd package should create these)
+            # Ensure config directories and config.yaml exist.
+            # Uses centralized ensure_structure() — creates dirs, deploys
+            # templates from templates/config.yaml.  NEVER overwrites user's
+            # config.yaml (MaxNodes, MaxMessageQueue, etc.).
             config_dir = Path('/etc/meshtasticd')
-            config_dir.mkdir(parents=True, exist_ok=True)
-            (config_dir / 'available.d').mkdir(exist_ok=True)
-            (config_dir / 'config.d').mkdir(exist_ok=True)
-            (config_dir / 'ssl').mkdir(mode=0o700, exist_ok=True)
-
-            # Check if meshtasticd installed a valid config.yaml
-            # Only create one if missing or empty - NEVER overwrite
             config_yaml = config_dir / 'config.yaml'
-            if config_yaml.exists() and 'Webserver:' in config_yaml.read_text():
-                self.dialog.infobox("Installing", "Using existing config.yaml from meshtasticd package")
-            elif not config_yaml.exists() or not config_yaml.read_text().strip():
-                # No config or empty - create minimal one
-                config_yaml.write_text("""---
-Lora:
-  Module: auto
-
-Logging:
-  LogLevel: info
-
-Webserver:
-  Port: 9443
-  RootPath: /usr/share/meshtasticd/web
-
-General:
-  MaxNodes: 200
-  MaxMessageQueue: 100
-  ConfigDirectory: /etc/meshtasticd/config.d/
-  AvailableDirectory: /etc/meshtasticd/available.d/
-""")
-                self.dialog.infobox("Installing", "Created minimal config.yaml")
+            from core.meshtasticd_config import MeshtasticdConfig
+            MeshtasticdConfig().ensure_structure()
+            if config_yaml.exists():
+                self.dialog.infobox("Installing", "Config structure ready")
 
             # NOTE: We do NOT create HAT templates - meshtasticd package provides them
             # User selects their HAT from /etc/meshtasticd/available.d/ via Hardware Config menu


### PR DESCRIPTION
## Summary
Refactored config.yaml creation logic to use a centralized `ensure_structure()` method from `MeshtasticdConfig`, ensuring consistent behavior across the codebase and preventing accidental overwrites of user configurations.

## Key Changes
- **Centralized config creation**: Replaced inline config.yaml generation in `service_menu_mixin.py` (two locations) with calls to `MeshtasticdConfig().ensure_structure()`
- **Safety guards added**: Enhanced `_create_main_config()` in `meshtasticd_config.py` with explicit checks to never overwrite existing config.yaml files
- **Removed hardware config write**: Eliminated direct write to config.yaml in `spi_hats.py` — hardware settings now go only to `available.d/` with symlinks in `config.d/`
- **Protected user settings**: Added safeguards in `config_file_manager.py` to prevent overwriting user's config.yaml during basic config creation
- **Improved documentation**: Added detailed comments explaining the safety-first approach and clarifying that user-edited settings (MaxNodes, MaxMessageQueue, etc.) are never overwritten

## Implementation Details
- The `ensure_structure()` method now serves as the single source of truth for config.yaml creation, using templates from `templates/config.yaml`
- All code paths that previously created config.yaml inline now delegate to the centralized method
- Defense-in-depth approach: multiple layers check for existing config before any write operations
- Hardware-specific configurations are properly isolated to `config.d/` subdirectory, keeping the main config.yaml reserved for user customization

https://claude.ai/code/session_01XoN6TE2wAndmNHgk67cBdM