### PR TITLE
Fix TUI runtime stability: thread-safe counters, async weather fetch, watchdog

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -1631,6 +1631,19 @@ def main():
                     launcher._map_server_process = None
             except Exception as e:
                 logger.warning(f"Cleanup failed for map server: {e}")
+            # Unsubscribe status bar before shutting down EventBus
+            try:
+                if hasattr(launcher, '_status_bar') and launcher._status_bar:
+                    launcher._status_bar.cleanup()
+            except Exception as e:
+                logger.warning(f"Cleanup failed for status bar: {e}")
+
+        # Shut down EventBus thread pool (prevents dangling worker threads)
+        try:
+            from utils.event_bus import event_bus
+            event_bus.shutdown()
+        except Exception as e:
+            logger.warning(f"Cleanup failed for event bus: {e}")
 
         # Restore stderr and close the log file handle
         try:

--- a/src/launcher_tui/service_menu_mixin.py
+++ b/src/launcher_tui/service_menu_mixin.py
@@ -230,6 +230,13 @@ class ServiceMenuMixin:
 
         try:
             import tempfile
+            # Clean up previous bridge log to prevent /tmp accumulation
+            prev_log = getattr(self, '_bridge_log_path', None)
+            if prev_log and prev_log.exists():
+                try:
+                    prev_log.unlink()
+                except OSError:
+                    pass  # Non-critical — old log may still be in use
             log_fd, log_path_str = tempfile.mkstemp(
                 suffix='.log', prefix='meshforge-gateway-'
             )

--- a/src/launcher_tui/status_bar.py
+++ b/src/launcher_tui/status_bar.py
@@ -21,6 +21,7 @@ Enhanced in v0.4.8:
 import time
 import subprocess
 import logging
+import threading
 from typing import Dict, Optional, List
 
 logger = logging.getLogger(__name__)
@@ -89,6 +90,7 @@ class StatusBar:
         # Space weather (separate cache with longer TTL)
         self._space_weather: Optional[str] = None
         self._space_weather_time: float = 0.0
+        self._space_weather_fetching = False  # Guard against stacking fetch threads
         # Enhanced startup checker (v0.4.8)
         self._startup_checker: Optional[StartupChecker] = None
         self._env_state: Optional[EnvironmentState] = None
@@ -100,6 +102,8 @@ class StatusBar:
         self._event_updated_services: set = set()
         # Unread message counter (Issue #17 Phase 3)
         self._unread_messages = 0
+        # Lock for counters modified from EventBus thread pool workers
+        self._counter_lock = threading.Lock()
         self._subscribe_to_events()
         self._seed_node_count()
 
@@ -124,9 +128,13 @@ class StatusBar:
             status = self._cache.get(service_name, SYM_UNKNOWN)
             parts.append(f"{short_name}:{status}")
 
-        # Node count if available
-        if self._node_count is not None:
-            parts.append(f"nodes:{self._node_count}")
+        # Node count if available (read under lock — written by EventBus workers)
+        with self._counter_lock:
+            node_count = self._node_count
+            unread = self._unread_messages
+
+        if node_count is not None:
+            parts.append(f"nodes:{node_count}")
 
         # Bridge status with subsystem detail
         if self._bridge_running is not None:
@@ -134,8 +142,8 @@ class StatusBar:
             parts.append(bridge_label)
 
         # Unread message count (Issue #17 Phase 3)
-        if self._unread_messages > 0:
-            parts.append(f"msg:{self._unread_messages}")
+        if unread > 0:
+            parts.append(f"msg:{unread}")
 
         # Space weather (compact format: SFI:125 K:2)
         if self._space_weather:
@@ -151,10 +159,11 @@ class StatusBar:
             self._check_services()
             self._check_bridge()
 
-        # Space weather has separate (longer) TTL
+        # Space weather has separate (longer) TTL — fetched in background
+        # thread to avoid blocking the TUI for up to 5s on slow networks.
         if now - self._space_weather_time >= SPACE_WEATHER_CACHE_TTL:
             self._space_weather_time = now
-            self._check_space_weather()
+            self._fetch_space_weather_async()
 
     def _check_services(self) -> None:
         """Check status of all monitored services.
@@ -204,15 +213,31 @@ class StatusBar:
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             self._bridge_running = None
 
-    def _check_space_weather(self) -> None:
-        """Fetch space weather from NOAA SWPC (non-blocking, cached).
+    def _fetch_space_weather_async(self) -> None:
+        """Launch a background thread to fetch space weather.
 
-        Uses a short timeout and runs in the calling thread since this
-        is already called infrequently (5-min TTL). Falls back gracefully
-        if network is unavailable.
+        Prevents the TUI main thread from blocking for up to 5s when
+        the network is slow or unreachable. If a fetch is already
+        in-flight, the call is skipped to avoid stacking threads.
+        """
+        if self._space_weather_fetching:
+            return  # Previous fetch still in-flight
+        self._space_weather_fetching = True
+        t = threading.Thread(
+            target=self._check_space_weather, daemon=True,
+            name="statusbar-weather",
+        )
+        t.start()
+
+    def _check_space_weather(self) -> None:
+        """Fetch space weather from NOAA SWPC.
+
+        Runs in a background thread (launched by _fetch_space_weather_async)
+        to avoid blocking the TUI. Falls back gracefully if network is
+        unavailable.
         """
         try:
-            api = SpaceWeatherAPI(timeout=5)  # Short timeout for TUI
+            api = SpaceWeatherAPI(timeout=3)
             data = api.get_current_conditions()
 
             # Build compact status: "SFI:125 K:2"
@@ -231,6 +256,8 @@ class StatusBar:
             # Network error or API failure - don't break status bar
             logger.debug(f"Space weather fetch failed: {e}")
             self._space_weather = None
+        finally:
+            self._space_weather_fetching = False
 
     def _format_bridge_status(self) -> str:
         """Format bridge status with subsystem detail.
@@ -374,29 +401,49 @@ class StatusBar:
 
         Increments the unread message counter shown in the status bar.
         Counter is reset when the user views messages.
+        Uses _counter_lock since this runs in an EventBus thread pool worker.
         """
         direction = getattr(event, 'direction', '')
         if direction == 'rx':
-            self._unread_messages += 1
-            logger.debug(f"StatusBar unread count: {self._unread_messages}")
+            with self._counter_lock:
+                self._unread_messages += 1
+                count = self._unread_messages
+            logger.debug(f"StatusBar unread count: {count}")
 
     def _on_node_event(self, event) -> None:
         """Handle a NodeEvent from the EventBus.
 
         Tracks node count for display in the status bar. Increments on
         'discovered'/'updated' events, decrements on 'lost' events.
+        Uses _counter_lock since this runs in an EventBus thread pool worker.
         """
         event_type = getattr(event, 'event_type', '')
         if event_type == 'discovered':
-            if self._node_count is None:
-                self._node_count = 1
-            else:
-                self._node_count += 1
-            logger.debug(f"StatusBar node count: {self._node_count}")
+            with self._counter_lock:
+                if self._node_count is None:
+                    self._node_count = 1
+                else:
+                    self._node_count += 1
+                count = self._node_count
+            logger.debug(f"StatusBar node count: {count}")
 
     def clear_unread(self) -> None:
         """Reset unread message counter (called when user views messages)."""
-        self._unread_messages = 0
+        with self._counter_lock:
+            self._unread_messages = 0
+
+    def cleanup(self) -> None:
+        """Unsubscribe from EventBus and release resources.
+
+        Must be called before event_bus.shutdown() during TUI exit
+        to prevent stale callbacks from firing into a dead status bar.
+        """
+        if self._event_subscribed:
+            event_bus.unsubscribe('service', self._on_service_event)
+            event_bus.unsubscribe('message', self._on_message_event)
+            event_bus.unsubscribe('node', self._on_node_event)
+            self._event_subscribed = False
+            logger.debug("StatusBar unsubscribed from EventBus")
 
     # =========================================================================
     # Enhanced Status Methods (v0.4.8)

--- a/src/utils/active_health_probe.py
+++ b/src/utils/active_health_probe.py
@@ -258,25 +258,40 @@ class ActiveHealthProbe:
                     logger.debug(f"Health callback error: {e}")
 
     def _probe_loop(self) -> None:
-        """Background thread that runs periodic health checks."""
+        """Background thread that runs periodic health checks.
+
+        The outer try/except acts as a watchdog — if the loop body
+        crashes due to an unexpected error (e.g., dict mutation during
+        iteration), we log it and continue rather than letting the
+        probe thread die silently.
+        """
         logger.info(
             f"Active health probe started (interval={self.interval}s, "
             f"fails={self.fails}, passes={self.passes})"
         )
+        loop_errors = 0
 
         while not self._stop_event.is_set():
-            services = list(self._checks.keys())
-            for service_name in services:
-                if self._stop_event.is_set():
-                    break
-                try:
-                    self._run_check(service_name)
-                except Exception as e:
-                    logger.debug(f"Health check error for {service_name}: {e}")
+            try:
+                services = list(self._checks.keys())
+                for service_name in services:
+                    if self._stop_event.is_set():
+                        break
+                    try:
+                        self._run_check(service_name)
+                    except Exception as e:
+                        logger.debug(f"Health check error for {service_name}: {e}")
 
-            # Wait for interval or until stop is signaled
-            # wait() returns True if event was set, False on timeout
-            self._stop_event.wait(self.interval)
+                # Wait for interval or until stop is signaled
+                # wait() returns True if event was set, False on timeout
+                self._stop_event.wait(self.interval)
+            except Exception as e:
+                loop_errors += 1
+                logger.warning(
+                    f"Health probe loop error #{loop_errors}: {e}"
+                )
+                # Back off briefly to avoid tight error loops
+                self._stop_event.wait(min(self.interval, 5))
 
         logger.info("Active health probe stopped")
 

--- a/tests/test_tui_runtime_stability.py
+++ b/tests/test_tui_runtime_stability.py
@@ -1,0 +1,239 @@
+"""
+Tests for TUI runtime stability fixes.
+
+Covers: EventBus shutdown, StatusBar thread-safety, health probe watchdog,
+and non-blocking space weather fetch.
+
+Run: python3 -m pytest tests/test_tui_runtime_stability.py -v
+"""
+
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Path setup matching test_status_bar.py
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'launcher_tui'))
+
+from src.utils.event_bus import EventBus, MessageEvent, NodeEvent
+from src.utils.active_health_probe import ActiveHealthProbe, HealthResult
+
+from status_bar import StatusBar
+
+
+class TestEventBusShutdown:
+    """Verify EventBus shutdown is safe and idempotent."""
+
+    def test_shutdown_is_idempotent(self):
+        """Calling shutdown() twice must not raise."""
+        bus = EventBus()
+        bus.shutdown()
+        bus.shutdown()  # Second call should be safe
+
+    def test_emit_after_shutdown_is_silent(self):
+        """emit() after shutdown must not raise (RuntimeError caught)."""
+        bus = EventBus()
+        received = []
+        bus.subscribe('test', lambda e: received.append(e))
+        bus.shutdown()
+        # Should not raise — RuntimeError from executor is caught
+        bus.emit('test', 'hello')
+        time.sleep(0.1)
+        assert len(received) == 0
+
+    def test_emit_sync_after_shutdown_still_works(self):
+        """emit_sync() doesn't use executor, so it should still work."""
+        bus = EventBus()
+        received = []
+        bus.subscribe('test', lambda e: received.append(e))
+        bus.shutdown()
+        bus.emit_sync('test', 'hello')
+        assert len(received) == 1
+
+
+class TestStatusBarThreadSafety:
+    """Verify StatusBar counters are thread-safe."""
+
+    def test_concurrent_message_increments(self):
+        """Multiple threads incrementing _unread_messages must not lose counts."""
+        bar = StatusBar(version="test")
+
+        num_threads = 10
+        increments_per_thread = 100
+        barrier = threading.Barrier(num_threads)
+
+        def increment():
+            barrier.wait()
+            for _ in range(increments_per_thread):
+                event = MagicMock()
+                event.direction = 'rx'
+                bar._on_message_event(event)
+
+        threads = [threading.Thread(target=increment) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert bar._unread_messages == num_threads * increments_per_thread
+
+    def test_concurrent_node_increments(self):
+        """Multiple threads incrementing _node_count must not lose counts."""
+        bar = StatusBar(version="test")
+        bar._node_count = 0
+
+        num_threads = 10
+        increments_per_thread = 100
+        barrier = threading.Barrier(num_threads)
+
+        def increment():
+            barrier.wait()
+            for _ in range(increments_per_thread):
+                event = MagicMock()
+                event.event_type = 'discovered'
+                bar._on_node_event(event)
+
+        threads = [threading.Thread(target=increment) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=5)
+
+        assert bar._node_count == num_threads * increments_per_thread
+
+
+class TestStatusBarCleanup:
+    """Verify StatusBar cleanup unsubscribes from EventBus."""
+
+    def test_cleanup_unsubscribes(self):
+        """cleanup() must call unsubscribe for all event types."""
+        bar = StatusBar(version="test")
+
+        with patch('status_bar.event_bus') as mock_bus:
+            bar.cleanup()
+
+        unsub_events = {call.args[0] for call in mock_bus.unsubscribe.call_args_list}
+        assert unsub_events == {'service', 'message', 'node'}
+        assert not bar._event_subscribed
+
+    def test_cleanup_idempotent(self):
+        """Calling cleanup() twice must not double-unsubscribe."""
+        bar = StatusBar(version="test")
+
+        with patch('status_bar.event_bus') as mock_bus:
+            bar.cleanup()
+            bar.cleanup()
+
+        # Should still be 3, not 6
+        assert mock_bus.unsubscribe.call_count == 3
+
+
+class TestStatusBarSpaceWeatherAsync:
+    """Verify space weather fetch runs in background thread."""
+
+    def test_fetch_does_not_block(self):
+        """_fetch_space_weather_async must return immediately."""
+        bar = StatusBar(version="test")
+
+        # Make the API call slow
+        mock_data = MagicMock()
+        mock_data.solar_flux = 150
+        mock_data.k_index = 3
+
+        def slow_fetch():
+            time.sleep(1)
+            return mock_data
+
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.side_effect = slow_fetch
+
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            start = time.time()
+            bar._fetch_space_weather_async()
+            elapsed = time.time() - start
+
+        # Must return immediately (< 0.5s), not block for 1s
+        assert elapsed < 0.5
+
+    def test_no_stacking_fetches(self):
+        """Concurrent calls must not stack fetch threads."""
+        bar = StatusBar(version="test")
+        call_count = 0
+        lock = threading.Lock()
+
+        def slow_fetch():
+            nonlocal call_count
+            with lock:
+                call_count += 1
+            time.sleep(0.5)
+            data = MagicMock()
+            data.solar_flux = 100
+            data.k_index = 2
+            return data
+
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.side_effect = slow_fetch
+
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            bar._fetch_space_weather_async()
+            bar._fetch_space_weather_async()  # Should be skipped
+            bar._fetch_space_weather_async()  # Should be skipped
+
+        time.sleep(0.8)
+        assert call_count == 1
+
+    def test_fetch_resets_flag_on_error(self):
+        """_space_weather_fetching flag must reset even on fetch error."""
+        bar = StatusBar(version="test")
+
+        MockAPI = MagicMock()
+        MockAPI.return_value.get_current_conditions.side_effect = Exception("network error")
+
+        with patch('status_bar.SpaceWeatherAPI', MockAPI):
+            bar._fetch_space_weather_async()
+            time.sleep(0.3)
+
+        # Flag must be reset so next fetch can proceed
+        assert not bar._space_weather_fetching
+
+
+class TestHealthProbeWatchdog:
+    """Verify health probe loop survives unexpected exceptions."""
+
+    def test_probe_survives_check_exception(self):
+        """Probe must continue running even if a check raises unexpectedly."""
+        probe = ActiveHealthProbe(interval=1, fails=1, passes=1)
+        call_count = 0
+
+        def flaky_check():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("Simulated unexpected error")
+            return HealthResult(healthy=True, reason="ok")
+
+        probe.register_check("flaky", flaky_check)
+        probe.start()
+        time.sleep(3)  # Allow at least 2 check cycles
+        probe.stop(timeout=2)
+
+        # Must have run more than once (i.e., survived the first error)
+        assert call_count >= 2
+
+    def test_probe_stops_cleanly(self):
+        """Probe must stop within timeout even after errors."""
+        probe = ActiveHealthProbe(interval=1, fails=1, passes=1)
+
+        def always_fail():
+            raise ValueError("permanent failure")
+
+        probe.register_check("broken", always_fail)
+        probe.start()
+        time.sleep(1.5)
+
+        probe.stop(timeout=3)
+        assert not probe._thread.is_alive()


### PR DESCRIPTION
## Summary
This PR hardens the TUI runtime stability by fixing three critical issues: race conditions in status bar counters, blocking network calls in the main thread, and a health probe that could crash silently on unexpected errors.

## Key Changes

- **Thread-safe status bar counters**: Added `_counter_lock` to protect `_unread_messages` and `_node_count` from concurrent modification by EventBus worker threads. Reads in `get_status_line()` and writes in event handlers now use the lock.

- **Non-blocking space weather fetch**: Moved `_check_space_weather()` to run in a background daemon thread via new `_fetch_space_weather_async()` method. Prevents the TUI from blocking for up to 5 seconds on slow/unreachable networks. Includes guard flag `_space_weather_fetching` to prevent stacking multiple fetch threads.

- **Health probe watchdog**: Wrapped the main loop in `_probe_loop()` with an outer try/except to catch and log unexpected exceptions (e.g., dict mutation during iteration). The probe now continues running even if a check raises unexpectedly, with brief backoff to avoid tight error loops.

- **EventBus shutdown safety**: Added `shutdown()` call in main crash hook to cleanly shut down the thread pool executor. Made `emit()` catch `RuntimeError` from dead executors so post-shutdown calls fail silently rather than crashing.

- **StatusBar cleanup**: Added `cleanup()` method to unsubscribe from EventBus before shutdown, preventing stale callbacks from firing into a dead status bar. Called in main crash hook before `event_bus.shutdown()`.

- **Bridge log cleanup**: Added cleanup of previous bridge log file in `_start_bridge_background()` to prevent `/tmp` accumulation.

## Implementation Details

- Counter reads in `get_status_line()` snapshot values under lock to minimize lock hold time.
- Space weather fetch timeout reduced from 5s to 3s since it now runs in background.
- Health probe loop errors are logged with a counter and brief backoff to avoid tight loops.
- All cleanup operations are wrapped in try/except to prevent one failure from blocking others.

## Testing
Comprehensive test suite added in `test_tui_runtime_stability.py` covering:
- EventBus idempotent shutdown and post-shutdown behavior
- Concurrent counter increments (10 threads × 100 ops each)
- StatusBar cleanup unsubscription
- Space weather async fetch (non-blocking, no stacking)
- Health probe exception survival and clean shutdown

https://claude.ai/code/session_018LP8CHBz3e5fZ8PU9iEGw6