### PR TITLE
Style thin dark scrollbars for map control panel

### DIFF
--- a/.claude/foundations/persistent_issues.md
+++ b/.claude/foundations/persistent_issues.md
@@ -1251,3 +1251,22 @@ if MESHTASTIC_CONNECTION_LOCK.acquire(timeout=10):
 **Updating ratchet counts:**
 When fixing a violation, update the expected count in the corresponding test class.
 The test will fail if the count goes DOWN without updating (forces tightening).
+
+---
+
+## #10 Map Control Panel Scrollbar Overlap (2026-02-25)
+
+**Symptom**: On the `:5000` map page, the right-side control panel's native browser scrollbar
+(~15-17px wide) obstructs filter checkboxes, buttons, and stat rows when content overflows.
+
+**Root cause**: `.panel-body` used `overflow-y: auto` without any scrollbar styling, so the
+browser rendered a full-width native scrollbar inside the panel, consuming content space.
+
+**Fix**: Added thin dark-themed scrollbar CSS to `web/node_map.html`:
+- `scrollbar-width: thin` + `scrollbar-color` (Firefox)
+- `::-webkit-scrollbar` at 6px width (Chrome/Safari/Edge)
+- `scrollbar-gutter: stable` to prevent layout shift
+- `padding-right: 4px` on `.panel-body` for content buffer
+- Applied to `.panel-body`, `.no-gps-list`, and `.sim-links-list`
+
+**Status**: **FIXED**

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -265,6 +265,37 @@
             overflow-y: auto;
             flex: 1;
             min-height: 0;
+            padding-right: 4px;
+        }
+        /* Thin dark-themed scrollbar for panel */
+        .panel-body,
+        .panel-body .no-gps-list,
+        .panel-body .sim-links-list {
+            scrollbar-width: thin;
+            scrollbar-color: #2a3a4a #141e2e;
+            scrollbar-gutter: stable;
+        }
+        .panel-body::-webkit-scrollbar,
+        .panel-body .no-gps-list::-webkit-scrollbar,
+        .panel-body .sim-links-list::-webkit-scrollbar {
+            width: 6px;
+        }
+        .panel-body::-webkit-scrollbar-track,
+        .panel-body .no-gps-list::-webkit-scrollbar-track,
+        .panel-body .sim-links-list::-webkit-scrollbar-track {
+            background: #141e2e;
+            border-radius: 3px;
+        }
+        .panel-body::-webkit-scrollbar-thumb,
+        .panel-body .no-gps-list::-webkit-scrollbar-thumb,
+        .panel-body .sim-links-list::-webkit-scrollbar-thumb {
+            background: #2a3a4a;
+            border-radius: 3px;
+        }
+        .panel-body::-webkit-scrollbar-thumb:hover,
+        .panel-body .no-gps-list::-webkit-scrollbar-thumb:hover,
+        .panel-body .sim-links-list::-webkit-scrollbar-thumb:hover {
+            background: #3a4a5a;
         }
         .control-panel.collapsed .panel-body {
             display: none;


### PR DESCRIPTION
## Summary
Styled the scrollbars in the map control panel to be thin and dark-themed, preventing them from obstructing UI elements when content overflows.

## Changes
- Added `padding-right: 4px` to `.panel-body` to provide content buffer space
- Implemented thin dark-themed scrollbar styling using:
  - `scrollbar-width: thin` and `scrollbar-color` for Firefox compatibility
  - `::-webkit-scrollbar` pseudo-elements (6px width) for Chrome/Safari/Edge
  - `scrollbar-gutter: stable` to prevent layout shift when scrollbar appears
- Applied scrollbar styles to `.panel-body`, `.no-gps-list`, and `.sim-links-list`
- Scrollbar uses dark theme colors (#2a3a4a thumb on #141e2e track) with hover state (#3a4a5a)

## Details
The native browser scrollbar was consuming ~15-17px of panel width, obstructing filter checkboxes, buttons, and stat rows. The fix reduces scrollbar width to 6px and applies dark styling that matches the existing UI theme while maintaining usability.

https://claude.ai/code/session_01TFNNybhbmcBAWszQvtWPzF