### PR TITLE
docs: Update README — test counts, linter rules MF005-MF010, handler …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/Nursedude/meshforge"><img src="https://img.shields.io/badge/version-0.5.4--beta-blue.svg" alt="Version"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-GPL--3.0-green.svg" alt="License"></a>
   <a href="https://python.org"><img src="https://img.shields.io/badge/python-3.9+-yellow.svg" alt="Python"></a>
-  <a href="https://github.com/Nursedude/meshforge/actions"><img src="https://img.shields.io/badge/tests-1986%20passing-brightgreen.svg" alt="Tests"></a>
+  <a href="https://github.com/Nursedude/meshforge/actions"><img src="https://img.shields.io/badge/tests-2203%20passing-brightgreen.svg" alt="Tests"></a>
 </p>
 
 <p align="center">
@@ -207,7 +207,7 @@ Main Menu (MeshForge NOC)
 | Category | Capabilities | Status |
 |----------|-------------|--------|
 | **TUI Interface** | Installer, service control, device config wizard, gateway config, diagnostics | Stable |
-| **TUI Reliability** | Defense-in-depth error handling — 47 mixin dispatch loops protected with `_safe_call` | Stable |
+| **TUI Reliability** | Defense-in-depth error handling — 46 mixin dispatch loops protected with `_safe_call`, 27 handlers migrated to command registry | Stable |
 | **Radio Management** | Install/configure meshtasticd, LoRa presets, channels, SPI/USB auto-detect | Stable |
 | **RF Engineering** | Link budget, Fresnel zone, path loss, site planning, space weather | Stable |
 | **AI Diagnostics** | Offline knowledge base (20+ topics), rule-based troubleshooting | Stable |
@@ -253,12 +253,17 @@ Main Menu (MeshForge NOC)
 | Feature | Status | Notes |
 |---------|--------|-------|
 | MQTT bridge architecture | Done (v0.5.4) | Zero-interference gateway |
-| Defense-in-depth TUI | Done (v0.5.2) | 47 mixin `_safe_call` protection |
-| Gateway-essential test suite | Done (v0.5.3) | 1,986 tests across 60 files |
+| Defense-in-depth TUI | Done (v0.5.2) | 46 mixin `_safe_call` protection |
+| Gateway-essential test suite | Done (v0.5.3) | 2,203 tests across 70 files |
 | First-run setup wizard | Done (v0.5.1) | Hardware auto-detect templates |
 | Network topology visualization | Done | D3.js + ASCII modes |
 | Node health & predictive maintenance | Done | Battery forecasting, signal trending |
 | Tactical messaging (XTOC interop) | Done (v0.5.4) | 8 templates, X1 codec, KML/CoT/ATAK export |
+| BaseMessageHandler ABC | Done (v0.5.4) | Shared constructor, truncation, status notification |
+| Logging consolidation | Done (v0.5.4) | 9 `basicConfig()` calls → canonical `setup_logging()` |
+| Handler registry migration | Done (v0.5.4) | 27 of 46 mixins migrated to plugin-based dispatch |
+| Service pre-flight expansion | Done (v0.5.4) | Advisory `check_service()` on all TCP/MQTT connections |
+| Error visibility hardening | Done (v0.5.4) | Connection failures upgraded DEBUG → WARNING |
 
 **Next Phase: Hardening & Hardware (v0.6.x - v0.8.x)**
 
@@ -820,7 +825,7 @@ connection (port 4403):
 
 ### Test Coverage
 
-**1,986 tests** across 60 test files:
+**2,203 tests** across 70 test files:
 
 | Test File | Tests | Covers |
 |-----------|-------|--------|
@@ -841,7 +846,7 @@ connection (port 4403):
 | `test_startup_health.py` | 20 | Startup health checks, service verification |
 | `test_compliance.py` | 13 | HAM compliance validation, encryption modes |
 
-*Note: Test suite was trimmed from 4,017 to 1,411 in v0.5.4 to focus on gateway-essential coverage. Since then, tests have grown to 1,986 across 60 files as new features (topology, node health, MQTT robustness, protobuf client, tactical ops, RNS shared instance detection, RF engineering, deployment profiles) were added with test coverage.*
+*Note: Test suite was trimmed from 4,017 to 1,411 in v0.5.4 to focus on gateway-essential coverage. Since then, tests have grown to 2,203 across 70 files as new features (topology, node health, MQTT robustness, protobuf client, tactical ops, RNS shared instance detection, RF engineering, deployment profiles, handler registry, service pre-flight) were added with test coverage.*
 
 ```bash
 python3 -m pytest tests/ -v            # Run all tests
@@ -870,17 +875,26 @@ print(f'Issues: {report.total_issues}, Files scanned: {report.total_files_scanne
 | MF002 | No `shell=True` in subprocess calls | Active monitoring |
 | MF003 | No bare `except:` — specify exception types | Active monitoring |
 | MF004 | All subprocess calls need `timeout` parameter | Active monitoring |
+| MF005 | GLib.idle_add for thread-safe UI updates | Active monitoring |
+| MF006 | No `safe_import` for first-party modules — use direct imports | Active monitoring |
+| MF007 | No direct `TCPInterface()` — use connection manager | Active monitoring |
+| MF008 | No raw `systemctl` for service state — use `service_check` | Active monitoring |
+| MF009 | `RNS.Reticulum()` must include `configdir=` parameter | Active monitoring |
+| MF010 | No `time.sleep()` in daemon loops — use `_stop_event.wait()` | Active monitoring |
 
 **Reliability patterns** (inspired by [Raspberry Pi systemd best practices](https://www.thedigitalpictureframe.com/ultimate-guide-systemd-autostart-scripts-raspberry-pi/)):
 - Services use `Restart=on-failure` with `RestartSec=5` for auto-recovery
 - Crash-loop protection: `StartLimitBurst=5` / `StartLimitIntervalSec=60` on rnsd
 - Startup ordering: meshforge.service `After=rnsd.service` ensures identity exists
-- Pre-flight `check_service()` before connecting to meshtasticd/rnsd
+- Advisory pre-flight `check_service()` on all TCPInterface and MQTT connections (9 files hardened)
 - RNS shared instance detection via abstract Unix domain socket (`@rns/default`), with TCP/UDP fallback
 - RNS repair wizard pre-flight: validates `share_instance = Yes`, detects config drift, checks NomadNet conflicts
 - RNS identity pre-flight: startup checks verify `~/.reticulum/storage/identities` exists
 - Shared connection manager prevents TCP:4403 client contention
 - Exponential backoff reconnection (1s → 2s → 4s → ... → 30s max)
+- Canonical logging via `setup_logging()` — all 9 `basicConfig()` calls consolidated
+- Handler registry pattern: 27 TUI handlers migrated from mixin inheritance to plugin dispatch
+- Connection failure logs upgraded to WARNING level for visibility (cleanup errors stay DEBUG)
 
 ---
 


### PR DESCRIPTION
…registry, reliability patterns

- Test badge: 1986 → 2203 passing, 60 → 70 test files
- Linter rules table: added MF005-MF010 (GLib, safe_import, TCPInterface, systemctl, Reticulum configdir, daemon sleep)
- Mixin count: corrected 47 → 46, added 27 handler registry mention
- Reliability patterns: expanded with pre-flight hardening, canonical logging, log level visibility
- Roadmap: added BaseMessageHandler, logging consolidation, handler registry, pre-flight, error visibility

https://claude.ai/code/session_016Xanaz6ZGSAp4XWMyBLHyb