### PR TITLE
Add device config persistence across meshtasticd restarts

### DIFF
--- a/src/config/lora.py
+++ b/src/config/lora.py
@@ -686,6 +686,11 @@ class LoRaConfigurator:
 
             if result.returncode == 0:
                 console.print(f"[green]Modem preset set to {preset_key}[/green]")
+                try:
+                    from utils.device_config_store import save_device_setting
+                    save_device_setting('lora', 'modem_preset', preset_key)
+                except Exception:
+                    pass  # Non-critical: persistence is best-effort here
                 return True
             else:
                 console.print(f"[yellow]Warning: {result.stderr or 'Could not set preset'}[/yellow]")

--- a/src/core/meshtastic_cli.py
+++ b/src/core/meshtastic_cli.py
@@ -302,21 +302,70 @@ class MeshtasticCLI:
     # Radio Configuration
     # ─────────────────────────────────────────────────────────────
 
+    def set_with_verify(
+        self,
+        key: str,
+        value: str,
+        verify_section: Optional[str] = None,
+    ) -> CLIResult:
+        """Set a device config value and verify it took effect.
+
+        Sends --set, waits briefly for the device to process, then
+        reads back via --get to confirm the value was applied.
+
+        Args:
+            key: Full config key (e.g., 'lora.modem_preset')
+            value: Value to set
+            verify_section: Config section to read back (default: derived from key)
+
+        Returns:
+            CLIResult with '[verified]' or '[unverified]' appended to output
+        """
+        result = self.run(['--set', key, value])
+        if not result.success:
+            return result
+
+        # Allow device to process the AdminMessage
+        time.sleep(0.5)
+
+        # Read back to verify
+        section = verify_section or key.split('.')[0]
+        check = self.run(['--get', section], retries=1)
+        if check.success and value.lower() in check.output.lower():
+            result.output = (result.output or '') + "\n[verified]"
+            logger.debug("Verified %s = %s", key, value)
+        else:
+            result.output = (result.output or '') + "\n[unverified]"
+            logger.warning("Could not verify %s = %s", key, value)
+
+        return result
+
+    def configure(self, yaml_path: str) -> CLIResult:
+        """Apply a configuration YAML file via meshtastic --configure.
+
+        Args:
+            yaml_path: Path to YAML config file
+
+        Returns:
+            CLIResult from the configure command
+        """
+        return self.run(['--configure', yaml_path], timeout=60)
+
     def set_lora_region(self, region: str) -> CLIResult:
         """Set LoRa region (e.g., US, EU_868)."""
-        return self.run(['--set', 'lora.region', region])
+        return self.set_with_verify('lora.region', region)
 
     def set_lora_preset(self, preset: str) -> CLIResult:
         """Set LoRa modem preset (e.g., LONG_FAST, MEDIUM_SLOW)."""
-        return self.run(['--set', 'lora.modem_preset', preset])
+        return self.set_with_verify('lora.modem_preset', preset)
 
     def set_channel_num(self, channel_num: int) -> CLIResult:
         """Set LoRa frequency slot (channel_num)."""
-        return self.run(['--set', 'lora.channel_num', str(channel_num)])
+        return self.set_with_verify('lora.channel_num', str(channel_num))
 
     def set_hop_limit(self, hops: int) -> CLIResult:
         """Set hop limit for messages."""
-        return self.run(['--set', 'lora.hop_limit', str(hops)])
+        return self.set_with_verify('lora.hop_limit', str(hops))
 
     # ─────────────────────────────────────────────────────────────
     # MQTT Configuration

--- a/src/launcher_tui/meshtasticd_config_mixin.py
+++ b/src/launcher_tui/meshtasticd_config_mixin.py
@@ -355,8 +355,20 @@ Press Cancel to keep current values."""
                     self.dialog.msgbox("Error", f"Failed to set short name:\n{result.message}")
                     return
 
+            # Persist owner settings for restart survival
             if changes_made:
-                self.dialog.msgbox("Success", f"Owner settings updated:\n\n" + "\n".join(changes_made))
+                from utils.device_config_store import save_device_settings
+                owner_data = {}
+                if long_name:
+                    owner_data['long_name'] = long_name
+                if short_name:
+                    owner_data['short_name'] = short_name
+                save_device_settings({'owner': owner_data})
+
+                self.dialog.msgbox("Success",
+                    f"Owner settings updated:\n\n"
+                    + "\n".join(changes_made)
+                    + "\n\nSaved for restart persistence.")
             else:
                 self.dialog.msgbox("Info", "No changes made.")
 
@@ -474,7 +486,7 @@ Press Cancel to keep current values."""
         try:
             cli = get_cli()
 
-            # Apply modem preset
+            # Apply modem preset (with verification)
             result = cli.set_lora_preset(preset)
             if not result.success:
                 self.dialog.msgbox("Error",
@@ -483,7 +495,9 @@ Press Cancel to keep current values."""
                     "meshtasticd is running with region set.")
                 return
 
-            # Apply frequency slot
+            verified = '[verified]' in (result.output or '')
+
+            # Apply frequency slot (with verification)
             slot_result = cli.set_channel_num(freq_slot)
             slot_msg = ""
             if not slot_result.success:
@@ -491,11 +505,21 @@ Press Cancel to keep current values."""
             else:
                 slot_msg = f"\nFrequency slot: {freq_slot}"
 
+            # Persist settings for restart survival
+            from utils.device_config_store import save_device_settings
+            save_device_settings({
+                'lora': {
+                    'modem_preset': preset,
+                    'channel_num': freq_slot,
+                }
+            })
+
+            verify_note = " (verified)" if verified else ""
             self.dialog.msgbox("Success",
-                f"{preset} preset applied!\n\n"
+                f"{preset} preset applied!{verify_note}\n\n"
                 f"Modem preset: {preset}{slot_msg}\n\n"
-                "Settings applied via meshtastic CLI.\n"
-                "Device will reboot to apply changes.")
+                "Settings saved for restart persistence.\n"
+                "Will be re-applied if meshtasticd restarts.")
         except Exception as e:
             self.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
 
@@ -1580,14 +1604,15 @@ Press Cancel to keep current values."""
             self._edit_file(choice)
 
     def _restart_meshtasticd(self):
-        """Restart meshtasticd service."""
+        """Restart meshtasticd service and re-apply saved device settings."""
         confirm = self.dialog.yesno(
             "Restart Service",
             "Restart meshtasticd?\n\n"
             "This will:\n"
             "1. Reload systemd daemon\n"
             "2. Restart meshtasticd service\n"
-            "3. Apply any config changes",
+            "3. Wait for TCP readiness\n"
+            "4. Re-apply saved device settings",
             default_no=True
         )
 
@@ -1598,10 +1623,55 @@ Press Cancel to keep current values."""
             self.dialog.infobox("Restarting", "Restarting meshtasticd...")
 
             success, msg = apply_config_and_restart('meshtasticd')
-            if success:
-                self.dialog.msgbox("Success", "meshtasticd restarted successfully!")
-            else:
+            if not success:
                 self.dialog.msgbox("Error", f"Restart failed:\n{msg}")
+                return
+
+            # Check for saved device settings to re-apply
+            from utils.device_config_store import load_device_config, apply_saved_config
+            saved = load_device_config()
+
+            if not saved:
+                self.dialog.msgbox("Success", f"meshtasticd restarted.\n\n{msg}")
+                return
+
+            # Summarize what will be re-applied
+            sections = []
+            for section, values in saved.items():
+                items = [f"  {k}: {v}" for k, v in values.items()]
+                sections.append(f"{section}:\n" + "\n".join(items))
+            summary = "\n".join(sections)
+
+            reapply = self.dialog.yesno(
+                "Re-apply Settings?",
+                f"meshtasticd restarted.\n\n"
+                f"Saved device settings found:\n{summary}\n\n"
+                "Re-apply these settings now?\n"
+                "(Device config may have reverted to defaults)",
+                default_no=False
+            )
+
+            if not reapply:
+                self.dialog.msgbox("Info",
+                    "Settings NOT re-applied.\n\n"
+                    "You can re-apply manually via the\n"
+                    "Radio Presets or Owner Name menus.")
+                return
+
+            self.dialog.infobox("Applying", "Re-applying saved device settings...")
+
+            cli = get_cli()
+            all_ok, results = apply_saved_config(cli)
+
+            if all_ok:
+                self.dialog.msgbox("Success",
+                    "meshtasticd restarted and settings restored!\n\n"
+                    f"{results}")
+            else:
+                self.dialog.msgbox("Partial Success",
+                    "Some settings could not be restored:\n\n"
+                    f"{results}\n\n"
+                    "Check the web UI at :9443 to verify.")
 
         except subprocess.TimeoutExpired:
             self.dialog.msgbox("Error", "Restart timed out")
@@ -1694,6 +1764,8 @@ Press Cancel to keep current values."""
             )
             if result.returncode == 0:
                 print(f"\nMQTT {'enabled' if enabled else 'disabled'} successfully.")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'enabled', enabled)
             else:
                 print("\nCommand failed.")
         except Exception as e:
@@ -1731,6 +1803,8 @@ Press Cancel to keep current values."""
             )
             if result.returncode == 0:
                 print(f"\nMQTT broker set to: {broker}")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'address', broker.strip())
             else:
                 print("\nCommand failed.")
         except Exception as e:
@@ -1771,6 +1845,14 @@ Press Cancel to keep current values."""
                 result = subprocess.run(cmd, timeout=15)
                 if result.returncode == 0:
                     print("\nMQTT credentials updated.")
+                    from utils.device_config_store import save_device_settings
+                    cred_data = {}
+                    if username:
+                        cred_data['username'] = username
+                    if password:
+                        cred_data['password'] = password
+                    if cred_data:
+                        save_device_settings({'mqtt': cred_data})
                 else:
                     print("\nCommand failed.")
             else:
@@ -1802,6 +1884,8 @@ Press Cancel to keep current values."""
             )
             if result.returncode == 0:
                 print(f"\nMQTT root topic set to: {topic}")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'root_topic', topic.strip())
             else:
                 print("\nCommand failed.")
         except Exception as e:

--- a/src/utils/device_config_store.py
+++ b/src/utils/device_config_store.py
@@ -1,0 +1,278 @@
+"""
+MeshForge Device Config Store
+
+Persists device-level Meshtastic settings (modem preset, channels, owner name,
+etc.) to a MeshForge-managed YAML file. These settings are NOT supported by
+meshtasticd's config.d/ YAML overlay — they can only be applied via the
+meshtastic CLI or protobuf admin API after the daemon starts.
+
+After meshtasticd restarts, this store enables MeshForge to re-apply saved
+settings automatically so the user doesn't lose their configuration.
+
+Usage:
+    from utils.device_config_store import save_device_setting, apply_saved_config
+
+    # Save a setting after successful CLI apply
+    save_device_setting('lora', 'modem_preset', 'LONG_FAST')
+
+    # Re-apply all saved settings after meshtasticd restart
+    ok, msg = apply_saved_config(cli)
+"""
+
+import logging
+import os
+import time
+import yaml
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+from utils.paths import MeshForgePaths, atomic_write_text
+
+logger = logging.getLogger(__name__)
+
+DEVICE_CONFIG_FILE = 'device_config.yaml'
+DEVICE_CONFIG_HEADER = (
+    "# MeshForge saved device settings\n"
+    "# Re-applied automatically after meshtasticd restart\n"
+    "# Edit via MeshForge TUI, not directly\n"
+)
+
+
+def _get_config_path() -> Path:
+    """Get path to device config file."""
+    return MeshForgePaths.get_config_dir() / DEVICE_CONFIG_FILE
+
+
+def load_device_config() -> Dict[str, Any]:
+    """Load saved device settings from disk.
+
+    Returns:
+        Dict of saved settings, or empty dict if no file or parse error.
+    """
+    path = _get_config_path()
+    if not path.exists():
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text())
+        return data if isinstance(data, dict) else {}
+    except Exception as e:
+        logger.warning("Failed to read device config store: %s", e)
+        return {}
+
+
+def save_device_setting(section: str, key: str, value: Any) -> bool:
+    """Save a single device setting to the config store.
+
+    Args:
+        section: Config section (e.g., 'lora', 'owner', 'mqtt')
+        key: Setting key (e.g., 'modem_preset', 'long_name')
+        value: Setting value
+
+    Returns:
+        True if saved successfully.
+    """
+    try:
+        config = load_device_config()
+        if section not in config:
+            config[section] = {}
+        config[section][key] = value
+
+        content = DEVICE_CONFIG_HEADER + "\n" + yaml.dump(
+            config, default_flow_style=False, sort_keys=False
+        )
+        atomic_write_text(_get_config_path(), content)
+
+        # Fix ownership if running under sudo
+        _fix_file_ownership(_get_config_path())
+
+        logger.info("Saved device setting: %s.%s = %s", section, key, value)
+        return True
+    except Exception as e:
+        logger.error("Failed to save device setting %s.%s: %s", section, key, e)
+        return False
+
+
+def save_device_settings(settings: Dict[str, Dict[str, Any]]) -> bool:
+    """Save multiple device settings at once.
+
+    Args:
+        settings: Nested dict like {'lora': {'modem_preset': 'LONG_FAST'}}
+
+    Returns:
+        True if saved successfully.
+    """
+    try:
+        config = load_device_config()
+        for section, values in settings.items():
+            if section not in config:
+                config[section] = {}
+            config[section].update(values)
+
+        content = DEVICE_CONFIG_HEADER + "\n" + yaml.dump(
+            config, default_flow_style=False, sort_keys=False
+        )
+        atomic_write_text(_get_config_path(), content)
+        _fix_file_ownership(_get_config_path())
+
+        logger.info("Saved device settings: %s", list(settings.keys()))
+        return True
+    except Exception as e:
+        logger.error("Failed to save device settings: %s", e)
+        return False
+
+
+def clear_device_config() -> bool:
+    """Remove the saved device config file.
+
+    Returns:
+        True if removed or didn't exist.
+    """
+    path = _get_config_path()
+    try:
+        if path.exists():
+            path.unlink()
+            logger.info("Cleared device config store")
+        return True
+    except Exception as e:
+        logger.error("Failed to clear device config: %s", e)
+        return False
+
+
+def apply_saved_config(cli=None) -> Tuple[bool, str]:
+    """Re-apply all saved device settings via meshtastic CLI.
+
+    Should be called after meshtasticd restart to restore device config.
+
+    Args:
+        cli: MeshtasticCLI instance (auto-created if None)
+
+    Returns:
+        Tuple of (all_succeeded: bool, summary_message: str)
+    """
+    config = load_device_config()
+    if not config:
+        return True, "No saved device settings to apply"
+
+    if cli is None:
+        try:
+            from core.meshtastic_cli import get_cli
+            cli = get_cli()
+        except Exception as e:
+            return False, f"Cannot create CLI: {e}"
+
+    results = []
+    all_ok = True
+
+    # Apply LoRa settings
+    lora = config.get('lora', {})
+    if lora.get('modem_preset'):
+        ok = _apply_setting(cli, 'lora.modem_preset', str(lora['modem_preset']))
+        results.append(f"modem_preset={lora['modem_preset']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    if 'channel_num' in lora:
+        ok = _apply_setting(cli, 'lora.channel_num', str(lora['channel_num']))
+        results.append(f"channel_num={lora['channel_num']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    if lora.get('region'):
+        ok = _apply_setting(cli, 'lora.region', str(lora['region']))
+        results.append(f"region={lora['region']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    if 'hop_limit' in lora:
+        ok = _apply_setting(cli, 'lora.hop_limit', str(lora['hop_limit']))
+        results.append(f"hop_limit={lora['hop_limit']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    # Apply owner settings
+    owner = config.get('owner', {})
+    if owner.get('long_name'):
+        ok = _apply_owner(cli, owner['long_name'], short=False)
+        results.append(f"long_name={owner['long_name']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    if owner.get('short_name'):
+        ok = _apply_owner(cli, owner['short_name'], short=True)
+        results.append(f"short_name={owner['short_name']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    # Apply MQTT settings
+    mqtt = config.get('mqtt', {})
+    if 'enabled' in mqtt:
+        val = 'true' if mqtt['enabled'] else 'false'
+        ok = _apply_setting(cli, 'mqtt.enabled', val)
+        results.append(f"mqtt.enabled={val}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    if mqtt.get('address'):
+        ok = _apply_setting(cli, 'mqtt.address', mqtt['address'])
+        results.append(f"mqtt.address={mqtt['address']}: {'OK' if ok else 'FAILED'}")
+        all_ok = all_ok and ok
+
+    summary = "\n".join(results) if results else "No settings to apply"
+    return all_ok, summary
+
+
+def verify_setting(cli, key: str, expected: str) -> bool:
+    """Verify a setting took effect by reading it back.
+
+    Args:
+        cli: MeshtasticCLI instance
+        key: Full setting key (e.g., 'lora.modem_preset')
+        expected: Expected value string
+
+    Returns:
+        True if the expected value was found in the readback.
+    """
+    section = key.split('.')[0] if '.' in key else key
+    try:
+        result = cli.run(['--get', section])
+        if result.success and expected.lower() in result.output.lower():
+            return True
+        logger.debug("Verify failed for %s: expected '%s' in output", key, expected)
+        return False
+    except Exception as e:
+        logger.debug("Verify exception for %s: %s", key, e)
+        return False
+
+
+def _apply_setting(cli, key: str, value: str) -> bool:
+    """Apply a single --set setting with retry."""
+    for attempt in range(2):
+        result = cli.run(['--set', key, value])
+        if result.success:
+            # Brief pause to let device process
+            time.sleep(0.3)
+            return True
+        if attempt == 0:
+            time.sleep(1)
+    logger.warning("Failed to apply %s=%s after 2 attempts", key, value)
+    return False
+
+
+def _apply_owner(cli, name: str, short: bool = False) -> bool:
+    """Apply owner name setting."""
+    flag = '--set-owner-short' if short else '--set-owner'
+    for attempt in range(2):
+        result = cli.run([flag, name])
+        if result.success:
+            time.sleep(0.3)
+            return True
+        if attempt == 0:
+            time.sleep(1)
+    return False
+
+
+def _fix_file_ownership(path: Path) -> None:
+    """Fix ownership of config file when running under sudo."""
+    sudo_user = os.environ.get('SUDO_USER', '')
+    if not sudo_user or sudo_user == 'root' or '/' in sudo_user or '..' in sudo_user:
+        return
+    try:
+        import pwd
+        pw = pwd.getpwnam(sudo_user)
+        if path.exists() and path.stat().st_uid == 0:
+            os.chown(str(path), pw.pw_uid, pw.pw_gid)
+    except (KeyError, OSError):
+        pass

--- a/src/utils/service_check.py
+++ b/src/utils/service_check.py
@@ -30,6 +30,7 @@ import re
 import socket
 import subprocess
 import logging
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Tuple
@@ -979,6 +980,16 @@ def apply_config_and_restart(service_name: str = 'meshtasticd', timeout: int = 3
             return False, f"restart {service_name} failed: {error_msg}"
 
         logger.info(f"Successfully restarted {service_name}")
+
+        # Wait for TCP port readiness (meshtasticd binds 4403 on startup)
+        if service_name == 'meshtasticd':
+            tcp_ready = _wait_for_tcp_ready(4403, max_wait=15)
+            if tcp_ready:
+                return True, f"{service_name} restarted and accepting connections"
+            else:
+                logger.warning("meshtasticd restarted but TCP:4403 not ready within 15s")
+                return True, f"{service_name} restarted (TCP port not yet ready)"
+
         return True, f"{service_name} restarted successfully"
 
     except subprocess.TimeoutExpired:
@@ -990,6 +1001,30 @@ def apply_config_and_restart(service_name: str = 'meshtasticd', timeout: int = 3
     except Exception as e:
         logger.error(f"Error restarting {service_name}: {e}")
         return False, f"Error: {e}"
+
+
+def _wait_for_tcp_ready(port: int, host: str = 'localhost', max_wait: int = 15) -> bool:
+    """Poll a TCP port until it accepts connections.
+
+    Used after service restart to ensure the daemon is fully initialized
+    and accepting client connections before returning.
+
+    Args:
+        port: TCP port number to check
+        host: Host to connect to (default: localhost)
+        max_wait: Maximum seconds to wait (default: 15)
+
+    Returns:
+        True if port became ready, False if timeout
+    """
+    for _attempt in range(max_wait):
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                logger.debug("TCP port %d ready", port)
+                return True
+        except (ConnectionRefusedError, OSError):
+            time.sleep(1)
+    return False
 
 
 def daemon_reload(timeout: int = 30) -> Tuple[bool, str]:

--- a/tests/test_device_config_store.py
+++ b/tests/test_device_config_store.py
@@ -1,0 +1,375 @@
+"""
+Tests for MeshForge Device Config Store.
+
+Tests save/load/apply/verify/clear operations for device-level
+Meshtastic settings persistence.
+"""
+
+import os
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import MagicMock, patch, PropertyMock
+
+# Ensure src is importable
+import sys
+sys.path.insert(0, str(Path(__file__).parent.parent / 'src'))
+
+
+@pytest.fixture
+def tmp_config_dir(tmp_path):
+    """Create a temporary config directory for tests."""
+    config_dir = tmp_path / '.config' / 'meshforge'
+    config_dir.mkdir(parents=True)
+    return config_dir
+
+
+@pytest.fixture
+def mock_config_path(tmp_config_dir, monkeypatch):
+    """Patch device_config_store to use temp directory."""
+    config_file = tmp_config_dir / 'device_config.yaml'
+    monkeypatch.setattr(
+        'utils.device_config_store._get_config_path',
+        lambda: config_file
+    )
+    return config_file
+
+
+class TestSaveDeviceSetting:
+    """Test save_device_setting()."""
+
+    def test_save_single_setting(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, load_device_config
+
+        result = save_device_setting('lora', 'modem_preset', 'LONG_FAST')
+        assert result is True
+
+        config = load_device_config()
+        assert config['lora']['modem_preset'] == 'LONG_FAST'
+
+    def test_save_multiple_settings_same_section(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, load_device_config
+
+        save_device_setting('lora', 'modem_preset', 'LONG_FAST')
+        save_device_setting('lora', 'channel_num', 12)
+
+        config = load_device_config()
+        assert config['lora']['modem_preset'] == 'LONG_FAST'
+        assert config['lora']['channel_num'] == 12
+
+    def test_save_different_sections(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, load_device_config
+
+        save_device_setting('lora', 'modem_preset', 'LONG_FAST')
+        save_device_setting('owner', 'long_name', 'TestNode')
+
+        config = load_device_config()
+        assert config['lora']['modem_preset'] == 'LONG_FAST'
+        assert config['owner']['long_name'] == 'TestNode'
+
+    def test_overwrite_existing_setting(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, load_device_config
+
+        save_device_setting('lora', 'modem_preset', 'LONG_FAST')
+        save_device_setting('lora', 'modem_preset', 'SHORT_TURBO')
+
+        config = load_device_config()
+        assert config['lora']['modem_preset'] == 'SHORT_TURBO'
+
+    def test_save_creates_file(self, mock_config_path):
+        from utils.device_config_store import save_device_setting
+
+        assert not mock_config_path.exists()
+        save_device_setting('lora', 'region', 'US')
+        assert mock_config_path.exists()
+
+    def test_file_contains_header(self, mock_config_path):
+        from utils.device_config_store import save_device_setting
+
+        save_device_setting('lora', 'region', 'US')
+        content = mock_config_path.read_text()
+        assert '# MeshForge saved device settings' in content
+
+
+class TestSaveDeviceSettings:
+    """Test save_device_settings() (batch save)."""
+
+    def test_save_batch(self, mock_config_path):
+        from utils.device_config_store import save_device_settings, load_device_config
+
+        result = save_device_settings({
+            'lora': {'modem_preset': 'LONG_FAST', 'channel_num': 0},
+            'owner': {'long_name': 'MyNode', 'short_name': 'MYND'},
+        })
+        assert result is True
+
+        config = load_device_config()
+        assert config['lora']['modem_preset'] == 'LONG_FAST'
+        assert config['lora']['channel_num'] == 0
+        assert config['owner']['long_name'] == 'MyNode'
+        assert config['owner']['short_name'] == 'MYND'
+
+    def test_batch_merges_with_existing(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, save_device_settings, load_device_config
+
+        save_device_setting('lora', 'region', 'US')
+        save_device_settings({'lora': {'modem_preset': 'LONG_FAST'}})
+
+        config = load_device_config()
+        assert config['lora']['region'] == 'US'
+        assert config['lora']['modem_preset'] == 'LONG_FAST'
+
+
+class TestLoadDeviceConfig:
+    """Test load_device_config()."""
+
+    def test_load_empty_returns_dict(self, mock_config_path):
+        from utils.device_config_store import load_device_config
+
+        config = load_device_config()
+        assert config == {}
+
+    def test_load_corrupted_file(self, mock_config_path):
+        from utils.device_config_store import load_device_config
+
+        mock_config_path.write_text("not: valid: yaml: [[[")
+        config = load_device_config()
+        # Should return whatever yaml.safe_load returns, not crash
+        assert isinstance(config, dict)
+
+    def test_load_non_dict_file(self, mock_config_path):
+        from utils.device_config_store import load_device_config
+
+        mock_config_path.write_text("- just\n- a\n- list\n")
+        config = load_device_config()
+        assert config == {}
+
+
+class TestClearDeviceConfig:
+    """Test clear_device_config()."""
+
+    def test_clear_removes_file(self, mock_config_path):
+        from utils.device_config_store import save_device_setting, clear_device_config
+
+        save_device_setting('lora', 'region', 'US')
+        assert mock_config_path.exists()
+
+        result = clear_device_config()
+        assert result is True
+        assert not mock_config_path.exists()
+
+    def test_clear_nonexistent_is_ok(self, mock_config_path):
+        from utils.device_config_store import clear_device_config
+
+        result = clear_device_config()
+        assert result is True
+
+
+class TestVerifySetting:
+    """Test verify_setting()."""
+
+    def test_verify_success(self, mock_config_path):
+        from utils.device_config_store import verify_setting
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(
+            success=True,
+            output='lora.modem_preset: LONG_FAST\nlora.region: US'
+        )
+
+        result = verify_setting(mock_cli, 'lora.modem_preset', 'LONG_FAST')
+        assert result is True
+
+    def test_verify_failure_wrong_value(self, mock_config_path):
+        from utils.device_config_store import verify_setting
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(
+            success=True,
+            output='lora.modem_preset: SHORT_FAST'
+        )
+
+        result = verify_setting(mock_cli, 'lora.modem_preset', 'LONG_FAST')
+        assert result is False
+
+    def test_verify_failure_cli_error(self, mock_config_path):
+        from utils.device_config_store import verify_setting
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(success=False, output='')
+
+        result = verify_setting(mock_cli, 'lora.modem_preset', 'LONG_FAST')
+        assert result is False
+
+    def test_verify_case_insensitive(self, mock_config_path):
+        from utils.device_config_store import verify_setting
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(
+            success=True,
+            output='lora.modem_preset: long_fast'
+        )
+
+        result = verify_setting(mock_cli, 'lora.modem_preset', 'LONG_FAST')
+        assert result is True
+
+
+class TestApplySavedConfig:
+    """Test apply_saved_config()."""
+
+    def test_apply_empty_config(self, mock_config_path):
+        from utils.device_config_store import apply_saved_config
+
+        mock_cli = MagicMock()
+        ok, msg = apply_saved_config(mock_cli)
+        assert ok is True
+        assert "No saved" in msg
+
+    def test_apply_lora_settings(self, mock_config_path):
+        from utils.device_config_store import save_device_settings, apply_saved_config
+
+        save_device_settings({
+            'lora': {'modem_preset': 'LONG_FAST', 'channel_num': 12}
+        })
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(success=True, output='OK')
+
+        ok, msg = apply_saved_config(mock_cli)
+        assert ok is True
+        assert 'modem_preset=LONG_FAST: OK' in msg
+        assert 'channel_num=12: OK' in msg
+
+    def test_apply_owner_settings(self, mock_config_path):
+        from utils.device_config_store import save_device_settings, apply_saved_config
+
+        save_device_settings({
+            'owner': {'long_name': 'TestNode', 'short_name': 'TEST'}
+        })
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(success=True, output='OK')
+
+        ok, msg = apply_saved_config(mock_cli)
+        assert ok is True
+        assert 'long_name=TestNode: OK' in msg
+        assert 'short_name=TEST: OK' in msg
+
+    def test_apply_partial_failure(self, mock_config_path):
+        from utils.device_config_store import save_device_settings, apply_saved_config
+
+        save_device_settings({
+            'lora': {'modem_preset': 'LONG_FAST', 'region': 'US'}
+        })
+
+        mock_cli = MagicMock()
+        # modem_preset succeeds (1 call), region fails on both attempts (2 calls)
+        mock_cli.run.side_effect = [
+            MagicMock(success=True, output='OK'),    # set modem_preset (attempt 1 - success)
+            MagicMock(success=False, output='ERR'),   # set region (attempt 1 - fail)
+            MagicMock(success=False, output='ERR'),   # set region (attempt 2 - fail)
+        ]
+
+        with patch('utils.device_config_store.time.sleep'):
+            ok, msg = apply_saved_config(mock_cli)
+
+        # At least one setting failed
+        assert 'FAILED' in msg
+        assert ok is False
+
+    def test_apply_mqtt_settings(self, mock_config_path):
+        from utils.device_config_store import save_device_settings, apply_saved_config
+
+        save_device_settings({
+            'mqtt': {'enabled': True, 'address': 'mqtt.example.com'}
+        })
+
+        mock_cli = MagicMock()
+        mock_cli.run.return_value = MagicMock(success=True, output='OK')
+
+        ok, msg = apply_saved_config(mock_cli)
+        assert ok is True
+        assert 'mqtt.enabled=true: OK' in msg
+        assert 'mqtt.address=mqtt.example.com: OK' in msg
+
+
+class TestPathCompliance:
+    """Test MF001 compliance - never uses Path.home() directly."""
+
+    def test_uses_meshforge_paths(self):
+        """Verify device_config_store uses MeshForgePaths, not Path.home()."""
+        import inspect
+        from utils import device_config_store
+
+        source = inspect.getsource(device_config_store)
+        assert 'Path.home()' not in source
+        assert 'MeshForgePaths' in source
+
+
+class TestTcpReadinessCheck:
+    """Test the TCP readiness check in service_check.py."""
+
+    def test_wait_for_tcp_ready_immediate(self):
+        from utils.service_check import _wait_for_tcp_ready
+
+        with patch('utils.service_check.socket.create_connection') as mock_conn:
+            mock_conn.return_value.__enter__ = MagicMock()
+            mock_conn.return_value.__exit__ = MagicMock(return_value=False)
+            result = _wait_for_tcp_ready(4403, max_wait=3)
+            assert result is True
+
+    def test_wait_for_tcp_timeout(self):
+        from utils.service_check import _wait_for_tcp_ready
+
+        with patch('utils.service_check.socket.create_connection') as mock_conn:
+            mock_conn.side_effect = ConnectionRefusedError()
+            with patch('utils.service_check.time.sleep'):
+                result = _wait_for_tcp_ready(4403, max_wait=2)
+                assert result is False
+
+
+class TestSetWithVerify:
+    """Test MeshtasticCLI.set_with_verify()."""
+
+    def test_set_with_verify_success(self):
+        from core.meshtastic_cli import MeshtasticCLI, CLIResult
+
+        cli = MeshtasticCLI(cli_path='/usr/bin/meshtastic')
+
+        with patch.object(cli, 'run') as mock_run:
+            mock_run.side_effect = [
+                CLIResult(success=True, output='Set modem_preset to LONG_FAST'),
+                CLIResult(success=True, output='lora.modem_preset: LONG_FAST'),
+            ]
+            with patch('core.meshtastic_cli.time.sleep'):
+                result = cli.set_with_verify('lora.modem_preset', 'LONG_FAST')
+
+            assert result.success is True
+            assert '[verified]' in result.output
+
+    def test_set_with_verify_unverified(self):
+        from core.meshtastic_cli import MeshtasticCLI, CLIResult
+
+        cli = MeshtasticCLI(cli_path='/usr/bin/meshtastic')
+
+        with patch.object(cli, 'run') as mock_run:
+            mock_run.side_effect = [
+                CLIResult(success=True, output='Set modem_preset'),
+                CLIResult(success=True, output='lora.modem_preset: SHORT_FAST'),
+            ]
+            with patch('core.meshtastic_cli.time.sleep'):
+                result = cli.set_with_verify('lora.modem_preset', 'LONG_FAST')
+
+            assert result.success is True
+            assert '[unverified]' in result.output
+
+    def test_set_with_verify_set_fails(self):
+        from core.meshtastic_cli import MeshtasticCLI, CLIResult
+
+        cli = MeshtasticCLI(cli_path='/usr/bin/meshtastic')
+
+        with patch.object(cli, 'run') as mock_run:
+            mock_run.return_value = CLIResult(success=False, error='Connection refused')
+            result = cli.set_with_verify('lora.modem_preset', 'LONG_FAST')
+
+            assert result.success is False


### PR DESCRIPTION
## Summary
Implements a device configuration store that persists Meshtastic device settings (modem preset, channels, owner name, MQTT config) across meshtasticd service restarts. Since these settings cannot be applied via meshtasticd's config.d/ YAML overlay, they are saved to a MeshForge-managed YAML file and automatically re-applied after the daemon restarts.

## Key Changes

- **New `device_config_store.py` module**: Provides save/load/apply/verify operations for device-level settings
  - `save_device_setting()` / `save_device_settings()`: Persist settings to YAML with atomic writes
  - `load_device_config()`: Load saved settings from disk
  - `apply_saved_config()`: Re-apply all saved settings via meshtastic CLI after restart
  - `verify_setting()`: Confirm settings took effect by reading them back
  - Handles file ownership when running under sudo

- **Enhanced `MeshtasticCLI.set_with_verify()`**: New method that sets a value and verifies it took effect
  - Sends `--set` command, waits for device processing, then reads back via `--get`
  - Appends `[verified]` or `[unverified]` to output for user feedback
  - Integrated into existing preset/region/channel/hop-limit setters

- **TCP readiness check in `service_check.py`**: Added `_wait_for_tcp_ready()` to poll port 4403 after restart
  - Ensures meshtasticd is fully initialized before attempting to apply settings
  - Prevents race conditions when re-applying device config immediately after restart

- **TUI integration in `meshtasticd_config_mixin.py`**:
  - Owner name changes now persist via `save_device_settings()`
  - Radio preset application saves modem_preset and channel_num for restart survival
  - Restart flow now prompts user to re-apply saved settings after meshtasticd restarts
  - Shows summary of what will be restored and confirms success/partial success

- **Comprehensive test suite** (`test_device_config_store.py`):
  - 375 lines of tests covering save/load/apply/verify/clear operations
  - Tests for batch operations, error handling, file corruption, and partial failures
  - Validates MF001 compliance (uses `MeshForgePaths`, not `Path.home()`)
  - Tests for TCP readiness check and CLI verification flow

## Implementation Details

- Settings are stored in `~/.config/meshforge/device_config.yaml` with a descriptive header
- Uses atomic writes to prevent corruption during concurrent access
- Supports sections: `lora` (modem_preset, channel_num, region, hop_limit), `owner` (long_name, short_name), `mqtt` (enabled, address)
- Retry logic (2 attempts with 1s delay) for CLI operations to handle transient failures
- File ownership is corrected when running under sudo to prevent permission issues
- All operations are logged for debugging and audit trails

https://claude.ai/code/session_01M5QWvQ7PLb7BmrDMAEQPXs