### PR TITLE
Add Space Weather & HF Propagation tools to TUI

### DIFF
--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -104,9 +104,11 @@ from latency_mixin import LatencyMixin
 from dashboard_mixin import DashboardMixin
 from meshcore_mixin import MeshCoreMixin
 from tactical_ops_mixin import TacticalOpsMixin
+from propagation_mixin import PropagationMixin
 
 
 class MeshForgeLauncher(
+    PropagationMixin,
     RFToolsMixin,
     ChannelConfigMixin,
     AIToolsMixin,
@@ -903,6 +905,7 @@ class MeshForgeLauncher(
                 ("site", "Site Planner        Coverage estimation"),
                 ("freq", "Frequency Slots     Channel calculator"),
                 ("antenna", "Antenna Analysis    Compare antenna types"),
+                ("weather", "Space Weather       Propagation & HF bands"),
                 ("sdr", "SDR Monitor         RF awareness (Airspy)"),
                 ("back", "Back"),
             ]
@@ -921,6 +924,7 @@ class MeshForgeLauncher(
                 "site": ("Site Planner", self._site_planner_menu),
                 "freq": ("Frequency Slots", self._calc_frequency_slot),
                 "antenna": ("Antenna Analysis", self._antenna_comparison),
+                "weather": ("Space Weather", self._propagation_menu),
                 "sdr": ("SDR Monitor", self._rf_awareness_menu),
             }
             entry = dispatch.get(choice)

--- a/src/launcher_tui/propagation_mixin.py
+++ b/src/launcher_tui/propagation_mixin.py
@@ -1,0 +1,433 @@
+"""
+Propagation Mixin for MeshForge Launcher TUI.
+
+Provides space weather, HF band conditions, DX spots, ionosonde data,
+VOACAP predictions, and data source configuration.
+Wires the commands/propagation.py backend into the TUI.
+"""
+
+from commands import propagation
+from commands.propagation import DataSource
+
+
+class PropagationMixin:
+    """Mixin providing space weather & HF propagation tools for the TUI."""
+
+    def _propagation_menu(self):
+        """Space Weather & Propagation submenu."""
+        while True:
+            choices = [
+                ("summary", "Propagation Summary   Quick overview"),
+                ("weather", "Space Weather         SFI, Kp, A-index"),
+                ("bands", "Band Conditions       HF band assessment"),
+                ("alerts", "NOAA Alerts           Active warnings"),
+                ("dx", "DX Spots              Telnet DX cluster"),
+                ("ionosonde", "Ionosonde Data        foF2 & MUF"),
+                ("voacap", "VOACAP Prediction     Point-to-point HF"),
+                ("sources", "Configure Sources     Data source setup"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Space Weather & Propagation",
+                "HF propagation and space weather tools:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "summary": ("Propagation Summary", self._show_propagation_summary),
+                "weather": ("Space Weather", self._show_space_weather),
+                "bands": ("Band Conditions", self._show_band_conditions),
+                "alerts": ("NOAA Alerts", self._show_noaa_alerts),
+                "dx": ("DX Spots", self._show_dx_spots),
+                "ionosonde": ("Ionosonde Data", self._show_ionosonde),
+                "voacap": ("VOACAP Prediction", self._show_voacap),
+                "sources": ("Configure Sources", self._configure_prop_sources),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self._safe_call(*entry)
+
+    # --- Display methods ---
+
+    def _show_propagation_summary(self):
+        """Show one-line propagation summary with overall assessment."""
+        result = propagation.get_propagation_summary()
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        lines = [
+            result.message,
+            "",
+            f"Overall:      {d.get('overall', 'Unknown')}",
+            f"Solar Flux:   {d.get('solar_flux', 'N/A')} SFU",
+            f"K-index:      {d.get('k_index', 'N/A')}",
+            f"A-index:      {d.get('a_index', 'N/A')}",
+            f"Geomag:       {d.get('geomag_storm', 'N/A')}",
+            "",
+            f"Source: {d.get('source', 'NOAA SWPC')}",
+        ]
+        self.dialog.msgbox("Propagation Summary", "\n".join(lines))
+
+    def _show_space_weather(self):
+        """Show detailed space weather conditions."""
+        result = propagation.get_space_weather()
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        lines = [
+            "Current Space Weather Conditions",
+            "=" * 40,
+            "",
+            f"Solar Flux Index (SFI):  {d.get('solar_flux', 'N/A')} SFU",
+            f"Sunspot Number:          {d.get('sunspot_number', 'N/A')}",
+            f"K-index (Kp):            {d.get('k_index', 'N/A')}",
+            f"A-index:                 {d.get('a_index', 'N/A')}",
+            f"X-ray Flux:              {d.get('xray_class', 'N/A')}",
+            f"Geomagnetic Storm:       {d.get('geomag_storm', 'N/A')}",
+        ]
+
+        updated = d.get('updated')
+        if updated:
+            lines.extend(["", f"Updated: {updated}"])
+
+        lines.extend(["", f"Source: {d.get('source', 'NOAA SWPC')}"])
+        self.dialog.msgbox("Space Weather", "\n".join(lines))
+
+    def _show_band_conditions(self):
+        """Show per-band HF condition assessment."""
+        result = propagation.get_band_conditions()
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        bands = d.get('bands', {})
+
+        lines = [
+            f"Overall: {d.get('overall', 'Unknown')}",
+            f"SFI={d.get('solar_flux', 'N/A')}  "
+            f"Kp={d.get('k_index', 'N/A')}  "
+            f"A={d.get('a_index', 'N/A')}",
+            "",
+            "Band        Condition",
+            "-" * 30,
+        ]
+
+        # Sort bands by frequency (descending = higher bands first)
+        band_order = [
+            '10m', '12m', '15m', '17m', '20m',
+            '30m', '40m', '60m', '80m', '160m',
+        ]
+        for band in band_order:
+            if band in bands:
+                lines.append(f"{band:<12}{bands[band]}")
+        # Any remaining bands not in our order
+        for band, cond in sorted(bands.items()):
+            if band not in band_order:
+                lines.append(f"{band:<12}{cond}")
+
+        lines.extend(["", f"Source: {d.get('source', 'NOAA SWPC')}"])
+        self.dialog.msgbox("HF Band Conditions", "\n".join(lines))
+
+    def _show_noaa_alerts(self):
+        """Show active NOAA space weather alerts."""
+        result = propagation.get_alerts()
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        alerts = d.get('alerts', [])
+
+        if not alerts:
+            self.dialog.msgbox("NOAA Alerts", "No active space weather alerts.")
+            return
+
+        lines = [f"{d.get('count', 0)} Active Space Weather Alerts", ""]
+        for i, alert in enumerate(alerts, 1):
+            msg = alert.get('message', '').strip()
+            issued = alert.get('issue_datetime', '')
+            # Truncate long alert messages for display
+            if len(msg) > 500:
+                msg = msg[:500] + "..."
+            lines.append(f"--- Alert {i} ({issued}) ---")
+            lines.append(msg)
+            lines.append("")
+
+        self.dialog.msgbox(
+            "NOAA Space Weather Alerts",
+            "\n".join(lines),
+            height=22,
+            width=76,
+        )
+
+    def _show_dx_spots(self):
+        """Show DX cluster spots via telnet."""
+        result = propagation.get_dx_spots_telnet()
+        if not result.success:
+            self.dialog.msgbox("DX Spots", result.message)
+            return
+
+        d = result.data
+        spots = d.get('spots', [])
+
+        lines = [
+            f"{d.get('count', 0)} spots from {d.get('server', 'DX Cluster')}",
+            "",
+            f"{'Freq':>10}  {'DX Call':<12} {'Spotter':<12} {'Comment'}",
+            "-" * 60,
+        ]
+        for spot in spots:
+            freq = spot.get('frequency', '')
+            dx_call = spot.get('dx_call', '')
+            spotter = spot.get('spotter', '')
+            comment = spot.get('comment', '')
+            time_z = spot.get('time', '')
+            line = f"{freq:>10}  {dx_call:<12} {spotter:<12} {comment}"
+            if time_z:
+                line += f" {time_z}"
+            lines.append(line)
+
+        self.dialog.msgbox(
+            "DX Cluster Spots",
+            "\n".join(lines),
+            height=22,
+            width=76,
+        )
+
+    def _show_ionosonde(self):
+        """Show real-time ionosonde data (foF2 & MUF)."""
+        result = propagation.get_ionosonde_data()
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        stations = d.get('stations', [])
+
+        lines = [
+            f"{d.get('count', 0)} ionosonde stations",
+        ]
+        avg_fof2 = d.get('avg_fof2')
+        avg_muf = d.get('avg_muf')
+        if avg_fof2:
+            lines.append(f"Average foF2: {avg_fof2:.1f} MHz")
+        if avg_muf:
+            lines.append(f"Average MUF:  {avg_muf:.1f} MHz")
+
+        lines.extend([
+            "",
+            f"{'Station':<20} {'foF2':>8} {'MUF':>8}",
+            "-" * 40,
+        ])
+        for stn in stations[:20]:
+            name = stn.get('name', '?')[:18]
+            fof2 = f"{stn['fof2']:.1f}" if stn.get('fof2') else "  --"
+            muf = f"{stn['muf']:.1f}" if stn.get('muf') else "  --"
+            lines.append(f"{name:<20} {fof2:>8} {muf:>8}")
+
+        lines.extend(["", f"Source: {d.get('source', 'prop.kc2g.com')}"])
+        self.dialog.msgbox(
+            "Ionosonde Data",
+            "\n".join(lines),
+            height=22,
+            width=76,
+        )
+
+    def _show_voacap(self):
+        """Show VOACAP point-to-point HF prediction with coordinate input."""
+        tx_lat = self.dialog.inputbox(
+            "VOACAP Prediction", "Transmitter latitude (decimal degrees):", "21.3"
+        )
+        if tx_lat is None:
+            return
+        tx_lon = self.dialog.inputbox(
+            "VOACAP Prediction", "Transmitter longitude (decimal degrees):", "-157.8"
+        )
+        if tx_lon is None:
+            return
+        rx_lat = self.dialog.inputbox(
+            "VOACAP Prediction", "Receiver latitude (decimal degrees):", "37.8"
+        )
+        if rx_lat is None:
+            return
+        rx_lon = self.dialog.inputbox(
+            "VOACAP Prediction", "Receiver longitude (decimal degrees):", "-122.4"
+        )
+        if rx_lon is None:
+            return
+
+        try:
+            result = propagation.get_voacap_online(
+                tx_lat=float(tx_lat),
+                tx_lon=float(tx_lon),
+                rx_lat=float(rx_lat),
+                rx_lon=float(rx_lon),
+            )
+        except ValueError:
+            self.dialog.msgbox("Error", "Invalid coordinate format. Use decimal degrees.")
+            return
+
+        if not result.success:
+            self.dialog.msgbox("Error", result.message)
+            return
+
+        d = result.data
+        bands = d.get('bands', {})
+        tx = d.get('tx', {})
+        rx = d.get('rx', {})
+
+        lines = [
+            f"TX: {tx.get('lat', '?')}, {tx.get('lon', '?')}",
+            f"RX: {rx.get('lat', '?')}, {rx.get('lon', '?')}",
+            "",
+        ]
+
+        if bands:
+            lines.append(f"{'Band':<10} {'Reliability'}")
+            lines.append("-" * 30)
+            for band, value in sorted(bands.items()):
+                lines.append(f"{band:<10} {value}")
+        else:
+            lines.append("No band predictions available.")
+
+        lines.extend(["", f"Source: {d.get('source', 'VOACAP Online')}"])
+        self.dialog.msgbox(
+            "VOACAP Prediction",
+            "\n".join(lines),
+            height=20,
+            width=60,
+        )
+
+    # --- Source configuration ---
+
+    def _configure_prop_sources(self):
+        """Configure optional propagation data sources."""
+        while True:
+            # Get current source status
+            src_result = propagation.get_sources()
+            sources = src_result.data.get('sources', {}) if src_result.success else {}
+
+            noaa_status = "ON (always)"
+            ohc = sources.get('openhamclock', {})
+            ohc_status = "ON" if ohc.get('enabled') else "OFF"
+            hc = sources.get('hamclock', {})
+            hc_status = "ON" if hc.get('enabled') else "OFF"
+            pskr = sources.get('pskreporter', {})
+            pskr_status = "ON" if pskr.get('enabled') else "OFF"
+
+            choices = [
+                ("noaa", f"NOAA SWPC           {noaa_status}"),
+                ("ohc", f"OpenHamClock        {ohc_status}"),
+                ("hc", f"HamClock (legacy)   {hc_status}"),
+                ("pskr", f"PSK Reporter        {pskr_status}"),
+                ("test", "Test Connectivity    Check all sources"),
+                ("back", "Back"),
+            ]
+
+            choice = self.dialog.menu(
+                "Propagation Sources",
+                "Configure data sources (NOAA is always primary):",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "noaa":
+                self.dialog.msgbox(
+                    "NOAA SWPC",
+                    "NOAA Space Weather Prediction Center is the primary\n"
+                    "data source and is always enabled.\n\n"
+                    "No configuration needed — uses public API."
+                )
+            elif choice == "ohc":
+                self._toggle_rest_source(
+                    DataSource.OPENHAMCLOCK, "OpenHamClock", 3000
+                )
+            elif choice == "hc":
+                self._toggle_rest_source(
+                    DataSource.HAMCLOCK, "HamClock", 8080
+                )
+            elif choice == "pskr":
+                self._toggle_psk_reporter()
+            elif choice == "test":
+                self._test_prop_sources()
+
+    def _toggle_rest_source(
+        self, source: DataSource, name: str, default_port: int
+    ):
+        """Toggle a REST-based data source (OpenHamClock/HamClock)."""
+        src_result = propagation.get_sources()
+        sources = src_result.data.get('sources', {}) if src_result.success else {}
+        current = sources.get(source.value, {})
+        is_enabled = current.get('enabled', False)
+
+        if is_enabled:
+            propagation.configure_source(source, enabled=False)
+            self.dialog.msgbox(name, f"{name} disabled.")
+        else:
+            host = self.dialog.inputbox(
+                name, f"{name} host:", current.get('host', 'localhost')
+            )
+            if host is None:
+                return
+            port = self.dialog.inputbox(
+                name, f"{name} port:", str(current.get('port', default_port))
+            )
+            if port is None:
+                return
+            try:
+                result = propagation.configure_source(
+                    source, host=host, port=int(port), enabled=True
+                )
+                self.dialog.msgbox(name, result.message)
+            except ValueError:
+                self.dialog.msgbox("Error", "Invalid port number.")
+
+    def _toggle_psk_reporter(self):
+        """Toggle PSK Reporter MQTT source."""
+        src_result = propagation.get_sources()
+        sources = src_result.data.get('sources', {}) if src_result.success else {}
+        current = sources.get('pskreporter', {})
+        is_enabled = current.get('enabled', False)
+
+        if is_enabled:
+            propagation.configure_source(DataSource.PSKREPORTER, enabled=False)
+            self.dialog.msgbox("PSK Reporter", "PSK Reporter disabled.")
+        else:
+            callsign = self.dialog.inputbox(
+                "PSK Reporter", "Your callsign (optional filter):", ""
+            )
+            if callsign is None:
+                return
+            result = propagation.configure_source(
+                DataSource.PSKREPORTER,
+                enabled=True,
+                callsign=callsign,
+            )
+            self.dialog.msgbox("PSK Reporter", result.message)
+
+    def _test_prop_sources(self):
+        """Test connectivity to all configured sources."""
+        lines = ["Testing data sources...", ""]
+
+        for source, name in [
+            (DataSource.NOAA, "NOAA SWPC"),
+            (DataSource.OPENHAMCLOCK, "OpenHamClock"),
+            (DataSource.HAMCLOCK, "HamClock"),
+            (DataSource.PSKREPORTER, "PSK Reporter"),
+        ]:
+            result = propagation.check_source(source)
+            status = "OK" if result.success else "FAIL"
+            lines.append(f"  {name:<20} [{status}] {result.message}")
+
+        self.dialog.msgbox("Source Connectivity", "\n".join(lines))

--- a/tests/test_propagation_mixin.py
+++ b/tests/test_propagation_mixin.py
@@ -1,0 +1,392 @@
+"""
+Propagation Mixin TUI Tests
+
+Tests the Space Weather & Propagation submenu wiring and display formatting.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure src and launcher_tui directories are importable
+# Insert launcher_tui FIRST so we can import the mixin directly
+# without triggering __init__.py (which pulls all mixin deps).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'launcher_tui'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from commands.base import CommandResult
+from propagation_mixin import PropagationMixin
+
+
+class FakeDialog:
+    """Minimal dialog stub for testing mixin display methods."""
+
+    def __init__(self):
+        self.last_msgbox_title = None
+        self.last_msgbox_text = None
+        self.last_menu_title = None
+        self.inputbox_returns = []
+        self._menu_return = None
+
+    def msgbox(self, title, text, height=None, width=None):
+        self.last_msgbox_title = title
+        self.last_msgbox_text = text
+
+    def menu(self, title, text, choices):
+        self.last_menu_title = title
+        return self._menu_return
+
+    def inputbox(self, title, text, default=""):
+        if self.inputbox_returns:
+            return self.inputbox_returns.pop(0)
+        return default
+
+
+def _make_launcher():
+    """Create a minimal launcher instance with PropagationMixin."""
+
+    class StubLauncher(PropagationMixin):
+        def __init__(self):
+            self.dialog = FakeDialog()
+
+        def _safe_call(self, name, method, *args, **kwargs):
+            method(*args, **kwargs)
+
+    return StubLauncher()
+
+
+# ===========================================================================
+# Import / smoke tests
+# ===========================================================================
+
+class TestPropagationMixinImport:
+    """Verify the mixin can be imported cleanly."""
+
+    def test_import(self):
+        assert hasattr(PropagationMixin, '_propagation_menu')
+
+    def test_has_all_display_methods(self):
+        expected = [
+            '_propagation_menu',
+            '_show_propagation_summary',
+            '_show_space_weather',
+            '_show_band_conditions',
+            '_show_noaa_alerts',
+            '_show_dx_spots',
+            '_show_ionosonde',
+            '_show_voacap',
+            '_configure_prop_sources',
+        ]
+        for method in expected:
+            assert hasattr(PropagationMixin, method), f"Missing {method}"
+
+
+# ===========================================================================
+# Space Weather display
+# ===========================================================================
+
+class TestShowSpaceWeather:
+    """Test _show_space_weather formatting."""
+
+    @patch('commands.propagation.get_space_weather')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "Space weather: SFI=150, Kp=2, A=8 (Quiet)",
+            data={
+                'solar_flux': 150,
+                'sunspot_number': 120,
+                'k_index': 2,
+                'a_index': 8,
+                'xray_class': 'B5.3',
+                'geomag_storm': 'Quiet',
+                'source': 'NOAA SWPC',
+                'updated': '2026-02-26T12:00:00',
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_space_weather()
+        assert launcher.dialog.last_msgbox_title == "Space Weather"
+        text = launcher.dialog.last_msgbox_text
+        assert "150" in text
+        assert "Kp" in text
+        assert "NOAA SWPC" in text
+
+    @patch('commands.propagation.get_space_weather')
+    def test_failure(self, mock_get):
+        mock_get.return_value = CommandResult.fail("Network error")
+        launcher = _make_launcher()
+        launcher._show_space_weather()
+        assert launcher.dialog.last_msgbox_title == "Error"
+        assert "Network error" in launcher.dialog.last_msgbox_text
+
+
+# ===========================================================================
+# Propagation Summary display
+# ===========================================================================
+
+class TestShowPropagationSummary:
+
+    @patch('commands.propagation.get_propagation_summary')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "SFI=150 Kp=2 — Good",
+            data={
+                'overall': 'Good',
+                'solar_flux': 150,
+                'k_index': 2,
+                'a_index': 8,
+                'geomag_storm': 'Quiet',
+                'source': 'NOAA SWPC',
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_propagation_summary()
+        assert launcher.dialog.last_msgbox_title == "Propagation Summary"
+        text = launcher.dialog.last_msgbox_text
+        assert "Good" in text
+        assert "150" in text
+
+    @patch('commands.propagation.get_propagation_summary')
+    def test_failure(self, mock_get):
+        mock_get.return_value = CommandResult.fail("No data")
+        launcher = _make_launcher()
+        launcher._show_propagation_summary()
+        assert launcher.dialog.last_msgbox_title == "Error"
+
+
+# ===========================================================================
+# Band Conditions display
+# ===========================================================================
+
+class TestShowBandConditions:
+
+    @patch('commands.propagation.get_band_conditions')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "Band conditions: Good (10 bands assessed)",
+            data={
+                'bands': {
+                    '20m': 'GOOD',
+                    '40m': 'FAIR',
+                    '80m': 'POOR',
+                    '10m': 'EXCELLENT',
+                },
+                'overall': 'Good',
+                'solar_flux': 130,
+                'k_index': 1,
+                'a_index': 5,
+                'source': 'NOAA SWPC',
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_band_conditions()
+        assert launcher.dialog.last_msgbox_title == "HF Band Conditions"
+        text = launcher.dialog.last_msgbox_text
+        assert "20m" in text
+        assert "GOOD" in text
+        assert "Good" in text
+
+    @patch('commands.propagation.get_band_conditions')
+    def test_failure(self, mock_get):
+        mock_get.return_value = CommandResult.fail("Timeout")
+        launcher = _make_launcher()
+        launcher._show_band_conditions()
+        assert launcher.dialog.last_msgbox_title == "Error"
+
+
+# ===========================================================================
+# NOAA Alerts display
+# ===========================================================================
+
+class TestShowNoaaAlerts:
+
+    @patch('commands.propagation.get_alerts')
+    def test_with_alerts(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "2 space weather alerts",
+            data={
+                'alerts': [
+                    {'message': 'Geomagnetic storm warning', 'issue_datetime': '2026-02-26'},
+                    {'message': 'Solar radiation storm', 'issue_datetime': '2026-02-25'},
+                ],
+                'count': 2,
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_noaa_alerts()
+        text = launcher.dialog.last_msgbox_text
+        assert "Geomagnetic storm warning" in text
+        assert "Alert 1" in text
+
+    @patch('commands.propagation.get_alerts')
+    def test_no_alerts(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "0 space weather alerts",
+            data={'alerts': [], 'count': 0}
+        )
+        launcher = _make_launcher()
+        launcher._show_noaa_alerts()
+        assert "No active" in launcher.dialog.last_msgbox_text
+
+
+# ===========================================================================
+# DX Spots display
+# ===========================================================================
+
+class TestShowDxSpots:
+
+    @patch('commands.propagation.get_dx_spots_telnet')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "5 DX spots from dxc.nc7j.com",
+            data={
+                'spots': [
+                    {'frequency': '14025.0', 'dx_call': 'JA1ABC',
+                     'spotter': 'W1XYZ', 'comment': 'CQ', 'time': '1234Z'},
+                ],
+                'count': 1,
+                'server': 'dxc.nc7j.com',
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_dx_spots()
+        text = launcher.dialog.last_msgbox_text
+        assert "JA1ABC" in text
+        assert "14025.0" in text
+
+    @patch('commands.propagation.get_dx_spots_telnet')
+    def test_failure(self, mock_get):
+        mock_get.return_value = CommandResult.fail("Connection timed out")
+        launcher = _make_launcher()
+        launcher._show_dx_spots()
+        assert "Connection timed out" in launcher.dialog.last_msgbox_text
+
+
+# ===========================================================================
+# Ionosonde display
+# ===========================================================================
+
+class TestShowIonosonde:
+
+    @patch('commands.propagation.get_ionosonde_data')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "Ionosonde: 5 stations (foF2=5.2MHz, MUF=18.3MHz)",
+            data={
+                'stations': [
+                    {'name': 'Boulder', 'fof2': 5.2, 'muf': 18.3},
+                    {'name': 'Millstone Hill', 'fof2': 4.8, 'muf': 16.1},
+                ],
+                'count': 2,
+                'avg_fof2': 5.0,
+                'avg_muf': 17.2,
+                'source': 'prop.kc2g.com',
+            }
+        )
+        launcher = _make_launcher()
+        launcher._show_ionosonde()
+        text = launcher.dialog.last_msgbox_text
+        assert "Boulder" in text
+        assert "5.0" in text  # avg foF2
+        assert "prop.kc2g.com" in text
+
+
+# ===========================================================================
+# VOACAP display
+# ===========================================================================
+
+class TestShowVoacap:
+
+    @patch('commands.propagation.get_voacap_online')
+    def test_success(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "VOACAP prediction: 5 bands",
+            data={
+                'bands': {'20m': '85%', '40m': '60%'},
+                'tx': {'lat': 21.3, 'lon': -157.8},
+                'rx': {'lat': 37.8, 'lon': -122.4},
+                'source': 'VOACAP Online',
+            }
+        )
+        launcher = _make_launcher()
+        launcher.dialog.inputbox_returns = ["21.3", "-157.8", "37.8", "-122.4"]
+        launcher._show_voacap()
+        text = launcher.dialog.last_msgbox_text
+        assert "20m" in text
+        assert "VOACAP" in launcher.dialog.last_msgbox_title
+
+    def test_cancel_on_first_input(self):
+        launcher = _make_launcher()
+        launcher.dialog.inputbox_returns = [None]
+        launcher._show_voacap()
+        # Should not crash; no msgbox shown
+        assert launcher.dialog.last_msgbox_title is None
+
+    @patch('commands.propagation.get_voacap_online')
+    def test_invalid_coords(self, mock_get):
+        launcher = _make_launcher()
+        launcher.dialog.inputbox_returns = ["abc", "def", "ghi", "jkl"]
+        launcher._show_voacap()
+        assert launcher.dialog.last_msgbox_title == "Error"
+        assert "Invalid" in launcher.dialog.last_msgbox_text
+
+
+# ===========================================================================
+# Source configuration
+# ===========================================================================
+
+class TestConfigureSources:
+
+    @patch('commands.propagation.get_sources')
+    def test_menu_renders(self, mock_get):
+        mock_get.return_value = CommandResult.ok(
+            "sources",
+            data={
+                'sources': {
+                    'noaa': {'enabled': True},
+                    'openhamclock': {'enabled': False, 'host': 'localhost', 'port': 3000},
+                    'hamclock': {'enabled': False, 'host': 'localhost', 'port': 8080},
+                    'pskreporter': {'enabled': False},
+                }
+            }
+        )
+        launcher = _make_launcher()
+        # Menu returns "back" immediately
+        launcher.dialog._menu_return = "back"
+        launcher._configure_prop_sources()
+        assert launcher.dialog.last_menu_title == "Propagation Sources"
+
+    @patch('commands.propagation.check_source')
+    @patch('commands.propagation.get_sources')
+    def test_test_connectivity(self, mock_sources, mock_check):
+        mock_sources.return_value = CommandResult.ok(
+            "sources",
+            data={'sources': {
+                'noaa': {'enabled': True},
+                'openhamclock': {'enabled': False},
+                'hamclock': {'enabled': False},
+                'pskreporter': {'enabled': False},
+            }}
+        )
+        mock_check.return_value = CommandResult.ok("Connected")
+        launcher = _make_launcher()
+        launcher._test_prop_sources()
+        assert "OK" in launcher.dialog.last_msgbox_text
+
+
+# ===========================================================================
+# Menu dispatch wiring
+# ===========================================================================
+
+class TestMenuWiring:
+    """Verify the mixin is wired into MeshForgeLauncher."""
+
+    def test_propagation_menu_exists_on_mixin(self):
+        assert callable(getattr(PropagationMixin, '_propagation_menu', None))
+
+    def test_mixin_module_has_class(self):
+        """Verify the propagation_mixin module exports PropagationMixin."""
+        import propagation_mixin as mod
+        assert hasattr(mod, 'PropagationMixin')


### PR DESCRIPTION
## Summary
Adds comprehensive space weather and HF radio propagation tools to the MeshForge Launcher TUI, including real-time solar/geomagnetic indices, band conditions, DX cluster spots, ionosonde data, VOACAP predictions, and configurable data sources.

## Key Changes

- **New PropagationMixin class** (`src/launcher_tui/propagation_mixin.py`):
  - Provides `_propagation_menu()` submenu with 8 options for space weather and propagation data
  - Display methods for propagation summary, space weather conditions, HF band assessments, NOAA alerts, DX spots, ionosonde data, and VOACAP predictions
  - Source configuration UI for NOAA SWPC (always enabled), OpenHamClock, HamClock, and PSK Reporter
  - Connectivity testing for all configured data sources
  - Wires backend `commands.propagation` module into the TUI

- **Integration with MeshForgeLauncher**:
  - Added `PropagationMixin` to the launcher class inheritance chain in `src/launcher_tui/main.py`
  - Makes propagation tools accessible from the main TUI menu

- **Comprehensive test suite** (`tests/test_propagation_mixin.py`):
  - 392 lines of tests covering all display methods and configuration workflows
  - Tests for success/failure cases, data formatting, user input handling, and menu wiring
  - Validates proper error handling and display formatting

## Implementation Details

- All display methods format data into readable text boxes with proper alignment and source attribution
- VOACAP prediction accepts user-provided transmitter/receiver coordinates (latitude/longitude in decimal degrees)
- Band conditions are sorted by frequency (10m–160m) with fallback for unlisted bands
- Source configuration supports toggling REST-based sources (host/port) and MQTT-based PSK Reporter (with optional callsign filter)
- Graceful error handling with user-friendly error messages for network failures and invalid input
- Uses existing `CommandResult` pattern from backend for consistent success/failure handling

https://claude.ai/code/session_01XQF3Lz76WnRJmEZGChm2kP