### PR TITLE
Add space weather overlay and improve node online status detection

### DIFF
--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -66,7 +66,7 @@ class UnifiedNodeTracker:
     - Path table change monitoring with event logging
     """
 
-    OFFLINE_THRESHOLD = 3600  # 1 hour
+    OFFLINE_THRESHOLD = 900  # 15 minutes — consistent with map_data_collector default
     MAX_NODES = 10000  # Prevent unbounded memory growth
 
     @classmethod
@@ -531,7 +531,14 @@ instance_control_port = 37429
 
         # Update status
         existing.is_gateway = existing.is_gateway or new.is_gateway
-        existing.update_seen()
+        # Only mark as online if the incoming data is fresh (within threshold)
+        if new.last_seen:
+            age = (datetime.now() - new.last_seen).total_seconds()
+            if age < self.OFFLINE_THRESHOLD:
+                existing.update_seen()
+            # If new data is stale, don't call update_seen() — preserve existing status
+        else:
+            existing.update_seen()
 
     def _notify_callbacks(self, event: str, node: UnifiedNode):
         """Notify registered callbacks and emit to EventBus."""

--- a/src/launcher_tui/topology_mixin.py
+++ b/src/launcher_tui/topology_mixin.py
@@ -176,14 +176,33 @@ class TopologyMixin:
                 except (AttributeError, TypeError) as e:
                     logger.debug("Service stats lookup failed: %s", e)
 
-            # Show help if no data
+            # Show help if no data, with diagnostics
             if node_count == 0 and stats.get('edge_count', 0) == 0:
                 lines.append("No topology data available.")
                 lines.append("")
-                lines.append("Topology is populated when:")
+                lines.append("Diagnostics:")
+                # Check what services are available
+                try:
+                    from utils.service_check import check_service
+                    rnsd = check_service("rnsd")
+                    meshtd = check_service("meshtasticd")
+                    if rnsd.get("active"):
+                        lines.append("  [OK] rnsd is running")
+                    else:
+                        lines.append("  [--] rnsd not running (no RNS topology)")
+                    if meshtd.get("active"):
+                        lines.append("  [OK] meshtasticd is running")
+                    else:
+                        lines.append("  [--] meshtasticd not running")
+                except Exception:
+                    lines.append("  Could not check service status")
+                lines.append("")
+                lines.append("Topology populates when:")
                 lines.append("  - RNS discovers paths to destinations")
-                lines.append("  - Meshtastic nodes are seen")
-                lines.append("  - Gateway bridge is running")
+                lines.append("  - Meshtastic nodes are seen via radio")
+                lines.append("  - Gateway bridge routes traffic")
+                lines.append("")
+                lines.append("Try: Open the :5000 map for node visualization")
                 lines.append("")
 
             self.dialog.msgbox("Topology Statistics", "\n".join(lines))

--- a/src/launcher_tui/traffic_inspector_mixin.py
+++ b/src/launcher_tui/traffic_inspector_mixin.py
@@ -163,14 +163,37 @@ class TrafficInspectorMixin:
                     height=10, width=50
                 )
             else:
+                # Diagnose exactly what failed
+                diag_lines = ["Could not start packet capture.\n", "Diagnostics:"]
+                try:
+                    from utils.safe_import import safe_import
+                    _pub, has_pubsub = safe_import('pubsub', 'pub')
+                    if not has_pubsub:
+                        diag_lines.append("  [FAIL] pubsub module not installed")
+                        diag_lines.append("    Fix: pip install pypubsub")
+                    else:
+                        diag_lines.append("  [OK] pubsub module available")
+                except Exception:
+                    diag_lines.append("  [FAIL] pubsub check error")
+
+                try:
+                    from utils.service_check import check_service
+                    svc = check_service("meshtasticd")
+                    if svc.get("active"):
+                        diag_lines.append("  [OK] meshtasticd is running")
+                    else:
+                        diag_lines.append("  [FAIL] meshtasticd is not running")
+                        diag_lines.append("    Fix: sudo systemctl start meshtasticd")
+                except Exception:
+                    diag_lines.append("  [WARN] Could not check meshtasticd")
+
+                if is_capture_running and is_capture_running():
+                    diag_lines.append("  [INFO] Capture is already running")
+
                 self.dialog.msgbox(
                     "Capture Failed",
-                    "Could not start packet capture.\n\n"
-                    "Possible causes:\n"
-                    "- meshtasticd not connected\n"
-                    "- pubsub module not available\n"
-                    "- Capture already running",
-                    height=12, width=45
+                    "\n".join(diag_lines),
+                    height=16, width=55
                 )
 
     def _traffic_live_view(self) -> None:
@@ -218,10 +241,29 @@ class TrafficInspectorMixin:
                 info.append("No packets captured yet.")
                 if not capturing:
                     info.append("")
-                    info.append("Use 'Start Capture' from the menu to begin")
-                info.append("")
-                info.append("Traffic will appear here once the bridge is active")
-                info.append("or packets are captured from the mesh network.")
+                    info.append("Capture is NOT running.")
+                    info.append("  -> Use 'Start/Stop Capture' from the menu")
+                    info.append("")
+                    # Check prerequisites
+                    try:
+                        from utils.safe_import import safe_import
+                        _pub, has_pubsub = safe_import('pubsub', 'pub')
+                        if not has_pubsub:
+                            info.append("  [!] pypubsub not installed")
+                            info.append("      pip install pypubsub")
+                    except Exception:
+                        pass
+                    try:
+                        from utils.service_check import check_service
+                        svc = check_service("meshtasticd")
+                        if not svc.get("active"):
+                            info.append("  [!] meshtasticd not running")
+                    except Exception:
+                        pass
+                else:
+                    info.append("")
+                    info.append("Capture is running — waiting for packets...")
+                    info.append("Traffic will appear once mesh activity occurs.")
 
             self.dialog.msgbox(
                 "Live Traffic",

--- a/src/utils/map_data_collector.py
+++ b/src/utils/map_data_collector.py
@@ -64,6 +64,11 @@ class MapDataCollector:
     DEFAULT_NODE_CACHE_MAX_AGE_HOURS = 48
     DEFAULT_RNS_CACHE_MAX_AGE_HOURS = 24  # Increased from 1 hour
     DEFAULT_ONLINE_THRESHOLD_MINUTES = 15
+    # Per-source online thresholds (minutes) — configurable via map_settings.json
+    DEFAULT_MESHTASTIC_THRESHOLD_MINUTES = 15
+    DEFAULT_MQTT_THRESHOLD_MINUTES = 15
+    DEFAULT_RNS_THRESHOLD_MINUTES = 30   # RNS announces less frequently
+    DEFAULT_AREDN_THRESHOLD_MINUTES = 60  # AREDN scans are infrequent
     # Meshtasticd connection defaults
     DEFAULT_MESHTASTICD_HOST = "localhost"
     DEFAULT_MESHTASTICD_PORT = 4403
@@ -89,6 +94,11 @@ class MapDataCollector:
                 "meshtasticd_host": self.DEFAULT_MESHTASTICD_HOST,
                 "meshtasticd_port": self.DEFAULT_MESHTASTICD_PORT,
                 "aredn_node_ips": [],  # e.g. ["10.54.25.1", "10.1.0.1"]
+                # Per-source online thresholds (minutes)
+                "meshtastic_threshold_minutes": self.DEFAULT_MESHTASTIC_THRESHOLD_MINUTES,
+                "mqtt_threshold_minutes": self.DEFAULT_MQTT_THRESHOLD_MINUTES,
+                "rns_threshold_minutes": self.DEFAULT_RNS_THRESHOLD_MINUTES,
+                "aredn_threshold_minutes": self.DEFAULT_AREDN_THRESHOLD_MINUTES,
             }
         )
 
@@ -190,6 +200,55 @@ class MapDataCollector:
             self._settings.set("online_status_threshold_minutes", minutes)
             self._settings.save()
             logger.info(f"Online status threshold set to {minutes} minutes")
+
+    def get_source_threshold_seconds(self, source: str) -> int:
+        """Get online threshold for a specific network source.
+
+        Per-source thresholds allow different timeout windows per network type:
+        - meshtastic: 15 min (frequent heartbeats)
+        - mqtt: 15 min (real-time broker)
+        - rns: 30 min (announces less frequently)
+        - aredn: 60 min (scans are infrequent)
+
+        Falls back to the global online_status_threshold_minutes setting.
+
+        Args:
+            source: Network source type ("meshtastic", "mqtt", "rns", "aredn")
+
+        Returns:
+            Threshold in seconds
+        """
+        key = f"{source}_threshold_minutes"
+        defaults = {
+            "meshtastic": self.DEFAULT_MESHTASTIC_THRESHOLD_MINUTES,
+            "mqtt": self.DEFAULT_MQTT_THRESHOLD_MINUTES,
+            "rns": self.DEFAULT_RNS_THRESHOLD_MINUTES,
+            "aredn": self.DEFAULT_AREDN_THRESHOLD_MINUTES,
+        }
+        default = defaults.get(source, self.DEFAULT_ONLINE_THRESHOLD_MINUTES)
+        if self._settings:
+            minutes = self._settings.get(key, default)
+        else:
+            minutes = default
+        return int(minutes * 60)
+
+    def _is_node_online(self, last_heard: float, source: str = "meshtastic") -> bool:
+        """Determine if a node is online based on last_heard timestamp.
+
+        Single source of truth for online status determination.
+        Uses per-source thresholds for accurate status across network types.
+
+        Args:
+            last_heard: Unix timestamp of last communication (0 or None = unknown)
+            source: Network source type for threshold lookup
+
+        Returns:
+            True if the node was heard within the source's threshold window
+        """
+        if not last_heard or last_heard <= 0:
+            return False
+        threshold = self.get_source_threshold_seconds(source)
+        return (time.time() - last_heard) < threshold
 
     def get_meshtasticd_host(self) -> str:
         """Get meshtasticd host setting."""
@@ -450,13 +509,11 @@ class MapDataCollector:
 
             features = []
             no_position_nodes = []
-            now = time.time()
-            online_threshold = self.get_online_threshold_seconds()
 
             for node in nodes:
                 if node.has_position:
                     last_heard = node.last_heard or 0
-                    is_online = (now - last_heard) < online_threshold if last_heard else False
+                    is_online = self._is_node_online(last_heard, source="meshtastic")
 
                     feature = {
                         "type": "Feature",
@@ -744,9 +801,9 @@ class MapDataCollector:
         else:
             formatted_id = str(node_id)
 
-        # All nodes in nodedb are considered online (matches other mesh maps)
+        # Determine online status from last_heard timestamp
         last_heard = data.get('lastHeard', 0)
-        is_online = True
+        is_online = self._is_node_online(last_heard, source="meshtastic")
 
         # Format last_seen
         if last_heard:
@@ -834,16 +891,18 @@ class MapDataCollector:
                         if self._is_valid_coordinate(lat, lon):
                             user = data.get('user', {})
                             device_metrics = data.get('deviceMetrics', {})
+                            cli_last_heard = data.get('lastHeard', 0)
                             feature = self._make_feature(
                                 node_id=data.get('num', data.get('id', 'unknown')),
                                 name=user.get('longName', ''),
                                 lat=lat, lon=lon,
                                 network='meshtastic',
-                                is_online=True,
+                                is_online=self._is_node_online(cli_last_heard, source="meshtastic"),
                                 snr=data.get('snr'),
                                 battery=device_metrics.get('batteryLevel'),
                                 hardware=user.get('hwModel', ''),
                                 role=user.get('role', ''),
+                                last_heard=cli_last_heard,
                             )
                             features.append(feature)
                 except (json.JSONDecodeError, ValueError, IndexError):
@@ -1083,8 +1142,10 @@ class MapDataCollector:
         if not node.has_location():
             return None
 
-        # Determine online status (if we got data, it's online)
-        is_online = True
+        # Determine online status from scan time — AREDN uses longer threshold
+        # If we just scanned it successfully, use current time as last_heard
+        aredn_last_heard = time.time()
+        is_online = self._is_node_online(aredn_last_heard, source="aredn")
 
         # Determine if this is a "gateway" type node
         # AREDN nodes with tunnels act as gateways
@@ -1102,6 +1163,7 @@ class MapDataCollector:
             is_online=is_online,
             is_gateway=is_gateway,
             hardware=node.model,
+            last_heard=aredn_last_heard,
             role=node.mesh_status or "AREDN",
             last_seen="online",
         )
@@ -1170,12 +1232,14 @@ class MapDataCollector:
                             name = (pos.get("name") if pos else None) or f"RNS:{hash_hex[:8]}"
 
                             if lat and lon:
+                                rns_last_heard = pos.get("last_heard", 0) if pos else 0
                                 feature = self._make_feature(
                                     node_id=node_id,
                                     name=name,
                                     lat=lat, lon=lon,
                                     network="rns",
-                                    is_online=True,
+                                    is_online=self._is_node_online(rns_last_heard, source="rns"),
+                                    last_heard=rns_last_heard,
                                 )
                                 features.append(feature)
 
@@ -1361,11 +1425,12 @@ class MapDataCollector:
         )
 
     def _make_feature(self, node_id: str, name: str, lat: float, lon: float,
-                      network: str = "meshtastic", is_online: bool = True,
+                      network: str = "meshtastic", is_online: bool = False,
                       snr: Optional[float] = None, battery: Optional[int] = None,
                       hardware: str = "", role: str = "",
                       is_gateway: bool = False, via_mqtt: bool = False,
                       is_local: bool = False, last_seen: str = "",
+                      last_heard: Optional[float] = None,
                       rssi: Optional[int] = None,
                       temperature: Optional[float] = None,
                       humidity: Optional[float] = None,
@@ -1374,7 +1439,9 @@ class MapDataCollector:
                       co2: Optional[int] = None,
                       iaq: Optional[int] = None,
                       channel_utilization: Optional[float] = None,
-                      air_util_tx: Optional[float] = None) -> Dict:
+                      air_util_tx: Optional[float] = None,
+                      channel_name: str = "",
+                      has_encryption: Optional[bool] = None) -> Dict:
         """Create a GeoJSON Feature for a node."""
         props = {
             "id": str(node_id),
@@ -1388,6 +1455,7 @@ class MapDataCollector:
             "rssi": rssi,
             "battery": battery,
             "last_seen": last_seen or ("online" if is_online else "unknown"),
+            "last_heard": last_heard or 0,
             "hardware": hardware,
             "role": role,
         }
@@ -1408,6 +1476,11 @@ class MapDataCollector:
             props["channel_utilization"] = channel_utilization
         if air_util_tx is not None:
             props["air_util_tx"] = air_util_tx
+        # Channel/encryption info (Phase 3)
+        if channel_name:
+            props["channel_name"] = channel_name
+        if has_encryption is not None:
+            props["has_encryption"] = has_encryption
         return {
             "type": "Feature",
             "geometry": {
@@ -1418,12 +1491,32 @@ class MapDataCollector:
         }
 
     def _merge_feature(self, existing: Dict, new: Dict) -> None:
-        """Merge new feature data into existing (prefer non-null values)."""
-        for key, value in new["properties"].items():
+        """Merge new feature data into existing.
+
+        - For is_online/last_heard: most recent last_heard wins (freshest data
+          determines online status). This prevents stale sources from overriding
+          accurate status.
+        - For other properties: prefer non-null values (fill gaps).
+        """
+        new_props = new["properties"]
+        ex_props = existing["properties"]
+
+        # Handle is_online via most-recent last_heard
+        new_lh = new_props.get("last_heard", 0) or 0
+        ex_lh = ex_props.get("last_heard", 0) or 0
+        if new_lh > ex_lh:
+            ex_props["last_heard"] = new_lh
+            if "is_online" in new_props:
+                ex_props["is_online"] = new_props["is_online"]
+
+        # Merge other properties (prefer non-null to fill gaps)
+        for key, value in new_props.items():
+            if key in ("is_online", "last_heard"):
+                continue  # Already handled above
             if value is not None and value != "" and value != "unknown":
-                existing_val = existing["properties"].get(key)
+                existing_val = ex_props.get(key)
                 if existing_val is None or existing_val == "" or existing_val == "unknown":
-                    existing["properties"][key] = value
+                    ex_props[key] = value
 
     def _load_cache(self) -> List[Dict]:
         """Load last-known node state from disk cache."""

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -148,6 +148,8 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             self._serve_websocket_status()
         elif self.path == '/api/network/topology' or self.path == '/api/network/topology/':
             self._serve_network_topology()
+        elif self.path == '/api/weather' or self.path == '/api/weather/':
+            self._serve_weather()
         # ─────────────────────────────────────────────────────────────
         # Meshtastic API Proxy - MeshForge owns the web client API
         # ─────────────────────────────────────────────────────────────
@@ -954,6 +956,86 @@ class MapRequestHandler(SimpleHTTPRequestHandler):
             },
             "timestamp": datetime.now().isoformat()
         })
+
+    # ─────────────────────────────────────────────────────────────────
+    # Space Weather API
+    # ─────────────────────────────────────────────────────────────────
+
+    # Cache space weather data (refreshes every 15 minutes)
+    _weather_cache: Optional[Dict] = None
+    _weather_cache_time: float = 0
+    _WEATHER_CACHE_TTL = 900  # 15 minutes
+
+    def _serve_weather(self):
+        """Serve space weather and HF band conditions for map overlay.
+
+        Returns NOAA SWPC data: SFI, Kp, A-index, X-ray class,
+        geomagnetic storm level, and per-band HF conditions.
+
+        Cached for 15 minutes (space weather changes slowly).
+        """
+        now = time.time()
+
+        # Return cached data if still fresh
+        if (MapRequestHandler._weather_cache
+                and (now - MapRequestHandler._weather_cache_time) < self._WEATHER_CACHE_TTL):
+            self._serve_json(MapRequestHandler._weather_cache)
+            return
+
+        try:
+            from commands.propagation import get_space_weather, get_band_conditions
+
+            weather_result = get_space_weather()
+            band_result = get_band_conditions()
+
+            if weather_result.success:
+                data = weather_result.data or {}
+                # Merge band conditions if available
+                if band_result.success and band_result.data:
+                    data["band_conditions"] = band_result.data.get(
+                        "bands", data.get("band_conditions", {})
+                    )
+                    data["overall_condition"] = band_result.data.get("overall", "Unknown")
+
+                # Add mesh-relevant assessment
+                kp = data.get("k_index")
+                sfi = data.get("solar_flux")
+                if kp is not None and kp >= 5:
+                    data["mesh_impact"] = "degraded"
+                    data["mesh_impact_note"] = (
+                        f"Kp={kp} — Geomagnetic storm may cause "
+                        "increased noise on LoRa frequencies"
+                    )
+                elif sfi and sfi >= 200:
+                    data["mesh_impact"] = "elevated"
+                    data["mesh_impact_note"] = (
+                        f"SFI={int(sfi)} — High solar activity, "
+                        "monitor for interference"
+                    )
+                else:
+                    data["mesh_impact"] = "nominal"
+                    data["mesh_impact_note"] = "Conditions favorable for mesh operations"
+
+                data["cached_at"] = now
+
+                # Cache the result
+                MapRequestHandler._weather_cache = data
+                MapRequestHandler._weather_cache_time = now
+
+                self._serve_json(data)
+            else:
+                self._serve_json({
+                    "error": weather_result.error or "Space weather data unavailable",
+                    "mesh_impact": "unknown",
+                    "cached_at": now,
+                })
+        except Exception as e:
+            logger.warning(f"Space weather fetch failed: {e}")
+            self._serve_json({
+                "error": str(e),
+                "mesh_impact": "unknown",
+                "cached_at": now,
+            })
 
     # ─────────────────────────────────────────────────────────────────
     # Meshtastic API Proxy - MeshForge owns the web client

--- a/web/node_map.html
+++ b/web/node_map.html
@@ -1364,6 +1364,45 @@
                 </div>
             </div>
 
+            <!-- Space Weather Panel -->
+            <div class="weather-section" id="weather-section" style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #2a3a4a;">
+                <div class="section-title" style="cursor: pointer;" onclick="toggleWeatherPanel()">
+                    Space Weather <span id="weather-toggle" style="float: right; font-size: 10px;">&#x25BC;</span>
+                </div>
+                <div id="weather-body">
+                    <div class="stat-row">
+                        <span class="label">SFI:</span>
+                        <span class="value" id="wx-sfi" title="Solar Flux Index (SFU)">--</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="label">Kp Index:</span>
+                        <span class="value" id="wx-kp" title="Planetary K-index (0-9)">--</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="label">A Index:</span>
+                        <span class="value" id="wx-a" title="Daily A-index">--</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="label">X-ray:</span>
+                        <span class="value" id="wx-xray" title="X-ray flux class">--</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="label">GeoMag:</span>
+                        <span class="value" id="wx-geomag" title="Geomagnetic storm level">--</span>
+                    </div>
+                    <div class="stat-row">
+                        <span class="label">Mesh Impact:</span>
+                        <span class="value" id="wx-mesh-impact" title="Impact on LoRa mesh operations">--</span>
+                    </div>
+                    <div id="wx-bands" style="margin-top: 6px; font-size: 10px; display: none;">
+                        <div style="color: #888; margin-bottom: 2px;">HF Band Conditions:</div>
+                        <div id="wx-band-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 2px;"></div>
+                    </div>
+                    <div id="wx-note" style="font-size: 10px; color: #888; margin-top: 4px;"></div>
+                    <div id="wx-updated" style="font-size: 9px; color: #555; margin-top: 2px;"></div>
+                </div>
+            </div>
+
             <div class="cache-section" id="cache-section">
                 <div class="stat-row">
                     <span class="label">Cached:</span>
@@ -2507,6 +2546,27 @@
             congestionHtml = `<div class="info-label">ChUtil</div><div class="info-value">${props.channel_utilization.toFixed(1)}%</div>`;
         }
 
+        // Format last_heard timestamp into human-readable age
+        let lastHeardText = props.last_seen || 'Unknown';
+        if (props.last_heard && props.last_heard > 0) {
+            const ageSec = Math.floor(Date.now() / 1000 - props.last_heard);
+            if (ageSec < 60) lastHeardText = ageSec + 's ago';
+            else if (ageSec < 3600) lastHeardText = Math.floor(ageSec / 60) + 'm ago';
+            else if (ageSec < 86400) lastHeardText = Math.floor(ageSec / 3600) + 'h ago';
+            else lastHeardText = Math.floor(ageSec / 86400) + 'd ago';
+        }
+
+        // Channel / encryption info
+        let channelHtml = '';
+        if (props.channel_name) {
+            channelHtml += `<div class="info-label">Channel</div><div class="info-value" style="font-size:11px">${props.channel_name}</div>`;
+        }
+        if (props.has_encryption === true) {
+            channelHtml += `<div class="info-label">Encryption</div><div class="info-value" style="color:#66bb6a">Encrypted</div>`;
+        } else if (props.has_encryption === false) {
+            channelHtml += `<div class="info-label">Encryption</div><div class="info-value" style="color:#ef5350">None</div>`;
+        }
+
         return `
             <div class="node-popup">
                 <h3>${props.name || props.id || 'Unknown'}</h3>
@@ -2519,8 +2579,9 @@
                     ${props.role ? `<div class="info-label">Role</div><div class="info-value">${props.role}</div>` : ''}
                     ${props.is_gateway ? `<div class="info-label">Type</div><div class="info-value status-gateway">Gateway</div>` : ''}
                     ${props.via_mqtt ? `<div class="info-label">Via</div><div class="info-value" style="color:#ab47bc">MQTT</div>` : ''}
-                    <div class="info-label">Last seen</div>
-                    <div class="info-value">${props.last_seen || 'Unknown'}</div>
+                    <div class="info-label">Last heard</div>
+                    <div class="info-value">${lastHeardText}</div>
+                    ${channelHtml}
                     ${hopHtml}
                     ${snrHtml}
                     ${batteryHtml}
@@ -4400,6 +4461,110 @@
     // for messaging, channel config, and device control.
 
     // ============================================
+    // Space Weather
+    // ============================================
+
+    function toggleWeatherPanel() {
+        const body = document.getElementById('weather-body');
+        const toggle = document.getElementById('weather-toggle');
+        if (body.style.display === 'none') {
+            body.style.display = 'block';
+            toggle.innerHTML = '&#x25BC;';
+        } else {
+            body.style.display = 'none';
+            toggle.innerHTML = '&#x25B6;';
+        }
+    }
+
+    async function refreshWeather() {
+        try {
+            const resp = await fetch('/api/weather');
+            if (!resp.ok) return;
+            const data = await resp.json();
+
+            if (data.error && !data.solar_flux) {
+                document.getElementById('wx-sfi').textContent = 'N/A';
+                document.getElementById('wx-note').textContent = data.error;
+                return;
+            }
+
+            // SFI with color coding
+            const sfiEl = document.getElementById('wx-sfi');
+            const sfi = data.solar_flux;
+            if (sfi !== null && sfi !== undefined) {
+                sfiEl.textContent = Math.round(sfi);
+                sfiEl.style.color = sfi >= 120 ? '#66bb6a' : sfi >= 80 ? '#ffa726' : '#ef5350';
+            }
+
+            // Kp with color coding
+            const kpEl = document.getElementById('wx-kp');
+            const kp = data.k_index;
+            if (kp !== null && kp !== undefined) {
+                kpEl.textContent = kp;
+                kpEl.style.color = kp <= 3 ? '#66bb6a' : kp <= 5 ? '#ffa726' : '#ef5350';
+            }
+
+            // A index
+            const aEl = document.getElementById('wx-a');
+            if (data.a_index !== null && data.a_index !== undefined) {
+                aEl.textContent = data.a_index;
+            }
+
+            // X-ray class
+            const xrayEl = document.getElementById('wx-xray');
+            if (data.xray_class) {
+                xrayEl.textContent = data.xray_class;
+                const cls = data.xray_class.charAt(0);
+                xrayEl.style.color = (cls === 'A' || cls === 'B') ? '#66bb6a' :
+                    cls === 'C' ? '#ffa726' : '#ef5350';
+            }
+
+            // Geomagnetic storm
+            const geoEl = document.getElementById('wx-geomag');
+            if (data.geomag_storm) {
+                geoEl.textContent = data.geomag_storm;
+                const storm = data.geomag_storm.toLowerCase();
+                geoEl.style.color = storm === 'quiet' ? '#66bb6a' :
+                    storm === 'active' ? '#ffa726' : '#ef5350';
+            }
+
+            // Mesh impact
+            const impactEl = document.getElementById('wx-mesh-impact');
+            const impact = data.mesh_impact;
+            if (impact) {
+                impactEl.textContent = impact.charAt(0).toUpperCase() + impact.slice(1);
+                impactEl.style.color = impact === 'nominal' ? '#66bb6a' :
+                    impact === 'elevated' ? '#ffa726' : '#ef5350';
+            }
+
+            // Band conditions grid
+            const bands = data.band_conditions;
+            if (bands && typeof bands === 'object') {
+                const grid = document.getElementById('wx-band-grid');
+                grid.innerHTML = '';
+                for (const [band, condition] of Object.entries(bands)) {
+                    const color = condition === 'good' || condition === 'excellent' ? '#66bb6a' :
+                        condition === 'fair' ? '#ffa726' : '#ef5350';
+                    grid.innerHTML += `<span style="color: ${color};">${band}: ${condition}</span>`;
+                }
+                document.getElementById('wx-bands').style.display = 'block';
+            }
+
+            // Notes and timestamp
+            if (data.mesh_impact_note) {
+                document.getElementById('wx-note').textContent = data.mesh_impact_note;
+            }
+            if (data.updated) {
+                const updated = new Date(data.updated);
+                document.getElementById('wx-updated').textContent = 'Updated: ' + updated.toLocaleTimeString();
+            }
+        } catch (e) {
+            // Silent fail — weather is supplementary
+            console.debug('Weather fetch failed:', e);
+        }
+    }
+
+    // ============================================
     // Initialization
     // ============================================
 
@@ -4415,6 +4580,10 @@
 
     // Periodic cache status update
     setInterval(updateCacheStatus, 60000);
+
+    // Space weather: fetch on load, refresh every 15 minutes
+    refreshWeather();
+    setInterval(refreshWeather, 900000);
 
     // Fallback: Poll for received messages if WebSocket is disconnected
     setInterval(() => {


### PR DESCRIPTION
## Summary
This PR adds a space weather panel to the map interface and refactors node online status detection to use per-source thresholds and last_heard timestamps for more accurate status tracking across heterogeneous networks.

## Key Changes

### Space Weather Integration
- **New UI Panel**: Added collapsible "Space Weather" section to the map sidebar displaying:
  - Solar Flux Index (SFI) with color-coded severity
  - Kp Index (geomagnetic activity)
  - A-index and X-ray class
  - Geomagnetic storm level
  - Mesh impact assessment (nominal/elevated/degraded)
  - HF band conditions grid
- **New API Endpoint** (`/api/weather`): Fetches NOAA SWPC data via `propagation.get_space_weather()` and `get_band_conditions()`, with 15-minute caching
- **Frontend Refresh**: Weather data fetches on page load and refreshes every 15 minutes
- **Mesh Impact Logic**: Automatically assesses impact on LoRa operations based on Kp and SFI values

### Node Online Status Refactoring
- **Per-Source Thresholds**: Replaced single global threshold with network-type-specific windows:
  - Meshtastic: 15 minutes (frequent heartbeats)
  - MQTT: 15 minutes (real-time broker)
  - RNS: 30 minutes (less frequent announces)
  - AREDN: 60 minutes (infrequent scans)
- **New Methods**:
  - `get_source_threshold_seconds(source)`: Retrieves threshold for a network type
  - `_is_node_online(last_heard, source)`: Single source of truth for online status determination
- **last_heard Tracking**: All node features now include `last_heard` timestamp (Unix epoch) for accurate status calculation
- **Improved Merge Logic**: When merging node data from multiple sources, the most recent `last_heard` timestamp wins, preventing stale sources from overriding fresh data

### Node Popup Enhancements
- Changed "Last seen" label to "Last heard" with human-readable age formatting (e.g., "5m ago", "2h ago")
- Added channel name and encryption status display in node popups
- Improved timestamp formatting for better UX

### Diagnostic Improvements
- **Traffic Inspector**: Enhanced error messages with diagnostics for pubsub availability and meshtasticd service status
- **Topology View**: Added service status checks (rnsd, meshtasticd) and clearer guidance when no topology data is available

### Configuration
- New settings in `map_settings.json`:
  - `meshtastic_threshold_minutes`
  - `mqtt_threshold_minutes`
  - `rns_threshold_minutes`
  - `aredn_threshold_minutes`

### Bug Fixes
- Fixed node online status logic in `_extract_node_info_without_position()` to use actual last_heard instead of always marking as online
- Fixed CLI-parsed nodes to include last_heard timestamp
- Corrected AREDN node online status to use scan time as last_heard
- Updated `node_tracker.py` OFFLINE_THRESHOLD from 1 hour to 15 minutes for consistency

## Implementation Details
- Space weather data is cached client-side for 15 minutes to reduce API calls
- Color coding uses consistent palette: green (#66bb6a) for good, orange (#ffa726) for elevated, red (#ef5350) for degraded
- Feature merge strategy prioritizes freshness: most recent last_heard determines online status, other properties fill gaps
- All network sources now properly track last_heard for unified status determination

https://claude.ai/code/session_01UD8ocxHLAEBtJEXPqgLkDC