### PR TITLE
refactor: Migrate Batch 4 handlers to registry (30 of 49)

### DIFF
--- a/src/launcher_tui/handlers/__init__.py
+++ b/src/launcher_tui/handlers/__init__.py
@@ -91,4 +91,14 @@ def get_all_handlers() -> List[Type]:
         UpdatesHandler,
     ])
 
+    # Batch 4 — dashboard, quick actions, emergency mode
+    from handlers.dashboard import DashboardHandler
+    from handlers.quick_actions import QuickActionsHandler
+    from handlers.emergency_mode import EmergencyModeHandler
+    handlers.extend([
+        DashboardHandler,
+        QuickActionsHandler,
+        EmergencyModeHandler,
+    ])
+
     return handlers

--- a/src/launcher_tui/handlers/dashboard.py
+++ b/src/launcher_tui/handlers/dashboard.py
@@ -1,0 +1,508 @@
+"""
+Dashboard Handler — Service status, node counts, data path diagnostics, alerts.
+
+Converted from dashboard_mixin.py as part of the mixin-to-registry migration.
+Also absorbs _dashboard_space_weather() from main.py.
+"""
+
+import logging
+import subprocess
+
+from backend import clear_screen
+from handler_protocol import BaseHandler
+from utils.safe_import import safe_import
+
+logger = logging.getLogger(__name__)
+
+# --- Module-level safe imports (replaces try/except ImportError blocks) ---
+ServiceRunState, _HAS_STARTUP_CHECKS = safe_import('startup_checks', 'ServiceRunState')
+get_http_client, reset_http_client, _HAS_MESHTASTIC_HTTP = safe_import(
+    'utils.meshtastic_http', 'get_http_client', 'reset_http_client'
+)
+from utils.map_data_collector import MapDataCollector
+generate_report, generate_and_save, _HAS_REPORT_GEN = safe_import(
+    'utils.report_generator', 'generate_report', 'generate_and_save'
+)
+from utils.health_score import get_health_scorer
+from plugins.eas_alerts import EASAlertsPlugin
+pub, _HAS_PUBSUB = safe_import('pubsub', 'pub')
+
+
+class DashboardHandler(BaseHandler):
+    """TUI handler for dashboard display methods."""
+
+    handler_id = "dashboard"
+    menu_section = "dashboard"
+
+    def menu_items(self):
+        return [
+            ("status", "Service Status      All services with health", None),
+            ("weather", "Space Weather       SFI, Kp, bands at a glance", None),
+            ("nodes", "Node Count          Meshtastic + RNS nodes", None),
+            ("score", "Health Score        Network health snapshot", None),
+            ("datapath", "Data Path Check     Test all data sources", None),
+            ("reports", "Reports             Generate status report", None),
+            ("alerts", "View Alerts         Current warnings", None),
+        ]
+
+    def execute(self, action):
+        dispatch = {
+            "status": ("Service Status", self._service_status_display),
+            "weather": ("Space Weather", self._dashboard_space_weather),
+            "nodes": ("Node Count", self._show_node_counts),
+            "score": ("Health Score", self._health_score_display),
+            "datapath": ("Data Path Check", self._data_path_diagnostic),
+            "reports": ("Reports", self._reports_menu),
+            "alerts": ("View Alerts", self._show_alerts),
+        }
+        entry = dispatch.get(action)
+        if entry:
+            self.ctx.safe_call(*entry)
+
+    @staticmethod
+    def _check_webserver_config() -> str:
+        """Check if meshtasticd config.yaml has Webserver section enabled."""
+        from pathlib import Path
+        config_path = Path("/etc/meshtasticd/config.yaml")
+        if not config_path.exists():
+            return "Fix: /etc/meshtasticd/config.yaml not found"
+        try:
+            content = config_path.read_text()
+            if 'Webserver:' not in content:
+                return "Fix: Add 'Webserver: Port: 443' to /etc/meshtasticd/config.yaml"
+            for line in content.splitlines():
+                stripped = line.strip()
+                if stripped.startswith('#'):
+                    continue
+                if 'Webserver:' in stripped:
+                    return "Config has Webserver section — check meshtasticd logs"
+            return "Fix: Webserver section may be commented out in config.yaml"
+        except PermissionError:
+            return "Cannot read config (try running with sudo)"
+        except Exception:
+            return "Fix: Check Webserver section in /etc/meshtasticd/config.yaml"
+
+    def _service_status_display(self):
+        """Show comprehensive service status."""
+        clear_screen()
+        print("=== Service Status ===\n")
+
+        if self.ctx.env_state and _HAS_STARTUP_CHECKS:
+            for name, info in self.ctx.env_state.services.items():
+                if info.state == ServiceRunState.RUNNING:
+                    print(f"  \033[0;32m●\033[0m {name:<18} running")
+                elif info.state == ServiceRunState.FAILED:
+                    print(f"  \033[0;31m●\033[0m {name:<18} FAILED")
+                else:
+                    print(f"  \033[2m○\033[0m {name:<18} stopped")
+        else:
+            for svc in ['meshtasticd', 'rnsd', 'mosquitto']:
+                try:
+                    result = subprocess.run(
+                        ['systemctl', 'is-active', svc],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    status = result.stdout.strip()
+                    if status == 'active':
+                        print(f"  \033[0;32m●\033[0m {svc:<18} running")
+                    else:
+                        print(f"  \033[2m○\033[0m {svc:<18} {status}")
+                except Exception:
+                    print(f"  ? {svc:<18} unknown")
+
+        print()
+        self.ctx.wait_for_enter()
+
+    def _dashboard_space_weather(self):
+        """Quick-look space weather for the Dashboard.
+
+        Shows a compact summary with SFI, Kp, band conditions, and
+        a link to the full propagation suite under RF & SDR.
+        """
+        from commands import propagation as prop_mod
+
+        result = prop_mod.get_space_weather()
+        if not result.success:
+            self.ctx.dialog.msgbox(
+                "Space Weather",
+                f"Could not fetch space weather data:\n{result.message}\n\n"
+                "Ensure internet connectivity is available.\n"
+                "NOAA SWPC is the primary data source."
+            )
+            return
+
+        d = result.data
+        lines = [
+            "SPACE WEATHER SNAPSHOT",
+            "=" * 40,
+            "",
+            f"Solar Flux (SFI):  {d.get('solar_flux', 'N/A')} SFU",
+            f"Kp Index:          {d.get('k_index', 'N/A')}",
+            f"A Index:           {d.get('a_index', 'N/A')}",
+            f"X-ray Flux:        {d.get('xray_flux', 'N/A')}",
+            f"Geomagnetic:       {d.get('geomag_storm', 'Quiet')}",
+            "",
+        ]
+
+        bands = d.get('band_conditions', {})
+        if bands:
+            lines.append("HF BAND CONDITIONS")
+            lines.append("-" * 40)
+            for band, cond in bands.items():
+                lines.append(f"  {band:<12s} {cond}")
+            lines.append("")
+
+        lines.append("-" * 40)
+        lines.append("Full propagation tools: RF & SDR > Space Weather")
+        lines.append(f"Source: {d.get('source', 'NOAA SWPC')}")
+
+        self.ctx.dialog.msgbox("Space Weather", "\n".join(lines), width=50, height=22)
+
+    def _show_node_counts(self):
+        """Show node counts from all sources."""
+        clear_screen()
+        print("=== Node Counts ===\n")
+
+        if not _HAS_MESHTASTIC_HTTP:
+            print("  Meshtastic: meshtastic_http module not available")
+        else:
+            try:
+                client = get_http_client()
+                if client.is_available:
+                    nodes = client.get_nodes()
+                    print(f"  Meshtastic nodes: {len(nodes)}")
+                else:
+                    print("  Meshtastic: HTTP API unavailable")
+            except Exception as e:
+                print(f"  Meshtastic: unavailable ({e})")
+
+        try:
+            result = subprocess.run(
+                ['rnstatus', '-a'],
+                capture_output=True, text=True, timeout=10
+            )
+            dest_count = len([line for line in result.stdout.splitlines()
+                             if line.strip().startswith('<')])
+            print(f"  RNS destinations: {dest_count}")
+        except Exception:
+            print("  RNS: unavailable")
+
+        print()
+        self.ctx.wait_for_enter()
+
+    def _data_path_diagnostic(self):
+        """Test all data collection paths to diagnose zero-data issues."""
+        clear_screen()
+        print("=== Data Path Diagnostic ===\n")
+        print("Testing all data sources...\n")
+
+        results = []
+
+        # Test 1: meshtasticd TCP connection
+        print("[1/6] Testing meshtasticd TCP (port 4403)...")
+        try:
+            import socket
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(3)
+            result = sock.connect_ex(('localhost', 4403))
+            sock.close()
+            if result == 0:
+                results.append(("meshtasticd TCP", "OK", "Port 4403 accepting connections"))
+                print("      \033[0;32mOK\033[0m - Port 4403 reachable")
+            else:
+                results.append(("meshtasticd TCP", "FAIL", f"Connection refused (code {result})"))
+                print("      \033[0;31mFAIL\033[0m - Connection refused")
+        except Exception as e:
+            results.append(("meshtasticd TCP", "FAIL", str(e)))
+            print(f"      \033[0;31mFAIL\033[0m - {e}")
+
+        # Test 2: meshtastic CLI node count
+        print("[2/6] Testing meshtastic CLI...")
+        try:
+            result = subprocess.run(
+                ['meshtastic', '--host', 'localhost', '--info'],
+                capture_output=True, text=True, timeout=15
+            )
+            if result.returncode == 0:
+                node_lines = [line for line in result.stdout.split('\n')
+                             if 'Node' in line or '!' in line]
+                results.append(("meshtastic CLI", "OK", f"Responded, ~{len(node_lines)} node refs"))
+                print("      \033[0;32mOK\033[0m - CLI responded")
+            else:
+                results.append(("meshtastic CLI", "WARN",
+                               result.stderr[:50] if result.stderr else "No output"))
+                print("      \033[0;33mWARN\033[0m - Non-zero exit")
+        except FileNotFoundError:
+            results.append(("meshtastic CLI", "SKIP", "CLI not installed"))
+            print("      \033[0;33mSKIP\033[0m - CLI not found")
+        except subprocess.TimeoutExpired:
+            results.append(("meshtastic CLI", "FAIL", "Timeout after 15s"))
+            print("      \033[0;31mFAIL\033[0m - Timeout")
+        except Exception as e:
+            results.append(("meshtastic CLI", "FAIL", str(e)[:50]))
+            print(f"      \033[0;31mFAIL\033[0m - {e}")
+
+        # Test 3: meshtasticd HTTP API
+        print("[3/6] Testing meshtasticd HTTP API...")
+        if not _HAS_MESHTASTIC_HTTP:
+            results.append(("meshtasticd HTTP", "SKIP", "meshtastic_http module not available"))
+            print("      \033[0;33mSKIP\033[0m - Module not available")
+        else:
+            try:
+                reset_http_client()
+                client = get_http_client()
+                if client.is_available:
+                    nodes = client.get_nodes()
+                    results.append(("meshtasticd HTTP", "OK",
+                                   f"{len(nodes)} nodes via {client._base_url}"))
+                    print(f"      \033[0;32mOK\033[0m - {len(nodes)} nodes at {client._base_url}")
+                else:
+                    hint = self._check_webserver_config()
+                    detail = f"Not reachable (tried ports 9443,443,80,4403). {hint}"
+                    results.append(("meshtasticd HTTP", "FAIL", detail))
+                    print(f"      \033[0;31mFAIL\033[0m - HTTP API not reachable")
+                    print(f"      \033[2m{hint}\033[0m")
+            except Exception as e:
+                err_msg = str(e)[:50]
+                results.append(("meshtasticd HTTP", "FAIL", err_msg))
+                print(f"      \033[0;31mFAIL\033[0m - {err_msg}")
+
+        # Test 4: pubsub availability
+        print("[4/6] Testing pubsub (for live capture)...")
+        if not _HAS_PUBSUB:
+            results.append(("pubsub", "SKIP", "pubsub module not installed"))
+            print("      \033[0;33mSKIP\033[0m - Module not installed")
+        else:
+            try:
+                listeners = pub.getDefaultTopicMgr().getTopic('meshtastic.receive', okIfNone=True)
+                if listeners:
+                    count = len(list(listeners.getListeners()))
+                    results.append(("pubsub", "OK", f"{count} listener(s) on meshtastic.receive"))
+                    print(f"      \033[0;32mOK\033[0m - {count} listener(s) registered")
+                else:
+                    results.append(("pubsub", "WARN", "Topic exists but no listeners"))
+                    print("      \033[0;33mWARN\033[0m - No listeners registered")
+            except Exception as e:
+                results.append(("pubsub", "WARN", str(e)[:50]))
+                print(f"      \033[0;33mWARN\033[0m - {e}")
+
+        # Test 5: MapDataCollector
+        print("[5/6] Testing MapDataCollector...")
+        try:
+            collector = MapDataCollector(enable_history=False)
+            geojson = collector.collect(max_age_seconds=30)
+            props = geojson.get('properties', {})
+            total = props.get('total_nodes', 0)
+            with_gps = props.get('nodes_with_position', 0)
+            sources = props.get('sources', {})
+            active_sources = [k for k, v in sources.items() if isinstance(v, (int, float)) and v > 0]
+            if total > 0:
+                results.append(("MapDataCollector", "OK", f"{total} nodes ({with_gps} with GPS)"))
+                print(f"      \033[0;32mOK\033[0m - {total} nodes, sources: {active_sources}")
+            else:
+                results.append(("MapDataCollector", "WARN", "0 nodes returned"))
+                print("      \033[0;33mWARN\033[0m - 0 nodes (check meshtasticd connection)")
+        except Exception as e:
+            results.append(("MapDataCollector", "FAIL", str(e)[:50]))
+            print(f"      \033[0;31mFAIL\033[0m - {e}")
+
+        # Test 6: RNS path table
+        print("[6/6] Testing RNS path table...")
+        try:
+            result = subprocess.run(
+                ['rnpath', '-t'],
+                capture_output=True, text=True, timeout=10
+            )
+            lines = [line for line in result.stdout.splitlines()
+                     if line.strip() and not line.startswith('Path')]
+            path_count = len(lines)
+            if path_count > 0:
+                results.append(("RNS paths", "OK", f"{path_count} known paths"))
+                print(f"      \033[0;32mOK\033[0m - {path_count} paths in table")
+            else:
+                results.append(("RNS paths", "WARN", "Path table empty"))
+                print("      \033[0;33mWARN\033[0m - No paths (normal if no RNS traffic yet)")
+        except FileNotFoundError:
+            results.append(("RNS paths", "SKIP", "rnpath not installed"))
+            print("      \033[0;33mSKIP\033[0m - rnpath not found")
+        except Exception as e:
+            results.append(("RNS paths", "WARN", str(e)[:50]))
+            print(f"      \033[0;33mWARN\033[0m - {e}")
+
+        # Summary
+        print("\n" + "=" * 50)
+        print("SUMMARY")
+        print("=" * 50)
+        ok_count = len([r for r in results if r[1] == "OK"])
+        fail_count = len([r for r in results if r[1] == "FAIL"])
+        warn_count = len([r for r in results if r[1] == "WARN"])
+
+        for test, status, detail in results:
+            if status == "OK":
+                print(f"  \033[0;32m✓\033[0m {test:<20} {detail}")
+            elif status == "FAIL":
+                print(f"  \033[0;31m✗\033[0m {test:<20} {detail}")
+            elif status == "WARN":
+                print(f"  \033[0;33m!\033[0m {test:<20} {detail}")
+            else:
+                print(f"  \033[2m-\033[0m {test:<20} {detail}")
+
+        print()
+        if fail_count > 0:
+            print(f"Result: {fail_count} FAILED - check service connections")
+        elif warn_count > 0 and ok_count == 0:
+            print("Result: No data sources working - check meshtasticd")
+        elif ok_count > 0:
+            print(f"Result: {ok_count} sources OK - data should be flowing")
+        print()
+        self.ctx.wait_for_enter()
+
+    def _reports_menu(self):
+        """Network status reports: generate, view, save."""
+        while True:
+            choices = [
+                ("generate", "Generate & View     Full status report"),
+                ("save", "Generate & Save     Save to file"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Reports",
+                "Network status report generation:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            if choice == "generate":
+                self.ctx.safe_call("Generate Report", self._generate_and_view_report)
+            elif choice == "save":
+                self.ctx.safe_call("Save Report", self._generate_and_save_report)
+
+    def _generate_and_view_report(self):
+        """Generate a full status report and display it."""
+        import subprocess as _sp
+        _sp.run(['clear'], check=False, timeout=5)
+        print("=== Generating Network Status Report ===\n")
+        print("Collecting data from all subsystems...\n")
+
+        if not _HAS_REPORT_GEN:
+            print("  Report generator module not available.")
+            print("  File: src/utils/report_generator.py")
+            self.ctx.wait_for_enter()
+            return
+
+        report = generate_report()
+        print(report)
+        print()
+        self.ctx.wait_for_enter()
+
+    def _generate_and_save_report(self):
+        """Generate a report and save it to a file."""
+        import subprocess as _sp
+        _sp.run(['clear'], check=False, timeout=5)
+        print("=== Generating & Saving Report ===\n")
+
+        if not _HAS_REPORT_GEN:
+            print("  Report generator module not available.")
+            print("  File: src/utils/report_generator.py")
+            self.ctx.wait_for_enter()
+            return
+
+        saved_path = generate_and_save()
+        print(f"Report saved to:\n  {saved_path}\n")
+        self.ctx.wait_for_enter()
+
+    def _health_score_display(self):
+        """Show comprehensive network health score with category breakdown."""
+        import subprocess as _sp
+        _sp.run(['clear'], check=False, timeout=5)
+        print("=== Network Health Score ===\n")
+
+        scorer = get_health_scorer()
+        snapshot = scorer.get_snapshot()
+
+        score = snapshot.overall_score
+        bar_len = 30
+        filled = int(score / 100 * bar_len)
+        bar = "\033[0;32m" + "=" * filled + "\033[0m" + "-" * (bar_len - filled)
+
+        if score >= 80:
+            color = "\033[0;32m"
+        elif score >= 60:
+            color = "\033[0;33m"
+        elif score >= 40:
+            color = "\033[0;31m"
+        else:
+            color = "\033[1;31m"
+
+        print(f"  Overall: {color}{score:.0f}/100\033[0m ({snapshot.status})")
+        print(f"  [{bar}]\n")
+
+        print(f"  {'Category':<18} {'Score':>6}  Status")
+        print(f"  {'-'*42}")
+        for cat, cat_score in snapshot.category_scores.items():
+            if cat_score >= 80:
+                status = "Good"
+                c = "\033[0;32m"
+            elif cat_score >= 60:
+                status = "Fair"
+                c = "\033[0;33m"
+            elif cat_score >= 40:
+                status = "Degraded"
+                c = "\033[0;31m"
+            else:
+                status = "Critical"
+                c = "\033[1;31m"
+            print(f"  {cat.title():<18} {c}{cat_score:>5.0f}\033[0m  {status}")
+
+        print(f"\n  Nodes reporting:  {snapshot.node_count}")
+        print(f"  Services tracked: {snapshot.service_count}")
+
+        trend = scorer.get_trend()
+        trend_icons = {
+            'improving': '\033[0;32m  improving\033[0m',
+            'declining': '\033[0;31m  declining\033[0m',
+            'stable': '  stable',
+        }
+        print(f"  Trend:           {trend_icons.get(trend, trend)}")
+
+        print()
+        self.ctx.wait_for_enter()
+
+    def _show_alerts(self):
+        """Show current alerts from environment state and EAS."""
+        clear_screen()
+        print("=== Current Alerts ===\n")
+
+        if self.ctx.env_state:
+            alerts = self.ctx.env_state.get_alerts()
+            if alerts:
+                print("SYSTEM ALERTS:")
+                for alert in alerts:
+                    print(f"  \033[0;33m!\033[0m {alert}")
+            else:
+                print("  System: No alerts - healthy")
+        else:
+            print("  Environment state not available")
+
+        print()
+        try:
+            plugin = EASAlertsPlugin()
+            eas_alerts = plugin.get_weather_alerts()
+            if eas_alerts:
+                print(f"WEATHER ALERTS ({len(eas_alerts)}):")
+                for alert in eas_alerts[:5]:
+                    severity = getattr(alert, 'severity', 'Unknown')
+                    headline = getattr(alert, 'headline', str(alert))
+                    if len(headline) > 65:
+                        headline = headline[:62] + "..."
+                    print(f"  \033[0;31m!\033[0m [{severity}] {headline}")
+            else:
+                print("  Weather: No active alerts")
+        except Exception as e:
+            logger.debug("EAS alert check failed: %s", e)
+
+        print()
+        self.ctx.wait_for_enter()

--- a/src/launcher_tui/handlers/emergency_mode.py
+++ b/src/launcher_tui/handlers/emergency_mode.py
@@ -1,0 +1,378 @@
+"""
+Emergency Mode Handler — simplified EMCOMM interface for field operators.
+
+Converted from emergency_mode_mixin.py as part of the mixin-to-registry migration.
+Dispatched from the main menu (not a section submenu).
+
+Designed for high-stress field use: minimal menus, clear confirmations,
+no unnecessary options.
+"""
+
+import re
+import subprocess
+import time
+import logging
+
+from backend import clear_screen
+from handler_protocol import BaseHandler
+from plugins.eas_alerts import EASAlertsPlugin
+
+logger = logging.getLogger(__name__)
+
+# Emergency broadcast prefix for EMCOMM messages
+EMCOMM_PREFIX = "[EMCOMM] "
+
+
+class EmergencyModeHandler(BaseHandler):
+    """Simplified EMCOMM interface for field operations.
+
+    This handler owns the emergency mode submenu, dispatched from
+    the main menu via tag 'e'. It is NOT a section submenu handler.
+    """
+
+    handler_id = "emergency_mode"
+    menu_section = "main"
+
+    def menu_items(self):
+        return [
+            ("e", "Emergency Mode      EMCOMM field operations", None),
+        ]
+
+    def execute(self, action):
+        if action == "e":
+            self._emergency_mode()
+
+    def _get_emcomm_cli(self) -> str:
+        """Get meshtastic CLI path with emergency-safe error handling.
+
+        Returns the CLI path or 'meshtastic' as fallback.
+        Emergency mode must never crash on CLI lookup.
+        """
+        try:
+            return self.ctx.get_meshtastic_cli()
+        except Exception as e:
+            logger.warning(f"CLI lookup failed in EMCOMM mode: {e}")
+            return 'meshtastic'
+
+    def _emergency_mode(self):
+        """Run emergency mode — simplified menu for field ops.
+
+        This mode is designed for high-stress field use.
+        Every action is individually protected to ensure the menu
+        always returns, even if individual operations fail.
+        """
+        while True:
+            choices = [
+                ("send", "SEND MESSAGE (broadcast)"),
+                ("direct", "SEND DIRECT (to node)"),
+                ("status", "WHO IS ONLINE"),
+                ("msgs", "RECENT MESSAGES"),
+                ("pos", "MY POSITION"),
+                ("sos", "SOS BEACON (repeating)"),
+                ("alerts", "WEATHER/EAS ALERTS"),
+                ("exit", "EXIT Emergency Mode"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "EMERGENCY MODE",
+                "EMCOMM Quick Actions — field operations:",
+                choices
+            )
+
+            if choice is None or choice == "exit":
+                break
+
+            dispatch = {
+                "send": ("EMCOMM Broadcast", self._emcomm_broadcast),
+                "direct": ("EMCOMM Direct Message", self._emcomm_direct),
+                "status": ("EMCOMM Node Status", self._emcomm_status),
+                "msgs": ("EMCOMM Messages", self._emcomm_messages),
+                "pos": ("EMCOMM Position", self._emcomm_position),
+                "sos": ("EMCOMM SOS Beacon", self._emcomm_sos_beacon),
+                "alerts": ("EMCOMM EAS Alerts", self._emcomm_eas_alerts),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _emcomm_broadcast(self):
+        """Send a broadcast message to all nodes."""
+        msg = self.ctx.dialog.inputbox(
+            "BROADCAST MESSAGE",
+            "Enter message to send to ALL nodes:\n"
+            "(Will be prefixed with [EMCOMM])",
+            ""
+        )
+
+        if msg is None or msg.strip() == "":
+            return
+
+        full_msg = f"{EMCOMM_PREFIX}{msg.strip()}"
+
+        if not self.ctx.dialog.yesno(
+            "Confirm Broadcast",
+            f"Send to ALL nodes?\n\n"
+            f"Message: {full_msg}\n\n"
+            f"This will transmit on all channels.",
+            default_no=True
+        ):
+            return
+
+        clear_screen()
+        print(f"Broadcasting: {full_msg}\n")
+        try:
+            cli_path = self._get_emcomm_cli()
+            subprocess.run(
+                [cli_path, '--sendtext', full_msg],
+                timeout=30
+            )
+            print("\nMessage sent.")
+        except FileNotFoundError:
+            print("ERROR: meshtastic CLI not available.")
+        except subprocess.TimeoutExpired:
+            print("ERROR: Send timed out. Check radio connection.")
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _emcomm_direct(self):
+        """Send a direct message to a specific node."""
+        dest = self.ctx.dialog.inputbox(
+            "DIRECT MESSAGE",
+            "Enter destination node ID (e.g., !abc12345)\n"
+            "or short name:",
+            ""
+        )
+
+        if dest is None or dest.strip() == "":
+            return
+
+        msg = self.ctx.dialog.inputbox(
+            "MESSAGE TEXT",
+            f"Message to {dest.strip()}:\n"
+            "(Will be prefixed with [EMCOMM])",
+            ""
+        )
+
+        if msg is None or msg.strip() == "":
+            return
+
+        full_msg = f"{EMCOMM_PREFIX}{msg.strip()}"
+        dest_clean = dest.strip()
+
+        if not re.match(r'^(![\da-fA-F]{6,16}|\^all)$', dest_clean):
+            self.ctx.dialog.msgbox(
+                "Invalid Destination",
+                f"'{dest_clean}' is not a valid node ID.\n"
+                "Use format: !abc12345 or ^all"
+            )
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Confirm Direct Message",
+            f"Send to: {dest_clean}\n"
+            f"Message: {full_msg}",
+            default_no=True
+        ):
+            return
+
+        clear_screen()
+        print(f"Sending to {dest_clean}: {full_msg}\n")
+        try:
+            cli_path = self._get_emcomm_cli()
+            subprocess.run(
+                [cli_path, '--dest', dest_clean, '--sendtext', full_msg],
+                timeout=30
+            )
+            print("\nMessage sent.")
+        except FileNotFoundError:
+            print("ERROR: meshtastic CLI not available.")
+        except subprocess.TimeoutExpired:
+            print("ERROR: Send timed out. Check radio connection.")
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _emcomm_status(self):
+        """Show which nodes are currently online."""
+        clear_screen()
+        print("=== NODES ONLINE ===\n")
+        try:
+            cli_path = self._get_emcomm_cli()
+            subprocess.run(
+                [cli_path, '--nodes'],
+                timeout=30
+            )
+        except FileNotFoundError:
+            print("ERROR: meshtastic CLI not available.")
+            print("Install: pipx install meshtastic[cli]")
+        except subprocess.TimeoutExpired:
+            print("ERROR: Command timed out.")
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _emcomm_messages(self):
+        """Show recent messages from the mesh."""
+        clear_screen()
+        print("=== RECENT MESSAGES ===\n")
+
+        try:
+            result = subprocess.run(
+                ['journalctl', '-u', 'meshtasticd', '--no-pager',
+                 '-n', '100', '--output', 'cat'],
+                capture_output=True, text=True, timeout=10
+            )
+            if result.returncode == 0:
+                lines = result.stdout.split('\n')
+                msg_lines = [
+                    l for l in lines
+                    if 'received' in l.lower() or
+                       'text' in l.lower() or
+                       'message' in l.lower()
+                ]
+                if msg_lines:
+                    for line in msg_lines[-20:]:
+                        print(f"  {line.strip()}")
+                else:
+                    print("  No recent messages found in logs.")
+            else:
+                print("  Could not read meshtasticd logs.")
+        except FileNotFoundError:
+            print("  journalctl not available.")
+        except subprocess.TimeoutExpired:
+            print("  Log read timed out.")
+        except Exception as e:
+            print(f"  Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _emcomm_position(self):
+        """Show current GPS position."""
+        clear_screen()
+        print("=== MY POSITION ===\n")
+        try:
+            cli_path = self._get_emcomm_cli()
+            subprocess.run(
+                [cli_path, '--get', 'position'],
+                timeout=30
+            )
+        except FileNotFoundError:
+            print("ERROR: meshtastic CLI not available.")
+        except subprocess.TimeoutExpired:
+            print("ERROR: Command timed out.")
+        except Exception as e:
+            print(f"ERROR: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _emcomm_sos_beacon(self):
+        """Send repeating SOS beacon messages."""
+        if not self.ctx.dialog.yesno(
+            "SOS BEACON",
+            "This will send repeating SOS messages every 60 seconds.\n\n"
+            "USE ONLY IN REAL EMERGENCIES.\n\n"
+            "Press Ctrl+C to stop.\n\n"
+            "Start SOS beacon?",
+            default_no=True
+        ):
+            return
+
+        info = self.ctx.dialog.inputbox(
+            "BEACON INFO",
+            "Optional: Your callsign/name and situation:\n"
+            "(Press Enter for generic SOS)",
+            ""
+        )
+
+        if info is None:
+            return
+
+        beacon_msg = f"{EMCOMM_PREFIX}SOS"
+        if info.strip():
+            beacon_msg += f" - {info.strip()}"
+
+        clear_screen()
+        print(f"=== SOS BEACON ACTIVE ===\n")
+        print(f"Message: {beacon_msg}")
+        print(f"Interval: 60 seconds")
+        print(f"Press Ctrl+C to stop\n")
+
+        count = 0
+        try:
+            while True:
+                count += 1
+                print(f"  [{count}] Sending beacon... ", end="", flush=True)
+                try:
+                    cli_path = self._get_emcomm_cli()
+                    result = subprocess.run(
+                        [cli_path, '--sendtext', beacon_msg],
+                        capture_output=True, timeout=30
+                    )
+                    if result.returncode == 0:
+                        print("SENT")
+                    else:
+                        print("FAILED (radio error)")
+                except FileNotFoundError:
+                    print("FAILED (meshtastic not found)")
+                    break
+                except subprocess.TimeoutExpired:
+                    print("TIMEOUT")
+
+                print(f"  Next beacon in 60s (Ctrl+C to stop)...")
+                time.sleep(60)
+
+        except KeyboardInterrupt:
+            print(f"\n\nSOS Beacon stopped after {count} transmission(s).")
+
+        self.ctx.wait_for_enter()
+
+    def _emcomm_eas_alerts(self):
+        """Check weather and emergency alerts — field-safe implementation."""
+        clear_screen()
+        print("=== WEATHER / EAS ALERTS ===\n")
+
+        try:
+            plugin = EASAlertsPlugin()
+
+            print("Checking NOAA weather alerts...")
+            alerts = plugin.get_weather_alerts()
+
+            if not alerts:
+                print("\n  No active weather alerts for your area.")
+                print("  (Configure location in MeshForge Settings)")
+            else:
+                print(f"\n  {len(alerts)} active alert(s):\n")
+                for i, alert in enumerate(alerts[:10], 1):
+                    severity = getattr(alert, 'severity', 'Unknown')
+                    headline = getattr(alert, 'headline', str(alert))
+                    if len(headline) > 70:
+                        headline = headline[:67] + "..."
+                    print(f"  {i}. [{severity}] {headline}")
+
+            print("\nChecking USGS volcano alerts...")
+            try:
+                volcano_alerts = plugin.get_volcano_alerts()
+                if volcano_alerts:
+                    print(f"\n  {len(volcano_alerts)} volcano alert(s):")
+                    for alert in volcano_alerts[:5]:
+                        name = getattr(alert, 'volcano_name', str(alert))
+                        level = getattr(alert, 'alert_level', 'Unknown')
+                        print(f"  - [{level}] {name}")
+                else:
+                    print("  No active volcano alerts.")
+            except Exception:
+                print("  Volcano alert check unavailable.")
+
+        except Exception as e:
+            print(f"  Alert check failed: {e}")
+            print("  (Check network connectivity)")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/handlers/quick_actions.py
+++ b/src/launcher_tui/handlers/quick_actions.py
@@ -1,0 +1,523 @@
+"""
+Quick Actions Handler — single-key shortcuts for common NOC operations.
+
+Converted from quick_actions_mixin.py as part of the mixin-to-registry migration.
+Dispatched from the main menu (not a section submenu).
+"""
+
+import logging
+import subprocess
+
+from backend import clear_screen
+from handler_protocol import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+# Centralized service checking — first-party, always available
+from utils.service_check import (
+    check_systemd_service, check_process_running, check_port,
+    check_rns_shared_instance,
+    apply_config_and_restart, restart_service,
+)
+
+# First-party modules for quick actions
+from utils.report_generator import generate_report
+from utils.node_inventory import NodeInventory
+from utils.gps_integration import GPSManager
+from utils.diagnostic_engine import get_diagnostic_engine
+from utils.channel_scan import ChannelMonitor
+
+# Quick action definitions: (tag, description, method_name)
+QUICK_ACTIONS = [
+    ('s', 'Service status overview', '_qa_service_status'),
+    ('w', 'Space weather (SFI, Kp, bands)', '_qa_space_weather'),
+    ('n', 'Node list (meshtastic --nodes)', '_qa_node_list'),
+    ('i', 'Node inventory (tracked nodes)', '_qa_node_inventory'),
+    ('G', 'GPS position / distance to nodes', '_qa_gps_position'),
+    ('l', 'Follow logs (meshtasticd)', '_qa_follow_logs'),
+    ('r', 'Restart meshtasticd', '_qa_restart_meshtasticd'),
+    ('R', 'Restart rnsd', '_qa_restart_rnsd'),
+    ('p', 'Port / network check', '_qa_port_check'),
+    ('g', 'Generate status report', '_qa_generate_report'),
+    ('d', 'Run diagnostics', '_qa_run_diagnostics'),
+    ('c', 'Channel activity scan', '_qa_channel_scan'),
+    ('u', 'Check for software updates', '_qa_check_updates'),
+    ('m', 'Generate coverage map', '_qa_coverage_map'),
+]
+
+
+class QuickActionsHandler(BaseHandler):
+    """Single-key shortcuts for frequent NOC operations.
+
+    This handler owns the quick_actions submenu, dispatched from
+    the main menu via tag 'q'. It is NOT a section submenu handler.
+    """
+
+    handler_id = "quick_actions"
+    menu_section = "main"
+
+    def menu_items(self):
+        return [
+            ("q", "Quick Actions       Single-key NOC shortcuts", None),
+        ]
+
+    def execute(self, action):
+        if action == "q":
+            self._quick_actions_menu()
+
+    def _quick_actions_menu(self):
+        """Display quick actions menu with single-key shortcuts."""
+        while True:
+            choices = [(tag, desc) for tag, desc, _ in QUICK_ACTIONS]
+            choices.append(('b', 'Back to main menu'))
+
+            choice = self.ctx.dialog.menu(
+                "Quick Actions",
+                "Single-key shortcuts (press letter to select):",
+                choices
+            )
+
+            if choice is None or choice == 'b':
+                break
+
+            for tag, desc, method_name in QUICK_ACTIONS:
+                if choice == tag:
+                    method = getattr(self, method_name, None)
+                    if method:
+                        self.ctx.safe_call(desc, method)
+                    break
+
+    def _qa_service_status(self):
+        """Quick: show all service statuses."""
+        clear_screen()
+        print("=== Quick Service Status ===\n")
+
+        services = ['meshtasticd', 'rnsd', 'mosquitto', 'meshforge']
+        warnings = []
+        for svc in services:
+            if svc == 'meshforge':
+                is_systemd = False
+                try:
+                    is_running, _ = check_systemd_service(svc)
+                    is_systemd = is_running
+                except Exception:
+                    pass
+                mode = "service" if is_systemd else "interactive"
+                print(f"  * {svc:<18} running ({mode})")
+                continue
+
+            try:
+                is_running, is_enabled = check_systemd_service(svc)
+                status = 'active' if is_running else 'inactive'
+
+                boot_info = ""
+                if status == 'active' and not is_enabled:
+                    boot_info = "  (not enabled at boot)"
+                    warnings.append(svc)
+
+                if status == 'active':
+                    if svc == 'rnsd' and not check_rns_shared_instance():
+                        print(f"  ! {svc:<18} running (shared instance not available)")
+                    else:
+                        print(f"  * {svc:<18} running{boot_info}")
+                elif status == 'failed':
+                    print(f"  ! {svc:<18} FAILED")
+                else:
+                    print(f"  - {svc:<18} {status}")
+            except (subprocess.SubprocessError, OSError) as e:
+                logger.debug("Service status check for %s failed: %s", svc, e)
+                print(f"  ? {svc:<18} unknown")
+
+        try:
+            bridge_running = check_process_running('rns_bridge')
+            bridge_status = "running" if bridge_running else "not running"
+            sym = "*" if bridge_running else "-"
+            print(f"  {sym} {'rns_bridge':<18} {bridge_status}")
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Bridge process check failed: %s", e)
+            print(f"  ? {'rns_bridge':<18} unknown")
+
+        if warnings:
+            print(f"\n  Warning: {', '.join(warnings)} running but won't start on reboot.")
+            print(f"  Fix: sudo systemctl enable {' '.join(warnings)}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_node_list(self):
+        """Quick: show meshtastic node list."""
+        clear_screen()
+        print("=== Node List ===\n")
+        try:
+            cli_path = self.ctx.get_meshtastic_cli()
+            subprocess.run(
+                [cli_path, '--nodes'],
+                timeout=30
+            )
+        except FileNotFoundError:
+            print("Error: 'meshtastic' CLI not installed.")
+            print("Install with: pipx install meshtastic[cli]")
+        except subprocess.TimeoutExpired:
+            print("Error: Command timed out. Is meshtasticd running?")
+        except Exception as e:
+            print(f"Error: {e}")
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_follow_logs(self):
+        """Quick: follow meshtasticd journal logs."""
+        clear_screen()
+        print("=== meshtasticd Logs (Ctrl+C to stop, auto-exits after 2 min) ===\n")
+        try:
+            subprocess.run(
+                ['journalctl', '-fu', 'meshtasticd', '--no-pager', '-n', '50'],
+                timeout=120
+            )
+        except subprocess.TimeoutExpired:
+            pass
+        except KeyboardInterrupt:
+            pass
+        except Exception as e:
+            print(f"Error: {e}")
+            self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_restart_meshtasticd(self):
+        """Quick: restart meshtasticd service."""
+        clear_screen()
+        print("Restarting meshtasticd...\n")
+        try:
+            success, msg = apply_config_and_restart('meshtasticd')
+            print(msg)
+            subprocess.run(
+                ['systemctl', 'status', 'meshtasticd', '--no-pager', '-l'],
+                timeout=10
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if self.ctx.status_bar:
+            self.ctx.status_bar.invalidate()
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_restart_rnsd(self):
+        """Quick: restart rnsd service."""
+        clear_screen()
+        print("Restarting rnsd...\n")
+        try:
+            success, msg = restart_service('rnsd')
+            print(msg)
+            subprocess.run(
+                ['systemctl', 'status', 'rnsd', '--no-pager', '-l'],
+                timeout=10
+            )
+        except Exception as e:
+            print(f"Error: {e}")
+
+        if self.ctx.status_bar:
+            self.ctx.status_bar.invalidate()
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_port_check(self):
+        """Quick: check network ports."""
+        clear_screen()
+        print("=== Port Check ===\n")
+
+        ports = [
+            (4403, 'meshtasticd TCP API'),
+            (9443, 'meshtasticd Web Client'),
+            (37428, 'rnsd (RNS shared instance)'),
+            (1883, 'MQTT broker'),
+        ]
+
+        _rns_port = 37428
+
+        for port, desc in ports:
+            try:
+                if port == _rns_port:
+                    port_open = check_rns_shared_instance()
+                else:
+                    port_open = check_port(port, host='127.0.0.1', timeout=1.0)
+
+                if port_open:
+                    print(f"  * {port:<6} {desc}")
+                else:
+                    print(f"  - {port:<6} {desc} (not listening)")
+            except (OSError, ValueError) as e:
+                logger.debug("Port %d check failed: %s", port, e)
+                print(f"  ? {port:<6} {desc} (check failed)")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_generate_report(self):
+        """Quick: generate and display a status report."""
+        clear_screen()
+        print("Generating status report...\n")
+
+        try:
+            report = generate_report()
+            lines = report.split('\n')
+            for i, line in enumerate(lines):
+                print(line)
+                if (i + 1) % 40 == 0 and i + 1 < len(lines):
+                    try:
+                        resp = input("\n--- More (Enter=continue, q=quit) ---\n")
+                    except (KeyboardInterrupt, EOFError):
+                        print()
+                        break
+                    if resp.strip().lower() == 'q':
+                        break
+        except Exception as e:
+            print(f"Error generating report: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_node_inventory(self):
+        """Quick: show tracked node inventory."""
+        clear_screen()
+        print("=== Node Inventory ===\n")
+
+        try:
+            from utils.paths import get_real_user_home
+
+            path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+            inv = NodeInventory(path=path)
+
+            stats = inv.get_stats()
+            print(f"  Total nodes:    {stats['total']}")
+            print(f"  Online:         {stats['online']}")
+            print(f"  Offline:        {stats['offline']}")
+            print(f"  Stale (>7d):    {stats['stale']}")
+            print(f"  With position:  {stats['with_position']}")
+
+            if stats['total'] > 0:
+                nodes = [n for n in inv.get_all_nodes() if not n.is_stale]
+                if nodes:
+                    print(f"\n  {'ID':<12} {'Name':<20} {'Status':<8} {'SNR':>5}  {'Hardware'}")
+                    print(f"  {'-'*12} {'-'*20} {'-'*8} {'-'*5}  {'-'*12}")
+                    for node in nodes[:25]:
+                        name = node.display_name[:20]
+                        nid = node.node_id[:12]
+                        status = node.status
+                        snr = f"{node.last_snr:.1f}" if node.last_snr is not None else "  -"
+                        hw = node.hardware[:12] if node.hardware else "-"
+                        print(f"  {nid:<12} {name:<20} {status:<8} {snr:>5}  {hw}")
+                    if len(nodes) > 25:
+                        print(f"\n  ... and {len(nodes) - 25} more nodes")
+
+                if stats['roles']:
+                    roles_str = ", ".join(f"{r}: {c}" for r, c in stats['roles'].items())
+                    print(f"\n  Roles: {roles_str}")
+            else:
+                print("\n  No nodes tracked yet.")
+                print("  Nodes are added when received via MQTT or meshtastic CLI.")
+
+        except Exception as e:
+            logger.debug(f"Node inventory quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_gps_position(self):
+        """Quick: show GPS position and distance to nodes."""
+        clear_screen()
+        print("=== GPS Position ===\n")
+
+        try:
+            from utils.paths import get_real_user_home
+
+            config_path = get_real_user_home() / ".config" / "meshforge" / "operator_position.json"
+            gps = GPSManager(config_path=config_path)
+
+            nodes = []
+            try:
+                from utils.node_inventory import NodeInventory as _NodeInv
+                inv_path = get_real_user_home() / ".config" / "meshforge" / "node_inventory.json"
+                inv = _NodeInv(path=inv_path)
+                for node in inv.get_all_nodes():
+                    if node.has_position:
+                        nodes.append({
+                            'id': node.node_id,
+                            'name': node.display_name,
+                            'lat': node.lat,
+                            'lon': node.lon,
+                        })
+            except Exception as e:
+                logger.debug("Node inventory for GPS report unavailable: %s", e)
+
+            report = gps.format_position_report(nodes=nodes if nodes else None)
+            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+
+            print()
+            if gps.gpsd_available:
+                print("  gpsd: connected")
+            else:
+                print("  gpsd: not available")
+                if not gps.has_position:
+                    print("  Tip: Set position manually in Tools > GPS")
+
+        except Exception as e:
+            logger.debug(f"GPS quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_run_diagnostics(self):
+        """Quick: run diagnostic engine health check."""
+        clear_screen()
+        print("=== Diagnostic Health Check ===\n")
+
+        try:
+            engine = get_diagnostic_engine()
+            summary = engine.get_health_summary()
+
+            print(f"  Overall Health:    {summary['overall_health']}")
+            print(f"  Symptoms (1h):     {summary['symptoms_last_hour']}")
+            print(f"  Total Diagnoses:   {summary['stats'].get('diagnoses_made', 0)}")
+            print(f"  Auto-Recoveries:   {summary['stats'].get('auto_recoveries', 0)}")
+            print(f"  Rules Loaded:      {summary['stats'].get('rules_loaded', 0)}")
+
+            recent = engine.get_recent_diagnoses(limit=5)
+            if recent:
+                print(f"\n  Recent Issues ({len(recent)}):")
+                for d in recent[-5:]:
+                    cat = d.symptom.category.value
+                    print(f"    [{cat}] {d.likely_cause[:60]}")
+            else:
+                print("\n  No recent issues detected.")
+
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_channel_scan(self):
+        """Quick: show channel activity scan."""
+        clear_screen()
+        print("=== Channel Activity ===\n")
+
+        try:
+            monitor = ChannelMonitor()
+
+            channels = monitor.query_device_channels()
+            if not channels:
+                print("  (Could not query device channels)")
+                print("  Showing activity from MQTT monitoring only.")
+                print()
+
+            report = monitor.get_activity_report()
+            print(f"  {report.replace(chr(10), chr(10) + '  ')}")
+
+        except Exception as e:
+            logger.debug(f"Channel scan quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_space_weather(self):
+        """Quick: show space weather snapshot."""
+        clear_screen()
+        print("=== Space Weather ===\n")
+
+        try:
+            from commands import propagation as prop_mod
+
+            result = prop_mod.get_space_weather()
+            if not result.success:
+                print(f"  Could not fetch data: {result.message}")
+                self.ctx.wait_for_enter("Press Enter to continue...")
+                return
+
+            d = result.data
+            print(f"  Solar Flux (SFI):  {d.get('solar_flux', 'N/A')} SFU")
+            print(f"  Kp Index:          {d.get('k_index', 'N/A')}")
+            print(f"  A Index:           {d.get('a_index', 'N/A')}")
+            print(f"  X-ray:             {d.get('xray_flux', 'N/A')}")
+            print(f"  Geomagnetic:       {d.get('geomag_storm', 'Quiet')}")
+
+            bands = d.get('band_conditions', {})
+            if bands:
+                print(f"\n  HF Band Conditions:")
+                for band, cond in bands.items():
+                    print(f"    {band:<12s} {cond}")
+
+            print(f"\n  Source: {d.get('source', 'NOAA SWPC')}")
+
+        except Exception as e:
+            logger.debug(f"Space weather quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_check_updates(self):
+        """Quick: check for available software updates."""
+        clear_screen()
+        print("=== Software Update Check ===\n")
+
+        try:
+            from utils.safe_import import safe_import
+            _check_all_versions, _VersionInfo, _has = safe_import(
+                'updates.version_checker', 'check_all_versions', 'VersionInfo'
+            )
+            if not _has:
+                print("  Version checker not available.")
+                print("  Ensure updates/version_checker.py exists.")
+                self.ctx.wait_for_enter("Press Enter to continue...")
+                return
+
+            print("  Checking versions...\n")
+            versions = _check_all_versions()
+
+            updates_count = 0
+            for key, info in versions.items():
+                installed = info.installed or "Not installed"
+                latest = info.latest or "Unknown"
+                flag = ""
+                if info.update_available:
+                    flag = " << UPDATE AVAILABLE"
+                    updates_count += 1
+                print(f"  {info.name:<25s} {installed:<12s} -> {latest}{flag}")
+
+            print(f"\n  {'=' * 50}")
+            if updates_count:
+                print(f"  {updates_count} update(s) available!")
+                print("  Go to: Configuration > Software Updates")
+            else:
+                print("  All components up to date!")
+
+        except Exception as e:
+            logger.debug(f"Update check quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")
+
+    def _qa_coverage_map(self):
+        """Quick: generate and open a coverage map."""
+        clear_screen()
+        print("=== Coverage Map ===\n")
+
+        try:
+            # Try to find the coverage map method via the registry
+            # (it lives in the maps/ai_tools handler, dispatched via maps_viz section)
+            if self.ctx.registry:
+                if self.ctx.registry.dispatch("maps_viz", "coverage"):
+                    return
+            print("  Coverage map generation not available.")
+            print("  Ensure folium is installed: pip install folium")
+        except Exception as e:
+            logger.debug(f"Coverage map quick action failed: {e}")
+            print(f"Error: {e}")
+
+        print()
+        self.ctx.wait_for_enter("Press Enter to continue...")

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -911,6 +911,10 @@ class MeshForgeLauncher(
         exceptions in any mixin show a user-friendly error dialog
         instead of crashing the TUI.
         """
+        # Try registry-based dispatch for main-menu handlers (Batch 4+)
+        if self._registry.dispatch("main", choice):
+            return
+
         dispatch = {
             "1": ("Dashboard", self._dashboard_menu),
             "2": ("Mesh Networks", self._mesh_networks_menu),
@@ -919,8 +923,6 @@ class MeshForgeLauncher(
             "5": ("Configuration", self._configuration_menu),
             "6": ("System Tools", self._system_menu),
             "t": ("Tactical Ops", self._tactical_ops_menu),
-            "q": ("Quick Actions", self._quick_actions_menu),
-            "e": ("Emergency Mode", self._emergency_mode),
             "a": ("About", self._about_menu),
         }
         entry = dispatch.get(choice)
@@ -935,18 +937,11 @@ class MeshForgeLauncher(
         _ORDERING = ["status", "weather", "network", "nodes", "health", "score",
                       "datapath", "metrics", "analytics", "latency", "reports", "alerts"]
         while True:
-            # Legacy items — removed automatically as handlers take over their tags
+            # Legacy items — most now handled by DashboardHandler (Batch 4)
             legacy = [
-                ("status", "Service Status      All services with health"),
-                ("weather", "Space Weather       SFI, Kp, bands at a glance"),
                 ("network", "Network Status      Ports, interfaces, conflicts"),
-                ("nodes", "Node Count          Meshtastic + RNS nodes"),
                 ("health", "Node Health         Battery, signal, latency"),
-                ("score", "Health Score        Network health snapshot"),
-                ("datapath", "Data Path Check     Test all data sources"),
                 ("metrics", "Historical Trends   Metrics over time"),
-                ("reports", "Reports             Generate status report"),
-                ("alerts", "View Alerts         Current warnings"),
             ]
             choices = self._build_section_menu("dashboard", legacy, _ORDERING)
 
@@ -963,66 +958,13 @@ class MeshForgeLauncher(
             if self._registry.dispatch("dashboard", choice):
                 continue
 
-            # Legacy mixin dispatch (not yet converted)
+            # Legacy mixin dispatch (network still routes via mixin)
             dispatch = {
-                "status": ("Service Status", self._service_status_display),
-                "weather": ("Space Weather", self._dashboard_space_weather),
                 "network": ("Network Status", self._network_menu),
-                "nodes": ("Node Count", self._show_node_counts),
-                "score": ("Health Score", self._health_score_display),
-                "datapath": ("Data Path Check", self._data_path_diagnostic),
-                "reports": ("Reports", self._reports_menu),
-                "alerts": ("View Alerts", self._show_alerts),
             }
             entry = dispatch.get(choice)
             if entry:
                 self._safe_call(*entry)
-
-    def _dashboard_space_weather(self):
-        """Quick-look space weather for the Dashboard.
-
-        Shows a compact summary with SFI, Kp, band conditions, and
-        a link to the full propagation suite under RF & SDR.
-        """
-        from commands import propagation as prop_mod
-
-        result = prop_mod.get_space_weather()
-        if not result.success:
-            self.dialog.msgbox(
-                "Space Weather",
-                f"Could not fetch space weather data:\n{result.message}\n\n"
-                "Ensure internet connectivity is available.\n"
-                "NOAA SWPC is the primary data source."
-            )
-            return
-
-        d = result.data
-        lines = [
-            "SPACE WEATHER SNAPSHOT",
-            "=" * 40,
-            "",
-            f"Solar Flux (SFI):  {d.get('solar_flux', 'N/A')} SFU",
-            f"Kp Index:          {d.get('k_index', 'N/A')}",
-            f"A Index:           {d.get('a_index', 'N/A')}",
-            f"X-ray Flux:        {d.get('xray_flux', 'N/A')}",
-            f"Geomagnetic:       {d.get('geomag_storm', 'Quiet')}",
-            "",
-        ]
-
-        # Band conditions
-        bands = d.get('band_conditions', {})
-        if bands:
-            lines.append("HF BAND CONDITIONS")
-            lines.append("-" * 40)
-            for band, cond in bands.items():
-                lines.append(f"  {band:<12s} {cond}")
-            lines.append("")
-
-        lines.append("-" * 40)
-        lines.append("Full propagation tools: RF & SDR > Space Weather")
-        lines.append(f"Source: {d.get('source', 'NOAA SWPC')}")
-
-        self.dialog.msgbox("Space Weather", "\n".join(lines), width=50, height=22)
 
     # --- Submenu: Mesh Networks (2) ---
 

--- a/tests/test_phase1_handlers.py
+++ b/tests/test_phase1_handlers.py
@@ -325,5 +325,5 @@ class TestRegistryDispatchIntegration:
 
     def test_unknown_tag_falls_through(self):
         registry = self._make_registry()
-        # "status" is NOT a registry handler yet — it's still a mixin
-        assert registry.dispatch("dashboard", "status") is False
+        # "nonexistent" is not registered anywhere — should fall through
+        assert registry.dispatch("dashboard", "nonexistent") is False


### PR DESCRIPTION
- DashboardHandler: status, weather, nodes, score, datapath, reports, alerts (7 tags migrated from dashboard_mixin + _dashboard_space_weather moved from main.py)
- QuickActionsHandler: quick actions submenu (14 shortcuts) migrated from quick_actions_mixin, dispatched from main menu via "main" section
- EmergencyModeHandler: EMCOMM field ops (7 actions) migrated from emergency_mode_mixin, dispatched from main menu via "main" section
- Remove _dashboard_space_weather from main.py (now in DashboardHandler)
- Update dashboard legacy dispatch to only keep "network" tag
- Add registry dispatch to _handle_main_choice for top-level handlers
- Fix test: update test_unknown_tag_falls_through for new "status" tag

30 handlers registered, 19 remaining. Dashboard section nearly complete (only "network" tag still in legacy dispatch, handled by NetworkToolsHandler in a different section).

https://claude.ai/code/session_01Djg9CR3sUuVDzgviiSGT5s