### PR TITLE
feat: Make TUI daemon-aware for coexistence

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -373,6 +373,25 @@ class MeshForgeLauncher(
 
         return env
 
+    def _is_daemon_running(self) -> bool:
+        """Check if meshforged is running via PID file.
+
+        Used on TUI startup to avoid auto-starting services the
+        daemon already owns (Config API, health probe, etc.).
+        """
+        pid_file = Path("/run/meshforge/meshforged.pid")
+        if not pid_file.exists():
+            return False
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, 0)  # Check if process exists (signal 0)
+            return True
+        except (ProcessLookupError, ValueError):
+            return False
+        except PermissionError:
+            # Process exists but owned by different user — daemon is running
+            return True
+
     def run(self):
         """Run the launcher."""
         if not self.dialog.available:
@@ -395,28 +414,26 @@ class MeshForgeLauncher(
         # Check for service misconfiguration (SPI HAT with USB config)
         self._check_service_misconfig()
 
-        # Auto-start map server if configured
-        self._maybe_auto_start_map()
-
-        # Auto-start MQTT subscriber and TelemetryPoller if configured
-        self._maybe_auto_start_mqtt_and_telemetry()
-
-        # Auto-start Config API Server on localhost
-        self._maybe_auto_start_config_api()
-
-        # Auto-lock port 9443 so meshtasticd web is only via MeshForge proxy
-        self._maybe_auto_lock_port()
-
-        # Start continuous health monitoring (Phase 1 — reliability)
-        # Background thread checks meshtasticd, rnsd, mosquitto every 30s.
-        # State changes push to EventBus → StatusBar updates automatically.
-        self._start_health_monitor()
+        # Detect if daemon is managing core services
+        self._daemon_active = self._is_daemon_running()
+        if self._daemon_active:
+            logger.info("Daemon detected — TUI running in tool-only mode")
+        else:
+            # Only auto-start services when daemon ISN'T running.
+            # If daemon owns these, starting them here would cause
+            # port conflicts (Config API :8081) or singleton clashes.
+            self._maybe_auto_start_map()
+            self._maybe_auto_start_mqtt_and_telemetry()
+            self._maybe_auto_start_config_api()
+            self._maybe_auto_lock_port()
+            self._start_health_monitor()
 
         try:
             self._run_main_menu()
         finally:
-            self._stop_health_monitor()
-            self._stop_config_api_server()
+            if not self._daemon_active:
+                self._stop_health_monitor()
+                self._stop_config_api_server()
 
     def _start_health_monitor(self) -> None:
         """Start the background health monitoring loop.

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -43,8 +43,16 @@ class ServiceMenuMixin:
         while True:
             # Check if bridge is already running
             bridge_running = self._is_bridge_running()
+            daemon_managed = getattr(self, '_daemon_active', False)
 
-            if bridge_running:
+            if daemon_managed and bridge_running:
+                choices = [
+                    ("status", "Bridge Status"),
+                    ("logs", "View Bridge Logs"),
+                    ("back", "Back"),
+                ]
+                subtitle = "Gateway bridge is RUNNING (managed by daemon)"
+            elif bridge_running:
                 choices = [
                     ("status", "Bridge Status"),
                     ("logs", "View Bridge Logs"),


### PR DESCRIPTION
When meshforged is running, TUI now skips auto-starting services the daemon already owns (Config API, health probe, MQTT, maps). This prevents port conflicts and singleton clashes, allowing users to open TUI for interactive tools while daemon manages core services.

Changes:
- Add _is_daemon_running() to detect daemon via PID file
- Skip auto-starts (map, MQTT, config API, health monitor) when daemon detected
- Skip cleanup of daemon-owned services on TUI exit
- Bridge menu shows "managed by daemon" when daemon owns it (removes stop option, keeps status/logs)

https://claude.ai/code/session_01HNFwqxTRSKQ24dkTkjLdDE