### PR TITLE
Add 17 new hardware radio & display configuration templates

### DIFF
--- a/src/core/meshtasticd_config.py
+++ b/src/core/meshtasticd_config.py
@@ -563,6 +563,465 @@ Logging:
   LogLevel: info
 """
     },
+    # ─────────────────────────────────────────────
+    # USB Radios via CH341 USB-to-SPI (upstream naming)
+    # ─────────────────────────────────────────────
+    "lora-pinedio-usb-sx1262": {
+        "name": "lora-pinedio-usb-sx1262",
+        "radio_type": RadioType.USB_SERIAL,
+        "chip": "sx1262",
+        "description": "Pine64 Pinedio USB (CH341 + SX1262)",
+        "config": """\
+# Pine64 Pinedio USB LoRa Adapter (CH341 + SX1262)
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 10
+  spidev: ch341
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-usb-meshtoad-e22": {
+        "name": "lora-usb-meshtoad-e22",
+        "radio_type": RadioType.USB_SERIAL,
+        "chip": "sx1262",
+        "description": "MeshToad E22 USB (CH341 + SX1262)",
+        "config": """\
+# MeshToad E22 USB LoRa Adapter (CH341 + SX1262)
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  RXen: 1
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: ch341
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    # ─────────────────────────────────────────────
+    # SPI HATs — upstream meshtasticd naming (lora-* prefix)
+    # ─────────────────────────────────────────────
+    "display-waveshare-1-44": {
+        "name": "display-waveshare-1-44",
+        "radio_type": RadioType.NATIVE_SPI,
+        "description": "Waveshare 1.44\" LCD HAT (ST7735S, trackball)",
+        "config": """\
+# Waveshare 1.44" LCD HAT (ST7735S) Display Configuration
+
+Display:
+  Panel: ST7735S
+  spidev: spidev0.0
+  DC: 25
+  Backlight: 24
+  Width: 128
+  Height: 128
+  Reset: 27
+  OffsetX: 2
+  OffsetY: 1
+
+Input:
+  TrackballUp: 6
+  TrackballDown: 19
+  TrackballLeft: 5
+  TrackballRight: 26
+  TrackballPress: 13
+  TrackballDirection: FALLING
+"""
+    },
+    "display-waveshare-2.8": {
+        "name": "display-waveshare-2.8",
+        "radio_type": RadioType.NATIVE_SPI,
+        "description": "Waveshare 2.8\" LCD + Touchscreen (ST7789)",
+        "config": """\
+# Waveshare 2.8" RPi LCD Display + Touchscreen
+
+Display:
+  Panel: ST7789
+  CS: 8
+  DC: 22
+  Backlight: 18
+  Width: 240
+  Height: 320
+  Reset: 27
+  Rotate: true
+  Invert: true
+
+Touchscreen:
+  Module: XPT2046
+  CS: 7
+  IRQ: 17
+"""
+    },
+    "lora-Adafruit-RFM9x": {
+        "name": "lora-Adafruit-RFM9x",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "RF95",
+        "description": "Adafruit RFM9x (upstream naming, RF95/SX1276)",
+        "config": """\
+# Adafruit RFM9x LoRa Radio Bonnet (upstream naming)
+
+Lora:
+  Module: RF95
+  Reset: 25
+  CS: 7
+  IRQ: 22
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-MeshAdv-900M30S": {
+        "name": "lora-MeshAdv-900M30S",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshAdv-Pi E22-900M30S 1W (SX1262, high-power)",
+        "config": """\
+# MeshAdv-Pi E22-900M30S SPI Configuration (1W)
+
+Lora:
+  Module: sx1262
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  TXen: 13
+  RXen: 12
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-MeshAdv-Mini-900M22S": {
+        "name": "lora-MeshAdv-Mini-900M22S",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshAdv Mini E22-900M22S (SX1262)",
+        "config": """\
+# MeshAdv Mini E22-900M22S SPI Configuration
+
+Lora:
+  Module: sx1262
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  RXen: 12
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-RAK6421-13300-slot1": {
+        "name": "lora-RAK6421-13300-slot1",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "RAK6421 Pi-HAT RAK13300 Slot 1 (SX1262)",
+        "config": """\
+# RAK6421 Pi-HAT with RAK13300 — Slot 1
+
+Lora:
+  Module: sx1262
+  IRQ: 22
+  Reset: 16
+  Busy: 24
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-RAK6421-13300-slot2": {
+        "name": "lora-RAK6421-13300-slot2",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "RAK6421 Pi-HAT RAK13300 Slot 2 (SX1262)",
+        "config": """\
+# RAK6421 Pi-HAT with RAK13300 — Slot 2
+
+Lora:
+  Module: sx1262
+  IRQ: 18
+  Reset: 24
+  Busy: 19
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-lyra-picocalc-wio-sx1262": {
+        "name": "lora-lyra-picocalc-wio-sx1262",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Lyra PicoCalc WIO SX1262 (custom gpiochip)",
+        "config": """\
+# Lyra PicoCalc WIO SX1262 SPI Configuration
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  SX126X_MAX_POWER: 22
+  spidev: spidev1.0
+  SPI_Speed: 2000000
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-meshstick-1262": {
+        "name": "lora-meshstick-1262",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "MeshStick 1262 SPI (CH341 + SX1262)",
+        "config": """\
+# MeshStick 1262 SPI Configuration (CH341)
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  spidev: ch341
+  DIO3_TCXO_VOLTAGE: true
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-piggystick-lr1121": {
+        "name": "lora-piggystick-lr1121",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "lr1121",
+        "description": "PiggyStick LR1121 (CH341 + LR1121)",
+        "config": """\
+# PiggyStick LR1121 SPI Configuration (CH341)
+
+Lora:
+  Module: lr1121
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  spidev: ch341
+  DIO3_TCXO_VOLTAGE: 1.8
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-raxda-rock2f-starter-edition-hat": {
+        "name": "lora-raxda-rock2f-starter-edition-hat",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Radxa Rock 2F Starter Edition HAT (SX1262)",
+        "config": """\
+# Radxa Rock 2F Starter Edition HAT SPI Configuration
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: 1.8
+  spidev: spidev0.1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-starter-edition-sx1262-i2c": {
+        "name": "lora-starter-edition-sx1262-i2c",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Starter Edition SX1262 I2C RPi HAT",
+        "config": """\
+# Starter Edition SX1262 I2C Raspberry Pi HAT
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  CS: 8
+  IRQ: 22
+  Busy: 4
+  Reset: 18
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-waveshare-sxxx": {
+        "name": "lora-waveshare-sxxx",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Waveshare SX126X XXXM LoRa HAT (SX1262)",
+        "config": """\
+# Waveshare SX126X XXXM LoRa HAT SPI Configuration
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  SX126X_ANT_SW: 6
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-ws-raspberry-pi-pico-to-rpi-adapter": {
+        "name": "lora-ws-raspberry-pi-pico-to-rpi-adapter",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Waveshare Pico-to-RPi Adapter (SX1262)",
+        "config": """\
+# Waveshare Raspberry Pi Pico to RPi Adapter
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
+    "lora-ws-raspberry-pico-to-orangepi-03": {
+        "name": "lora-ws-raspberry-pico-to-orangepi-03",
+        "radio_type": RadioType.NATIVE_SPI,
+        "chip": "sx1262",
+        "description": "Waveshare SX1262 on Orange Pi Zero3 (gpiochip)",
+        "config": """\
+# Waveshare SX1262 on Orange Pi Zero3 via Pico Adapter
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev1.1
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+    },
 }
 
 
@@ -572,9 +1031,9 @@ class MeshtasticdConfig:
 
     Directory structure:
         /etc/meshtasticd/
-        ├── available.d/     # Available radio configs (19 templates)
-        │   ├── heltec-usb.yaml, tbeam-usb.yaml, ...  (7 USB)
-        │   └── meshtoad-spi.yaml, rak-hat-spi.yaml, ... (12 SPI)
+        ├── available.d/     # Available radio configs (36 templates)
+        │   ├── heltec-usb.yaml, tbeam-usb.yaml, ...  (9 USB)
+        │   └── meshtoad-spi.yaml, rak-hat-spi.yaml, ... (27 SPI)
         ├── config.d/        # Enabled configs (symlinks to available.d)
         │   └── active.yaml -> ../available.d/meshtoad-spi.yaml
         ├── config.yaml      # Main config (merged from config.d)

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -499,8 +499,34 @@ Press Cancel to keep current values."""
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
 
+    def _classify_hardware_config(self, config_path: Path) -> str:
+        """Classify a hardware config as 'usb' or 'spi'.
+
+        Uses RADIO_TEMPLATES radio_type first, then falls back to
+        inspecting the YAML content for Serial: (USB) vs Lora:/Display: (SPI).
+        """
+        try:
+            from core.meshtasticd_config import RADIO_TEMPLATES, RadioType
+            template = RADIO_TEMPLATES.get(config_path.stem, {})
+            if template:
+                rtype = template.get("radio_type")
+                if rtype == RadioType.USB_SERIAL:
+                    return "usb"
+                return "spi"
+        except ImportError:
+            pass
+
+        # Fallback: inspect file content
+        try:
+            content = config_path.read_text(errors='replace')[:500]
+            if 'Serial:' in content and 'spidev' not in content.lower():
+                return "usb"
+        except Exception:
+            pass
+        return "spi"
+
     def _hardware_config_menu(self):
-        """Hardware configuration selection."""
+        """Hardware configuration selection with USB/SPI categorization."""
         # Auto-create directory structure and templates if missing
         try:
             from core.meshtasticd_config import MeshtasticdConfig
@@ -534,26 +560,48 @@ Press Cancel to keep current values."""
         if config_d.exists():
             active = {f.name for f in config_d.glob('*.yaml')}
 
-        choices = []
+        # Classify configs into USB and SPI categories
+        usb_configs = []
+        spi_configs = []
         for cfg in sorted(available):
-            status = "[ACTIVE]" if cfg.name in active else ""
-            # Truncate name for display
-            name = cfg.stem[:25]
-            choices.append((cfg.name, f"{name} {status}"))
+            if self._classify_hardware_config(cfg) == "usb":
+                usb_configs.append(cfg)
+            else:
+                spi_configs.append(cfg)
+
+        # Build categorized menu choices
+        choices = []
+        choices.append(("--usb--", f"--- USB Radios ({len(usb_configs)}) ---"))
+        for cfg in usb_configs:
+            status = " [ACTIVE]" if cfg.name in active else ""
+            choices.append((cfg.name, f"  {cfg.stem}{status}"))
+
+        choices.append(("--spi--", f"--- SPI HATs ({len(spi_configs)}) ---"))
+        for cfg in spi_configs:
+            status = " [ACTIVE]" if cfg.name in active else ""
+            choices.append((cfg.name, f"  {cfg.stem}{status}"))
 
         choices.append(("view", "View Config Details"))
         choices.append(("back", "Back"))
 
+        # Build subtitle with active config info
+        active_names = [n.replace('.yaml', '') for n in active
+                        if n != 'meshforge-overrides.yaml']
+        active_display = ', '.join(active_names) if active_names else 'none'
+
         choice = self.dialog.menu(
             "Hardware Config",
-            "Select hardware configuration to activate:\n\n"
-            f"Templates: {available_dir}\n"
-            f"Active: {config_d}",
+            f"Total: {len(available)} templates | "
+            f"Active: {active_display}\n\n"
+            "Select hardware configuration to activate:",
             choices
         )
 
         if choice is None or choice == "back":
             return
+        elif choice in ("--usb--", "--spi--"):
+            # Category header selected — re-show menu
+            self._hardware_config_menu()
         elif choice == "view":
             self._view_hardware_config(available)
         else:

--- a/templates/available.d/display-waveshare-1-44.yaml
+++ b/templates/available.d/display-waveshare-1-44.yaml
@@ -1,0 +1,33 @@
+# Waveshare 1.44" LCD HAT (ST7735S) Display Configuration
+# Hardware: ST7735S SPI display with trackball input
+# Resolution: 128x128 pixels
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/display-waveshare-1-44.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Display:
+  Panel: ST7735S
+  spidev: spidev0.0
+  DC: 25
+  Backlight: 24
+  Width: 128
+  Height: 128
+  Reset: 27
+  OffsetX: 2
+  OffsetY: 1
+  # CS: 8
+  # OffsetY: 31     # For 180-degree rotation
+  # OffsetRotate: 3
+
+Input:
+  TrackballUp: 6
+  TrackballDown: 19
+  TrackballLeft: 5
+  TrackballRight: 26
+  TrackballPress: 13
+  TrackballDirection: FALLING
+  # User: 21

--- a/templates/available.d/display-waveshare-2.8.yaml
+++ b/templates/available.d/display-waveshare-2.8.yaml
@@ -1,0 +1,28 @@
+# Waveshare 2.8" RPi LCD Display + Touchscreen Configuration
+# Hardware: ST7789 SPI display with XPT2046 resistive touch
+# Resolution: 240x320 pixels
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/display-waveshare-2.8.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Display:
+  Panel: ST7789
+  CS: 8
+  DC: 22
+  Backlight: 18
+  Width: 240
+  Height: 320
+  Reset: 27
+  Rotate: true
+  Invert: true
+
+Touchscreen:
+  Module: XPT2046
+  CS: 7
+  IRQ: 17
+  # Note: Touchscreen MUST have a CS pin defined,
+  # even if Linux manages CS switching.

--- a/templates/available.d/lora-Adafruit-RFM9x.yaml
+++ b/templates/available.d/lora-Adafruit-RFM9x.yaml
@@ -1,0 +1,29 @@
+# Adafruit RFM9x LoRa Radio Bonnet (Upstream Config)
+# Hardware: RF95 (SX1276/RFM95/RFM96)
+# Manufacturer: Adafruit
+# Source: meshtastic/firmware bin/config.d
+#
+# Note: This is the upstream meshtasticd naming convention.
+#       See also: adafruit-rfm9x.yaml (MeshForge naming)
+#
+# Copy to: /etc/meshtasticd/config.d/lora-Adafruit-RFM9x.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: RF95
+  Reset: 25
+  CS: 7
+  IRQ: 22
+  # Busy: 23
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-MeshAdv-900M30S.yaml
+++ b/templates/available.d/lora-MeshAdv-900M30S.yaml
@@ -1,0 +1,33 @@
+# MeshAdv-Pi E22-900M30S SPI Configuration (1W High-Power)
+# Hardware: SX1262 (Ebyte E22-900M30S), +30dBm (1W)
+# Manufacturer: chrismyers2000
+# Source: meshtastic/firmware bin/config.d
+# Reference: https://github.com/chrismyers2000/MeshAdv-Pi-Hat
+#
+# Copy to: /etc/meshtasticd/config.d/lora-MeshAdv-900M30S.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  TXen: 13
+  RXen: 12
+  DIO3_TCXO_VOLTAGE: true
+  # Only for E22-900M33S:
+  # Limit the output power to 8 dBm
+  # SX126X_MAX_POWER: 8
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-MeshAdv-Mini-900M22S.yaml
+++ b/templates/available.d/lora-MeshAdv-Mini-900M22S.yaml
@@ -1,0 +1,30 @@
+# MeshAdv Mini E22-900M22S SPI Configuration
+# Hardware: SX1262 (Ebyte E22-900M22S)
+# Manufacturer: chrismyers2000
+# Source: meshtastic/firmware bin/config.d
+# Reference: https://github.com/chrismyers2000/MeshAdv-Mini
+#
+# Copy to: /etc/meshtasticd/config.d/lora-MeshAdv-Mini-900M22S.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  CS: 8
+  IRQ: 16
+  Busy: 20
+  Reset: 24
+  RXen: 12
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-RAK6421-13300-slot1.yaml
+++ b/templates/available.d/lora-RAK6421-13300-slot1.yaml
@@ -1,0 +1,30 @@
+# RAK6421 Pi-HAT with RAK13300 LoRa Module — Slot 1
+# Hardware: SX1262 (RAK13300)
+# Manufacturer: RAKwireless
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-RAK6421-13300-slot1.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  IRQ: 22       # IO6
+  Reset: 16     # IO4
+  Busy: 24      # IO5
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.0
+  # Ant_sw: 13  # IO3
+  # CS: 8
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-RAK6421-13300-slot2.yaml
+++ b/templates/available.d/lora-RAK6421-13300-slot2.yaml
@@ -1,0 +1,30 @@
+# RAK6421 Pi-HAT with RAK13300 LoRa Module — Slot 2
+# Hardware: SX1262 (RAK13300)
+# Manufacturer: RAKwireless
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-RAK6421-13300-slot2.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  IRQ: 18       # IO6
+  Reset: 24     # IO4
+  Busy: 19      # IO5
+  DIO3_TCXO_VOLTAGE: true
+  DIO2_AS_RF_SWITCH: true
+  spidev: spidev0.1
+  # Ant_sw: 23  # IO3
+  # CS: 7
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-lyra-picocalc-wio-sx1262.yaml
+++ b/templates/available.d/lora-lyra-picocalc-wio-sx1262.yaml
@@ -1,0 +1,49 @@
+# Lyra PicoCalc WIO SX1262 SPI Configuration
+# Hardware: SX1262 with custom gpiochip mapping
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-lyra-picocalc-wio-sx1262.yaml
+#
+# Note: Uses spidev1.0 and multi-gpiochip GPIO mapping.
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  SX126X_MAX_POWER: 22
+  spidev: spidev1.0
+  SPI_Speed: 2000000
+  MOSI:
+    gpiochip: 0
+    line: 12
+  MISO:
+    gpiochip: 0
+    line: 13
+  SCK:
+    gpiochip: 0
+    line: 11
+  CS:
+    gpiochip: 1
+    line: 9
+  IRQ:
+    gpiochip: 0
+    line: 1
+  Busy:
+    gpiochip: 0
+    line: 23
+  Reset:
+    gpiochip: 0
+    line: 22
+  RXen:
+    gpiochip: 0
+    line: 0
+  # TXen bridges to DIO2 on E22 module
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-meshstick-1262.yaml
+++ b/templates/available.d/lora-meshstick-1262.yaml
@@ -1,0 +1,31 @@
+# MeshStick 1262 SPI Configuration (CH341 USB-to-SPI)
+# Hardware: SX1262 via CH341 USB-to-SPI bridge
+# USB ID: 1A86:5512 (WCH CH341)
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-meshstick-1262.yaml
+#
+# Ensure the ch341 kernel module is loaded:
+#   sudo modprobe ch341
+#   lsmod | grep ch341
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  spidev: ch341
+  DIO3_TCXO_VOLTAGE: true
+  # USB_Serialnum: 12345678
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-piggystick-lr1121.yaml
+++ b/templates/available.d/lora-piggystick-lr1121.yaml
@@ -1,0 +1,31 @@
+# PiggyStick LR1121 SPI Configuration (CH341 USB-to-SPI)
+# Hardware: LR1121 via CH341 USB-to-SPI bridge
+# USB ID: 1A86:5512 (WCH CH341)
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-piggystick-lr1121.yaml
+#
+# Ensure the ch341 kernel module is loaded:
+#   sudo modprobe ch341
+#   lsmod | grep ch341
+
+Lora:
+  Module: lr1121
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  spidev: ch341
+  DIO3_TCXO_VOLTAGE: 1.8
+  # USB_Serialnum: 12345678
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-pinedio-usb-sx1262.yaml
+++ b/templates/available.d/lora-pinedio-usb-sx1262.yaml
@@ -1,0 +1,24 @@
+# Pine64 Pinedio USB LoRa Adapter (CH341 + SX1262)
+# Hardware: SX1262 via CH341 USB-to-SPI bridge
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-pinedio-usb-sx1262.yaml
+#
+# Ensure the ch341 kernel module is loaded:
+#   sudo modprobe ch341
+#   lsmod | grep ch341
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 10
+  spidev: ch341
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-raxda-rock2f-starter-edition-hat.yaml
+++ b/templates/available.d/lora-raxda-rock2f-starter-edition-hat.yaml
@@ -1,0 +1,51 @@
+# Radxa Rock 2F Starter Edition HAT SPI Configuration
+# Hardware: SX1262 on Radxa Rock 2F (Armbian Linux)
+# Manufacturer: Mark Birss (Starter Edition HAT)
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-raxda-rock2f-starter-edition-hat.yaml
+#
+# Note: Rock 2F uses multiple GPIO chips. Pin assignments
+#       specify physical pin, gpiochip, and line number.
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: 1.8
+  spidev: spidev0.1
+  CS:                    # Physical pin 24
+    gpiochip: 4
+    line: 14
+  SCK:                   # Physical pin 23
+    gpiochip: 4
+    line: 12
+  MOSI:                  # Physical pin 19
+    gpiochip: 4
+    line: 10
+  MISO:                  # Physical pin 21
+    gpiochip: 4
+    line: 11
+  Busy:                  # Physical pin 7
+    gpiochip: 4
+    line: 6
+  IRQ:                   # Physical pin 15
+    gpiochip: 4
+    line: 22
+  Reset:                 # Physical pin 12
+    gpiochip: 1
+    line: 13
+  # RXen:               # Physical pin 11
+  #   gpiochip: 4
+  #   line: 23
+  # TXen:               # Physical pin 13
+  #   gpiochip: 4
+  #   line: 21
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-starter-edition-sx1262-i2c.yaml
+++ b/templates/available.d/lora-starter-edition-sx1262-i2c.yaml
@@ -1,0 +1,27 @@
+# Starter Edition SX1262 I2C Raspberry Pi HAT
+# Hardware: SX1262
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-starter-edition-sx1262-i2c.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  CS: 8
+  IRQ: 22
+  Busy: 4
+  Reset: 18
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-usb-meshtoad-e22.yaml
+++ b/templates/available.d/lora-usb-meshtoad-e22.yaml
@@ -1,0 +1,37 @@
+# MeshToad E22 USB LoRa Adapter (CH341 + SX1262)
+# Hardware: SX1262 via CH341 USB-to-SPI bridge
+# USB ID: 1A86:5512 (WCH CH341)
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-usb-meshtoad-e22.yaml
+#
+# Ensure the ch341 kernel module is loaded:
+#   sudo modprobe ch341
+#   lsmod | grep ch341
+
+Lora:
+  Module: sx1262
+  CS: 0
+  IRQ: 6
+  Reset: 2
+  Busy: 4
+  RXen: 1
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: ch341
+  USB_PID: 0x5512
+  USB_VID: 0x1A86
+  # Optional: Reduce power to 10 dBm to
+  # avoid over-drawing the USB port
+  # SX126X_MAX_POWER: 10
+  # Optional: Set serial number for multi-radio support
+  # USB_Serialnum: 13374201
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-waveshare-sxxx.yaml
+++ b/templates/available.d/lora-waveshare-sxxx.yaml
@@ -1,0 +1,28 @@
+# Waveshare SX126X XXXM LoRa HAT SPI Configuration
+# Hardware: SX1262 with antenna switch control
+# Manufacturer: Waveshare
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-waveshare-sxxx.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+  SX126X_ANT_SW: 6
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-ws-raspberry-pi-pico-to-rpi-adapter.yaml
+++ b/templates/available.d/lora-ws-raspberry-pi-pico-to-rpi-adapter.yaml
@@ -1,0 +1,28 @@
+# Waveshare Raspberry Pi Pico to RPi Adapter SPI Configuration
+# Hardware: SX1262 via Pico-to-RPi adapter board
+# Manufacturer: Waveshare
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-ws-raspberry-pi-pico-to-rpi-adapter.yaml
+#
+# IMPORTANT: Enable SPI first!
+#   sudo raspi-config nonint do_spi 0
+#   sudo reboot
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  CS: 21
+  IRQ: 16
+  Busy: 20
+  Reset: 18
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info

--- a/templates/available.d/lora-ws-raspberry-pico-to-orangepi-03.yaml
+++ b/templates/available.d/lora-ws-raspberry-pico-to-orangepi-03.yaml
@@ -1,0 +1,47 @@
+# Waveshare SX1262 on Orange Pi Zero3 via Pico Adapter
+# Hardware: SX1262 via SPI1.1 with gpiochip line mapping
+# Source: meshtastic/firmware bin/config.d
+#
+# Copy to: /etc/meshtasticd/config.d/lora-ws-raspberry-pico-to-orangepi-03.yaml
+#
+# Note: Orange Pi Zero3 uses gpiochip1 for all GPIO lines.
+#       Pin numbers reference the 26-pin header.
+
+Lora:
+  Module: sx1262
+  DIO2_AS_RF_SWITCH: true
+  DIO3_TCXO_VOLTAGE: true
+  spidev: spidev1.1
+  SCK:
+    pin: 23
+    gpiochip: 1
+    line: 230
+  Busy:
+    pin: 18
+    gpiochip: 1
+    line: 78
+  MOSI:
+    pin: 19
+    gpiochip: 1
+    line: 231
+  MISO:
+    pin: 21
+    gpiochip: 1
+    line: 232
+  Reset:
+    pin: 22
+    gpiochip: 1
+    line: 71
+  IRQ:
+    pin: 26
+    gpiochip: 1
+    line: 74
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info


### PR DESCRIPTION
## Summary
Expanded the hardware configuration library with 17 new device templates for LoRa radios and displays, bringing the total from 19 to 36 supported configurations. Added infrastructure for categorizing configs by interface type (USB vs SPI) in the TUI.

## Key Changes

### Configuration Templates Added (17 new)
**USB Radios (2):**
- `lora-pinedio-usb-sx1262` - Pine64 Pinedio USB adapter (CH341 + SX1262)
- `lora-usb-meshtoad-e22` - MeshToad E22 USB adapter (CH341 + SX1262)

**SPI HATs & Adapters (13):**
- `lora-Adafruit-RFM9x` - Adafruit RFM9x bonnet (RF95/SX1276)
- `lora-MeshAdv-900M30S` - MeshAdv-Pi E22-900M30S (1W high-power SX1262)
- `lora-MeshAdv-Mini-900M22S` - MeshAdv Mini E22-900M22S (SX1262)
- `lora-RAK6421-13300-slot1` & `slot2` - RAKwireless Pi-HAT with dual slot support
- `lora-lyra-picocalc-wio-sx1262` - Lyra PicoCalc WIO with custom gpiochip mapping
- `lora-meshstick-1262` - MeshStick 1262 (CH341 + SX1262)
- `lora-piggystick-lr1121` - PiggyStick LR1121 (CH341 + LR1121)
- `lora-raxda-rock2f-starter-edition-hat` - Radxa Rock 2F HAT with multi-gpiochip support
- `lora-starter-edition-sx1262-i2c` - Starter Edition I2C HAT
- `lora-waveshare-sxxx` - Waveshare SX126X XXXM HAT
- `lora-ws-raspberry-pi-pico-to-rpi-adapter` - Waveshare Pico-to-RPi adapter
- `lora-ws-raspberry-pico-to-orangepi-03` - Waveshare SX1262 on Orange Pi Zero3

**Display Configs (2):**
- `display-waveshare-1-44` - Waveshare 1.44" LCD HAT (ST7735S with trackball)
- `display-waveshare-2.8` - Waveshare 2.8" LCD + touchscreen (ST7789 + XPT2046)

### Core Infrastructure Updates
- **RadioType enum** - Added `USB_SERIAL` and `NATIVE_SPI` classification to `RADIO_TEMPLATES` entries
- **TUI Hardware Menu** - Implemented `_classify_hardware_config()` method to categorize configs by interface type
- **Menu Categorization** - Hardware config menu now displays USB and SPI sections separately with active status indicators
- **Documentation** - Updated directory structure comments to reflect 36 total templates (9 USB, 27 SPI)

### Implementation Details
- Each template includes proper YAML structure with Lora/Display/TCP/Webserver/Logging sections
- Complex configs (Radxa Rock 2F, Lyra PicoCalc) include multi-gpiochip GPIO mappings with physical pin references
- USB configs document required kernel modules (ch341) and USB VID/PID identifiers
- Display configs include SPI enablement instructions and pin offset/rotation parameters
- Fallback classification logic inspects YAML content for `Serial:` (USB) vs `Lora:/Display:` (SPI) when template metadata unavailable

https://claude.ai/code/session_01BpPcta2sX8p8TALpSkwaS2