### PR TITLE
Remove auto-deployment of meshtasticd radio configs

### DIFF
--- a/scripts/install_noc.sh
+++ b/scripts/install_noc.sh
@@ -571,7 +571,7 @@ SPI_NEEDS_NATIVE
                         cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'FALLBACK_CONFIG'
 ---
 Lora:
-  Module: auto
+  # Module: auto  # Disabled — select hardware via TUI or copy template to config.d/
 
 Logging:
   LogLevel: info
@@ -659,7 +659,7 @@ FALLBACK_CONFIG
                             cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'REBOOT_CONFIG'
 ---
 Lora:
-  Module: auto
+  # Module: auto  # Disabled — select hardware via TUI or copy template to config.d/
 
 Logging:
   LogLevel: info
@@ -776,7 +776,7 @@ ADD_WEBSERVER
                         cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'SPI_CONFIG'
 ---
 Lora:
-  Module: auto
+  # Module: auto  # Disabled — select hardware via TUI or copy template to config.d/
 
 Logging:
   LogLevel: info

--- a/scripts/upgrade_to_native.sh
+++ b/scripts/upgrade_to_native.sh
@@ -167,7 +167,7 @@ else
     cat > "$MESHTASTICD_CONFIG_DIR/config.yaml" << 'MAIN_CONFIG'
 ---
 Lora:
-  Module: auto
+  # Module: auto  # Disabled — select hardware via TUI or copy template to config.d/
 
 Logging:
   LogLevel: info

--- a/scripts/verify_post_install.sh
+++ b/scripts/verify_post_install.sh
@@ -213,7 +213,7 @@ if [[ -f "$CONFIG_YAML" ]]; then
         MODULE=$(grep -A1 "Lora:" "$CONFIG_YAML" | grep "Module:" | awk '{print $2}' || echo "auto")
         check_pass "Lora section" "Module: ${MODULE:-auto}"
     else
-        check_warn "Lora section" "Missing from config.yaml" "Add: Lora:\\n  Module: auto"
+        check_warn "Lora section" "Missing from config.yaml" "Reinstall meshtasticd package or run MeshForge ensure_structure() to regenerate"
     fi
 
     # Check for WRONG content (radio parameters that shouldn't be here)

--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -683,11 +683,12 @@ class MeshtasticdConfig:
 ### To activate, simply copy or link the appropriate file into /etc/meshtasticd/config.d
 
 ### Define your devices here using Broadcom pin numbering
-### Uncomment the block that corresponds to your hardware
-### Including the "Module:" line!
+### Module is set by hardware templates in config.d/
+### DO NOT set Module: auto — it triggers meshtasticd autoconf crashes
+### Select your radio via TUI or: sudo cp available.d/<radio>.yaml config.d/
 ---
 Lora:
-  Module: auto
+#  Module: sx1262
 
 GPS:
 #  SerialPath: /dev/ttyS0
@@ -998,29 +999,17 @@ def get_config() -> MeshtasticdConfig:
 
 def setup_meshtasticd() -> bool:
     """
-    Quick setup: ensure config structure and detect radio.
+    Quick setup: ensure config structure exists.
+
+    Creates /etc/meshtasticd/{available.d,config.d,ssl} and deploys
+    templates to available.d/ if missing. Does NOT auto-enable any
+    radio config — the user must explicitly select their hardware.
 
     Returns:
         True if setup successful
     """
     config = get_config()
-
-    if not config.ensure_structure():
-        return False
-
-    radio_type = config.detect_radio_type()
-    daemon_type = config.get_daemon_type()
-
-    logger.info(f"Radio type: {radio_type.value}, Daemon: {daemon_type}")
-
-    # Auto-enable appropriate config
-    if radio_type == RadioType.NATIVE_SPI:
-        # Check for Meshtoad specifically
-        config.enable("meshtoad-spi")
-    elif radio_type == RadioType.USB_SERIAL:
-        config.enable("usb-serial")
-
-    return True
+    return config.ensure_structure()
 
 
 def print_status():

--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -141,7 +141,6 @@ class ServiceOrchestrator:
         self.STARTUP_ORDER = list(self.__class__.STARTUP_ORDER)
         self._config_path = config_path or NOC_CONFIG_PATH
         self._running = False
-        self._config_auto_deployed = False
         self._stop_event = threading.Event()
         self._monitor_thread: Optional[threading.Thread] = None
         self._callbacks: Dict[str, List[Callable]] = {
@@ -296,11 +295,12 @@ class ServiceOrchestrator:
         Without a radio config template, meshtasticd starts but never binds
         TCP port 4403 — causing health checks to fail.
 
-        If config.d/ is empty, attempts auto-detection of connected hardware
-        and deploys the matching template.
+        If config.d/ is empty, REFUSES to start and logs clear instructions
+        directing the user to select hardware via the TUI or manual copy.
+        No auto-detection or auto-deployment of configs.
 
         Returns:
-            True if config.d/ has at least one config (or was auto-populated).
+            True if config.d/ has at least one valid config.
         """
         config_d = MESHTASTICD_CONFIG_DIR / "config.d"
         available_d = MESHTASTICD_CONFIG_DIR / "available.d"
@@ -309,160 +309,52 @@ class ServiceOrchestrator:
         if config_d.exists():
             existing = list(config_d.glob("*.yaml"))
             if existing:
-                # Ensure all SPI templates have explicit Module: to
-                # prevent config.yaml's 'Module: auto' from triggering
-                # meshtasticd's autoconf hardware scan (which can fail
-                # on EEPROM CRC32 and crash the service).
+                # Defense-in-depth: ensure SPI templates have explicit
+                # Module: to prevent any residual Module: auto in
+                # config.yaml from triggering meshtasticd autoconf.
                 for tmpl in existing:
-                    self._ensure_template_has_module(tmpl)
+                    self._validate_template_module(tmpl)
                 return True
 
-        logger.warning("No radio config in /etc/meshtasticd/config.d/")
-        logger.info("Attempting auto-detection of radio hardware...")
+        # ── config.d/ is empty — REFUSE to start ──
+        logger.error(
+            "No radio config in /etc/meshtasticd/config.d/ — "
+            "meshtasticd cannot start without hardware configuration."
+        )
+        logger.error("")
+        logger.error("Select your radio hardware using one of these methods:")
+        logger.error("")
+        logger.error(
+            "  1. TUI: sudo python3 src/launcher_tui/main.py"
+        )
+        logger.error(
+            "     → Meshtasticd Config → Hardware Config"
+        )
+        logger.error("")
+        logger.error(
+            "  2. Manual: sudo cp /etc/meshtasticd/available.d/"
+            "<your-radio>.yaml /etc/meshtasticd/config.d/"
+        )
+        logger.error("")
 
-        # Detect hardware
-        hw = _detect_radio_hardware()
+        # List available templates if the directory exists
+        if available_d.exists():
+            templates = sorted(available_d.glob("*.yaml"))
+            if templates:
+                logger.error("Available templates:")
+                for tmpl in templates:
+                    logger.error(f"  - {tmpl.name}")
+                logger.error("")
 
-        if not available_d.exists():
-            logger.error(
-                "No templates in /etc/meshtasticd/available.d/ — "
-                "reinstall meshtasticd or run install_noc.sh"
-            )
-            return False
+        return False
 
-        template_name = None
+    def _validate_template_module(self, deployed_path: Path) -> None:
+        """Validate that a deployed config.d template has an explicit Lora.Module line.
 
-        # USB auto-detection via vendor:product ID → template mapping
-        if hw['has_usb']:
-            try:
-                from config.hardware import HardwareDetector
-                # Get USB vendor:product ID for first device
-                usb_dev = Path(hw['usb_device'])
-                usb_id_result = subprocess.run(
-                    ['udevadm', 'info', '--query=property', str(usb_dev)],
-                    capture_output=True, text=True, timeout=5
-                )
-                vendor = product = None
-                for line in usb_id_result.stdout.splitlines():
-                    if line.startswith('ID_VENDOR_ID='):
-                        vendor = line.split('=', 1)[1].strip()
-                    elif line.startswith('ID_MODEL_ID='):
-                        product = line.split('=', 1)[1].strip()
-
-                if vendor and product:
-                    usb_id = f"{vendor}:{product}"
-                    template_name = HardwareDetector.match_usb_to_template(usb_id)
-                    if template_name:
-                        device_name = HardwareDetector.get_device_name_for_usb_id(usb_id) or usb_id
-                        logger.info(f"Detected USB radio: {device_name} → {template_name}")
-            except (ImportError, subprocess.SubprocessError, OSError) as e:
-                logger.debug(f"USB auto-detection failed: {e}")
-
-            # Fallback: use usb-serial-generic.yaml
-            if not template_name:
-                template_name = 'usb-serial-generic.yaml'
-                logger.info(f"USB device found at {hw['usb_device']} — using {template_name}")
-
-        # SPI auto-detection: use EEPROM if available, otherwise fail-safe
-        elif hw['has_spi']:
-            try:
-                from config.hardware import HardwareDetector
-                eeprom_template = HardwareDetector.match_eeprom_to_template()
-                if eeprom_template:
-                    template_name = eeprom_template
-                    logger.info(
-                        f"SPI HAT identified via EEPROM → {template_name}"
-                    )
-                    self._config_auto_deployed = True
-                else:
-                    # No EEPROM match — refuse to guess, list options
-                    spi_templates = sorted(
-                        list(available_d.glob("*-spi.yaml"))
-                        + list(available_d.glob("*-hat*.yaml"))
-                        + [t for t in available_d.glob("*.yaml")
-                           if '-usb' not in t.name
-                           and not t.name.startswith('usb-')]
-                    )
-                    seen = set()
-                    unique_templates = []
-                    for t in spi_templates:
-                        if t.name not in seen:
-                            seen.add(t.name)
-                            unique_templates.append(t)
-
-                    logger.error(
-                        "SPI detected but cannot identify HAT model "
-                        "(no EEPROM match). "
-                        "Auto-detection refused to guess — "
-                        "wrong GPIO pins will prevent radio init."
-                    )
-                    if unique_templates:
-                        logger.error(
-                            "Available SPI/HAT templates — "
-                            "select one manually:"
-                        )
-                        for t in unique_templates:
-                            logger.error(f"  - {t.name}")
-                    logger.error(
-                        "Fix: sudo cp /etc/meshtasticd/available.d/"
-                        "<your-hat>.yaml /etc/meshtasticd/config.d/"
-                    )
-                    logger.error(
-                        "Or run the interactive HAT wizard via the TUI: "
-                        "Hardware → Select & Configure Device"
-                    )
-                    return False
-            except ImportError:
-                logger.error(
-                    "SPI detected but hardware detection module unavailable"
-                )
-                return False
-
-        if not template_name:
-            logger.error(
-                "No radio hardware detected (no SPI or USB devices). "
-                "meshtasticd cannot bind port 4403 without a radio config."
-            )
-            logger.error(
-                "Fix: cp /etc/meshtasticd/available.d/<your-radio>.yaml "
-                "/etc/meshtasticd/config.d/"
-            )
-            return False
-
-        # Deploy the template
-        template_path = available_d / template_name
-        if not template_path.exists():
-            logger.error(f"Template not found: {template_path}")
-            return False
-
-        try:
-            config_d.mkdir(parents=True, exist_ok=True)
-            import shutil
-            deployed_path = config_d / template_name
-            shutil.copy2(str(template_path), str(deployed_path))
-            logger.info(f"Auto-deployed radio config: {template_name} → config.d/")
-            # Ensure deployed template has explicit Module: to prevent
-            # autoconf crash (defence-in-depth for older templates)
-            self._ensure_template_has_module(deployed_path)
-            logger.info(
-                "Config will be validated when meshtasticd starts "
-                "(port 4403 binding check)"
-            )
-            return True
-        except (OSError, PermissionError) as e:
-            logger.error(f"Failed to deploy config: {e}")
-            logger.error(
-                "Fix: sudo cp /etc/meshtasticd/available.d/"
-                f"{template_name} /etc/meshtasticd/config.d/"
-            )
-            return False
-
-    def _ensure_template_has_module(self, deployed_path: Path) -> None:
-        """Ensure a deployed config.d template has an explicit Lora.Module line.
-
-        Without Module:, the main config.yaml's 'Module: auto' survives
-        the merge, triggering meshtasticd's autoconf hardware scan which
-        can fail (EEPROM CRC32 missing) and crash the service.
+        Defense-in-depth: if a user manually copies an SPI template that
+        lacks Module:, this patches it to prevent any residual Module: auto
+        from triggering meshtasticd's autoconf hardware scan (which crashes
+        on EEPROM CRC32 missing, no CH341, etc.).
 
         If Module: is missing, infers the correct value from the
         RADIO_TEMPLATES metadata or falls back to sx1262 (most common).
@@ -953,12 +845,11 @@ class ServiceOrchestrator:
                             f"service state: {post_port_status.state.value})"
                         )
                         self._log_journal_tail(service_name, lines=10)
-                        if self._config_auto_deployed:
-                            logger.error(
-                                "The auto-deployed radio config may be "
-                                "wrong. Check /etc/meshtasticd/config.d/ "
-                                "and verify GPIO pins match your HAT."
-                            )
+                        logger.error(
+                            "Check /etc/meshtasticd/config.d/ — verify "
+                            "the radio config matches your hardware "
+                            "(correct GPIO pins, Module type, etc.)."
+                        )
                         self._emit('service_failed', service_name)
                         return False
 

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -43,7 +43,6 @@ class MeshtasticdConfigMixin:
 
     # LoRa module types supported by meshtasticd
     LORA_MODULES = {
-        "auto": "Auto-detect module type",
         "sx1262": "SX1262 (Waveshare, Ebyte E22-900M, MeshAdv, etc.)",
         "sx1268": "SX1268 (Ebyte E22-400M, etc.)",
         "sx1280": "SX1280 (2.4 GHz)",

--- a/templates/config.yaml
+++ b/templates/config.yaml
@@ -6,9 +6,12 @@
 ### Including the "Module:" line!
 ---
 Lora:
-  # Default to auto-detecting the module type
-  # This will be overridden by configs from config.d
-  Module: auto
+  # Module is set by hardware templates in config.d/
+  # DO NOT set Module: auto — it triggers meshtasticd's native autoconf
+  # which crashes when no hardware is detected (EEPROM CRC32, no CH341, etc.)
+  # Select your radio via TUI > Meshtasticd Config > Hardware Config
+  # Or: sudo cp /etc/meshtasticd/available.d/<radio>.yaml /etc/meshtasticd/config.d/
+#  Module: sx1262
 
 #  # Uncomment to enable Simulation mode, or use --sim
 #  Module: sim

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -373,83 +373,74 @@ class TestFixStalePlaceholder:
             assert '@MESHTASTICD_BIN@' not in written_content
 
 
-class TestSPIAutoDetection:
-    """Test EEPROM-based SPI HAT auto-detection in _check_meshtasticd_config."""
+class TestConfigDValidation:
+    """Test _check_meshtasticd_config validates config.d/ state."""
 
-    def _mock_hardware_module(self, eeprom_return):
-        """Create a mock config.hardware module with HardwareDetector."""
-        mock_module = MagicMock()
-        mock_module.HardwareDetector.match_eeprom_to_template.return_value = eeprom_return
-        return mock_module
-
-    def test_eeprom_match_deploys_correct_template(self, orchestrator, tmp_path):
-        """When EEPROM matches a known HAT, deploy that template."""
-        config_d = tmp_path / "config.d"
-        available_d = tmp_path / "available.d"
-        config_d.mkdir()
-        available_d.mkdir()
-        (available_d / "meshadv-mini.yaml").write_text("Lora:\n  CS: 8\n")
-
-        mock_hw = self._mock_hardware_module('meshadv-mini.yaml')
-
-        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path), \
-             patch('core.orchestrator._detect_radio_hardware', return_value={
-                 'has_spi': True, 'has_usb': False,
-                 'spi_devices': ['/dev/spidev0.0'],
-                 'usb_devices': [], 'hardware_type': 'spi',
-             }), \
-             patch.dict(sys.modules, {'config.hardware': mock_hw}):
-
-            result = orchestrator._check_meshtasticd_config()
-
-            assert result is True
-            assert (config_d / "meshadv-mini.yaml").exists()
-            assert orchestrator._config_auto_deployed is True
-
-    def test_no_eeprom_match_refuses_to_guess(self, orchestrator, tmp_path):
-        """When EEPROM has no match, refuse to deploy and return False."""
-        config_d = tmp_path / "config.d"
-        available_d = tmp_path / "available.d"
-        config_d.mkdir()
-        available_d.mkdir()
-        (available_d / "meshadv-mini.yaml").write_text("Lora:\n  CS: 8\n")
-        (available_d / "rak-hat-spi.yaml").write_text("Lora:\n  CS: 8\n")
-
-        mock_hw = self._mock_hardware_module(None)
-
-        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path), \
-             patch('core.orchestrator._detect_radio_hardware', return_value={
-                 'has_spi': True, 'has_usb': False,
-                 'spi_devices': ['/dev/spidev0.0'],
-                 'usb_devices': [], 'hardware_type': 'spi',
-             }), \
-             patch.dict(sys.modules, {'config.hardware': mock_hw}):
-
-            result = orchestrator._check_meshtasticd_config()
-
-            assert result is False
-            # config_d should remain empty — no wrong config deployed
-            assert list(config_d.glob("*.yaml")) == []
-
-    def test_existing_config_skips_auto_detection(self, orchestrator, tmp_path):
-        """When config.d/ already has a config, skip auto-detection entirely."""
+    def test_existing_config_returns_true(self, orchestrator, tmp_path):
+        """When config.d/ has a config, return True."""
         config_d = tmp_path / "config.d"
         config_d.mkdir()
-        (config_d / "existing.yaml").write_text("Lora:\n  CS: 8\n")
+        (config_d / "my-radio.yaml").write_text("Lora:\n  Module: sx1262\n  CS: 8\n")
 
         with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path):
             result = orchestrator._check_meshtasticd_config()
-
             assert result is True
-            assert orchestrator._config_auto_deployed is False
+
+    def test_empty_config_d_returns_false(self, orchestrator, tmp_path):
+        """When config.d/ is empty, refuse to start."""
+        config_d = tmp_path / "config.d"
+        available_d = tmp_path / "available.d"
+        config_d.mkdir()
+        available_d.mkdir()
+        (available_d / "meshtoad-spi.yaml").write_text("Lora:\n  CS: 8\n")
+
+        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path):
+            result = orchestrator._check_meshtasticd_config()
+            assert result is False
+
+    def test_no_config_d_returns_false(self, orchestrator, tmp_path):
+        """When config.d/ doesn't exist, refuse to start."""
+        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path):
+            result = orchestrator._check_meshtasticd_config()
+            assert result is False
+
+    def test_logs_available_templates(self, orchestrator, tmp_path, caplog):
+        """When refusing to start, log available templates."""
+        import logging
+        config_d = tmp_path / "config.d"
+        available_d = tmp_path / "available.d"
+        config_d.mkdir()
+        available_d.mkdir()
+        (available_d / "meshtoad-spi.yaml").write_text("Lora:\n")
+        (available_d / "heltec-usb.yaml").write_text("Serial:\n")
+
+        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path), \
+             caplog.at_level(logging.ERROR):
+            result = orchestrator._check_meshtasticd_config()
+            assert result is False
+            assert "meshtoad-spi.yaml" in caplog.text
+            assert "heltec-usb.yaml" in caplog.text
+
+    def test_no_auto_deployment(self, orchestrator, tmp_path):
+        """When config.d/ is empty, no templates are auto-deployed."""
+        config_d = tmp_path / "config.d"
+        available_d = tmp_path / "available.d"
+        config_d.mkdir()
+        available_d.mkdir()
+        (available_d / "heltec-usb.yaml").write_text("Serial:\n  Device: auto\n")
+
+        with patch('core.orchestrator.MESHTASTICD_CONFIG_DIR', tmp_path):
+            result = orchestrator._check_meshtasticd_config()
+            assert result is False
+            # config_d should remain empty — no auto-deployment
+            assert list(config_d.glob("*.yaml")) == []
 
 
 class TestPostPortCrashDetection:
     """Test that service crash after port timeout is detected."""
 
-    def test_auto_deployed_config_hint_on_crash(self, orchestrator):
-        """When auto-deployed config causes crash, error includes config hint."""
-        orchestrator._config_auto_deployed = True
+    def test_config_hint_on_crash(self, orchestrator):
+        """When service crashes after start, error includes config check hint."""
         call_count = {'n': 0}
 
         def mock_check_service(name):


### PR DESCRIPTION
## Summary
This PR removes the automatic hardware detection and config deployment logic from the meshtasticd configuration system. Instead of attempting to auto-detect radio hardware and deploy matching templates, the system now refuses to start without an explicit user-selected configuration and provides clear instructions for manual setup.

## Key Changes

- **Removed auto-detection logic**: Eliminated all hardware detection code (USB vendor:product ID matching, EEPROM-based SPI HAT detection) from `_check_meshtasticd_config()`
- **Removed auto-deployment**: Deleted the template copying/deployment mechanism that previously populated `config.d/` automatically
- **Removed `_config_auto_deployed` flag**: Eliminated the instance variable that tracked whether a config was auto-deployed
- **Fail-safe approach**: When `config.d/` is empty, the system now logs clear error messages with instructions for:
  - Using the TUI (Hardware Config menu)
  - Manual template copying from `available.d/`
  - Lists available templates to guide user selection
- **Renamed validation method**: `_ensure_template_has_module()` → `_validate_template_module()` to better reflect its purpose (validation rather than enforcement)
- **Updated config templates**: Changed `Module: auto` to commented-out `#  Module: sx1262` in all config templates with explanatory comments about why auto-detection is disabled
- **Simplified setup**: `setup_meshtasticd()` now only ensures directory structure exists; removed automatic radio type detection and config enablement
- **Updated error messages**: Removed auto-deployment-specific hints from service crash diagnostics; now provides generic config validation guidance
- **Updated tests**: Replaced `TestSPIAutoDetection` with `TestConfigDValidation` to test the new validation-only behavior

## Implementation Details

- The `_validate_template_module()` method remains as a defense-in-depth measure to prevent any residual `Module: auto` from triggering meshtasticd's native autoconf (which can crash on missing EEPROM/hardware)
- All config files now explicitly document that `Module: auto` is disabled and direct users to select hardware via TUI or manual template copy
- The system still validates existing configs in `config.d/` but refuses to start if the directory is empty
- Available templates are listed in error logs to help users identify which config to copy

https://claude.ai/code/session_01Kgh9rdxyqWvyRRJhCLfZAS