### PR TITLE
Fix meshtasticd startup to skip config validation when already running

### DIFF
--- a/src/core/orchestrator.py
+++ b/src/core/orchestrator.py
@@ -745,15 +745,18 @@ class ServiceOrchestrator:
             logger.error(f"{service_name} is not installed")
             return False
 
+        # Already running — no need to validate pre-start config
+        # (the service's configuration is valid however it was set up)
+        if self.is_running(service_name):
+            logger.info(f"{service_name} is already running")
+            return True
+
         # Pre-start: ensure meshtasticd has a radio config in config.d/
+        # Only reached when we are about to START the service.
         if service_name == 'meshtasticd' and config.check_port:
             if not self._check_meshtasticd_config():
                 logger.error("meshtasticd cannot start without a radio config")
                 return False
-
-        if self.is_running(service_name):
-            logger.info(f"{service_name} is already running")
-            return True
 
         # Auto-fix stale placeholder service files before starting
         self._fix_stale_placeholder(service_name)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -212,14 +212,32 @@ class TestStartServiceAlreadyRunning:
     """Test early return when service is already running."""
 
     def test_already_running(self, orchestrator):
-        """Service already running — return True immediately."""
+        """Service already running — return True without checking config.d."""
         with patch.object(orchestrator, 'is_installed', return_value=True), \
              patch.object(orchestrator, 'is_running', return_value=True), \
-             patch.object(orchestrator, '_check_meshtasticd_config', return_value=True):
+             patch.object(orchestrator, '_check_meshtasticd_config') as mock_config_check:
 
             result = orchestrator.start_service('meshtasticd')
 
             assert result is True
+            # Config check must NOT be called when service is already running
+            mock_config_check.assert_not_called()
+
+    def test_already_running_empty_config_d(self, orchestrator):
+        """Service running with empty config.d — return True (bug fix).
+
+        Regression test: meshtasticd configured via config.yaml (not config.d/)
+        should not be rejected when it is already running and healthy.
+        """
+        with patch.object(orchestrator, 'is_installed', return_value=True), \
+             patch.object(orchestrator, 'is_running', return_value=True), \
+             patch.object(orchestrator, '_check_meshtasticd_config', return_value=False) as mock_config_check:
+
+            result = orchestrator.start_service('meshtasticd')
+
+            assert result is True
+            # Config check must not be called — service is already running
+            mock_config_check.assert_not_called()
 
 
 class TestLogJournalTail:


### PR DESCRIPTION
## Summary
Reorder the service startup checks in `start_service()` to validate the radio configuration only when actually starting the service, not when it's already running. This fixes a regression where meshtasticd configured via `config.yaml` (rather than `config.d/`) would be incorrectly rejected even when already running and healthy.

## Key Changes
- **Moved the `is_running()` check earlier** in `start_service()` to occur before the meshtasticd config validation, allowing early return without unnecessary validation
- **Config validation now only runs when needed**: The `_check_meshtasticd_config()` check is only performed when we're about to start the service, not when it's already running
- **Added regression test** `test_already_running_empty_config_d()` to ensure services with empty or missing `config.d/` directories are not rejected when already running
- **Updated existing test** `test_already_running()` to verify that config checks are not called for running services

## Implementation Details
The fix recognizes that if a service is already running, its configuration is by definition valid (regardless of how it was set up). The pre-start config validation is only necessary when we're about to start the service. This prevents false negatives for valid configurations that don't use the `config.d/` directory structure.

https://claude.ai/code/session_013rYTwDPthMRdQrFMwXsZbe