### PR TITLE
Migrate Batch 8 mixins to handler registry (AI, system, chat, nomad, setup)

### DIFF
--- a/src/launcher_tui/handlers/__init__.py
+++ b/src/launcher_tui/handlers/__init__.py
@@ -139,4 +139,20 @@ def get_all_handlers() -> List[Type]:
         WebClientHandler,
     ])
 
+    # Batch 8 — AI tools, system tools, MeshChat, NomadNet, first run
+    from handlers.ai_tools import AIToolsHandler
+    from handlers.auto_review import AutoReviewHandler
+    from handlers.system_tools import SystemToolsHandler
+    from handlers.meshchat import MeshChatHandler
+    from handlers.nomadnet import NomadNetHandler
+    from handlers.first_run import FirstRunHandler
+    handlers.extend([
+        AIToolsHandler,
+        AutoReviewHandler,
+        SystemToolsHandler,
+        MeshChatHandler,
+        NomadNetHandler,
+        FirstRunHandler,
+    ])
+
     return handlers

--- a/src/launcher_tui/handlers/_lxmf_utils.py
+++ b/src/launcher_tui/handlers/_lxmf_utils.py
@@ -1,0 +1,121 @@
+"""
+LXMF Exclusivity Utility — Shared between MeshChat and NomadNet handlers.
+
+MeshChat and NomadNet both use LXMF and can conflict on port 37428
+when connecting to rnsd.  Only one should run at a time.
+
+Extracted from meshchat_client_mixin.py as part of the Batch 8 migration.
+"""
+
+import subprocess
+import time
+from typing import Callable, Optional
+
+from utils.safe_import import safe_import
+
+check_process_running, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running'
+)
+
+MESHCHAT_SERVICE_NAME = "reticulum-meshchat"
+
+
+def ensure_lxmf_exclusive(
+    dialog,
+    starting_app: str,
+    is_meshchat_running_fn: Optional[Callable[[], bool]] = None,
+) -> bool:
+    """Ensure only one LXMF app runs at a time.
+
+    Args:
+        dialog: DialogBackend instance for user prompts.
+        starting_app: ``"meshchat"`` or ``"nomadnet"``.
+        is_meshchat_running_fn: Optional callable returning True when MeshChat
+            is running.  If *None*, a pgrep fallback is used.
+
+    Returns:
+        True if OK to proceed, False if the user cancelled.
+    """
+    if starting_app == "meshchat":
+        # Check if NomadNet is running
+        nomadnet_running = False
+        if _HAS_SERVICE_CHECK and check_process_running:
+            nomadnet_running = check_process_running('nomadnet')
+        if not nomadnet_running:
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'bin/nomadnet'],
+                    capture_output=True, text=True, timeout=5,
+                )
+                nomadnet_running = (
+                    result.returncode == 0 and
+                    bool(result.stdout.strip())
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        if nomadnet_running:
+            if not dialog.yesno(
+                "NomadNet Running",
+                "NomadNet is currently running.\n\n"
+                "Only one LXMF app should run at a time\n"
+                "to avoid port 37428 conflicts.\n\n"
+                "Stop NomadNet and start MeshChat?",
+            ):
+                return False
+            # Stop NomadNet
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'bin/nomadnet'],
+                    capture_output=True, timeout=10,
+                )
+                time.sleep(2)
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+    elif starting_app == "nomadnet":
+        # Check if MeshChat is running
+        meshchat_running = False
+        if is_meshchat_running_fn is not None:
+            meshchat_running = is_meshchat_running_fn()
+        else:
+            # Fallback: pgrep
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-f', 'meshchat.py'],
+                    capture_output=True, text=True, timeout=5,
+                )
+                meshchat_running = (
+                    result.returncode == 0 and
+                    bool(result.stdout.strip())
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        if meshchat_running:
+            if not dialog.yesno(
+                "MeshChat Running",
+                "MeshChat is currently running.\n\n"
+                "Only one LXMF app should run at a time\n"
+                "to avoid port 37428 conflicts.\n\n"
+                "Stop MeshChat and start NomadNet?",
+            ):
+                return False
+            # Stop MeshChat
+            try:
+                subprocess.run(
+                    ['systemctl', 'stop', MESHCHAT_SERVICE_NAME],
+                    capture_output=True, timeout=15,
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'meshchat.py'],
+                    capture_output=True, timeout=5,
+                )
+            except (subprocess.SubprocessError, OSError):
+                pass
+            time.sleep(2)
+
+    return True

--- a/src/launcher_tui/handlers/ai_tools.py
+++ b/src/launcher_tui/handlers/ai_tools.py
@@ -1,0 +1,1298 @@
+"""
+AI Tools Handler — Maps, coverage, diagnostics, knowledge base, Claude assistant.
+
+Converted from ai_tools_mixin.py as part of the mixin-to-registry migration (Batch 8).
+
+Provides:
+- Live NOC Map (browser snapshot + HTTP server + auto-start)
+- Coverage Map generation (all sources, meshtasticd, MQTT, file)
+- Node density heatmap
+- Offline tile caching
+- Intelligent diagnostics (rule-based symptom analysis)
+- Knowledge base queries
+- Claude Assistant (Standalone + PRO)
+
+Implements LifecycleHandler for on_startup (auto-start map server).
+"""
+
+import json
+import logging
+import os
+import socket
+import subprocess
+import threading
+import time
+import webbrowser
+from pathlib import Path
+from typing import Optional
+
+from handler_protocol import BaseHandler
+from utils.safe_import import safe_import
+
+# --- Optional dependencies (safe_import returns (*attrs, available_bool)) ---
+diagnose, Category, Severity, _HAS_DIAGNOSTICS = safe_import(
+    'utils.diagnostic_engine', 'diagnose', 'Category', 'Severity'
+)
+get_knowledge_base, _HAS_KNOWLEDGE = safe_import(
+    'utils.knowledge_base', 'get_knowledge_base'
+)
+ClaudeAssistant, _HAS_ASSISTANT = safe_import(
+    'utils.claude_assistant', 'ClaudeAssistant'
+)
+CoverageMapGenerator, MapNode, _HAS_COVERAGE_MAP = safe_import(
+    'utils.coverage_map', 'CoverageMapGenerator', 'MapNode'
+)
+MapDataCollector, get_all_ips, _HAS_MAP_SERVICE = safe_import(
+    'utils.map_data_service', 'MapDataCollector', 'get_all_ips'
+)
+TileCache, HAWAII_BOUNDS, _HAS_TILE_CACHE = safe_import(
+    'utils.tile_cache', 'TileCache', 'HAWAII_BOUNDS'
+)
+
+# Import service helpers for privileged systemctl calls
+from utils.service_check import _sudo_cmd, start_service
+
+logger = logging.getLogger(__name__)
+
+
+class AIToolsHandler(BaseHandler):
+    """TUI handler for maps, coverage, diagnostics, knowledge base, and Claude assistant."""
+
+    handler_id = "ai_tools"
+    menu_section = "maps_viz"
+
+    def menu_items(self):
+        return [
+            ("livemap",   "Live NOC Map        Real-time browser view", None),
+            ("coverage",  "Coverage Map        Generate coverage map",  None),
+            ("heatmap",   "Heatmap             Node density heatmap",   None),
+            ("tiles",     "Offline Tiles       Cache map tiles",        None),
+            ("ai",        "AI Diagnostics      Knowledge base, assistant", None),
+        ]
+
+    def execute(self, action):
+        dispatch = {
+            "livemap": ("Live NOC Map", self._open_live_map),
+            "coverage": ("Coverage Map", self._generate_coverage_map),
+            "heatmap": ("Heatmap", self._generate_heatmap),
+            "tiles": ("Offline Tile Cache", self._tile_cache_menu),
+            "ai": ("AI Diagnostics", self._ai_tools_menu),
+        }
+        entry = dispatch.get(action)
+        if entry:
+            self.ctx.safe_call(*entry)
+
+    # -- Lifecycle hooks (LifecycleHandler protocol) --
+
+    def on_startup(self):
+        """Start map server on TUI launch if user has enabled auto-open."""
+        self._maybe_auto_start_map()
+
+    # =========================================================================
+    # AI Tools sub-menu
+    # =========================================================================
+
+    def _ai_tools_menu(self):
+        """Maps and coverage tools menu."""
+        choices = [
+            ("livemap", "Live Network Map"),
+            ("coverage", "Generate Coverage Map (All Sources)"),
+            ("diagnose", "Intelligent Diagnostics"),
+            ("knowledge", "Knowledge Base Query"),
+            ("assistant", "Claude Assistant"),
+            ("back", "Back"),
+        ]
+
+        while True:
+            choice = self.ctx.dialog.menu(
+                "Maps & Coverage",
+                "Network mapping and analysis tools:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "livemap": ("Live Network Map", self._open_live_map),
+                "diagnose": ("Intelligent Diagnostics", self._intelligent_diagnostics),
+                "knowledge": ("Knowledge Base Query", self._knowledge_base_query),
+                "assistant": ("Claude Assistant", self._claude_assistant),
+                "coverage": ("Coverage Map", self._generate_coverage_map),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    # =========================================================================
+    # Map auto-start (LifecycleHandler)
+    # =========================================================================
+
+    def _maybe_auto_start_map(self):
+        """Start map server on TUI launch if user has enabled auto-open.
+
+        Prefers systemd service (meshforge-map) for reliability.
+        Falls back to in-process server if systemd unavailable.
+        """
+        settings_file = self._get_map_settings_file()
+        if not settings_file.exists():
+            return
+
+        try:
+            with open(settings_file) as f:
+                settings = json.load(f)
+        except (json.JSONDecodeError, OSError):
+            return
+
+        if not settings.get("auto_open_map", False):
+            return
+
+        # Check if server already running (port 5000)
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            result = sock.connect_ex(('localhost', 5000))
+            sock.close()
+            if result == 0:
+                return  # Already running
+        except OSError:
+            pass
+
+        # Try to start via systemd service first (preferred for reliability)
+        if self._try_start_map_service_quiet():
+            return  # Successfully started via systemd
+
+        # Fall back to in-process server (non-systemd environments)
+        # Suppress console output to prevent TUI corruption, keep file logging
+        try:
+            from contextlib import redirect_stdout, redirect_stderr
+            from io import StringIO
+
+            root_logger = logging.getLogger()
+            old_handler_levels = []
+            for handler in root_logger.handlers:
+                if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
+                    old_handler_levels.append((handler, handler.level))
+                    handler.setLevel(logging.CRITICAL + 1)
+
+            try:
+                with redirect_stdout(StringIO()), redirect_stderr(StringIO()):
+                    from utils.map_data_service import MapServer
+                    server = MapServer(port=5000)
+                    server.start_background()
+            finally:
+                for handler, level in old_handler_levels:
+                    handler.setLevel(level)
+
+            self._map_server = server
+        except Exception as e:
+            logger.warning("Map server auto-start failed: %s", e)
+
+    def _try_start_map_service_quiet(self) -> bool:
+        """Try to start map server via systemd (quiet, no TUI output).
+
+        Returns True if service started successfully.
+        """
+        try:
+            # Check if systemd is available
+            result = subprocess.run(
+                ['systemctl', 'is-enabled', 'meshforge-map'],
+                capture_output=True, timeout=5
+            )
+            if result.returncode != 0:
+                return False  # Service not installed
+
+            # Start the service
+            start_service('meshforge-map')
+
+            # Wait briefly for service to start
+            for _ in range(5):
+                time.sleep(0.5)
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(1)
+                    result = sock.connect_ex(('localhost', 5000))
+                    sock.close()
+                    if result == 0:
+                        return True
+                except OSError:
+                    pass
+
+            return False
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Map systemd service start failed: %s", e)
+            return False
+
+    def _get_map_settings_file(self) -> Path:
+        """Get the map settings file path."""
+        from utils.paths import get_real_user_home
+        config_dir = get_real_user_home() / ".config" / "meshforge"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        return config_dir / "map_settings.json"
+
+    # =========================================================================
+    # Live Map
+    # =========================================================================
+
+    def _open_live_map(self):
+        """Open the live network map with real node data."""
+        while True:
+            # Check current auto-open setting (refresh each loop)
+            auto_enabled = False
+            settings_file = self._get_map_settings_file()
+            if settings_file.exists():
+                try:
+                    with open(settings_file) as f:
+                        auto_enabled = json.load(f).get("auto_open_map", False)
+                except (json.JSONDecodeError, OSError):
+                    pass
+
+            auto_label = "ON" if auto_enabled else "OFF"
+            choices = [
+                ("browser", "Open map in browser (snapshot)"),
+                ("server", "Start map server (live updates)"),
+                ("autostart", f"Auto-open on launch [{auto_label}]"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Live Network Map",
+                "Select map mode:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "browser": ("Browser Map Snapshot", self._open_live_map_browser),
+                "server": ("Map Server", self._start_map_server),
+                "autostart": ("Toggle Auto-open", self._toggle_auto_map),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _open_live_map_browser(self):
+        """Generate browser snapshot of the live map with current node data."""
+        # Browser mode: collect data, inject into HTML, open
+        self.ctx.dialog.infobox("Loading", "Collecting node data from all sources...")
+
+        try:
+            from utils.map_data_service import MapDataCollector
+
+            collector = MapDataCollector()
+            geojson = collector.collect()
+            node_count = len(geojson.get("features", []))
+            sources = geojson.get("properties", {}).get("sources", {})
+
+            # Find the map template
+            src_dir = Path(__file__).parent.parent.parent
+            map_template = src_dir / "web" / "node_map.html"
+
+            if not map_template.exists():
+                self.ctx.dialog.msgbox(
+                    "Map Not Found",
+                    f"Map template not found at:\n{map_template}"
+                )
+                return
+
+            # Read template and inject data
+            with open(map_template, 'r') as f:
+                html_content = f.read()
+
+            if node_count > 0:
+                geojson_str = json.dumps(geojson)
+                inject_script = (
+                    f'\n<script>\n'
+                    f'// MeshForge: {node_count} nodes from '
+                    f'meshtasticd({sources.get("meshtasticd", 0)}) '
+                    f'mqtt({sources.get("mqtt", 0)}) '
+                    f'tracker({sources.get("node_tracker", 0)})\n'
+                    f'window.meshforgeData = {geojson_str};\n'
+                    f'</script>\n</body>'
+                )
+                html_content = html_content.replace('</body>', inject_script)
+
+            # Write to user-accessible location
+            from utils.paths import get_real_user_home
+            output_dir = get_real_user_home() / ".local" / "share" / "meshforge"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_file = output_dir / "live_map.html"
+
+            with open(output_file, 'w') as f:
+                f.write(html_content)
+
+            # Build detailed source breakdown
+            source_info = []
+            source_info.append(f"meshtasticd: {sources.get('meshtasticd', 0)}")
+            source_info.append(f"MQTT: {sources.get('mqtt', 0)}")
+            source_info.append(f"node_tracker: {sources.get('node_tracker', 0)}")
+
+            msg = (
+                f"Map saved: {output_file}\n\n"
+                f"Total nodes: {node_count}\n"
+                f"Sources:\n  " + "\n  ".join(source_info) + "\n\n"
+                "Opening in browser..."
+            )
+            self.ctx.dialog.msgbox("Live Map", msg)
+            self._open_in_browser(f"file://{output_file}")
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to generate live map: {e}")
+
+    def _is_headless(self) -> bool:
+        """Check if running without a display (headless/SSH)."""
+        display = os.environ.get('DISPLAY')
+        wayland = os.environ.get('WAYLAND_DISPLAY')
+        ssh = os.environ.get('SSH_CONNECTION')
+        return (not display and not wayland) or bool(ssh)
+
+    def _start_map_server(self):
+        """Start the map HTTP server for live-updating browser access.
+
+        Prefers systemd service (meshforge-map) for reliability.
+        Falls back to in-process server if systemd unavailable.
+        """
+        port = 5000
+
+        # Get all available IPs for display
+        from utils.map_data_service import get_all_ips
+        all_ips = get_all_ips()
+
+        # Check if port is already in use
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.settimeout(1)
+            result = sock.connect_ex(('127.0.0.1', port))
+            sock.close()
+            if result == 0:
+                urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
+                service_status = self._get_map_service_status()
+                self.ctx.dialog.msgbox(
+                    "Map Server",
+                    f"Map server already running!\n\n"
+                    f"Access via:\n{urls}\n\n"
+                    f"Service: {service_status}\n\n"
+                    "Open any URL in your browser.\n"
+                    "The map auto-refreshes every 30 seconds."
+                )
+                return
+        except OSError:
+            pass
+
+        # Try systemd service first (preferred for reliability)
+        service_started = self._try_start_map_service()
+
+        if service_started:
+            urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
+            self.ctx.dialog.msgbox(
+                "Map Server Started",
+                f"Map server running as system service!\n\n"
+                f"Access via:\n{urls}\n\n"
+                "Open any URL in your browser.\n"
+                "The map pulls fresh data every 30 seconds.\n\n"
+                "Service persists after TUI exits.\n"
+                "Manage with: meshforge-map start|stop|status"
+            )
+            return
+
+        # Fall back to in-process server
+        try:
+            from contextlib import redirect_stdout, redirect_stderr
+            from io import StringIO
+
+            captured_out = StringIO()
+            captured_err = StringIO()
+
+            root_logger = logging.getLogger()
+            old_handler_levels = []
+            for handler in root_logger.handlers:
+                if isinstance(handler, logging.StreamHandler) and not isinstance(handler, logging.FileHandler):
+                    old_handler_levels.append((handler, handler.level))
+                    handler.setLevel(logging.CRITICAL + 1)
+
+            try:
+                with redirect_stdout(captured_out), redirect_stderr(captured_err):
+                    from utils.map_data_service import MapServer
+
+                    server = MapServer(port=port)  # Binds to 0.0.0.0
+                    server.start_background()
+
+                    time.sleep(0.1)
+            finally:
+                for handler, level in old_handler_levels:
+                    handler.setLevel(level)
+
+            self._map_server = server
+
+            urls = "\n".join(f"  http://{ip}:{port}" for ip in all_ips)
+            msg = (
+                f"Live map server running (in-process)!\n\n"
+                f"Access via:\n{urls}\n\n"
+                "Open any URL in your browser.\n"
+                "The map pulls fresh data every 30 seconds.\n"
+                "Server runs until MeshForge exits.\n\n"
+                "Tip: Install meshforge-map service for\n"
+                "persistent operation."
+            )
+            self.ctx.dialog.msgbox("Map Server Started", msg)
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to start map server: {e}")
+
+    def _try_start_map_service(self) -> bool:
+        """Try to start map server via systemd service.
+
+        Returns True if service started successfully.
+        """
+        try:
+            # Check if systemd service is available
+            result = subprocess.run(
+                ['systemctl', 'is-enabled', 'meshforge-map'],
+                capture_output=True, timeout=5
+            )
+            if result.returncode != 0:
+                return False  # Service not installed
+
+            # Start the service
+            start_service('meshforge-map')
+
+            # Wait for service to start (up to 3 seconds)
+            for _ in range(6):
+                time.sleep(0.5)
+                try:
+                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    sock.settimeout(1)
+                    result = sock.connect_ex(('localhost', 5000))
+                    sock.close()
+                    if result == 0:
+                        return True
+                except OSError:
+                    pass
+
+            return False
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Map service restart failed: %s", e)
+            return False
+
+    def _get_map_service_status(self) -> str:
+        """Get map server service status for display."""
+        try:
+            result = subprocess.run(
+                ['systemctl', 'is-active', 'meshforge-map'],
+                capture_output=True, text=True, timeout=5
+            )
+            status = result.stdout.strip()
+            if status == "active":
+                return "systemd service (active)"
+            elif result.returncode != 0:
+                return "in-process (TUI)"
+            return f"systemd ({status})"
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Map service status check failed: %s", e)
+            return "in-process (TUI)"
+
+    def _toggle_auto_map(self):
+        """Toggle the auto-open map on launch setting."""
+        settings_file = self._get_map_settings_file()
+        settings = {}
+
+        if settings_file.exists():
+            try:
+                with open(settings_file) as f:
+                    settings = json.load(f)
+            except (json.JSONDecodeError, OSError):
+                pass
+
+        current = settings.get("auto_open_map", False)
+        settings["auto_open_map"] = not current
+
+        try:
+            with open(settings_file, 'w') as f:
+                json.dump(settings, f, indent=2)
+
+            state = "ENABLED" if settings["auto_open_map"] else "DISABLED"
+            msg = (
+                f"Auto-open map: {state}\n\n"
+            )
+            if settings["auto_open_map"]:
+                from utils.map_data_service import get_all_ips
+                ips = get_all_ips()
+                urls = ", ".join(f"http://{ip}:5000" for ip in ips[:2])
+                if len(ips) > 2:
+                    urls += ", ..."
+                msg += (
+                    "The map server will start automatically\n"
+                    "when MeshForge launches.\n\n"
+                    f"Access at: {urls}"
+                )
+            else:
+                msg += "Map server will not start automatically."
+
+            self.ctx.dialog.msgbox("Map Settings", msg)
+        except OSError as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to save setting: {e}")
+
+        # Return to caller — _open_live_map loop will re-show menu
+
+    # =========================================================================
+    # Intelligent Diagnostics
+    # =========================================================================
+
+    def _intelligent_diagnostics(self):
+        """Run intelligent diagnostics with symptom analysis."""
+        # Common symptoms to diagnose
+        symptom_choices = [
+            ("connection", "Connection refused to meshtasticd"),
+            ("no_nodes", "No nodes visible in mesh"),
+            ("weak_signal", "Weak signal / low SNR"),
+            ("timeout", "Message timeouts"),
+            ("service", "Service not starting"),
+            ("custom", "Describe custom symptom"),
+            ("back", "Back"),
+        ]
+
+        while True:
+            choice = self.ctx.dialog.menu(
+                "Intelligent Diagnostics",
+                "Select a symptom to diagnose:",
+                symptom_choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            symptom_text = None
+            if choice == "custom":
+                symptom_text = self.ctx.dialog.inputbox(
+                    "Custom Symptom",
+                    "Describe the issue you're experiencing:"
+                )
+                if not symptom_text:
+                    continue
+            else:
+                # Map choice to symptom text
+                symptom_map = {
+                    "connection": "Connection refused to meshtasticd on port 4403",
+                    "no_nodes": "No nodes visible in mesh network",
+                    "weak_signal": "Weak signal with low SNR values",
+                    "timeout": "Message timeouts when sending",
+                    "service": "Service meshtasticd failed to start",
+                }
+                symptom_text = symptom_map.get(choice, choice)
+
+            self._run_diagnosis(symptom_text)
+
+    def _run_diagnosis(self, symptom: str):
+        """Run diagnosis on a symptom."""
+        self.ctx.dialog.infobox("Analyzing", f"Analyzing: {symptom[:40]}...")
+
+        if not _HAS_DIAGNOSTICS:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Diagnostic engine not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
+
+        try:
+            # Run diagnosis
+            diagnosis_result = diagnose(
+                symptom,
+                category=Category.CONNECTIVITY,
+                severity=Severity.ERROR
+            )
+
+            if diagnosis_result:
+                # Format diagnosis for display
+                result_lines = [
+                    f"SYMPTOM: {symptom}",
+                    "",
+                    f"LIKELY CAUSE:",
+                    f"  {diagnosis_result.likely_cause}",
+                    "",
+                    f"CONFIDENCE: {diagnosis_result.confidence:.0%}",
+                    "",
+                ]
+
+                if diagnosis_result.evidence:
+                    result_lines.append("EVIDENCE:")
+                    for ev in diagnosis_result.evidence[:3]:
+                        result_lines.append(f"  - {ev}")
+                    result_lines.append("")
+
+                if diagnosis_result.suggestions:
+                    result_lines.append("SUGGESTIONS:")
+                    for i, sug in enumerate(diagnosis_result.suggestions[:5], 1):
+                        result_lines.append(f"  {i}. {sug}")
+                    result_lines.append("")
+
+                if diagnosis_result.auto_recoverable:
+                    result_lines.append(f"AUTO-RECOVERY: {diagnosis_result.recovery_action}")
+
+                self.ctx.dialog.msgbox(
+                    "Diagnosis Result",
+                    "\n".join(result_lines)
+                )
+            else:
+                self.ctx.dialog.msgbox(
+                    "Diagnosis",
+                    f"No specific diagnosis found for:\n{symptom}\n\n"
+                    "Try the Knowledge Base for general information,\n"
+                    "or use Claude Assistant for detailed help."
+                )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Diagnosis failed: {e}")
+
+    # =========================================================================
+    # Knowledge Base
+    # =========================================================================
+
+    def _knowledge_base_query(self):
+        """Query the knowledge base for mesh networking concepts."""
+        # Common topics
+        topic_choices = [
+            ("snr", "What is SNR?"),
+            ("rssi", "What is RSSI?"),
+            ("lora", "How does LoRa work?"),
+            ("meshtastic", "Meshtastic basics"),
+            ("reticulum", "Reticulum basics"),
+            ("antenna", "Antenna selection"),
+            ("range", "Improving range"),
+            ("custom", "Custom query"),
+            ("back", "Back"),
+        ]
+
+        while True:
+            choice = self.ctx.dialog.menu(
+                "Knowledge Base",
+                "Select a topic or enter custom query:",
+                topic_choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            query = None
+            if choice == "custom":
+                query = self.ctx.dialog.inputbox(
+                    "Knowledge Query",
+                    "Enter your question about mesh networking:"
+                )
+                if not query:
+                    continue
+            else:
+                query_map = {
+                    "snr": "What is SNR?",
+                    "rssi": "What is RSSI?",
+                    "lora": "How does LoRa modulation work?",
+                    "meshtastic": "What is Meshtastic and how does it work?",
+                    "reticulum": "What is Reticulum Network Stack?",
+                    "antenna": "How do I choose the right antenna?",
+                    "range": "How can I improve my mesh range?",
+                }
+                query = query_map.get(choice, choice)
+
+            self._query_knowledge(query)
+
+    def _query_knowledge(self, query: str):
+        """Query the knowledge base."""
+        self.ctx.dialog.infobox("Searching", f"Searching: {query[:40]}...")
+
+        if not _HAS_KNOWLEDGE:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Knowledge base not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
+
+        try:
+            kb = get_knowledge_base()
+            results = kb.query(query)
+
+            if results:
+                # Format results for display
+                result_lines = [f"QUERY: {query}", ""]
+
+                for i, result in enumerate(results[:3], 1):
+                    result_lines.append(f"--- Result {i}: {result.title} ---")
+                    # Truncate content for dialog display
+                    content = result.content.strip()
+                    if len(content) > 800:
+                        content = content[:800] + "..."
+                    result_lines.append(content)
+                    result_lines.append("")
+
+                self.ctx.dialog.msgbox(
+                    "Knowledge Base Results",
+                    "\n".join(result_lines)
+                )
+            else:
+                self.ctx.dialog.msgbox(
+                    "No Results",
+                    f"No knowledge base entries found for:\n{query}\n\n"
+                    "Try different keywords or use Claude Assistant."
+                )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Query failed: {e}")
+
+    # =========================================================================
+    # Claude Assistant
+    # =========================================================================
+
+    def _claude_assistant(self):
+        """Interactive Claude Assistant for mesh help."""
+        # Check for API key
+        api_key = os.environ.get("ANTHROPIC_API_KEY")
+        mode = "PRO" if api_key else "Standalone"
+
+        self.ctx.dialog.msgbox(
+            "Claude Assistant",
+            f"Mode: {mode}\n\n"
+            f"{'PRO mode: Full Claude AI capabilities' if api_key else 'Standalone: Rule-based + knowledge base'}\n\n"
+            f"{'Set ANTHROPIC_API_KEY for PRO features.' if not api_key else 'API key detected.'}"
+        )
+
+        while True:
+            question = self.ctx.dialog.inputbox(
+                f"Claude Assistant ({mode})",
+                "Ask a question about mesh networking:\n(Enter blank to exit)"
+            )
+
+            if not question:
+                break
+
+            self._ask_assistant(question)
+
+    def _ask_assistant(self, question: str):
+        """Ask the Claude assistant."""
+        self.ctx.dialog.infobox("Thinking", f"Processing: {question[:40]}...")
+
+        if not _HAS_ASSISTANT:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Claude assistant not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
+
+        try:
+            assistant = ClaudeAssistant()
+            response = assistant.ask(question)
+
+            # Format response
+            result_lines = [
+                f"Q: {question}",
+                "",
+                "ANSWER:",
+                response.answer,
+                "",
+            ]
+
+            if response.suggested_actions:
+                result_lines.append("SUGGESTED ACTIONS:")
+                for action in response.suggested_actions[:3]:
+                    result_lines.append(f"  - {action}")
+                result_lines.append("")
+
+            result_lines.append(f"Mode: {response.mode.value.upper()}")
+            if response.confidence > 0:
+                result_lines.append(f"Confidence: {response.confidence:.0%}")
+
+            self.ctx.dialog.msgbox(
+                "Claude Assistant",
+                "\n".join(result_lines)
+            )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Assistant failed: {e}")
+
+    # =========================================================================
+    # Coverage Map
+    # =========================================================================
+
+    def _generate_coverage_map(self):
+        """Generate a coverage map and open in browser."""
+        # Get node data source
+        source_choices = [
+            ("all", "All sources (recommended)"),
+            ("live", "Live from meshtasticd only"),
+            ("mqtt", "From MQTT broker"),
+            ("file", "From saved node file"),
+            ("back", "Back"),
+        ]
+
+        choice = self.ctx.dialog.menu(
+            "Coverage Map",
+            "Select node data source:",
+            source_choices
+        )
+
+        if choice is None or choice == "back":
+            return
+
+        self.ctx.dialog.infobox("Generating", "Creating coverage map...")
+
+        if not _HAS_COVERAGE_MAP:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Coverage map generator not available.\n\n"
+                "You may need to install folium:\n"
+                "pip3 install folium"
+            )
+            return
+
+        try:
+            from utils.paths import get_real_user_home
+
+            generator = CoverageMapGenerator()
+
+            if choice == "all":
+                # Use MapDataCollector to get nodes from ALL sources
+                # (meshtasticd, MQTT, node_cache.json, RNS cache)
+                if not _HAS_MAP_SERVICE:
+                    self.ctx.dialog.msgbox("Error", "MapDataCollector not available.")
+                    return
+                collector = MapDataCollector()
+                geojson = collector.collect()
+                features = geojson.get('features', [])
+                if features:
+                    generator.add_nodes_from_geojson(geojson)
+                    self.ctx.dialog.infobox(
+                        "Generating",
+                        f"Found {len(features)} nodes from all sources..."
+                    )
+                else:
+                    self.ctx.dialog.msgbox(
+                        "No Nodes",
+                        "No nodes found from any source.\n\n"
+                        "Check meshtasticd, MQTT, or node cache."
+                    )
+                    return
+
+            elif choice == "live":
+                # Get nodes from meshtasticd only
+                geojson = self._get_nodes_geojson_by_source("meshtasticd")
+                features = geojson.get('features', [])
+                if features:
+                    generator.add_nodes_from_geojson(geojson)
+                    self.ctx.dialog.infobox(
+                        "Generating",
+                        f"Found {len(features)} nodes from meshtasticd..."
+                    )
+                else:
+                    self.ctx.dialog.msgbox(
+                        "No Nodes",
+                        "No nodes found from meshtasticd.\n\n"
+                        "Ensure meshtasticd is running and has nodes with GPS."
+                    )
+                    return
+
+            elif choice == "mqtt":
+                # Get nodes from MQTT cache only
+                geojson = self._get_nodes_geojson_by_source("mqtt")
+                features = geojson.get('features', [])
+                if features:
+                    generator.add_nodes_from_geojson(geojson)
+                    self.ctx.dialog.infobox(
+                        "Generating",
+                        f"Found {len(features)} nodes from MQTT..."
+                    )
+                else:
+                    self.ctx.dialog.msgbox(
+                        "No Nodes",
+                        "No nodes found from MQTT cache.\n\n"
+                        "MQTT nodes are cached when monitoring is running."
+                    )
+                    return
+
+            elif choice == "file":
+                # Load from file
+                file_path = self.ctx.dialog.inputbox(
+                    "Node File",
+                    "Enter path to node JSON file:"
+                )
+                if not file_path:
+                    return
+                try:
+                    with open(file_path) as f:
+                        data = json.load(f)
+                    generator.add_nodes_from_geojson(data)
+                except Exception as e:
+                    self.ctx.dialog.msgbox("Error", f"Failed to load file: {e}")
+                    return
+
+            # Generate map
+            output_dir = get_real_user_home() / ".local" / "share" / "meshforge"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_file = output_dir / "coverage_map.html"
+
+            generator.generate(str(output_file))
+
+            # Open in browser
+            self.ctx.dialog.msgbox(
+                "Map Generated",
+                f"Coverage map saved to:\n{output_file}\n\n"
+                "Opening in browser..."
+            )
+
+            # Open browser in background
+            self._open_in_browser(str(output_file))
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Map generation failed: {e}")
+
+    def _get_nodes_geojson_by_source(self, source: str) -> dict:
+        """Get nodes from a specific source using MapDataCollector.
+
+        Args:
+            source: Source filter - "meshtasticd", "mqtt", or "rns"
+
+        Returns:
+            GeoJSON FeatureCollection filtered to the specified source.
+        """
+        if not _HAS_MAP_SERVICE:
+            return {"type": "FeatureCollection", "features": []}
+
+        try:
+            collector = MapDataCollector()
+            geojson = collector.collect()
+
+            # Filter features by source
+            filtered_features = [
+                f for f in geojson.get('features', [])
+                if f.get('properties', {}).get('source') == source
+            ]
+
+            return {
+                "type": "FeatureCollection",
+                "features": filtered_features,
+                "properties": {
+                    "source": source,
+                    "count": len(filtered_features)
+                }
+            }
+        except Exception as e:
+            logger.debug("GeoJSON collection failed: %s", e)
+            return {"type": "FeatureCollection", "features": []}
+
+    def _open_in_browser(self, url: str):
+        """Open URL in browser (in background thread).
+
+        Handles running as root by using sudo -u to run browser as real user.
+        On headless/SSH sessions, shows the URL for manual access instead.
+        """
+        # On headless/SSH, show URL instead of trying to open browser
+        if self._is_headless():
+            self.ctx.dialog.msgbox(
+                "No Display",
+                f"No graphical display detected (headless/SSH).\n\n"
+                f"Open this URL in your local browser:\n{url}"
+            )
+            return
+
+        def do_open():
+            try:
+                # When running as root, use sudo -u to run as real user
+                real_user = os.environ.get('SUDO_USER')
+                if os.geteuid() == 0 and real_user:
+                    subprocess.run(
+                        ['sudo', '-u', real_user, 'xdg-open', url],
+                        capture_output=True,
+                        timeout=10
+                    )
+                else:
+                    # Not root or no SUDO_USER - try xdg-open directly
+                    subprocess.run(
+                        ['xdg-open', url],
+                        capture_output=True,
+                        timeout=10
+                    )
+            except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+                try:
+                    webbrowser.open(url)
+                except (webbrowser.Error, OSError):
+                    pass
+
+        threading.Thread(target=do_open, daemon=True).start()
+
+    # =========================================================================
+    # Heatmap Generation
+    # =========================================================================
+
+    def _generate_heatmap(self):
+        """Generate a node density heatmap and open in browser."""
+        self.ctx.dialog.infobox("Generating", "Creating node density heatmap...")
+
+        if not _HAS_COVERAGE_MAP:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Coverage map generator not available.\n\n"
+                "You may need to install folium:\n"
+                "pip3 install folium"
+            )
+            return
+
+        if not _HAS_MAP_SERVICE:
+            self.ctx.dialog.msgbox("Error", "MapDataCollector not available.")
+            return
+
+        try:
+            from utils.paths import get_real_user_home
+
+            generator = CoverageMapGenerator()
+
+            # Collect nodes from all sources
+            collector = MapDataCollector()
+            geojson = collector.collect()
+            features = geojson.get('features', [])
+            if features:
+                generator.add_nodes_from_geojson(geojson)
+            else:
+                self.ctx.dialog.msgbox(
+                    "No Nodes",
+                    "No nodes found from any source.\n\n"
+                    "Check meshtasticd, MQTT, or node cache."
+                )
+                return
+
+            # Generate heatmap
+            output_dir = get_real_user_home() / ".local" / "share" / "meshforge"
+            output_dir.mkdir(parents=True, exist_ok=True)
+            output_file = str(output_dir / "coverage_heatmap.html")
+
+            result_path = generator.generate_heatmap(output_path=output_file)
+
+            if not result_path:
+                self.ctx.dialog.msgbox(
+                    "Error",
+                    "Heatmap generation failed.\n\n"
+                    "Folium with HeatMap plugin is required:\n"
+                    "pip3 install folium"
+                )
+                return
+
+            self.ctx.dialog.msgbox(
+                "Heatmap Generated",
+                f"Node density heatmap saved to:\n{result_path}\n\n"
+                "Opening in browser..."
+            )
+            self._open_in_browser(result_path)
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Heatmap generation failed: {e}")
+
+    # =========================================================================
+    # Tile Cache Manager
+    # =========================================================================
+
+    def _tile_cache_menu(self):
+        """Manage offline tile cache for maps."""
+        while True:
+            choices = [
+                ("stats", "Cache Stats         View tile cache status"),
+                ("download", "Download Region     Cache tiles for area"),
+                ("estimate", "Estimate Size       Preview download size"),
+                ("clear", "Clear Expired       Remove old tiles"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Offline Tile Cache",
+                "Manage cached map tiles for offline use:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "stats": ("Cache Stats", self._tile_cache_stats),
+                "download": ("Download Region", self._tile_cache_download),
+                "estimate": ("Estimate Size", self._tile_cache_estimate),
+                "clear": ("Clear Expired", self._tile_cache_clear),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _tile_cache_stats(self):
+        """Display tile cache statistics."""
+        if not _HAS_TILE_CACHE:
+            self.ctx.dialog.msgbox("Error", "Tile cache module not available.")
+            return
+
+        try:
+            cache = TileCache()
+            stats = cache.get_stats()
+
+            info = [
+                f"Cached Tiles: {stats['tile_count']}",
+                f"Cache Size:   {stats['size_mb']:.1f} MB",
+            ]
+            if stats.get('oldest'):
+                info.append(f"Oldest Tile:  {stats['oldest']}")
+            if stats.get('newest'):
+                info.append(f"Newest Tile:  {stats['newest']}")
+            if stats['tile_count'] == 0:
+                info.append("")
+                info.append("No tiles cached yet. Use 'Download Region'")
+                info.append("to cache tiles for offline map viewing.")
+
+            self.ctx.dialog.msgbox("Tile Cache Stats", "\n".join(info))
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to get cache stats: {e}")
+
+    def _tile_cache_download(self):
+        """Download tiles for a geographic region."""
+        if not _HAS_TILE_CACHE:
+            self.ctx.dialog.msgbox("Error", "Tile cache module not available.")
+            return
+
+        try:
+            # Get bounds from user
+            region_choices = [
+                ("hawaii", "Hawaii              (18.5-22.5N, 160.5-154.5W)"),
+                ("custom", "Custom Region       Enter coordinates"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Download Region",
+                "Select region to cache tiles for:",
+                region_choices
+            )
+
+            if choice is None or choice == "back":
+                return
+
+            if choice == "hawaii":
+                bounds = HAWAII_BOUNDS
+            elif choice == "custom":
+                coords = self.ctx.dialog.inputbox(
+                    "Custom Region",
+                    "Enter bounds as: south,west,north,east\n"
+                    "Example: 21.0,-158.5,21.7,-157.5"
+                )
+                if not coords:
+                    return
+                try:
+                    parts = [float(x.strip()) for x in coords.split(',')]
+                    if len(parts) != 4:
+                        self.ctx.dialog.msgbox("Error", "Enter exactly 4 coordinates.")
+                        return
+                    bounds = tuple(parts)
+                except ValueError:
+                    self.ctx.dialog.msgbox("Error", "Invalid coordinates.")
+                    return
+            else:
+                return
+
+            # Estimate first
+            estimate = TileCache.estimate_download_size(bounds)
+            if 'error' in estimate:
+                self.ctx.dialog.msgbox("Error", estimate['error'])
+                return
+
+            confirm = self.ctx.dialog.yesno(
+                "Confirm Download",
+                f"Tiles to download: {estimate['total_tiles']}\n"
+                f"Estimated size: {estimate['estimated_mb']:.1f} MB\n\n"
+                "Proceed with download?"
+            )
+
+            if not confirm:
+                return
+
+            self.ctx.dialog.infobox("Downloading", "Caching tiles... This may take a while.")
+
+            cache = TileCache()
+            result = cache.download_region(bounds)
+
+            if 'error' in result:
+                self.ctx.dialog.msgbox("Error", result['error'])
+            else:
+                self.ctx.dialog.msgbox(
+                    "Download Complete",
+                    f"Downloaded: {result['downloaded']} tiles\n"
+                    f"Skipped (cached): {result['skipped']}\n"
+                    f"Failed: {result['failed']}"
+                )
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Tile download failed: {e}")
+
+    def _tile_cache_estimate(self):
+        """Estimate download size for a region."""
+        if not _HAS_TILE_CACHE:
+            self.ctx.dialog.msgbox("Error", "Tile cache module not available.")
+            return
+
+        try:
+            coords = self.ctx.dialog.inputbox(
+                "Estimate Size",
+                "Enter bounds as: south,west,north,east\n"
+                "Example: 21.0,-158.5,21.7,-157.5\n"
+                "(Leave empty for Hawaii)"
+            )
+
+            if coords:
+                try:
+                    parts = [float(x.strip()) for x in coords.split(',')]
+                    if len(parts) != 4:
+                        self.ctx.dialog.msgbox("Error", "Enter exactly 4 coordinates.")
+                        return
+                    bounds = tuple(parts)
+                except ValueError:
+                    self.ctx.dialog.msgbox("Error", "Invalid coordinates.")
+                    return
+            else:
+                bounds = HAWAII_BOUNDS
+
+            estimate = TileCache.estimate_download_size(bounds)
+
+            if 'error' in estimate:
+                self.ctx.dialog.msgbox("Error", estimate['error'])
+            else:
+                self.ctx.dialog.msgbox(
+                    "Download Estimate",
+                    f"Region: ({bounds[0]:.1f}, {bounds[1]:.1f}) to "
+                    f"({bounds[2]:.1f}, {bounds[3]:.1f})\n"
+                    f"Tile count: {estimate['total_tiles']}\n"
+                    f"Estimated size: {estimate['estimated_mb']:.1f} MB\n"
+                    f"Within limit: {'Yes' if estimate['within_limit'] else 'No'}"
+                )
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Estimation failed: {e}")
+
+    def _tile_cache_clear(self):
+        """Clear expired tiles from cache."""
+        if not _HAS_TILE_CACHE:
+            self.ctx.dialog.msgbox("Error", "Tile cache module not available.")
+            return
+
+        try:
+            confirm = self.ctx.dialog.yesno(
+                "Clear Expired Tiles",
+                "Remove tiles older than 30 days?\n\n"
+                "This frees disk space but requires re-download\n"
+                "for offline use."
+            )
+
+            if not confirm:
+                return
+
+            cache = TileCache()
+            result = cache.clear_expired()
+
+            freed_mb = result['bytes_freed'] / (1024 * 1024)
+            self.ctx.dialog.msgbox(
+                "Cache Cleared",
+                f"Removed: {result['removed']} expired tiles\n"
+                f"Space freed: {freed_mb:.1f} MB"
+            )
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Cache clear failed: {e}")

--- a/src/launcher_tui/handlers/auto_review.py
+++ b/src/launcher_tui/handlers/auto_review.py
@@ -1,0 +1,127 @@
+"""
+Auto-Review Handler — Code review and self-audit for the TUI.
+
+Extracted from ai_tools_mixin.py to serve the system menu section (Batch 8).
+Provides automated code analysis using the ReviewOrchestrator.
+"""
+
+import logging
+
+from handler_protocol import BaseHandler
+from utils.safe_import import safe_import
+
+ReviewOrchestrator, ReviewScope, _HAS_AUTO_REVIEW = safe_import(
+    'utils.auto_review', 'ReviewOrchestrator', 'ReviewScope'
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AutoReviewHandler(BaseHandler):
+    """TUI handler for automated code review."""
+
+    handler_id = "auto_review"
+    menu_section = "system"
+
+    def menu_items(self):
+        return [
+            ("review", "Code Review         Auto-review codebase", None),
+        ]
+
+    def execute(self, action):
+        if action == "review":
+            self._auto_review_menu()
+
+    def _auto_review_menu(self):
+        """Code review system — run automated code analysis."""
+        while True:
+            choices = [
+                ("full", "Full Review         Run all review agents"),
+                ("security", "Security Review     Command injection, creds"),
+                ("redundancy", "Redundancy Review   Duplicate code, imports"),
+                ("performance", "Performance Review  Timeouts, loops, memory"),
+                ("reliability", "Reliability Review  Error handling, TODOs"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Code Review",
+                "Automated code analysis agents:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "full": ("Full Review", lambda: self._run_auto_review("ALL")),
+                "security": ("Security Review", lambda: self._run_auto_review("SECURITY")),
+                "redundancy": ("Redundancy Review", lambda: self._run_auto_review("REDUNDANCY")),
+                "performance": ("Performance Review", lambda: self._run_auto_review("PERFORMANCE")),
+                "reliability": ("Reliability Review", lambda: self._run_auto_review("RELIABILITY")),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _run_auto_review(self, scope_name: str):
+        """Execute an auto-review with the specified scope."""
+        self.ctx.dialog.infobox("Reviewing", f"Running {scope_name.lower()} review...")
+
+        if not _HAS_AUTO_REVIEW:
+            self.ctx.dialog.msgbox(
+                "Error",
+                "Auto-review module not available.\n\n"
+                "Ensure you're running from the src/ directory."
+            )
+            return
+
+        try:
+            scope_map = {
+                "ALL": ReviewScope.ALL,
+                "SECURITY": ReviewScope.SECURITY,
+                "REDUNDANCY": ReviewScope.REDUNDANCY,
+                "PERFORMANCE": ReviewScope.PERFORMANCE,
+                "RELIABILITY": ReviewScope.RELIABILITY,
+            }
+            scope = scope_map.get(scope_name, ReviewScope.ALL)
+
+            orchestrator = ReviewOrchestrator()
+            report = orchestrator.run_full_review(scope=scope)
+
+            # Build summary
+            lines = [
+                f"Scope: {scope_name}",
+                f"Files Scanned: {report.total_files_scanned}",
+                f"Total Issues: {report.total_issues}",
+                f"Fixes Applied: {report.total_fixes_applied}",
+                "",
+            ]
+
+            for category, result in report.agent_results.items():
+                lines.append(
+                    f"  {category.value.upper()}: "
+                    f"{result.total_issues} issues "
+                    f"({result.critical_count} critical, "
+                    f"{result.high_count} high)"
+                )
+
+            # Show top findings
+            findings = report.get_all_findings()
+            if findings:
+                lines.append("")
+                lines.append("Top findings:")
+                for finding in findings[:10]:
+                    lines.append(
+                        f"  [{finding.severity.value.upper()}] "
+                        f"{finding.file_path}:{finding.line_number or '?'}"
+                    )
+                    lines.append(f"    {finding.issue}")
+
+                if len(findings) > 10:
+                    lines.append(f"  ... and {len(findings) - 10} more")
+
+            self.ctx.dialog.msgbox("Review Results", "\n".join(lines))
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Review failed: {e}")

--- a/src/launcher_tui/handlers/first_run.py
+++ b/src/launcher_tui/handlers/first_run.py
@@ -1,0 +1,1143 @@
+"""
+First-Run Handler — Initial setup wizard for new MeshForge installations.
+
+Converted from first_run_mixin.py as part of the mixin-to-registry migration (Batch 8).
+
+Guides new users through MeshForge setup:
+1. Connection type selection (SPI/USB/Network)
+2. Hardware-specific configuration
+3. Service status check
+4. Basic configuration
+
+Implements LifecycleHandler for on_startup to auto-trigger the wizard on first run.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Optional, List, Dict, Tuple
+
+from handler_protocol import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
+
+# Import service check
+check_service, apply_config_and_restart, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_service', 'apply_config_and_restart'
+)
+
+# Import device scanner
+from utils.device_scanner import DeviceScanner
+
+# Import startup checker for hardware detection
+StartupChecker, _HAS_STARTUP_CHECKER = safe_import('startup_checks', 'StartupChecker')
+
+
+# =========================================================================
+# Hardware Configuration Templates
+# =========================================================================
+
+# SPI HAT configurations with their config file names
+# Legacy fallback — used only when /etc/meshtasticd/available.d/ is empty.
+# Filenames must match actual templates in templates/available.d/.
+SPI_HARDWARE_CONFIGS = {
+    'meshadv-mini': {
+        'name': 'MeshAdv-Mini',
+        'description': 'MeshAdv-Mini Pi HAT (recommended for Raspberry Pi)',
+        'config_file': 'meshadv-mini.yaml',
+        'requires_spi': True,
+        'requires_overlay': 'spi0-0cs',
+    },
+    'waveshare-sx1262': {
+        'name': 'Waveshare SX1262 HAT',
+        'description': 'Waveshare SX1262 868/915M LoRa HAT',
+        'config_file': 'waveshare-sx1262.yaml',
+        'requires_spi': True,
+        'requires_overlay': None,
+    },
+    'rak-hat': {
+        'name': 'RAK WisLink HAT',
+        'description': 'RAKwireless WisLink LoRa HAT',
+        'config_file': 'rak-hat-spi.yaml',
+        'requires_spi': True,
+        'requires_overlay': None,
+    },
+    'ebyte-e22': {
+        'name': 'Ebyte E22 Module',
+        'description': 'Ebyte E22-900M/E22-400M LoRa Module',
+        'config_file': 'ebyte-e22-900m30s.yaml',
+        'requires_spi': True,
+        'requires_overlay': None,
+    },
+    'custom-spi': {
+        'name': 'Custom SPI Device',
+        'description': 'Other SPI-connected LoRa module',
+        'config_file': None,  # Manual configuration required
+        'requires_spi': True,
+        'requires_overlay': None,
+    },
+}
+
+# Meshtastic regions for frequency configuration
+MESHTASTIC_REGIONS = [
+    ('US', 'United States (915 MHz)'),
+    ('EU_868', 'Europe 868 MHz'),
+    ('EU_433', 'Europe 433 MHz'),
+    ('CN', 'China (470-510 MHz)'),
+    ('JP', 'Japan (920 MHz)'),
+    ('ANZ', 'Australia/NZ (915/928 MHz)'),
+    ('KR', 'Korea (920 MHz)'),
+    ('TW', 'Taiwan (923 MHz)'),
+    ('RU', 'Russia (868 MHz)'),
+    ('IN', 'India (865-867 MHz)'),
+    ('NZ_865', 'New Zealand 865 MHz'),
+    ('TH', 'Thailand (920 MHz)'),
+    ('LORA_24', 'LoRa 2.4 GHz (worldwide)'),
+    ('UA_433', 'Ukraine 433 MHz'),
+    ('UA_868', 'Ukraine 868 MHz'),
+    ('MY_433', 'Malaysia 433 MHz'),
+    ('MY_919', 'Malaysia 919 MHz'),
+    ('SG_923', 'Singapore 923 MHz'),
+    ('UNSET', 'Unset (configure later)'),
+]
+
+
+class FirstRunHandler(BaseHandler):
+    """TUI handler for first-run wizard and initial setup."""
+
+    handler_id = "first_run"
+    menu_section = "configuration"
+
+    FIRST_RUN_FLAG = ".meshforge_setup_complete"
+
+    def menu_items(self):
+        return [
+            ("wizard", "Setup Wizard        First-run wizard", None),
+        ]
+
+    def execute(self, action):
+        if action == "wizard":
+            self._run_first_run_wizard()
+
+    # -- LifecycleHandler --------------------------------------------------
+
+    def on_startup(self):
+        """Check for first run and offer setup wizard."""
+        if self._check_first_run():
+            self._run_first_run_wizard()
+
+    def on_shutdown(self):
+        """No cleanup needed for first-run handler."""
+        pass
+
+    # -- Template classification -------------------------------------------
+
+    def _classify_templates(self, available_d: Path) -> Tuple[List[Path], List[Path]]:
+        """Classify available.d templates into USB and SPI categories.
+
+        Classification uses filename convention:
+          - USB: filename contains '-usb' or starts with 'usb-'
+          - SPI: everything else
+
+        Returns:
+            Tuple of (usb_templates, spi_templates), each a sorted list of Paths
+        """
+        usb_templates = []
+        spi_templates = []
+
+        if not available_d.exists():
+            return usb_templates, spi_templates
+
+        for tmpl in sorted(available_d.glob('*.yaml')):
+            name = tmpl.stem.lower()
+            if '-usb' in name or name.startswith('usb-'):
+                usb_templates.append(tmpl)
+            else:
+                spi_templates.append(tmpl)
+
+        return usb_templates, spi_templates
+
+    # -- Existing config check ---------------------------------------------
+
+    def _check_existing_configs(self, config_d: Path, config_type: str) -> bool:
+        """Check for existing configs in config.d and ask user if they want to change.
+
+        Args:
+            config_d: Path to /etc/meshtasticd/config.d
+            config_type: 'USB' or 'SPI HAT' for display purposes
+
+        Returns:
+            True if we should proceed with template selection,
+            False if user wants to keep existing config.
+        """
+        if not config_d.exists():
+            return True
+
+        existing_configs = list(config_d.glob('*.yaml'))
+        if not existing_configs:
+            return True
+
+        config_names = ", ".join(f.name for f in existing_configs)
+        change = self.ctx.dialog.yesno(
+            f"Existing {config_type} Config Found",
+            f"You already have hardware configured:\n\n"
+            f"  {config_names}\n\n"
+            f"Location: {config_d}\n\n"
+            "Do you want to change it?",
+            default_no=True
+        )
+
+        if not change:
+            self.ctx.dialog.msgbox(
+                "Keeping Existing Config",
+                f"Your current config will be kept:\n\n"
+                f"  {config_names}\n\n"
+                "You can change this later from:\n"
+                "  Configuration > meshtasticd Config > Hardware"
+            )
+            return False
+
+        return True
+
+    # -- Template structure ------------------------------------------------
+
+    def _ensure_template_structure(self):
+        """Ensure /etc/meshtasticd directory structure and templates exist."""
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            config_mgr = MeshtasticdConfig()
+            config_mgr.ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create templates (no root), using existing")
+        except ImportError:
+            logger.warning("core.meshtasticd_config not available, skipping template setup")
+        except (OSError, ValueError) as e:
+            logger.warning("Template auto-creation failed: %s", e)
+
+    # -- First-run state ---------------------------------------------------
+
+    def _check_first_run(self) -> bool:
+        """Check if this is a first run (no setup flag exists)."""
+        config_dir = get_real_user_home() / ".config" / "meshforge"
+        flag_file = config_dir / self.FIRST_RUN_FLAG
+        return not flag_file.exists()
+
+    def _mark_setup_complete(self):
+        """Mark setup as complete."""
+        config_dir = get_real_user_home() / ".config" / "meshforge"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        flag_file = config_dir / self.FIRST_RUN_FLAG
+        flag_file.touch()
+
+    # -- Main wizard flow --------------------------------------------------
+
+    def _run_first_run_wizard(self) -> bool:
+        """
+        Run the first-run wizard.
+        Returns True if completed, False if skipped.
+
+        Enhanced in v0.4.8 with SPI/USB selection first.
+        """
+        # Welcome
+        result = self.ctx.dialog.yesno(
+            "Welcome to MeshForge!",
+            "It looks like this is your first time running MeshForge.\n\n"
+            "Would you like to run the setup wizard?\n\n"
+            "The wizard will:\n"
+            "• Help you select your connection type (SPI/USB)\n"
+            "• Configure your hardware\n"
+            "• Set up mesh services\n\n"
+            "You can run this wizard again from Configuration > Setup Wizard."
+        )
+
+        if not result:
+            # User skipped - mark as complete anyway
+            skip = self.ctx.dialog.yesno(
+                "Skip Setup",
+                "Skip the wizard and mark setup as complete?\n\n"
+                "You can always run it later from Configuration."
+            )
+            if skip:
+                self._mark_setup_complete()
+            return False
+
+        # Step 1: Connection Type Selection (NEW in v0.4.8)
+        connection_type = self._wizard_step_connection_type()
+
+        if connection_type == 'skip':
+            self._mark_setup_complete()
+            return False
+
+        # Step 2: Hardware-specific configuration
+        if connection_type == 'spi':
+            self._wizard_step_spi_config()
+        elif connection_type == 'usb':
+            self._wizard_step_usb_config()
+        elif connection_type == 'network':
+            self._wizard_step_network_config()
+
+        # Step 3: Region Selection
+        self._wizard_step_region()
+
+        # Step 4: Service Configuration
+        self._wizard_step_services()
+
+        # Step 5: Completion
+        self._wizard_complete()
+
+        return True
+
+    # -- Step 1: Connection type -------------------------------------------
+
+    def _wizard_step_connection_type(self) -> str:
+        """
+        Step 1: Select connection type (SPI/USB/Network).
+
+        Returns: 'spi', 'usb', 'network', 'later', or 'skip'
+        """
+        # Auto-detect available options
+        spi_available = len(list(Path('/dev').glob('spidev*'))) > 0
+        usb_devices = self._find_usb_serial_devices()
+        is_pi = self._is_raspberry_pi()
+
+        # Build description based on detected hardware
+        desc = "How is your Meshtastic radio connected?\n\n"
+
+        if spi_available:
+            desc += "  SPI interface detected\n"
+        elif is_pi:
+            desc += "  Raspberry Pi detected (SPI can be enabled)\n"
+
+        if usb_devices:
+            # Show specific device names when possible
+            device_names = []
+            for dev in usb_devices:
+                name = dev.get('name', 'Unknown')
+                if name and name != 'Unknown':
+                    device_names.append(name)
+
+            if device_names:
+                desc += f"  USB detected: {', '.join(device_names[:3])}\n"
+            else:
+                desc += f"  {len(usb_devices)} USB serial device(s) found\n"
+
+        desc += "\nSelect your connection type:"
+
+        choices = [
+            ("spi", "SPI HAT         MeshAdv-Mini, Waveshare, etc."),
+            ("usb", "USB Serial      T-Beam, Heltec, RAK via USB"),
+            ("network", "Network         Remote meshtasticd (TCP)"),
+            ("later", "Configure Later Skip hardware setup"),
+        ]
+
+        choice = self.ctx.dialog.menu(
+            "Step 1: Connection Type",
+            desc,
+            choices
+        )
+
+        if choice is None:
+            return 'skip'
+
+        return choice
+
+    # -- Step 2a: SPI config -----------------------------------------------
+
+    def _wizard_step_spi_config(self):
+        """Configure SPI HAT hardware."""
+        # Check if SPI is enabled
+        spi_available = len(list(Path('/dev').glob('spidev*'))) > 0
+
+        if not spi_available:
+            # Offer to enable SPI
+            if self._is_raspberry_pi():
+                if self._offer_enable_spi():
+                    self.ctx.dialog.msgbox(
+                        "SPI Enabled",
+                        "SPI has been enabled.\n\n"
+                        "A REBOOT is required for changes to take effect.\n\n"
+                        "After reboot, run the wizard again to complete setup."
+                    )
+                    return
+                else:
+                    self.ctx.dialog.msgbox(
+                        "SPI Required",
+                        "SPI HATs require SPI to be enabled.\n\n"
+                        "You can enable SPI later using:\n"
+                        "  sudo raspi-config\n\n"
+                        "Or from System > Hardware in MeshForge."
+                    )
+                    return
+            else:
+                self.ctx.dialog.msgbox(
+                    "SPI Not Available",
+                    "No SPI interface detected on this system.\n\n"
+                    "SPI HATs are typically used with Raspberry Pi."
+                )
+                return
+
+        self._ensure_template_structure()
+
+        config_d = Path('/etc/meshtasticd/config.d')
+        available_d = Path('/etc/meshtasticd/available.d')
+
+        # Check for existing config (uses *.yaml, not broken lora-*.yaml)
+        if not self._check_existing_configs(config_d, 'SPI HAT'):
+            return
+
+        # Build choices from available.d SPI templates
+        choices = []
+        _, spi_templates = self._classify_templates(available_d)
+
+        if spi_templates:
+            active_configs = set()
+            if config_d.exists():
+                active_configs = {f.name for f in config_d.glob('*.yaml')}
+
+            for tmpl in spi_templates:
+                is_active = tmpl.name in active_configs
+                status = " [ACTIVE]" if is_active else ""
+                display_name = tmpl.stem.replace('-', ' ').title()
+                choices.append((tmpl.name, f"{display_name}{status}"))
+
+        # If no templates found in available.d, fall back to hardcoded list
+        if not choices:
+            for hw_id, hw_info in SPI_HARDWARE_CONFIGS.items():
+                choices.append((hw_id, f"{hw_info['name']:<20} {hw_info['description'][:30]}"))
+
+        # Always add manual option
+        choices.append(("custom-spi", "Custom/Other SPI Device"))
+
+        choice = self.ctx.dialog.menu(
+            "Step 2: Select SPI Hardware",
+            "Select your HAT from meshtasticd templates:\n\n"
+            f"Templates: {available_d}" if available_d.exists() else
+            "Which SPI HAT are you using?",
+            choices
+        )
+
+        if choice is None or choice == 'custom-spi':
+            self.ctx.dialog.msgbox(
+                "Manual Configuration",
+                "For custom SPI hardware, you'll need to:\n\n"
+                "1. Create a config file in /etc/meshtasticd/config.d/\n"
+                "2. Configure the SPI pins and radio chip type\n\n"
+                "See: Configuration > meshtasticd Config"
+            )
+            return
+
+        # Check if choice is a filename from available.d or a hardcoded key
+        if choice.endswith('.yaml') and available_d.exists():
+            # It's a template from available.d
+            src = available_d / choice
+            if src.exists():
+                self._apply_hardware_config_from_file(src, config_d)
+        else:
+            # It's a hardcoded config key
+            hw_config = SPI_HARDWARE_CONFIGS.get(choice)
+            if hw_config and hw_config['config_file']:
+                self._apply_hardware_config(hw_config)
+
+    # -- Apply config from template file -----------------------------------
+
+    def _apply_hardware_config_from_file(self, src: Path, config_d: Path):
+        """Apply a hardware config directly from available.d template."""
+        try:
+            config_d.mkdir(parents=True, exist_ok=True)
+            dst = config_d / src.name
+
+            # Copy config file
+            shutil.copy2(src, dst)
+
+            # Restart meshtasticd
+            apply_config_and_restart('meshtasticd')
+
+            self.ctx.dialog.msgbox(
+                "Configuration Applied",
+                f"Applied HAT configuration:\n\n"
+                f"Template: {src.name}\n"
+                f"Config: {dst}\n\n"
+                f"meshtasticd has been restarted.\n"
+                f"Check: systemctl status meshtasticd"
+            )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to apply config: {e}")
+
+    # -- USB auto-detect ---------------------------------------------------
+
+    def _detect_usb_device_template(self) -> 'tuple[Optional[str], Optional[str]]':
+        """Auto-detect connected USB radio and match to a template.
+
+        Uses DeviceScanner to find USB devices, then matches vendor:product
+        IDs against HardwareDetector.USB_ID_TO_TEMPLATE.
+
+        Returns:
+            Tuple of (template_filename, device_name) or (None, None).
+        """
+        try:
+            from config.hardware import HardwareDetector
+        except ImportError:
+            logger.debug("config.hardware not available for USB auto-detect")
+            return None, None
+
+        try:
+            scanner = DeviceScanner()
+            results = scanner.scan_all()
+
+            # Check USB devices for known vendor:product IDs
+            for dev in results.get('usb_devices', []):
+                vid = getattr(dev, 'vendor_id', '')
+                pid = getattr(dev, 'product_id', '')
+                if vid and pid:
+                    usb_id = f"{vid}:{pid}"
+                    template = HardwareDetector.match_usb_to_template(usb_id)
+                    if template:
+                        device_name = HardwareDetector.get_device_name_for_usb_id(usb_id)
+                        if not device_name:
+                            device_name = getattr(dev, 'description', 'Unknown USB device')
+                        return template, device_name
+
+            # Fallback: check serial ports for USB IDs
+            for port in results.get('serial_ports', []):
+                vid = getattr(port, 'usb_vendor', '')
+                pid = getattr(port, 'usb_product', '')
+                if vid and pid:
+                    usb_id = f"{vid}:{pid}"
+                    template = HardwareDetector.match_usb_to_template(usb_id)
+                    if template:
+                        device_name = HardwareDetector.get_device_name_for_usb_id(usb_id)
+                        if not device_name:
+                            device_name = getattr(port, 'description', 'Unknown USB device')
+                        return template, device_name
+
+        except Exception as e:
+            logger.debug("USB auto-detect failed: %s", e)
+
+        return None, None
+
+    # -- Step 2b: USB config -----------------------------------------------
+
+    def _wizard_step_usb_config(self):
+        """Configure USB serial connection using templates from available.d.
+
+        Enhanced: auto-detects connected USB device and recommends the
+        matching template before falling back to the full template list.
+        """
+        self._ensure_template_structure()
+
+        config_d = Path('/etc/meshtasticd/config.d')
+        available_d = Path('/etc/meshtasticd/available.d')
+
+        # Check for existing configuration first
+        if not self._check_existing_configs(config_d, 'USB'):
+            return
+
+        # --- Auto-detect connected USB radio ---
+        matched_template, device_name = self._detect_usb_device_template()
+
+        if matched_template and available_d.exists():
+            src = available_d / matched_template
+            if src.exists():
+                apply_auto = self.ctx.dialog.yesno(
+                    "USB Radio Detected!",
+                    f"Detected: {device_name}\n"
+                    f"Recommended template: {matched_template}\n\n"
+                    f"Apply this configuration now?\n\n"
+                    f"(Select No to choose a different template)"
+                )
+                if apply_auto:
+                    self._apply_hardware_config_from_file(src, config_d)
+                    return
+                # User declined — fall through to full template list
+
+        # --- Full template list (original behavior) ---
+        usb_templates, _ = self._classify_templates(available_d)
+
+        if usb_templates:
+            # Build menu from USB templates
+            choices = []
+            active_configs = set()
+            if config_d.exists():
+                active_configs = {f.name for f in config_d.glob('*.yaml')}
+
+            for tmpl in usb_templates:
+                is_active = tmpl.name in active_configs
+                status = " [ACTIVE]" if is_active else ""
+                # Create readable name: "heltec-usb" -> "Heltec Usb"
+                display_name = tmpl.stem.replace('-', ' ').title()
+                # Mark recommended template if detected
+                recommend = " [DETECTED]" if tmpl.name == matched_template else ""
+                choices.append((tmpl.name, f"{display_name}{status}{recommend}"))
+
+            choices.append(("custom", "Custom USB Device (manual path)"))
+
+            desc = "Select your USB radio from meshtasticd templates:\n\n"
+            if matched_template:
+                desc += f"Detected device: {device_name}\n"
+            desc += f"Templates: {available_d}"
+
+            choice = self.ctx.dialog.menu(
+                "Step 2: Select USB Hardware",
+                desc,
+                choices
+            )
+
+            if choice is None:
+                return
+
+            if choice == "custom":
+                # Fall back to manual USB device selection
+                self._wizard_step_usb_manual()
+                return
+
+            # Apply template from available.d
+            src = available_d / choice
+            if src.exists():
+                self._apply_hardware_config_from_file(src, config_d)
+            else:
+                self.ctx.dialog.msgbox("Error", f"Template not found: {src}")
+        else:
+            # No templates available -- fall back to manual selection
+            self._wizard_step_usb_manual()
+
+    # -- USB manual fallback -----------------------------------------------
+
+    def _wizard_step_usb_manual(self):
+        """Fallback: manually select USB device when no templates available."""
+        devices = self._find_usb_serial_devices()
+
+        if not devices:
+            self.ctx.dialog.msgbox(
+                "No USB Devices",
+                "No USB serial devices detected.\n\n"
+                "Connect your Meshtastic device via USB and try again.\n\n"
+                "Supported devices:\n"
+                "  - T-Beam (CP2102 or CH340)\n"
+                "  - Heltec LoRa\n"
+                "  - RAK WisBlock\n"
+                "  - LilyGo T-Deck"
+            )
+            return
+
+        # Build device selection menu
+        choices = []
+        for dev in devices:
+            path = dev.get('path', '/dev/ttyUSB0')
+            name = dev.get('name', 'Unknown')
+            likely = " *" if dev.get('likely_meshtastic', False) else ""
+            choices.append((path, f"{name[:25]}{likely}"))
+
+        choices.append(("rescan", "Rescan        Detect devices again"))
+
+        choice = self.ctx.dialog.menu(
+            "Select USB Device",
+            "No hardware templates found. Select device manually:\n"
+            "(* = likely Meshtastic)",
+            choices
+        )
+
+        if choice == "rescan":
+            self._wizard_step_usb_manual()
+            return
+
+        if choice is None:
+            return
+
+        # Use the generic USB template if available, else create minimal config
+        available_d = Path('/etc/meshtasticd/available.d')
+        generic_template = available_d / 'usb-serial-generic.yaml'
+        config_d = Path('/etc/meshtasticd/config.d')
+
+        if generic_template.exists():
+            self._apply_hardware_config_from_file(generic_template, config_d)
+        else:
+            self._create_usb_config(choice)
+
+    # -- Step 2c: Network config -------------------------------------------
+
+    def _wizard_step_network_config(self):
+        """Configure network connection to remote meshtasticd."""
+        host = self.ctx.dialog.inputbox(
+            "Step 2: Network Host",
+            "Enter the hostname or IP of the meshtasticd server:",
+            "localhost"
+        )
+
+        if not host:
+            return
+
+        port = self.ctx.dialog.inputbox(
+            "Network Port",
+            "Enter the port number (default 4403):",
+            "4403"
+        )
+
+        if not port:
+            port = "4403"
+
+        # Save network configuration
+        try:
+            config_dir = get_real_user_home() / ".config" / "meshforge"
+            config_dir.mkdir(parents=True, exist_ok=True)
+
+            import json
+            settings_file = config_dir / "settings.json"
+            settings = {}
+            if settings_file.exists():
+                settings = json.loads(settings_file.read_text())
+
+            settings['meshtasticd_host'] = host
+            settings['meshtasticd_port'] = int(port)
+
+            settings_file.write_text(json.dumps(settings, indent=2))
+
+            self.ctx.dialog.msgbox(
+                "Network Configured",
+                f"Configured to connect to:\n\n"
+                f"  Host: {host}\n"
+                f"  Port: {port}\n\n"
+                f"Make sure meshtasticd is running on the remote host."
+            )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to save settings: {e}")
+
+    # -- Step 3: Region selection ------------------------------------------
+
+    def _wizard_step_region(self):
+        """Step 3: Select regulatory region."""
+        choices = [(code, desc) for code, desc in MESHTASTIC_REGIONS]
+
+        choice = self.ctx.dialog.menu(
+            "Step 3: Region Selection",
+            "Select your regulatory region:\n(This determines allowed frequencies)",
+            choices
+        )
+
+        if choice and choice != 'UNSET':
+            # Save region to settings
+            try:
+                config_dir = get_real_user_home() / ".config" / "meshforge"
+                config_dir.mkdir(parents=True, exist_ok=True)
+
+                import json
+                settings_file = config_dir / "settings.json"
+                settings = {}
+                if settings_file.exists():
+                    settings = json.loads(settings_file.read_text())
+
+                settings['region'] = choice
+
+                settings_file.write_text(json.dumps(settings, indent=2))
+            except (OSError, ValueError) as e:
+                logger.debug("Failed to save region setting: %s", e)
+
+    # -- USB device detection ----------------------------------------------
+
+    def _find_usb_serial_devices(self) -> List[Dict[str, str]]:
+        """Find USB serial devices."""
+        devices = []
+
+        for pattern in ['ttyUSB*', 'ttyACM*']:
+            for path in Path('/dev').glob(pattern):
+                device = {'path': str(path), 'name': 'Unknown', 'likely_meshtastic': False}
+
+                try:
+                    result = subprocess.run(
+                        ['udevadm', 'info', '--query=property', str(path)],
+                        capture_output=True, text=True, timeout=5
+                    )
+                    props = {}
+                    for line in result.stdout.splitlines():
+                        if '=' in line:
+                            key, value = line.split('=', 1)
+                            props[key] = value
+
+                    vendor = props.get('ID_VENDOR', '')
+                    model = props.get('ID_MODEL', '')
+                    if vendor or model:
+                        device['name'] = f"{vendor} {model}".strip()
+
+                    device['likely_meshtastic'] = any(
+                        kw in (vendor + model).lower()
+                        for kw in ['meshtastic', 't-beam', 'heltec', 'rak', 'lilygo', 'cp210', 'ch340']
+                    )
+                except (subprocess.SubprocessError, OSError) as e:
+                    logger.debug("USB device detection for %s failed: %s", path, e)
+
+                devices.append(device)
+
+        return devices
+
+    # -- Apply hardware config (hardcoded) ---------------------------------
+
+    def _apply_hardware_config(self, hw_config: dict):
+        """Apply a hardware configuration file."""
+        config_file = hw_config.get('config_file')
+        if not config_file:
+            return
+
+        # Source and destination paths
+        available_dir = Path('/etc/meshtasticd/available.d')
+        config_d = Path('/etc/meshtasticd/config.d')
+        source = available_dir / config_file
+
+        if not source.exists():
+            self.ctx.dialog.msgbox(
+                "Config Not Found",
+                f"Configuration file not found:\n{source}\n\n"
+                f"You may need to install or update meshtasticd."
+            )
+            return
+
+        try:
+            config_d.mkdir(parents=True, exist_ok=True)
+            dest = config_d / config_file
+
+            # Copy config file
+            shutil.copy2(source, dest)
+
+            # Restart meshtasticd
+            apply_config_and_restart('meshtasticd')
+
+            self.ctx.dialog.msgbox(
+                "Configuration Applied",
+                f"Applied configuration for {hw_config['name']}.\n\n"
+                f"Config: {dest}\n\n"
+                f"meshtasticd has been restarted.\n"
+                f"Check: systemctl status meshtasticd"
+            )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to apply config: {e}")
+
+    # -- Create USB config -------------------------------------------------
+
+    def _create_usb_config(self, device_path: str):
+        """Create USB serial configuration."""
+        config_d = Path('/etc/meshtasticd/config.d')
+
+        try:
+            config_d.mkdir(parents=True, exist_ok=True)
+            config_file = config_d / 'usb-serial.yaml'
+
+            config_content = f"""# USB Serial Configuration
+# Generated by MeshForge Setup Wizard
+#
+# The device handles its own LoRa configuration.
+# Radio settings are configured via Meshtastic app/CLI:
+#   meshtastic --host localhost --set lora.region US
+#   meshtastic --host localhost --set lora.modem_preset LONG_FAST
+
+Serial:
+  Device: {device_path}
+
+TCP:
+  Port: 4403
+
+Webserver:
+  Port: 443
+
+Logging:
+  LogLevel: info
+"""
+            config_file.write_text(config_content)
+
+            # Restart meshtasticd
+            apply_config_and_restart('meshtasticd')
+
+            self.ctx.dialog.msgbox(
+                "USB Configured",
+                f"USB serial configuration created.\n\n"
+                f"Device: {device_path}\n"
+                f"Config: {config_file}\n\n"
+                f"meshtasticd has been restarted."
+            )
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to create config: {e}")
+
+    # -- Legacy hardware detection step ------------------------------------
+
+    def _wizard_step_hardware(self):
+        """Wizard Step 1: Hardware Detection"""
+        self.ctx.dialog.infobox("Step 1/4", "Detecting connected hardware...")
+
+        lines = ["Hardware Detection\n"]
+        lines.append("=" * 40)
+
+        # Check for SPI devices (HAT-based radios like MeshAdv-Pi-Hat)
+        spi_devices = list(Path('/dev').glob('spidev*'))
+        is_raspberry_pi = self._is_raspberry_pi()
+
+        if spi_devices:
+            lines.append(f"\n✓ SPI Interface Available:")
+            for spi in spi_devices[:3]:
+                lines.append(f"  • {spi.name}")
+            lines.append("  (Supports HAT radios: MeshAdv-Pi-Hat, Waveshare)")
+        elif is_raspberry_pi:
+            # No SPI but on Pi - offer to enable it
+            lines.append("\n✗ SPI Interface Not Enabled")
+            lines.append("  HAT radios require SPI to be enabled.")
+            self.ctx.dialog.msgbox("Step 1: Hardware", "\n".join(lines))
+
+            # Ask if they want to enable SPI
+            if self._offer_enable_spi():
+                # Re-check after enable
+                spi_devices = list(Path('/dev').glob('spidev*'))
+                if spi_devices:
+                    self.ctx.dialog.msgbox(
+                        "SPI Enabled",
+                        "SPI has been enabled!\n\n"
+                        "A REBOOT is required for changes to take effect.\n\n"
+                        "After reboot, your HAT radio will be detected."
+                    )
+                    lines = ["Hardware Detection\n", "=" * 40]
+                    lines.append("\n✓ SPI Enabled (reboot required)")
+
+        scanner = DeviceScanner()
+        results = scanner.scan_all()
+
+        if results['meshtastic_candidates']:
+            lines.append(f"\n✓ Found {len(results['meshtastic_candidates'])} Meshtastic-compatible device(s):\n")
+            for dev in results['meshtastic_candidates']:
+                lines.append(f"  • {dev.description}")
+        elif not spi_devices:
+            lines.append("\n✗ No Meshtastic devices detected")
+            lines.append("\nTo use MeshForge with a radio:")
+            lines.append("  1. Connect a Meshtastic device via USB")
+            lines.append("  2. Or configure meshtasticd for HAT/SPI")
+
+        if results['serial_ports']:
+            compat_ports = [p for p in results['serial_ports'] if p.meshtastic_compatible]
+            if compat_ports:
+                lines.append(f"\n✓ Serial Ports Available:")
+                for port in compat_ports[:3]:  # Show first 3
+                    lines.append(f"  • {port.device}")
+
+        if results['recommended_port']:
+            lines.append(f"\n→ Recommended port: {results['recommended_port']}")
+
+        # Summary for new users
+        if spi_devices or results.get('meshtastic_candidates'):
+            lines.append("\n" + "-" * 40)
+            lines.append("Hardware detected! Continue to configure.")
+        else:
+            lines.append("\n" + "-" * 40)
+            lines.append("No radio found - you can still explore")
+            lines.append("the interface and configure later.")
+
+        self.ctx.dialog.msgbox("Step 1: Hardware", "\n".join(lines))
+
+    # -- Raspberry Pi detection --------------------------------------------
+
+    def _is_raspberry_pi(self) -> bool:
+        """Check if running on Raspberry Pi."""
+        try:
+            # Check /proc/cpuinfo for Raspberry Pi
+            cpuinfo = Path('/proc/cpuinfo')
+            if cpuinfo.exists():
+                content = cpuinfo.read_text()
+                if 'Raspberry Pi' in content or 'BCM' in content:
+                    return True
+            # Check device tree model
+            model = Path('/proc/device-tree/model')
+            if model.exists():
+                if 'Raspberry Pi' in model.read_text():
+                    return True
+        except OSError as e:
+            logger.debug("RPi detection failed: %s", e)
+        return False
+
+    # -- SPI enable offer --------------------------------------------------
+
+    def _offer_enable_spi(self) -> bool:
+        """Offer to enable SPI on Raspberry Pi. Returns True if enabled."""
+        result = self.ctx.dialog.yesno(
+            "Enable SPI?",
+            "No SPI interface detected.\n\n"
+            "HAT-based radios (MeshAdv-Pi-Hat, Waveshare, etc.)\n"
+            "require SPI to be enabled.\n\n"
+            "Would you like to enable SPI now?\n\n"
+            "(Requires reboot to take effect)"
+        )
+
+        if not result:
+            return False
+
+        self.ctx.dialog.infobox("Enabling SPI", "Configuring SPI interface...")
+
+        try:
+            import subprocess
+
+            # Find the boot config file
+            boot_config = None
+            for path in ['/boot/firmware/config.txt', '/boot/config.txt']:
+                if Path(path).exists():
+                    boot_config = path
+                    break
+
+            if not boot_config:
+                self.ctx.dialog.msgbox("Error", "Could not find boot config file.")
+                return False
+
+            # Enable SPI using raspi-config if available
+            raspi_config = shutil.which('raspi-config')
+            if raspi_config:
+                subprocess.run(
+                    ['raspi-config', 'nonint', 'set_config_var', 'dtparam=spi', 'on', boot_config],
+                    timeout=30,
+                    check=False
+                )
+
+            # Add dtoverlay=spi0-0cs if not present (for HAT compatibility)
+            config_content = Path(boot_config).read_text()
+            if 'dtoverlay=spi0-0cs' not in config_content:
+                # Find dtparam=spi=on line and add overlay after it
+                lines = config_content.split('\n')
+                new_lines = []
+                added = False
+                for line in lines:
+                    new_lines.append(line)
+                    if 'dtparam=spi=on' in line and not added:
+                        new_lines.append('dtoverlay=spi0-0cs')
+                        added = True
+
+                # If dtparam=spi=on wasn't found, add both at the end
+                if not added:
+                    new_lines.append('dtparam=spi=on')
+                    new_lines.append('dtoverlay=spi0-0cs')
+
+                Path(boot_config).write_text('\n'.join(new_lines))
+
+            return True
+
+        except subprocess.TimeoutExpired:
+            self.ctx.dialog.msgbox("Error", "Timeout while configuring SPI.")
+            return False
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to enable SPI: {e}")
+            return False
+
+    # -- Step 4: Service status --------------------------------------------
+
+    def _wizard_step_services(self):
+        """Wizard Step 2: Service Status"""
+        self.ctx.dialog.infobox("Step 2/4", "Checking mesh services...")
+
+        services = [
+            ('meshtasticd', 'Meshtastic Daemon', 'Required for radio communication'),
+            ('rnsd', 'Reticulum Network Stack', 'Optional - enables RNS mesh'),
+        ]
+
+        lines = ["Service Status\n"]
+        lines.append("=" * 40)
+
+        all_running = True
+        for svc_id, svc_name, description in services:
+            status = check_service(svc_id)
+            if status.available:
+                lines.append(f"\n✓ {svc_name}")
+                lines.append(f"  Status: running")
+            else:
+                all_running = False
+                lines.append(f"\n✗ {svc_name}")
+                lines.append(f"  Status: {status.message}")
+                lines.append(f"  ({description})")
+                if status.fix_hint:
+                    lines.append(f"  Fix: {status.fix_hint}")
+
+        if all_running:
+            lines.append("\n" + "-" * 40)
+            lines.append("All services are running!")
+        else:
+            lines.append("\n" + "-" * 40)
+            lines.append("Some services need to be started.")
+            lines.append("Use Service Manager from the main menu.")
+
+        self.ctx.dialog.msgbox("Step 2: Services", "\n".join(lines))
+
+    # -- Legacy config step ------------------------------------------------
+
+    def _wizard_step_config(self):
+        """Wizard Step 3: Quick Configuration"""
+        # Check if basic config exists
+        config_dir = get_real_user_home() / ".config" / "meshforge"
+        settings_file = config_dir / "settings.json"
+
+        if settings_file.exists():
+            self.ctx.dialog.msgbox(
+                "Step 3: Configuration",
+                "Configuration file found.\n\n"
+                "Your settings are preserved from a previous install.\n\n"
+                "You can modify settings from:\n"
+                "  Main Menu → Settings"
+            )
+            return
+
+        # Offer basic setup
+        result = self.ctx.dialog.yesno(
+            "Step 3: Configuration",
+            "Would you like to configure basic settings?\n\n"
+            "This includes:\n"
+            "• Callsign (for ham operators)\n"
+            "• Default region\n"
+            "• UI preferences"
+        )
+
+        if result:
+            # Get callsign
+            callsign = self.ctx.dialog.inputbox(
+                "Callsign",
+                "Enter your callsign (optional):",
+                ""
+            )
+
+            if callsign:
+                # Save to settings
+                try:
+                    from utils.common import SettingsManager
+                    settings = SettingsManager("meshforge")
+                    settings.set("callsign", callsign.upper())
+                    settings.save()
+                    self.ctx.dialog.msgbox("Saved", f"Callsign set to: {callsign.upper()}")
+                except Exception as e:
+                    self.ctx.dialog.msgbox("Note", f"Could not save settings: {e}")
+
+    # -- Wizard completion -------------------------------------------------
+
+    def _wizard_complete(self):
+        """Wizard completion"""
+        self._mark_setup_complete()
+
+        self.ctx.dialog.msgbox(
+            "Setup Complete!",
+            "MeshForge is ready to use!\n\n"
+            "Next Steps:\n"
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "1. Service Manager → Start meshtasticd\n"
+            "2. Meshtasticd Config → Configure your radio\n"
+            "3. Diagnostics → Verify everything works\n"
+            "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n"
+            "\nNeed Help?\n"
+            "  • Run diagnostics for system health\n"
+            "  • Check GitHub issues for known fixes\n"
+            "  • HAM community: 73s and good luck!\n\n"
+            "Press Enter to continue to main menu."
+        )
+
+    # -- Settings menu entry point -----------------------------------------
+
+    def _settings_run_wizard(self):
+        """Run wizard from settings menu."""
+        result = self.ctx.dialog.yesno(
+            "Run Setup Wizard",
+            "Run the first-run setup wizard again?\n\n"
+            "This will walk through hardware detection,\n"
+            "service checks, and basic configuration."
+        )
+
+        if result:
+            self._run_first_run_wizard()

--- a/src/launcher_tui/handlers/meshchat.py
+++ b/src/launcher_tui/handlers/meshchat.py
@@ -1,0 +1,1048 @@
+"""
+MeshChat Handler — MeshChat client installation, management, and monitoring.
+
+Provides TUI handlers to install, manage, and monitor MeshChat --
+an LXMF messaging client with HTTP API and web UI.
+
+MeshChat runs as an external service (systemd or manual) and exposes
+a REST API on port 8000. This handler wraps the existing MeshChat plugin
+(src/plugins/meshchat/) with TUI menus.
+
+Data flow:
+  Meshtastic (Short Turbo) <> meshtasticd <> MeshForge Gateway
+  <> LXMF <> rnsd <> LXMF <> MeshChat
+
+Install:  Automated via TUI (git clone + npm + pip + systemd service)
+          Or manually: see plugins/meshchat/service.py INSTALL_HINT
+
+LXMF exclusivity:
+  MeshChat and NomadNet are both LXMF clients. Only one should run
+  at a time to avoid port 37428 conflicts. The _ensure_lxmf_exclusive()
+  helper delegates to handlers/_lxmf_utils.py for this check.
+
+Converted from meshchat_client_mixin.py as part of the mixin-to-registry migration (Batch 8).
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from pathlib import Path
+
+from backend import clear_screen
+from handler_protocol import BaseHandler
+from handlers._lxmf_utils import ensure_lxmf_exclusive
+
+from utils.paths import get_real_user_home
+from utils.safe_import import safe_import
+
+logger = logging.getLogger(__name__)
+
+# Import centralized service checking
+check_process_running, start_service, stop_service, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', 'start_service', 'stop_service'
+)
+
+check_rns_shared_instance, _HAS_RNS_CHECK = safe_import(
+    'utils.service_check', 'check_rns_shared_instance'
+)
+
+# Import MeshChat plugin components (optional external dependency)
+MeshChatService, ServiceState, _HAS_MESHCHAT_SERVICE = safe_import(
+    'plugins.meshchat.service', 'MeshChatService', 'ServiceState'
+)
+
+MeshChatClient, MeshChatError, _HAS_MESHCHAT_CLIENT = safe_import(
+    'plugins.meshchat.client', 'MeshChatClient', 'MeshChatError'
+)
+
+
+class MeshChatHandler(BaseHandler):
+    """TUI handler for MeshChat client management."""
+
+    handler_id = "meshchat"
+    menu_section = "mesh_networks"
+
+    MESHCHAT_REPO = "https://github.com/liamcottle/reticulum-meshchat"
+    MESHCHAT_SERVICE_NAME = "reticulum-meshchat"
+
+    def menu_items(self):
+        return [
+            ("meshchat", "MeshChat Client     RNS messaging", "rns"),
+        ]
+
+    def execute(self, action):
+        if action == "meshchat":
+            self._meshchat_menu()
+
+    # ------------------------------------------------------------------
+    # Detection helpers
+    # ------------------------------------------------------------------
+
+    def _is_meshchat_installed(self) -> bool:
+        """Check if MeshChat is installed (binary, service, or process)."""
+        # Check for meshchat.py or reticulum-meshchat in PATH
+        if shutil.which('meshchat') or shutil.which('meshchat.py'):
+            return True
+
+        # Check user local bin
+        user_home = get_real_user_home()
+        for candidate in [
+            user_home / 'reticulum-meshchat' / 'meshchat.py',
+            user_home / '.local' / 'bin' / 'meshchat',
+        ]:
+            if candidate.exists():
+                return True
+
+        # Check via service detection if plugin available
+        if _HAS_MESHCHAT_SERVICE:
+            try:
+                svc = MeshChatService()
+                status = svc.check_status(blocking=True)
+                return status.installed
+            except Exception:
+                pass
+
+        return False
+
+    def _is_meshchat_running(self) -> bool:
+        """Check if MeshChat process is running."""
+        # Try unified check first
+        if _HAS_SERVICE_CHECK and check_process_running:
+            if check_process_running('meshchat'):
+                return True
+
+        # Try plugin service check
+        if _HAS_MESHCHAT_SERVICE:
+            try:
+                svc = MeshChatService()
+                status = svc.check_status(blocking=True)
+                return status.running
+            except Exception:
+                pass
+
+        # Fallback to pgrep
+        try:
+            result = subprocess.run(
+                ['pgrep', '-f', 'meshchat.py'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                for pid in result.stdout.strip().split('\n'):
+                    if pid.strip() and pid.strip() != str(os.getpid()):
+                        return True
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        return False
+
+    # ------------------------------------------------------------------
+    # LXMF exclusivity (delegates to shared utility)
+    # ------------------------------------------------------------------
+
+    def _ensure_lxmf_exclusive(self, starting_app: str) -> bool:
+        """Ensure only one LXMF app runs at a time.
+
+        Delegates to handlers/_lxmf_utils.ensure_lxmf_exclusive().
+        """
+        return ensure_lxmf_exclusive(
+            self.ctx.dialog, starting_app,
+            is_meshchat_running_fn=self._is_meshchat_running,
+        )
+
+    # ------------------------------------------------------------------
+    # Top-level submenu
+    # ------------------------------------------------------------------
+
+    def _meshchat_menu(self):
+        """MeshChat LXMF client -- install, manage, monitor."""
+        while True:
+            running = self._is_meshchat_running()
+            installed = self._is_meshchat_installed()
+
+            if not installed:
+                subtitle = "MeshChat is NOT INSTALLED"
+            elif running:
+                subtitle = "MeshChat is RUNNING (http://127.0.0.1:8000)"
+            else:
+                subtitle = "MeshChat is installed (not running)"
+
+            choices = [
+                ("status", "MeshChat Status"),
+            ]
+
+            if installed:
+                if running:
+                    choices.append(("stop", "Stop MeshChat"))
+                    choices.append(("peers", "View LXMF Peers"))
+                    choices.append(("messages", "Recent Messages"))
+                    choices.append(("announce", "Send LXMF Announce"))
+                    choices.append(("web", "Web UI (show URL)"))
+                else:
+                    choices.append(("start", "Start MeshChat"))
+                choices.append(("logs", "View Logs"))
+                choices.append(("uninstall", "Disable MeshChat"))
+            else:
+                choices.append(("install", "Install MeshChat"))
+
+            choices.append(("back", "Back"))
+
+            choice = self.ctx.dialog.menu(
+                "MeshChat Client",
+                f"LXMF messaging with HTTP API & web UI:\n\n"
+                f"{subtitle}",
+                choices,
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "status": ("MeshChat Status", self._meshchat_status),
+                "start": ("Start MeshChat", self._launch_meshchat),
+                "stop": ("Stop MeshChat", self._stop_meshchat),
+                "peers": ("View LXMF Peers", self._meshchat_peers),
+                "messages": ("Recent Messages", self._meshchat_messages),
+                "announce": ("Send LXMF Announce", self._meshchat_announce),
+                "web": ("MeshChat Web UI", self._meshchat_web_ui),
+                "logs": ("View MeshChat Logs", self._meshchat_logs),
+                "install": ("Install MeshChat", self._install_meshchat),
+                "uninstall": ("Disable MeshChat", self._uninstall_meshchat),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    def _meshchat_status(self):
+        """Show comprehensive MeshChat status."""
+        clear_screen()
+        print("=== MeshChat Status ===\n")
+
+        # Installation
+        installed = self._is_meshchat_installed()
+        running = self._is_meshchat_running()
+
+        if not installed:
+            print("  Installed:  No")
+            print(f"\n  Install from: https://github.com/liamcottle/reticulum-meshchat")
+            self.ctx.wait_for_enter()
+            return
+
+        print(f"  Installed:  Yes")
+        print(f"  Running:    {'Yes' if running else 'No'}")
+
+        # Service details via plugin
+        if _HAS_MESHCHAT_SERVICE:
+            try:
+                svc = MeshChatService()
+                status = svc.check_status(blocking=True)
+                if status.service_name:
+                    print(f"  Service:    {status.service_name}")
+                if status.pid:
+                    print(f"  PID:        {status.pid}")
+                print(f"  Port 8000:  {'Open' if status.port_open else 'Closed'}")
+            except Exception as e:
+                logger.debug("MeshChat service check failed: %s", e)
+
+        # API details if running
+        if running and _HAS_MESHCHAT_CLIENT:
+            try:
+                client = MeshChatClient()
+                mc_status = client.get_status()
+                print()
+                if mc_status.version:
+                    print(f"  Version:    {mc_status.version}")
+                if mc_status.identity_hash:
+                    print(f"  Identity:   {mc_status.identity_hash}")
+                if mc_status.display_name:
+                    print(f"  Name:       {mc_status.display_name}")
+                print(f"  Peers:      {mc_status.peer_count}")
+                print(f"  Messages:   {mc_status.message_count}")
+                print(f"  RNS:        {'Connected' if mc_status.rns_connected else 'Disconnected'}")
+                if mc_status.uptime_seconds > 0:
+                    hrs = mc_status.uptime_seconds // 3600
+                    mins = (mc_status.uptime_seconds % 3600) // 60
+                    print(f"  Uptime:     {hrs}h {mins}m")
+                print(f"  Propagation: {'Yes' if mc_status.propagation_node else 'No'}")
+            except Exception as e:
+                print(f"\n  API Error:  {e}")
+
+        # RNS shared instance status
+        print()
+        rnsd_user = self._get_rnsd_user()
+        if rnsd_user:
+            print(f"  rnsd:       Running (as {rnsd_user})")
+        else:
+            print("  rnsd:       Not running")
+            if running:
+                print("              MeshChat may be running its own RNS instance")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Start / Stop
+    # ------------------------------------------------------------------
+
+    def _launch_meshchat(self):
+        """Start MeshChat service."""
+        # Preflight: ensure NomadNet is not running (one LXMF app at a time)
+        if not self._ensure_lxmf_exclusive("meshchat"):
+            return
+
+        # Preflight: check RNS availability
+        if not self._check_rns_for_meshchat():
+            return
+
+        if _HAS_MESHCHAT_SERVICE:
+            svc = MeshChatService()
+            status = svc.check_status(blocking=True)
+
+            if status.running:
+                self.ctx.dialog.msgbox(
+                    "Already Running",
+                    "MeshChat is already running.\n\n"
+                    f"Web UI: http://127.0.0.1:8000",
+                )
+                return
+
+            if status.service_name:
+                # Systemd service available — start it
+                self.ctx.dialog.infobox(
+                    "Starting MeshChat",
+                    f"Starting {status.service_name}...",
+                )
+                svc.start()
+                time.sleep(3)
+
+                # Verify
+                new_status = svc.check_status(blocking=True)
+                if new_status.running:
+                    self.ctx.dialog.msgbox(
+                        "MeshChat Started",
+                        f"MeshChat is running.\n\n"
+                        f"Web UI: http://127.0.0.1:8000",
+                    )
+                else:
+                    self.ctx.dialog.msgbox(
+                        "Start May Have Failed",
+                        f"MeshChat does not appear to be running.\n\n"
+                        f"Check: systemctl status {status.service_name}\n"
+                        f"       journalctl -u {status.service_name} -n 20",
+                    )
+                return
+
+        # No systemd service — show manual start instructions
+        self.ctx.dialog.msgbox(
+            "Manual Start Required",
+            "No systemd service found for MeshChat.\n\n"
+            "Start manually:\n"
+            "  cd ~/reticulum-meshchat\n"
+            "  python meshchat.py\n\n"
+            "Or create a systemd service for automatic startup.",
+        )
+
+    def _stop_meshchat(self):
+        """Stop MeshChat service."""
+        if not self.ctx.dialog.yesno(
+            "Stop MeshChat",
+            "Stop the MeshChat service?\n\n"
+            "LXMF messaging will be unavailable until restarted.",
+        ):
+            return
+
+        stopped = False
+
+        if _HAS_MESHCHAT_SERVICE:
+            svc = MeshChatService()
+            status = svc.check_status(blocking=True)
+            if status.service_name:
+                svc.stop()
+                time.sleep(2)
+                stopped = True
+
+        if not stopped:
+            # Fallback: kill process
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'meshchat.py'],
+                    capture_output=True, timeout=5,
+                )
+                time.sleep(1)
+                stopped = True
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        if stopped and not self._is_meshchat_running():
+            self.ctx.dialog.msgbox(
+                "MeshChat Stopped",
+                "MeshChat has been stopped.",
+            )
+        else:
+            self.ctx.dialog.msgbox(
+                "Stop May Have Failed",
+                "MeshChat may still be running.\n\n"
+                "Try: pkill -f meshchat.py",
+            )
+
+    # ------------------------------------------------------------------
+    # Peers, Messages, Announce
+    # ------------------------------------------------------------------
+
+    def _meshchat_peers(self):
+        """Show discovered LXMF peers."""
+        clear_screen()
+        print("=== MeshChat LXMF Peers ===\n")
+
+        if not _HAS_MESHCHAT_CLIENT:
+            print("  MeshChat client library not available.")
+            self.ctx.wait_for_enter()
+            return
+
+        try:
+            client = MeshChatClient()
+            peers = client.get_peers()
+
+            if not peers:
+                print("  No peers discovered yet.")
+                print("\n  Peers appear after LXMF announces propagate.")
+                print("  Try: Send Announce from the menu.")
+                self.ctx.wait_for_enter()
+                return
+
+            # Header
+            print(f"  {'Name':<20} {'Hash':<18} {'Online':<8} {'Last Announce'}")
+            print(f"  {'─' * 20} {'─' * 18} {'─' * 8} {'─' * 20}")
+
+            for peer in peers:
+                name = (peer.display_name or "Unknown")[:20]
+                short_hash = peer.destination_hash[:16] + ".."
+                online = "Yes" if peer.is_online else "No"
+                last = ""
+                if peer.last_announce:
+                    last = peer.last_announce.strftime("%Y-%m-%d %H:%M")
+                print(f"  {name:<20} {short_hash:<18} {online:<8} {last}")
+
+            print(f"\n  Total: {len(peers)} peers")
+
+        except Exception as e:
+            print(f"  Error fetching peers: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _meshchat_messages(self):
+        """Show recent LXMF messages."""
+        clear_screen()
+        print("=== MeshChat Recent Messages ===\n")
+
+        if not _HAS_MESHCHAT_CLIENT:
+            print("  MeshChat client library not available.")
+            self.ctx.wait_for_enter()
+            return
+
+        try:
+            client = MeshChatClient()
+            messages = client.get_messages(limit=20)
+
+            if not messages:
+                print("  No messages yet.")
+                self.ctx.wait_for_enter()
+                return
+
+            for msg in messages:
+                direction = "<<" if msg.is_incoming else ">>"
+                ts = msg.timestamp.strftime("%H:%M:%S")
+                src = msg.source_hash[:12] + ".."
+                delivered = "+" if msg.delivered else " "
+                content = msg.content[:60]
+                if len(msg.content) > 60:
+                    content += "..."
+                print(f"  {ts} {direction} {src} {delivered} {content}")
+
+            print(f"\n  Showing {len(messages)} most recent messages")
+
+        except Exception as e:
+            print(f"  Error fetching messages: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _meshchat_announce(self):
+        """Send LXMF announce to the network."""
+        if not self.ctx.dialog.yesno(
+            "Send Announce",
+            "Send an LXMF announce to the RNS network?\n\n"
+            "This advertises MeshChat's presence to other\n"
+            "LXMF clients (NomadNet, Sideband, other MeshChat).",
+        ):
+            return
+
+        if not _HAS_MESHCHAT_CLIENT:
+            self.ctx.dialog.msgbox(
+                "Not Available",
+                "MeshChat client library not available.",
+            )
+            return
+
+        try:
+            client = MeshChatClient()
+            if client.send_announce():
+                self.ctx.dialog.msgbox(
+                    "Announce Sent",
+                    "LXMF announce has been sent to the network.\n\n"
+                    "Other nodes will discover MeshChat within minutes.",
+                )
+            else:
+                self.ctx.dialog.msgbox(
+                    "Announce Failed",
+                    "Failed to send LXMF announce.\n\n"
+                    "Check that MeshChat is running and RNS is connected.",
+                )
+        except Exception as e:
+            self.ctx.dialog.msgbox(
+                "Announce Error",
+                f"Error sending announce: {e}",
+            )
+
+    # ------------------------------------------------------------------
+    # Web UI
+    # ------------------------------------------------------------------
+
+    def _meshchat_web_ui(self):
+        """Show MeshChat web UI URL."""
+        self.ctx.dialog.msgbox(
+            "MeshChat Web UI",
+            "MeshChat web interface is available at:\n\n"
+            "  http://127.0.0.1:8000\n\n"
+            "Access from the same machine in a browser,\n"
+            "or via SSH tunnel:\n\n"
+            "  ssh -L 8000:127.0.0.1:8000 user@host\n"
+            "  Then open: http://127.0.0.1:8000",
+        )
+
+    # ------------------------------------------------------------------
+    # Logs
+    # ------------------------------------------------------------------
+
+    def _meshchat_logs(self):
+        """View MeshChat logs."""
+        clear_screen()
+        print("=== MeshChat Logs ===\n")
+
+        shown = False
+
+        # Try systemd journal first
+        if _HAS_MESHCHAT_SERVICE:
+            try:
+                svc = MeshChatService()
+                status = svc.check_status(blocking=True)
+                if status.service_name:
+                    print(f"  Service: {status.service_name}\n")
+                    result = subprocess.run(
+                        ['journalctl', '-u', status.service_name,
+                         '-n', '30', '--no-pager'],
+                        capture_output=True, text=True, timeout=10
+                    )
+                    if result.stdout and result.stdout.strip():
+                        for line in result.stdout.strip().split('\n'):
+                            print(f"  {line}")
+                        shown = True
+            except (subprocess.SubprocessError, OSError) as e:
+                logger.debug("MeshChat journal read failed: %s", e)
+
+        # Try log file paths
+        if not shown:
+            user_home = get_real_user_home()
+            log_paths = [
+                user_home / '.config' / 'meshchat' / 'logs',
+                user_home / '.meshchat' / 'logs',
+                user_home / 'reticulum-meshchat' / 'logs',
+                Path('/var/log/meshchat'),
+            ]
+            for log_dir in log_paths:
+                if log_dir.exists() and log_dir.is_dir():
+                    # Find most recent log file
+                    log_files = sorted(
+                        log_dir.glob('*.log'),
+                        key=lambda p: p.stat().st_mtime,
+                        reverse=True,
+                    )
+                    if log_files:
+                        import collections
+                        print(f"  Log file: {log_files[0]}\n")
+                        try:
+                            with open(log_files[0], 'r') as f:
+                                last_lines = list(
+                                    collections.deque(f, maxlen=30)
+                                )
+                            for line in last_lines:
+                                print(f"  {line.rstrip()}")
+                            shown = True
+                        except (IOError, OSError) as e:
+                            print(f"  Error reading log: {e}")
+                    break
+
+        if not shown:
+            print("  No logs found.")
+            print("\n  If MeshChat is running as a systemd service:")
+            print("    journalctl -u meshchat -n 30 --no-pager")
+            print("    journalctl -u reticulum-meshchat -n 30 --no-pager")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Install (fully automated)
+    # ------------------------------------------------------------------
+
+    def _get_meshchat_install_dir(self) -> Path:
+        """Return the MeshChat install directory under user home."""
+        return get_real_user_home() / 'reticulum-meshchat'
+
+    def _get_pip_command(self) -> list:
+        """Return the pip command appropriate for this install.
+
+        Prefers MeshForge's venv pip, falls back to system pip3
+        with --break-system-packages for PEP 668 compatibility.
+        """
+        venv_pip = Path('/opt/meshforge/venv/bin/pip')
+        if venv_pip.exists():
+            return [str(venv_pip)]
+
+        # Check for PEP 668 (externally-managed Python)
+        import glob
+        if glob.glob('/usr/lib/python3*/EXTERNALLY-MANAGED'):
+            return ['pip3', 'install', '--break-system-packages']
+
+        return ['pip3']
+
+    def _install_meshchat(self):
+        """Automated MeshChat installation.
+
+        Steps:
+        1. Confirm with user
+        2. Check/install prerequisites (git, nodejs, npm)
+        3. git clone reticulum-meshchat
+        4. pip install -r requirements.txt
+        5. npm install && npm run build-frontend
+        6. Create systemd service
+        7. Enable + start service
+        """
+        if self._is_meshchat_installed():
+            self.ctx.dialog.msgbox(
+                "Already Installed",
+                "MeshChat is already installed.\n\n"
+                "Use Start/Stop from the menu to manage it.",
+            )
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Install MeshChat",
+            "Install MeshChat (Reticulum MeshChat)?\n\n"
+            "This will:\n"
+            "  1. Install Node.js/npm (if needed)\n"
+            "  2. Clone the MeshChat repository\n"
+            "  3. Install Python dependencies\n"
+            "  4. Build the web frontend (npm)\n"
+            "  5. Create a systemd service\n\n"
+            "MeshChat provides LXMF messaging with a\n"
+            "web UI at http://127.0.0.1:8000\n\n"
+            "Source: github.com/liamcottle/reticulum-meshchat\n\n"
+            "Install now?",
+        ):
+            return
+
+        # LXMF exclusivity check — stop NomadNet if running
+        if not self._ensure_lxmf_exclusive("meshchat"):
+            return
+
+        clear_screen()
+        print("=== Installing MeshChat ===\n")
+
+        install_dir = self._get_meshchat_install_dir()
+        sudo_user = os.environ.get('SUDO_USER')
+        run_as_user = sudo_user if sudo_user and sudo_user != 'root' else None
+
+        try:
+            # Step 1: Prerequisites
+            if not self._install_meshchat_prerequisites():
+                self.ctx.wait_for_enter()
+                return
+
+            # Step 2: Git clone
+            if not self._install_meshchat_clone(install_dir, run_as_user):
+                self.ctx.wait_for_enter()
+                return
+
+            # Step 3: pip install
+            if not self._install_meshchat_pip(install_dir, run_as_user):
+                self.ctx.wait_for_enter()
+                return
+
+            # Step 4: npm build
+            if not self._install_meshchat_npm(install_dir, run_as_user):
+                self.ctx.wait_for_enter()
+                return
+
+            # Step 5: systemd service
+            if not self._install_meshchat_service(install_dir, run_as_user):
+                print("\nSystemd service creation failed.")
+                print("You can still run MeshChat manually:")
+                print(f"  cd {install_dir} && python3 meshchat.py")
+
+            # Step 6: Start service
+            print("\nStarting MeshChat service...")
+            try:
+                subprocess.run(
+                    ['systemctl', 'start', self.MESHCHAT_SERVICE_NAME],
+                    capture_output=True, timeout=15,
+                )
+                time.sleep(3)
+            except (subprocess.SubprocessError, OSError) as e:
+                logger.debug("Service start failed: %s", e)
+
+            # Verify
+            if self._is_meshchat_running():
+                print("\nMeshChat is running!")
+                print("Web UI: http://127.0.0.1:8000")
+            else:
+                print("\nMeshChat installed but may not be running yet.")
+                print(f"Check: systemctl status {self.MESHCHAT_SERVICE_NAME}")
+
+            print("\nInstallation complete.")
+
+        except KeyboardInterrupt:
+            print("\n\nInstallation cancelled.")
+        except Exception as e:
+            print(f"\nInstallation error: {e}")
+            logger.exception("MeshChat install failed")
+
+        try:
+            self.ctx.wait_for_enter()
+        except (EOFError, KeyboardInterrupt):
+            pass
+
+    def _install_meshchat_prerequisites(self) -> bool:
+        """Check and install git, nodejs, npm. Returns True on success."""
+        # git
+        if not shutil.which('git'):
+            print("Installing git...")
+            result = subprocess.run(
+                ['apt-get', 'install', '-y', '-qq', 'git'],
+                capture_output=True, timeout=120,
+            )
+            if result.returncode != 0:
+                print("Failed to install git.")
+                print("Try: sudo apt install git")
+                return False
+
+        # Node.js + npm
+        if not shutil.which('node') or not shutil.which('npm'):
+            print("Installing Node.js and npm...")
+            result = subprocess.run(
+                ['apt-get', 'install', '-y', '-qq', 'nodejs', 'npm'],
+                capture_output=True, timeout=180,
+            )
+            if result.returncode != 0:
+                print("Failed to install Node.js/npm.")
+                print("Try: sudo apt install nodejs npm")
+                return False
+            print("Node.js and npm installed.")
+
+        # Verify
+        for tool in ['git', 'node', 'npm']:
+            if not shutil.which(tool):
+                print(f"Error: {tool} not found after install.")
+                return False
+
+        print("Prerequisites OK (git, node, npm)\n")
+        return True
+
+    def _install_meshchat_clone(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Clone the MeshChat repository. Returns True on success."""
+        if install_dir.exists():
+            print(f"Directory exists: {install_dir}")
+            # Pull latest instead of clone
+            print("Pulling latest changes...")
+            cmd = ['git', '-C', str(install_dir), 'pull', '--ff-only']
+            if run_as_user:
+                cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+            if result.returncode != 0:
+                print(f"Git pull failed: {result.stderr.strip()}")
+                print("Continuing with existing checkout.")
+            else:
+                print("Repository updated.")
+            return True
+
+        print(f"Cloning MeshChat to {install_dir}...")
+        cmd = ['git', 'clone', self.MESHCHAT_REPO, str(install_dir)]
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, timeout=120)
+        if result.returncode != 0:
+            print("Git clone failed.")
+            print(f"Try: git clone {self.MESHCHAT_REPO} {install_dir}")
+            return False
+
+        print("Repository cloned.\n")
+        return True
+
+    def _install_meshchat_pip(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Install MeshChat Python dependencies. Returns True on success."""
+        req_file = install_dir / 'requirements.txt'
+        if not req_file.exists():
+            print("No requirements.txt found — skipping pip install.")
+            return True
+
+        print("Installing Python dependencies...")
+        pip_cmd = self._get_pip_command()
+
+        # Build install command
+        if len(pip_cmd) > 1 and pip_cmd[1] == 'install':
+            # pip3 install --break-system-packages case
+            cmd = pip_cmd + ['--timeout', '60', '-r', str(req_file)]
+        else:
+            cmd = pip_cmd + ['install', '--timeout', '60', '-r', str(req_file)]
+
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, timeout=300)
+        if result.returncode != 0:
+            print("pip install failed.")
+            print(f"Try: pip3 install -r {req_file}")
+            return False
+
+        print("Python dependencies installed.\n")
+        return True
+
+    def _install_meshchat_npm(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Build MeshChat web frontend with npm. Returns True on success."""
+        pkg_json = install_dir / 'package.json'
+        if not pkg_json.exists():
+            print("No package.json found — skipping npm build.")
+            return True
+
+        print("Installing npm dependencies...")
+        cmd = ['npm', 'install', '--omit=dev']
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, cwd=str(install_dir), timeout=300)
+        if result.returncode != 0:
+            print("npm install failed.")
+            print(f"Try: cd {install_dir} && npm install --omit=dev")
+            return False
+
+        print("Building web frontend...")
+        cmd = ['npm', 'run', 'build-frontend']
+        if run_as_user:
+            cmd = ['sudo', '-H', '-u', run_as_user] + cmd
+
+        result = subprocess.run(cmd, cwd=str(install_dir), timeout=300)
+        if result.returncode != 0:
+            print("npm build failed.")
+            print(f"Try: cd {install_dir} && npm run build-frontend")
+            return False
+
+        print("Web frontend built.\n")
+        return True
+
+    def _install_meshchat_service(self, install_dir: Path, run_as_user: str = None) -> bool:
+        """Create systemd service for MeshChat. Returns True on success."""
+        service_user = run_as_user or 'root'
+        user_home = get_real_user_home()
+        python_path = shutil.which('python3') or '/usr/bin/python3'
+        meshchat_py = install_dir / 'meshchat.py'
+
+        service_content = (
+            f"[Unit]\n"
+            f"Description=Reticulum MeshChat LXMF Client\n"
+            f"After=network.target rnsd.service\n"
+            f"Wants=rnsd.service\n"
+            f"\n"
+            f"[Service]\n"
+            f"Type=simple\n"
+            f"User={service_user}\n"
+            f"WorkingDirectory={install_dir}\n"
+            f"ExecStart={python_path} {meshchat_py}\n"
+            f"Restart=on-failure\n"
+            f"RestartSec=5\n"
+            f"StartLimitBurst=5\n"
+            f"StartLimitIntervalSec=60\n"
+            f"Environment=HOME={user_home}\n"
+            f"\n"
+            f"[Install]\n"
+            f"WantedBy=multi-user.target\n"
+        )
+
+        service_path = f"/etc/systemd/system/{self.MESHCHAT_SERVICE_NAME}.service"
+        print(f"Creating systemd service: {service_path}")
+
+        try:
+            # Write service file
+            with open(service_path, 'w') as f:
+                f.write(service_content)
+
+            # Reload systemd and enable
+            subprocess.run(
+                ['systemctl', 'daemon-reload'],
+                capture_output=True, timeout=15,
+            )
+            subprocess.run(
+                ['systemctl', 'enable', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+            print("Service created and enabled.\n")
+            return True
+
+        except (IOError, OSError, subprocess.SubprocessError) as e:
+            print(f"Failed to create service: {e}")
+            return False
+
+    # ------------------------------------------------------------------
+    # Uninstall (stop + disable)
+    # ------------------------------------------------------------------
+
+    def _uninstall_meshchat(self):
+        """Stop and disable MeshChat service.
+
+        Leaves files in place for easy re-enable. Does not delete
+        the cloned repository or configuration.
+        """
+        if not self.ctx.dialog.yesno(
+            "Disable MeshChat",
+            "Stop and disable the MeshChat service?\n\n"
+            "This will:\n"
+            "  - Stop MeshChat if running\n"
+            "  - Disable auto-start on boot\n\n"
+            "Files remain at ~/reticulum-meshchat\n"
+            "for easy re-enable later.\n\n"
+            "Disable now?",
+        ):
+            return
+
+        clear_screen()
+        print("=== Disabling MeshChat ===\n")
+
+        # Stop service
+        try:
+            print("Stopping MeshChat...")
+            subprocess.run(
+                ['systemctl', 'stop', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Service stop: %s", e)
+
+        # Kill any running process
+        try:
+            subprocess.run(
+                ['pkill', '-f', 'meshchat.py'],
+                capture_output=True, timeout=5,
+            )
+        except (subprocess.SubprocessError, OSError):
+            pass
+
+        time.sleep(1)
+
+        # Disable service
+        try:
+            print("Disabling auto-start...")
+            subprocess.run(
+                ['systemctl', 'disable', self.MESHCHAT_SERVICE_NAME],
+                capture_output=True, timeout=15,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("Service disable: %s", e)
+
+        install_dir = self._get_meshchat_install_dir()
+        if self._is_meshchat_running():
+            print("\nMeshChat may still be running.")
+            print("Try: sudo pkill -f meshchat.py")
+        else:
+            print("\nMeshChat stopped and disabled.")
+
+        print(f"\nFiles remain at: {install_dir}")
+        print("To re-enable: systemctl enable --now reticulum-meshchat")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Cross-handler helpers
+    # ------------------------------------------------------------------
+
+    def _get_rnsd_user(self):
+        """Get the OS user running rnsd, via the rns_diagnostics handler.
+
+        Returns None if the handler is unavailable or rnsd is not running.
+        """
+        if self.ctx.registry:
+            diag = self.ctx.registry.get_handler("rns_diagnostics")
+            if diag and hasattr(diag, '_get_rnsd_user'):
+                return diag._get_rnsd_user()
+        return None
+
+    def _fix_rnsd_user(self, target_user: str) -> bool:
+        """Fix rnsd to run as the specified user, via the rns_diagnostics handler.
+
+        Returns False if the handler is unavailable.
+        """
+        if self.ctx.registry:
+            diag = self.ctx.registry.get_handler("rns_diagnostics")
+            if diag and hasattr(diag, '_fix_rnsd_user'):
+                return diag._fix_rnsd_user(target_user)
+        return False
+
+    # ------------------------------------------------------------------
+    # Preflight: RNS check
+    # ------------------------------------------------------------------
+
+    def _check_rns_for_meshchat(self) -> bool:
+        """Check that RNS is available for MeshChat.
+
+        MeshChat can run with or without rnsd:
+        - With rnsd: connects as shared instance client (recommended)
+        - Without: starts its own RNS instance
+
+        Returns True to proceed, False if user cancelled.
+        """
+        rnsd_user = self._get_rnsd_user()
+
+        if not rnsd_user:
+            # rnsd not running — warn but allow proceeding
+            return self.ctx.dialog.yesno(
+                "rnsd Not Running",
+                "The RNS daemon (rnsd) is not running.\n\n"
+                "MeshChat can start its own RNS instance,\n"
+                "but for Meshtastic bridging you should run rnsd\n"
+                "with share_instance = Yes in the Reticulum config.\n\n"
+                "Continue anyway?",
+            )
+
+        # rnsd is running — check for root mismatch
+        sudo_user = os.environ.get('SUDO_USER', '')
+        if rnsd_user == 'root' and sudo_user and sudo_user != 'root':
+            choice = self.ctx.dialog.menu(
+                "rnsd Running as Root",
+                f"rnsd is running as root, but MeshChat should\n"
+                f"use the same RNS identity as '{sudo_user}'.\n\n"
+                "This may cause RPC authentication failures.",
+                [
+                    ("continue", "Continue anyway"),
+                    ("fix", f"Fix rnsd to run as {sudo_user}"),
+                    ("cancel", "Cancel"),
+                ],
+            )
+            if choice == "fix":
+                self._fix_rnsd_user(sudo_user)
+                return True
+            elif choice == "cancel" or choice is None:
+                return False
+            # "continue" falls through
+
+        return True

--- a/src/launcher_tui/handlers/nomadnet.py
+++ b/src/launcher_tui/handlers/nomadnet.py
@@ -1,0 +1,1610 @@
+"""
+NomadNet Handler — NomadNet client installation, configuration, and management.
+
+Provides TUI handlers to install, configure, launch, and manage
+NomadNet -- the primary RNS client application used for verifying
+Meshtastic <> Reticulum connectivity.
+
+NomadNet runs its own text-UI with a built-in micron page browser
+for browsing content hosted on RNS nodes.  It can also run in daemon
+mode to serve pages and propagate LXMF messages.
+
+Config directory resolution (mirrors NomadNet upstream):
+  /etc/nomadnetwork  ->  ~/.config/nomadnetwork  ->  ~/.nomadnetwork
+
+Requires:  pipx install nomadnet   (pulls in rns + lxmf automatically)
+
+Converted from nomadnet_client_mixin.py as part of the mixin-to-registry migration (Batch 8).
+"""
+
+import os
+import shutil
+import subprocess
+import time
+import logging
+from pathlib import Path
+from typing import Optional
+
+from handler_protocol import BaseHandler
+from backend import clear_screen
+
+logger = logging.getLogger(__name__)
+
+from utils.paths import ReticulumPaths
+
+from utils.safe_import import safe_import
+
+# Import centralized service checking
+check_process_running, start_service, stop_service, apply_config_and_restart, _sudo_cmd, _HAS_SERVICE_CHECK = safe_import(
+    'utils.service_check', 'check_process_running', 'start_service', 'stop_service', 'apply_config_and_restart', '_sudo_cmd'
+)
+
+# Sudo-safe home directory — first-party, always available (MF001)
+from utils.paths import get_real_user_home
+
+# LXMF exclusivity — shared utility for MeshChat/NomadNet conflict prevention
+from handlers._lxmf_utils import ensure_lxmf_exclusive
+
+
+class NomadNetHandler(BaseHandler):
+    """TUI handler for NomadNet client management."""
+
+    handler_id = "nomadnet"
+    menu_section = "mesh_networks"
+
+    def menu_items(self):
+        return [
+            ("nomadnet", "NomadNet Client     RNS messaging", "rns"),
+        ]
+
+    def execute(self, action):
+        if action == "nomadnet":
+            self._nomadnet_menu()
+
+    # ------------------------------------------------------------------
+    # LXMF exclusivity — imported from shared utility
+    # ------------------------------------------------------------------
+
+    def _ensure_lxmf_exclusive(self, starting_app: str) -> bool:
+        """Ensure only one LXMF app runs at a time.
+
+        NomadNet doesn't have is_meshchat_running_fn, so it uses the
+        default pgrep fallback in the utility.
+        """
+        return ensure_lxmf_exclusive(self.ctx.dialog, starting_app)
+
+    # ------------------------------------------------------------------
+    # Cross-handler helpers (delegate to rns_diagnostics handler)
+    # ------------------------------------------------------------------
+
+    def _get_rns_diagnostics_handler(self):
+        """Get the RNS diagnostics handler from the registry."""
+        if self.ctx.registry:
+            return self.ctx.registry.get_handler("rns_diagnostics")
+        return None
+
+    def _get_rnsd_user(self) -> Optional[str]:
+        """Get the OS user running the rnsd process, or None if not running.
+
+        Delegates to RNSDiagnosticsHandler when available, falls back to
+        direct process check.
+        """
+        diag = self._get_rns_diagnostics_handler()
+        if diag:
+            return diag._get_rnsd_user()
+        # Fallback: direct ps check
+        try:
+            result = subprocess.run(
+                ['ps', '-o', 'user=', '-C', 'rnsd'],
+                capture_output=True, text=True, timeout=5
+            )
+            if result.returncode != 0:
+                return None
+            lines = result.stdout.strip().splitlines()
+            return lines[0].strip() if lines else None
+        except (subprocess.SubprocessError, OSError):
+            return None
+
+    def _fix_rnsd_user(self, target_user: str) -> bool:
+        """Configure rnsd systemd service to run as the specified user.
+
+        Delegates to RNSDiagnosticsHandler.
+        """
+        diag = self._get_rns_diagnostics_handler()
+        if diag:
+            return diag._fix_rnsd_user(target_user)
+        self.ctx.dialog.msgbox(
+            "Not Available",
+            "RNS diagnostics handler not available.\n\n"
+            "Cannot reconfigure rnsd user automatically.",
+        )
+        return False
+
+    def _wait_for_rns_port(self, max_wait: int = 10) -> bool:
+        """Wait for rnsd shared instance to become available.
+
+        Delegates to RNSDiagnosticsHandler when available.
+        """
+        diag = self._get_rns_diagnostics_handler()
+        if diag:
+            return diag._wait_for_rns_port(max_wait=max_wait)
+        # Fallback: simple socket check
+        import socket
+        for _ in range(max_wait):
+            try:
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                s.settimeout(1)
+                result = s.connect_ex(('127.0.0.1', 37428))
+                s.close()
+                if result == 0:
+                    return True
+            except OSError:
+                pass
+            time.sleep(1)
+        return False
+
+    def _find_blocking_interfaces(self) -> list:
+        """Check if enabled RNS interfaces have missing dependencies.
+
+        Delegates to RNSDiagnosticsHandler when available.
+        """
+        diag = self._get_rns_diagnostics_handler()
+        if diag:
+            return diag._find_blocking_interfaces()
+        return []
+
+    # ------------------------------------------------------------------
+    # RNS config path detection
+    # ------------------------------------------------------------------
+
+    def _get_rns_config_for_user(self) -> str:
+        """Get RNS config directory path appropriate for the current user.
+
+        Returns the EXPLICIT config dir that NomadNet should use via
+        --rnsconfig. This MUST match the config that rnsd is using to
+        prevent config drift (different identities, stale auth tokens).
+
+        Strategy:
+        1. If /etc/reticulum/config exists AND storage is writable -> use it
+        2. If storage is NOT writable -> FIX permissions (we run as root)
+        3. Never fall back to ~/.reticulum -- that creates config drift
+
+        IMPORTANT: Always return an explicit path. Never return None to
+        let RNS use its own resolution, because user-context resolution
+        may pick ~/.reticulum instead of /etc/reticulum, causing auth
+        mismatches with rnsd.
+
+        Returns:
+            Path string to pass to --rnsconfig.
+        """
+        import stat
+
+        etc_rns = Path('/etc/reticulum')
+        etc_config = etc_rns / 'config'
+
+        # If system config exists, always use it -- fix permissions if needed
+        if etc_config.is_file():
+            storage_dir = etc_rns / 'storage'
+            try:
+                if storage_dir.exists():
+                    mode = storage_dir.stat().st_mode
+                    if not (mode & stat.S_IWOTH):
+                        # Fix permissions -- we're root (sudo), we can do this.
+                        # This prevents NomadNet from falling back to ~/.reticulum
+                        # which would cause config drift with rnsd.
+                        logger.info(
+                            f"/etc/reticulum/storage mode {oct(mode)} missing "
+                            f"world-writable bit, fixing to 0o777"
+                        )
+                        old_umask = os.umask(0)
+                        try:
+                            storage_dir.chmod(0o777)
+                        finally:
+                            os.umask(old_umask)
+                        # Also fix file permissions inside storage
+                        ReticulumPaths._fix_storage_file_permissions()
+                else:
+                    # Create storage dir with correct permissions
+                    old_umask = os.umask(0)
+                    try:
+                        storage_dir.mkdir(mode=0o777, parents=True, exist_ok=True)
+                    finally:
+                        os.umask(old_umask)
+            except (OSError, PermissionError) as e:
+                logger.warning(f"Could not fix /etc/reticulum/storage: {e}")
+
+            return str(etc_rns)
+
+        # No system config -- use default resolution
+        # (ReticulumPaths.get_config_dir will find XDG or ~/.reticulum)
+        config_dir = ReticulumPaths.get_config_dir()
+        return str(config_dir)
+
+    # ------------------------------------------------------------------
+    # Ownership fix for user directories
+    # ------------------------------------------------------------------
+
+    def _fix_user_directory_ownership(self) -> bool:
+        """Fix ownership of user directories if they were created by root.
+
+        When MeshForge runs with sudo, any user-space applications (NomadNet,
+        rnstatus, etc.) that were previously launched as root may have created
+        ~/.reticulum or ~/.nomadnetwork with root ownership.
+
+        This function detects and fixes that situation so the real user can
+        access their own directories.
+
+        Returns:
+            True if directories are accessible (or were fixed successfully).
+            False if fix failed and user declined to proceed.
+        """
+        sudo_user = os.environ.get('SUDO_USER')
+        if not sudo_user or sudo_user == 'root':
+            # Not running via sudo, nothing to fix
+            return True
+
+        user_home = get_real_user_home()
+        if not user_home.exists():
+            return True
+
+        # Directories that should belong to the user, not root
+        user_dirs = [
+            user_home / '.reticulum',
+            user_home / '.nomadnetwork',
+            user_home / '.config' / 'nomadnetwork',
+        ]
+
+        dirs_to_fix = []
+        for dir_path in user_dirs:
+            if dir_path.exists():
+                try:
+                    stat_info = dir_path.stat()
+                    # Check if owned by root (uid 0)
+                    if stat_info.st_uid == 0:
+                        dirs_to_fix.append(dir_path)
+                except (OSError, PermissionError):
+                    # Can't stat, might still be a problem
+                    dirs_to_fix.append(dir_path)
+
+        if not dirs_to_fix:
+            return True
+
+        # Found directories with wrong ownership - offer to fix
+        dir_list = '\n'.join(f'  {d}' for d in dirs_to_fix)
+        if not self.ctx.dialog.yesno(
+            "Fix Directory Ownership",
+            f"The following directories are owned by root,\n"
+            f"which prevents NomadNet from accessing them:\n\n"
+            f"{dir_list}\n\n"
+            f"This happened because NomadNet or rnsd was\n"
+            f"previously run as root.\n\n"
+            f"Fix ownership to user '{sudo_user}'?",
+        ):
+            # User declined - warn but allow proceeding
+            return self.ctx.dialog.yesno(
+                "Proceed Anyway?",
+                "Ownership was not fixed.\n\n"
+                "NomadNet may fail with 'Permission denied' errors.\n\n"
+                "Continue anyway?",
+            )
+
+        # Fix ownership recursively
+        self.ctx.dialog.infobox("Fixing Ownership", f"Changing ownership to {sudo_user}...")
+
+        for dir_path in dirs_to_fix:
+            try:
+                # chown -R user:user dir_path
+                subprocess.run(
+                    ['chown', '-R', f'{sudo_user}:{sudo_user}', str(dir_path)],
+                    capture_output=True, timeout=30
+                )
+                logger.info(f"Fixed ownership of {dir_path} to {sudo_user}")
+            except Exception as e:
+                logger.warning(f"Failed to fix ownership of {dir_path}: {e}")
+                self.ctx.dialog.msgbox(
+                    "Ownership Fix Failed",
+                    f"Could not fix ownership of:\n  {dir_path}\n\n"
+                    f"Error: {e}\n\n"
+                    f"Try manually:\n  sudo chown -R {sudo_user}:{sudo_user} {dir_path}",
+                )
+                return False
+
+        return True
+
+    # ------------------------------------------------------------------
+    # Top-level submenu
+    # ------------------------------------------------------------------
+
+    def _nomadnet_menu(self):
+        """NomadNet RNS client -- install, configure, launch."""
+        while True:
+            running = self._is_nomadnet_running()
+            installed = self._is_nomadnet_installed()
+
+            if not installed:
+                subtitle = "NomadNet is NOT INSTALLED"
+            elif running:
+                subtitle = "NomadNet is RUNNING"
+            else:
+                subtitle = "NomadNet is installed (not running)"
+
+            choices = [
+                ("status", "NomadNet Status"),
+            ]
+
+            if installed:
+                if running:
+                    choices.append(("stop", "Stop NomadNet"))
+                else:
+                    choices.append(("textui", "Launch Text UI (interactive)"))
+                    choices.append(("daemon", "Start as Daemon (background)"))
+                choices.append(("logs", "View NomadNet Logs"))
+                choices.append(("config", "View NomadNet Config"))
+                choices.append(("edit", "Edit NomadNet Config"))
+                choices.append(("uninstall", "Disable NomadNet"))
+            else:
+                choices.append(("install", "Install NomadNet"))
+
+            choices.append(("back", "Back"))
+
+            choice = self.ctx.dialog.menu(
+                "NomadNet Client",
+                f"RNS client with page browser & LXMF messaging:\n\n"
+                f"{subtitle}",
+                choices,
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "status": ("NomadNet Status", self._nomadnet_status),
+                "textui": ("Launch NomadNet TUI", self._launch_nomadnet_textui),
+                "daemon": ("Start NomadNet Daemon", self._launch_nomadnet_daemon),
+                "stop": ("Stop NomadNet", self._stop_nomadnet),
+                "logs": ("View NomadNet Logs", self._view_nomadnet_logs),
+                "config": ("View NomadNet Config", self._view_nomadnet_config),
+                "edit": ("Edit NomadNet Config", self._edit_nomadnet_config),
+                "install": ("Install NomadNet", self._install_nomadnet),
+                "uninstall": ("Disable NomadNet", self._uninstall_nomadnet),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    # ------------------------------------------------------------------
+    # Status
+    # ------------------------------------------------------------------
+
+    def _nomadnet_status(self):
+        """Show comprehensive NomadNet status."""
+        clear_screen()
+        print("=== NomadNet Status ===\n")
+
+        # Installation
+        nn_path = shutil.which('nomadnet')
+        if not nn_path:
+            # Check user local bin (pipx / pip install --user)
+            user_home = get_real_user_home()
+            candidate = user_home / '.local' / 'bin' / 'nomadnet'
+            if candidate.exists():
+                nn_path = str(candidate)
+
+        if nn_path:
+            print(f"  Installed: {nn_path}")
+            # Get version
+            try:
+                result = subprocess.run(
+                    [nn_path, '--version'],
+                    capture_output=True, text=True, timeout=10
+                )
+                version = result.stdout.strip() or result.stderr.strip()
+                if version:
+                    print(f"  Version:   {version}")
+            except Exception as e:
+                logger.debug(f"NomadNet version check failed: {e}")
+        else:
+            print("  NOT INSTALLED")
+            print("  Install:   pipx install nomadnet")
+            print("             (installs rns + lxmf automatically)")
+
+        # Process
+        print()
+        running = self._is_nomadnet_running()
+        if running:
+            print("  Process:   RUNNING")
+            try:
+                result = subprocess.run(
+                    ['pgrep', '-fa', 'bin/nomadnet'],
+                    capture_output=True, text=True, timeout=5
+                )
+                if result.stdout.strip():
+                    for line in result.stdout.strip().split('\n'):
+                        if 'pgrep' not in line:
+                            print(f"             {line.strip()}")
+            except (subprocess.SubprocessError, OSError) as e:
+                logger.debug("NomadNet process check failed: %s", e)
+        else:
+            print("  Process:   not running")
+
+        # Config file
+        print()
+        config_path = self._get_nomadnet_config_path()
+        if config_path and config_path.exists():
+            print(f"  Config:    {config_path}")
+            try:
+                content = config_path.read_text()
+                # Parse key settings
+                for line in content.split('\n'):
+                    stripped = line.strip()
+                    if stripped.startswith('#') or not stripped:
+                        continue
+                    if any(k in stripped.lower() for k in [
+                        'user_interface', 'enable_node', 'enable_client',
+                        'announce_at_start', 'node_name', 'display_name',
+                    ]):
+                        print(f"             {stripped}")
+            except PermissionError:
+                print(f"             (permission denied)")
+        else:
+            print(f"  Config:    not found")
+            print(f"  Expected:  ~/.nomadnetwork/config")
+            print(f"             (created on first run)")
+
+        # RNS shared instance check
+        print()
+        print("--- RNS Connectivity ---")
+        try:
+            if _HAS_SERVICE_CHECK:
+                rnsd_running = check_process_running('rnsd')
+            else:
+                # Fallback to direct pgrep call
+                result = subprocess.run(
+                    ['pgrep', '-f', 'rnsd'],
+                    capture_output=True, text=True, timeout=5
+                )
+                rnsd_running = result.returncode == 0
+
+            if rnsd_running:
+                print("  rnsd:      RUNNING (shared instance available)")
+            else:
+                print("  rnsd:      NOT running")
+                print("  WARNING:   NomadNet needs rnsd or share_instance=Yes")
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("rnsd status check failed: %s", e)
+            print("  rnsd:      (check failed)")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Launch text UI
+    # ------------------------------------------------------------------
+
+    def _launch_nomadnet_textui(self):
+        """Launch NomadNet in interactive text UI mode.
+
+        This takes over the terminal (like running nomadnet directly).
+        The user returns to MeshForge when they exit NomadNet.
+
+        When running via sudo, launches as the real user so NomadNet
+        uses their config (~/.nomadnetwork) instead of root's.
+        """
+        nn_path = self._find_nomadnet_binary()
+        if not nn_path:
+            return
+
+        # LXMF exclusivity: stop MeshChat if running (one at a time)
+        if not self._ensure_lxmf_exclusive("nomadnet"):
+            return
+
+        # Fix ownership of user directories if they were created by root
+        # This is a common issue when MeshForge runs with sudo
+        if not self._fix_user_directory_ownership():
+            return
+
+        # Validate and repair config if needed (e.g., missing [textui] section)
+        if not self._validate_nomadnet_config():
+            return
+
+        # Check if rnsd is running (NomadNet needs RNS)
+        if not self._check_rns_for_nomadnet():
+            return
+
+        # Check if we need to use a specific RNS config path
+        # This handles the case where /etc/reticulum exists but isn't writable
+        rns_config_path = self._get_rns_config_for_user()
+
+        # Clear screen before launching
+        clear_screen()
+        print("=== Launching NomadNet ===")
+        if rns_config_path:
+            print(f"Using RNS config: {rns_config_path}")
+        print("Exit NomadNet (Ctrl+Q) to return to MeshForge.\n")
+
+        # When running via sudo, we must run NomadNet as the real user.
+        # Just setting HOME is not enough - RPC authentication between
+        # NomadNet and rnsd requires matching UIDs.
+        sudo_user = os.environ.get('SUDO_USER')
+
+        try:
+            # Build base command with optional --rnsconfig
+            nn_args = ['--textui']
+            if rns_config_path:
+                nn_args = ['--rnsconfig', rns_config_path, '--textui']
+
+            if sudo_user and sudo_user != 'root':
+                # Run as real user using 'sudo -u' with explicit PATH
+                # The -H sets HOME correctly, we pass PATH for pipx binaries
+                user_home = get_real_user_home()
+                user_path = f"{user_home}/.local/bin:/usr/local/bin:/usr/bin:/bin"
+                result = subprocess.run(
+                    ['sudo', '-u', sudo_user, '-H',
+                     f'PATH={user_path}', nn_path] + nn_args,
+                    timeout=None
+                )
+            else:
+                # Not running via sudo, run directly
+                result = subprocess.run([nn_path] + nn_args, timeout=None)
+
+            # After NomadNet exits, show status and wait for user
+            print()
+            if result.returncode != 0:
+                self._diagnose_nomadnet_error(result.returncode, sudo_user)
+            else:
+                print("NomadNet exited normally.")
+            print("\nPress Enter to return to MeshForge...")
+            try:
+                input()
+            except (EOFError, KeyboardInterrupt):
+                pass
+        except KeyboardInterrupt:
+            print("\n\nAborted.")
+        except FileNotFoundError:
+            print(f"\nError: NomadNet binary not found at: {nn_path}")
+            print("\nPress Enter to continue...")
+            try:
+                input()
+            except (EOFError, KeyboardInterrupt):
+                pass
+        except Exception as e:
+            print(f"\nFailed to launch NomadNet: {e}")
+            print("\nPress Enter to continue...")
+            try:
+                input()
+            except (EOFError, KeyboardInterrupt):
+                pass
+
+    def _diagnose_nomadnet_error(self, returncode: int, sudo_user: str = None):
+        """Analyze NomadNet failure and provide helpful diagnostics."""
+        print(f"NomadNet exited with error code {returncode}")
+
+        # Try to read the log file for clues
+        user_home = get_real_user_home()
+        logfile = user_home / '.nomadnetwork' / 'logfile'
+
+        error_hints = []
+        if logfile.exists():
+            try:
+                import collections
+                with open(logfile, 'r') as f:
+                    last_lines = list(
+                        collections.deque(f, maxlen=20)
+                    )
+
+                # Look for known error patterns
+                for line in last_lines:
+                    if 'AuthenticationError' in line or 'digest sent was rejected' in line:
+                        error_hints.append("RPC authentication failed between NomadNet and rnsd")
+                        # Check if rnsd is running as root
+                        rnsd_user = self._get_rnsd_user()
+                        if rnsd_user == 'root':
+                            error_hints.append("rnsd is running as root - identities don't match")
+                            error_hints.append("Fix: sudo systemctl stop rnsd")
+                            error_hints.append("     Then run rnsd as your user, or reconfigure")
+                        elif rnsd_user and rnsd_user != sudo_user:
+                            error_hints.append(f"rnsd runs as '{rnsd_user}', you are '{sudo_user}'")
+                        else:
+                            error_hints.append("Check that rnsd uses the same ~/.reticulum/ identity")
+                        break
+                    elif 'KeyError' in line and 'textui' in line.lower():
+                        error_hints.append("Config missing [textui] section")
+                        error_hints.append("Delete ~/.nomadnetwork/config and restart")
+                        break
+                    elif 'PermissionError' in line or 'Permission denied' in line:
+                        if '/etc/reticulum' in line:
+                            error_hints.append("Cannot write to /etc/reticulum/ (system config)")
+                            error_hints.append("This happens when rnsd was run as root first")
+                            error_hints.append("Fix: sudo rm -rf /etc/reticulum")
+                            error_hints.append("     (or sudo chown -R $USER /etc/reticulum)")
+                        else:
+                            error_hints.append("Permission denied accessing files")
+                            error_hints.append(f"Check ownership: ls -la ~/.nomadnetwork/")
+                        break
+                    elif 'meshtastic' in line.lower() and (
+                        'critical' in line.lower() or 'requires' in line.lower()
+                        or 'no module' in line.lower() or 'modulenotfounderror' in line.lower()
+                    ):
+                        error_hints.append("rnsd cannot load the meshtastic module")
+                        error_hints.append("The Meshtastic_Interface.py plugin requires meshtastic")
+                        error_hints.append(
+                            "Fix: sudo pip3 install --break-system-packages "
+                            "--ignore-installed meshtastic"
+                        )
+                        error_hints.append("Then: sudo systemctl restart rnsd")
+                        break
+                    elif 'ModuleNotFoundError' in line or 'ImportError' in line:
+                        error_hints.append("Missing Python dependencies")
+                        error_hints.append("Try: pipx reinstall nomadnet")
+                        break
+            except (OSError, PermissionError):
+                pass
+
+        # If no NomadNet-specific error found, check rnsd journal for clues.
+        # NomadNet fails when rnsd is down due to meshtastic module issue.
+        if not error_hints:
+            try:
+                journal_r = subprocess.run(
+                    ['journalctl', '-u', 'rnsd', '-n', '20', '--no-pager', '-q'],
+                    capture_output=True, text=True, timeout=5
+                )
+                journal_text = journal_r.stdout.lower()
+                if 'meshtastic' in journal_text and (
+                    'critical' in journal_text or 'module' in journal_text
+                ):
+                    error_hints.append("rnsd crashed because the meshtastic module is missing")
+                    error_hints.append("NomadNet depends on rnsd for network access")
+                    error_hints.append(
+                        "Fix: sudo pip3 install --break-system-packages "
+                        "--ignore-installed meshtastic"
+                    )
+                    error_hints.append("Then: sudo systemctl restart rnsd")
+                elif 'status=255' in journal_text or 'exception' in journal_text:
+                    error_hints.append("rnsd is crashing (exit code 255)")
+                    error_hints.append("Check: sudo journalctl -u rnsd -n 30")
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+        if error_hints:
+            print("\nDiagnosis:")
+            for hint in error_hints:
+                print(f"  - {hint}")
+        else:
+            print("\nCheck logs for details:")
+            print(f"  cat {logfile}")
+            print("  journalctl --user -u nomadnet -n 50")
+
+    # ------------------------------------------------------------------
+    # Log viewer
+    # ------------------------------------------------------------------
+
+    def _view_nomadnet_logs(self):
+        """View NomadNet logfile (works in daemon and textui mode).
+
+        NomadNet writes to ~/.nomadnetwork/logfile independently of
+        stdout/stderr, so this works regardless of launch mode.
+        """
+        import collections
+
+        user_home = get_real_user_home()
+        logfile = user_home / '.nomadnetwork' / 'logfile'
+
+        if not logfile.exists():
+            self.ctx.dialog.msgbox(
+                "No Logs",
+                "NomadNet logfile not found yet.\n\n"
+                f"Expected at: {logfile}\n\n"
+                "Logs are created when NomadNet runs.",
+            )
+            return
+
+        clear_screen()
+
+        # Offer view options
+        choices = [
+            ("last50", "Last 50 lines"),
+            ("last200", "Last 200 lines"),
+            ("errors", "Errors only (last 200 lines)"),
+            ("follow", "Follow live (Ctrl+C to stop)"),
+            ("back", "Back"),
+        ]
+
+        choice = self.ctx.dialog.menu(
+            "NomadNet Logs",
+            f"Logfile: {logfile}",
+            choices,
+        )
+
+        if choice is None or choice == "back":
+            return
+
+        if choice == "follow":
+            clear_screen()
+            print(f"=== NomadNet log — {logfile} "
+                  f"(Ctrl+C to stop) ===\n")
+            try:
+                subprocess.run(
+                    ['tail', '-f', '-n', '30', str(logfile)],
+                    timeout=None
+                )
+            except KeyboardInterrupt:
+                pass
+            return
+
+        # Read the logfile tail
+        if choice == "last200":
+            maxlines = 200
+        else:
+            maxlines = 50  # last50 and errors both read 200
+
+        clear_screen()
+
+        try:
+            with open(logfile, 'r') as f:
+                lines = list(collections.deque(
+                    f, maxlen=max(maxlines, 200)
+                ))
+
+            if choice == "errors":
+                error_patterns = [
+                    'Error', 'Exception', 'CRITICAL',
+                    'WARNING', 'AuthenticationError',
+                    'PermissionError', 'Traceback',
+                ]
+                lines = [
+                    line for line in lines
+                    if any(p in line for p in error_patterns)
+                ]
+                print(f"=== NomadNet errors "
+                      f"({len(lines)} found) ===\n")
+            else:
+                lines = lines[-maxlines:]
+                print(f"=== NomadNet log (last "
+                      f"{len(lines)} lines) ===\n")
+
+            if lines:
+                for line in lines:
+                    print(line.rstrip())
+            else:
+                print("  (no matching lines)")
+
+        except PermissionError:
+            print(f"Cannot read {logfile} — permission denied")
+        except OSError as e:
+            print(f"Error reading logfile: {e}")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Launch daemon
+    # ------------------------------------------------------------------
+
+    def _launch_nomadnet_daemon(self):
+        """Start NomadNet in daemon mode (background, no UI).
+
+        When running via sudo, launches as the real user so NomadNet
+        uses their config (~/.nomadnetwork) instead of root's.
+        """
+        nn_path = self._find_nomadnet_binary()
+        if not nn_path:
+            return
+
+        if self._is_nomadnet_running():
+            self.ctx.dialog.msgbox("Already Running", "NomadNet is already running.")
+            return
+
+        # LXMF exclusivity: stop MeshChat if running (one at a time)
+        if not self._ensure_lxmf_exclusive("nomadnet"):
+            return
+
+        # Fix ownership of user directories if they were created by root
+        if not self._fix_user_directory_ownership():
+            return
+
+        if not self._check_rns_for_nomadnet():
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Start NomadNet Daemon",
+            "Start NomadNet in daemon mode (background)?\n\n"
+            "This will:\n"
+            "  - Announce your node on the RNS network\n"
+            "  - Accept and propagate LXMF messages\n"
+            "  - Serve node pages (if enabled in config)\n\n"
+            "NomadNet will run until stopped.",
+        ):
+            return
+
+        self.ctx.dialog.infobox("Starting", "Starting NomadNet daemon...")
+
+        # Check if we need to use a specific RNS config path
+        rns_config_path = self._get_rns_config_for_user()
+
+        # Build command - run as real user if we're under sudo
+        # This ensures NomadNet uses ~/.nomadnetwork/config, not /root/.nomadnetwork/config
+        sudo_user = os.environ.get('SUDO_USER')
+
+        # Build base args with optional --rnsconfig
+        nn_args = ['--daemon']
+        if rns_config_path:
+            nn_args = ['--rnsconfig', rns_config_path, '--daemon']
+
+        if sudo_user and sudo_user != 'root':
+            # Run as real user with -H to set HOME correctly
+            # Using -H instead of -i avoids running shell profiles which can interfere
+            cmd = ['sudo', '-H', '-u', sudo_user, nn_path] + nn_args
+        else:
+            cmd = [nn_path] + nn_args
+
+        try:
+            subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True
+            )
+
+            # Wait briefly and verify
+            time.sleep(3)
+
+            if self._is_nomadnet_running():
+                self.ctx.dialog.msgbox(
+                    "Daemon Started",
+                    "NomadNet daemon is running in the background.\n\n"
+                    "Your node is now announcing on the RNS network.\n"
+                    "Use 'Stop NomadNet' to shut it down.",
+                )
+            else:
+                self.ctx.dialog.msgbox(
+                    "Start Failed",
+                    "NomadNet daemon failed to start.\n\n"
+                    "Check logs: ~/.nomadnetwork/logfile\n"
+                    "Or run manually: nomadnet --daemon --console",
+                )
+        except FileNotFoundError:
+            self.ctx.dialog.msgbox("Error", f"NomadNet binary not found at: {nn_path}")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to start NomadNet daemon:\n{e}")
+
+    # ------------------------------------------------------------------
+    # Stop
+    # ------------------------------------------------------------------
+
+    def _stop_nomadnet(self):
+        """Stop running NomadNet process(es)."""
+        if not self._is_nomadnet_running():
+            self.ctx.dialog.msgbox("Not Running", "NomadNet is not currently running.")
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Stop NomadNet",
+            "Stop all running NomadNet processes?",
+        ):
+            return
+
+        try:
+            subprocess.run(
+                ['pkill', '-f', 'bin/nomadnet'],
+                capture_output=True, timeout=10
+            )
+
+            time.sleep(2)
+
+            if self._is_nomadnet_running():
+                # Force kill
+                subprocess.run(
+                    ['pkill', '-9', '-f', 'bin/nomadnet'],
+                    capture_output=True, timeout=10
+                )
+                time.sleep(1)
+
+            if not self._is_nomadnet_running():
+                self.ctx.dialog.msgbox("Stopped", "NomadNet has been stopped.")
+            else:
+                self.ctx.dialog.msgbox("Warning", "NomadNet may still be running.\nTry: sudo pkill -9 -f nomadnet")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to stop NomadNet:\n{e}")
+
+    # ------------------------------------------------------------------
+    # Uninstall (stop + disable)
+    # ------------------------------------------------------------------
+
+    def _uninstall_nomadnet(self):
+        """Stop NomadNet and leave it disabled.
+
+        Does not remove files -- just stops the process and shows how
+        to reinstall later if desired.
+        """
+        if not self.ctx.dialog.yesno(
+            "Disable NomadNet",
+            "Stop NomadNet and disable it?\n\n"
+            "This will:\n"
+            "  - Stop NomadNet if running\n"
+            "  - Leave files in place\n\n"
+            "Reinstall later with: pipx install nomadnet\n\n"
+            "Disable now?",
+        ):
+            return
+
+        clear_screen()
+        print("=== Disabling NomadNet ===\n")
+
+        # Stop running processes
+        if self._is_nomadnet_running():
+            print("Stopping NomadNet...")
+            try:
+                subprocess.run(
+                    ['pkill', '-f', 'bin/nomadnet'],
+                    capture_output=True, timeout=10,
+                )
+                time.sleep(2)
+            except (subprocess.SubprocessError, OSError):
+                pass
+
+            if self._is_nomadnet_running():
+                try:
+                    subprocess.run(
+                        ['pkill', '-9', '-f', 'bin/nomadnet'],
+                        capture_output=True, timeout=10,
+                    )
+                    time.sleep(1)
+                except (subprocess.SubprocessError, OSError):
+                    pass
+
+        if self._is_nomadnet_running():
+            print("NomadNet may still be running.")
+            print("Try: sudo pkill -9 -f nomadnet")
+        else:
+            print("NomadNet stopped.")
+
+        user_home = get_real_user_home()
+        print(f"\nConfig remains at: {user_home}/.nomadnetwork/")
+        print("Reinstall: pipx install nomadnet")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Config management
+    # ------------------------------------------------------------------
+
+    def _view_nomadnet_config(self):
+        """View NomadNet configuration."""
+        clear_screen()
+        print("=== NomadNet Configuration ===\n")
+
+        config_path = self._get_nomadnet_config_path()
+        if config_path and config_path.exists():
+            print(f"Config: {config_path}\n")
+            try:
+                content = config_path.read_text()
+                print(content)
+
+                # Highlight key connectivity settings
+                print("\n--- Connectivity Notes ---")
+                content_lower = content.lower()
+                if 'enable_client = yes' in content_lower:
+                    print("  Client:    ENABLED (can send/receive messages)")
+                elif 'enable_client = no' in content_lower:
+                    print("  Client:    DISABLED")
+                if 'enable_node = yes' in content_lower:
+                    print("  Node:      ENABLED (serving pages, propagation)")
+                elif 'enable_node = no' in content_lower:
+                    print("  Node:      DISABLED (not serving)")
+                if 'announce_at_start = yes' in content_lower:
+                    print("  Announce:  YES (visible to other nodes)")
+                if 'user_interface = text' in content_lower:
+                    print("  UI mode:   text (interactive TUI with browser)")
+            except PermissionError:
+                print(f"Permission denied reading {config_path}")
+        else:
+            print("No NomadNet config found.\n")
+            print("Config is created on first run of NomadNet.")
+            print("Expected locations (checked in order):")
+            print("  1. /etc/nomadnetwork/config")
+            user_home = get_real_user_home()
+            print(f"  2. {user_home}/.config/nomadnetwork/config")
+            print(f"  3. {user_home}/.nomadnetwork/config")
+            print("\nRun 'Launch Text UI' to create the default config.")
+
+        self.ctx.wait_for_enter()
+
+    def _edit_nomadnet_config(self):
+        """Edit NomadNet config with available editor."""
+        config_path = self._get_nomadnet_config_path()
+
+        if not config_path or not config_path.exists():
+            if self.ctx.dialog.yesno(
+                "No Config Found",
+                "NomadNet config doesn't exist yet.\n\n"
+                "It is created automatically on first run.\n"
+                "Launch NomadNet once to generate it?\n\n"
+                "(It will create the config and exit.)",
+            ):
+                nn_path = self._find_nomadnet_binary()
+                if nn_path:
+                    self.ctx.dialog.infobox("Generating Config", "Running NomadNet briefly to generate config...")
+                    try:
+                        # Check if we need to use a specific RNS config path
+                        rns_config_path = self._get_rns_config_for_user()
+
+                        # Build command - run as real user if we're under sudo
+                        # This ensures config is created with correct ownership
+                        sudo_user = os.environ.get('SUDO_USER')
+
+                        # Build base args with optional --rnsconfig
+                        nn_args = ['--daemon']
+                        if rns_config_path:
+                            nn_args = ['--rnsconfig', rns_config_path, '--daemon']
+
+                        if sudo_user and sudo_user != 'root':
+                            # Using -H instead of -i to set HOME without shell profiles
+                            cmd = ['sudo', '-H', '-u', sudo_user, nn_path] + nn_args
+                        else:
+                            cmd = [nn_path] + nn_args
+
+                        # Run daemon briefly, then kill to generate config
+                        proc = subprocess.Popen(
+                            cmd,
+                            stdout=subprocess.DEVNULL,
+                            stderr=subprocess.DEVNULL,
+                            start_new_session=True,
+                        )
+                        time.sleep(5)
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            proc.kill()
+
+                        config_path = self._get_nomadnet_config_path()
+                        if config_path and config_path.exists():
+                            self.ctx.dialog.msgbox(
+                                "Config Generated",
+                                f"Config created at:\n  {config_path}\n\n"
+                                f"Opening editor...",
+                            )
+                        else:
+                            self.ctx.dialog.msgbox(
+                                "Config Not Found",
+                                "NomadNet ran but config was not generated.\n"
+                                "Check: ~/.nomadnetwork/config",
+                            )
+                            return
+                    except FileNotFoundError:
+                        self.ctx.dialog.msgbox("Error", f"NomadNet not found at: {nn_path}")
+                        return
+                    except Exception as e:
+                        self.ctx.dialog.msgbox("Error", f"Failed to generate config:\n{e}")
+                        return
+            else:
+                return
+
+        if not config_path or not config_path.exists():
+            return
+
+        # Find editor
+        editor = None
+        for cmd in ['nano', 'vim', 'vi']:
+            if shutil.which(cmd):
+                editor = cmd
+                break
+
+        if not editor:
+            self.ctx.dialog.msgbox("Error", "No text editor found (nano, vim, vi)")
+            return
+
+        subprocess.run([editor, str(config_path)], timeout=None)
+
+    # ------------------------------------------------------------------
+    # Install
+    # ------------------------------------------------------------------
+
+    def _install_nomadnet(self):
+        """Install NomadNet via pipx (isolated environment)."""
+        if self._is_nomadnet_installed():
+            self.ctx.dialog.msgbox("Already Installed", "NomadNet is already installed.")
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Install NomadNet",
+            "Install NomadNet RNS client?\n\n"
+            "This will run:\n"
+            "  pipx install nomadnet\n\n"
+            "NomadNet pulls in RNS and LXMF automatically.\n\n"
+            "It provides:\n"
+            "  - Text UI with micron page browser\n"
+            "  - LXMF encrypted messaging\n"
+            "  - Node hosting and page serving\n"
+            "  - Network announcement/discovery\n\n"
+            "Source: github.com/markqvist/NomadNet\n\n"
+            "Install now?",
+        ):
+            return
+
+        clear_screen()
+        print("=== Installing NomadNet ===\n")
+
+        # Determine if we should install as a different user (when running via sudo)
+        sudo_user = os.environ.get('SUDO_USER')
+        run_as_user = sudo_user if sudo_user and sudo_user != 'root' else None
+
+        try:
+            # Ensure pipx is available (this needs root for apt)
+            if not shutil.which('pipx'):
+                print("Installing pipx...\n")
+                result = subprocess.run(
+                    ['apt-get', 'install', '-y', 'pipx'],
+                    timeout=60
+                )
+                if result.returncode != 0:
+                    print("\nFailed to install pipx.")
+                    print("Try manually: sudo apt install pipx")
+                    self.ctx.wait_for_enter()
+                    return
+
+            # Build pipx commands - run as real user if we're under sudo
+            def run_pipx_cmd(args, timeout_sec=300):
+                """Run pipx command, as real user if running via sudo."""
+                if run_as_user:
+                    # Run as real user with login shell (-i) to set HOME correctly
+                    cmd = ['sudo', '-i', '-u', run_as_user] + args
+                else:
+                    cmd = args
+                return subprocess.run(cmd, timeout=timeout_sec)
+
+            # Ensure pipx bin dir is in PATH for this session
+            print("Ensuring pipx paths...\n")
+            run_pipx_cmd(['pipx', 'ensurepath'], timeout_sec=15)
+
+            # Add common pipx bin dirs to current process PATH
+            for bindir in [
+                get_real_user_home() / '.local' / 'bin',
+                Path('/root/.local/bin'),
+                Path('/usr/local/bin'),
+            ]:
+                if bindir.is_dir() and str(bindir) not in os.environ.get('PATH', ''):
+                    os.environ['PATH'] = f"{bindir}:{os.environ.get('PATH', '')}"
+
+            # Install nomadnet via pipx (live output)
+            if run_as_user:
+                print(f"\nInstalling NomadNet via pipx (as {run_as_user})...\n")
+            else:
+                print("\nInstalling NomadNet via pipx...\n")
+            result = run_pipx_cmd(['pipx', 'install', 'nomadnet'])
+
+            if result.returncode == 0:
+                print("\nInstallation complete.")
+                if self._is_nomadnet_installed():
+                    nn_path = shutil.which('nomadnet')
+                    if nn_path:
+                        print(f"NomadNet installed at: {nn_path}")
+                    else:
+                        # Check user's local bin
+                        user_bin = get_real_user_home() / '.local' / 'bin' / 'nomadnet'
+                        if user_bin.exists():
+                            print(f"NomadNet installed at: {user_bin}")
+
+                    # Configure NomadNet for shared instance mode (use rnsd)
+                    self._setup_nomadnet_shared_instance(run_as_user)
+                else:
+                    print("\nnomadnet not found in PATH.")
+                    print("You may need to log out and back in,")
+                    print("or run: eval \"$(pipx ensurepath)\"")
+            else:
+                print(f"\nInstallation failed (exit code {result.returncode}).")
+                print("Try manually: pipx install nomadnet")
+        except FileNotFoundError:
+            print("pipx not found.")
+            print("Try: sudo apt install pipx && pipx install nomadnet")
+        except KeyboardInterrupt:
+            print("\n\nInstallation cancelled.")
+        except subprocess.TimeoutExpired:
+            print("\nInstallation timed out. Check your internet connection.")
+            print("Try manually: pipx install nomadnet")
+        except Exception as e:
+            print(f"\nInstallation error: {e}")
+            print("Try manually: pipx install nomadnet")
+
+        try:
+            self.ctx.wait_for_enter()
+        except (EOFError, KeyboardInterrupt):
+            pass
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _is_nomadnet_installed(self) -> bool:
+        """Check if NomadNet is installed."""
+        if shutil.which('nomadnet'):
+            return True
+        # Check user local bin
+        user_home = get_real_user_home()
+        candidate = user_home / '.local' / 'bin' / 'nomadnet'
+        return candidate.exists()
+
+    def _setup_nomadnet_shared_instance(self, run_as_user: str = None):
+        """Post-install message for NomadNet.
+
+        NomadNet creates its own complete default config on first run.
+        We don't create configs - let NomadNet use its defaults.
+        """
+        user_home = get_real_user_home()
+        config_file = user_home / '.nomadnetwork' / 'config'
+
+        if config_file.exists():
+            print(f"\nNomadNet config exists: {config_file}")
+        else:
+            print("\nNomadNet will create its default config on first run.")
+
+        print("\nNomadNet uses the shared RNS instance from rnsd by default.")
+        print("Config location: ~/.nomadnetwork/config")
+
+    def _is_nomadnet_running(self) -> bool:
+        """Check if NomadNet process is running.
+
+        Uses centralized service_check module when available, with fallback
+        to direct pgrep for custom filtering.
+        """
+        # Try unified check first (faster and standardized)
+        if _HAS_SERVICE_CHECK:
+            if check_process_running('nomadnet'):
+                return True
+
+        # Fallback to direct pgrep with custom filtering
+        try:
+            result = subprocess.run(
+                ['pgrep', '-f', 'bin/nomadnet'],
+                capture_output=True, text=True, timeout=5
+            )
+            # Filter out false positives (our own grep, etc.)
+            if result.returncode == 0 and result.stdout.strip():
+                for pid in result.stdout.strip().split('\n'):
+                    if pid.strip() and pid.strip() != str(os.getpid()):
+                        return True
+            return False
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.debug("NomadNet running check failed: %s", e)
+            return False
+
+    def _find_nomadnet_binary(self) -> str:
+        """Find NomadNet binary path, or show error and return None."""
+        nn_path = shutil.which('nomadnet')
+        if not nn_path:
+            user_home = get_real_user_home()
+            candidate = user_home / '.local' / 'bin' / 'nomadnet'
+            if candidate.exists():
+                nn_path = str(candidate)
+
+        if not nn_path:
+            self.ctx.dialog.msgbox(
+                "Not Installed",
+                "NomadNet is not installed.\n\n"
+                "Install with: pipx install nomadnet\n"
+                "Or use the Install option from this menu.",
+            )
+            return None
+        return nn_path
+
+    def _get_nomadnet_config_path(self):
+        """Find the NomadNet config file.
+
+        Mirrors NomadNet's own resolution order:
+          /etc/nomadnetwork/config  ->
+          ~/.config/nomadnetwork/config  ->
+          ~/.nomadnetwork/config
+        """
+        user_home = get_real_user_home()
+
+        candidates = [
+            Path('/etc/nomadnetwork/config'),
+            user_home / '.config' / 'nomadnetwork' / 'config',
+            user_home / '.nomadnetwork' / 'config',
+        ]
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+
+        # Return the default path (even if it doesn't exist yet)
+        return user_home / '.nomadnetwork' / 'config'
+
+    def _check_rns_for_nomadnet(self) -> bool:
+        """Check that RNS/rnsd is available and properly configured.
+
+        Checks:
+        1. Is /etc/reticulum blocking user access?
+        2. Is rnsd running?
+        3. Is rnsd running as root? (causes RPC auth failures with user NomadNet)
+
+        Returns True if OK to proceed, False if user cancelled.
+        """
+        sudo_user = os.environ.get('SUDO_USER')
+
+        # Check for /etc/reticulum permission issues first.
+        # IMPORTANT: MeshForge runs as root (sudo) but NomadNet launches as
+        # the real user. Check permissions for the REAL USER, not root.
+        import stat
+        etc_rns = Path('/etc/reticulum')
+        if etc_rns.exists():
+            storage_dir = etc_rns / 'storage'
+            can_write = False
+            try:
+                if storage_dir.exists():
+                    if sudo_user and sudo_user != 'root':
+                        # Running via sudo -- check mode bits for real user
+                        mode = storage_dir.stat().st_mode
+                        can_write = bool(mode & stat.S_IWOTH)
+                    else:
+                        # Not running via sudo -- direct write test is valid
+                        test_file = storage_dir / '.write_test'
+                        try:
+                            test_file.touch()
+                            test_file.unlink()
+                            can_write = True
+                        except (OSError, PermissionError):
+                            pass
+                else:
+                    try:
+                        storage_dir.mkdir(parents=True, exist_ok=True)
+                        can_write = True
+                    except (OSError, PermissionError):
+                        pass
+            except (OSError, ValueError) as e:
+                logger.debug("RNS storage dir check failed: %s", e)
+
+            if not can_write:
+                # /etc/reticulum storage not writable -- fix it immediately.
+                # We're running as root (sudo), so we can fix permissions.
+                # NEVER fall back to ~/.reticulum -- that creates config drift
+                # (different identity/auth tokens than rnsd -> auth failures).
+                target_user = sudo_user if sudo_user and sudo_user != 'root' else 'current user'
+                logger.info(
+                    f"/etc/reticulum/storage not writable by {target_user}, "
+                    "fixing permissions to 0o777"
+                )
+                try:
+                    old_umask = os.umask(0)
+                    try:
+                        storage_dir.chmod(0o777)
+                        # Also fix subdirectories and files
+                        ReticulumPaths._fix_storage_file_permissions()
+                    finally:
+                        os.umask(old_umask)
+                    self.ctx.dialog.msgbox(
+                        "Storage Permissions Fixed",
+                        f"/etc/reticulum/storage/ permissions have been fixed.\n\n"
+                        f"NomadNet will use the system config (same as rnsd).",
+                    )
+                except (OSError, PermissionError) as e:
+                    self.ctx.dialog.msgbox(
+                        "Permission Fix Failed",
+                        f"Could not fix /etc/reticulum/storage permissions:\n"
+                        f"  {e}\n\n"
+                        f"Try manually:\n"
+                        f"  sudo chmod 777 /etc/reticulum/storage"
+                    )
+                    return False
+
+        # Check if rnsd is running and get its user
+        rnsd_user = self._get_rnsd_user()
+
+        if not rnsd_user:
+            # rnsd not running -- warn but allow proceeding
+            return self.ctx.dialog.yesno(
+                "rnsd Not Running",
+                "The RNS daemon (rnsd) is not running.\n\n"
+                "NomadNet can start its own RNS instance,\n"
+                "but for Meshtastic bridging you should run rnsd\n"
+                "with share_instance = Yes in the Reticulum config.\n\n"
+                "Continue anyway?",
+            )
+
+        # rnsd is running -- wait for it to bind port 37428.
+        # rnsd initializes crypto and interfaces BEFORE binding the shared
+        # instance port, so we give it time before declaring failure.
+        self.ctx.dialog.infobox(
+            "Checking rnsd",
+            "Verifying rnsd shared instance (port 37428)...",
+        )
+        port_listening = self._wait_for_rns_port(max_wait=10)
+
+        if not port_listening:
+            # rnsd running but not listening -- check for blocking interfaces
+            blocking = []
+            try:
+                blocking = self._find_blocking_interfaces()
+            except Exception as e:
+                logger.debug("Blocking interface check failed: %s", e)
+
+            if blocking:
+                lines = ["rnsd is running but NOT listening on port 37428.\n"]
+                lines.append("Cause: an enabled interface is blocking startup:\n")
+                for iface_name, reason, fix in blocking:
+                    lines.append(f"  [{iface_name}] {reason}")
+                    lines.append(f"  Fix: {fix}\n")
+                lines.append("NomadNet will fail to connect until this is resolved.")
+                return self.ctx.dialog.yesno(
+                    "rnsd Not Ready",
+                    "\n".join(lines) + "\n\nContinue anyway?",
+                )
+            else:
+                # No blocking interfaces found -- may still be initializing
+                return self.ctx.dialog.yesno(
+                    "rnsd Not Ready",
+                    "rnsd is running but not yet listening on port 37428.\n\n"
+                    "It may still be initializing (crypto, interfaces).\n"
+                    "NomadNet may fail to connect.\n\n"
+                    "Continue anyway?",
+                )
+
+        # rnsd is running and listening - check for user mismatches
+        current_uid = os.getuid()
+        we_are_root = current_uid == 0
+
+        if rnsd_user == 'root' and sudo_user and sudo_user != 'root':
+            # Case 1: rnsd as root, NomadNet wants to run as user
+            choice = self.ctx.dialog.menu(
+                "rnsd Running as Root",
+                "rnsd is running as root, but NomadNet needs to\n"
+                "run as your user for RPC authentication.\n\n"
+                "Different users = different RNS identities = auth failure.\n\n"
+                "How do you want to fix this?",
+                [
+                    ("fix", f"Fix rnsd to run as {sudo_user} (recommended)"),
+                    ("stop", "Stop rnsd (NomadNet will use its own RNS)"),
+                    ("cancel", "Cancel"),
+                ],
+            )
+
+            if choice == "fix":
+                return self._fix_rnsd_user(sudo_user)
+            elif choice == "stop":
+                # Just stop rnsd
+                self.ctx.dialog.infobox("Stopping rnsd", "Stopping rnsd service...")
+                try:
+                    stop_service('rnsd')
+                    subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
+                    time.sleep(1)
+                    self.ctx.dialog.msgbox(
+                        "rnsd Stopped",
+                        "rnsd has been stopped.\n\n"
+                        "NomadNet will start its own RNS instance.",
+                    )
+                    return True
+                except Exception as e:
+                    self.ctx.dialog.msgbox("Stop Failed", f"Could not stop rnsd: {e}")
+                    return False
+            else:
+                return False  # User cancelled
+
+        elif we_are_root and rnsd_user and rnsd_user != 'root' and not sudo_user:
+            # Case 2: We're root but SUDO_USER not set, rnsd runs as user
+            # This is a fresh install issue - NomadNet would run as root
+            # Store the rnsd user so we can run NomadNet as that user
+            choice = self.ctx.dialog.menu(
+                "User Mismatch Detected",
+                f"rnsd is running as '{rnsd_user}', but SUDO_USER is not set.\n\n"
+                f"NomadNet would run as root, causing RPC auth failure.\n\n"
+                f"Different users = different RNS identities = auth failure.\n\n"
+                f"How do you want to proceed?",
+                [
+                    ("run_as_user", f"Run NomadNet as '{rnsd_user}' (recommended)"),
+                    ("stop", "Stop rnsd (NomadNet will use its own RNS)"),
+                    ("cancel", "Cancel"),
+                ],
+            )
+
+            if choice == "run_as_user":
+                # Set SUDO_USER temporarily so _launch_nomadnet_textui uses it
+                os.environ['SUDO_USER'] = rnsd_user
+                self.ctx.dialog.msgbox(
+                    "User Set",
+                    f"NomadNet will run as '{rnsd_user}'.\n\n"
+                    f"This matches the user running rnsd.",
+                )
+                return True
+            elif choice == "stop":
+                self.ctx.dialog.infobox("Stopping rnsd", "Stopping rnsd service...")
+                try:
+                    stop_service('rnsd')
+                    subprocess.run(['pkill', '-f', 'rnsd'], capture_output=True, timeout=5)
+                    time.sleep(1)
+                    self.ctx.dialog.msgbox(
+                        "rnsd Stopped",
+                        "rnsd has been stopped.\n\n"
+                        "NomadNet will start its own RNS instance.",
+                    )
+                    return True
+                except Exception as e:
+                    self.ctx.dialog.msgbox("Stop Failed", f"Could not stop rnsd: {e}")
+                    return False
+            else:
+                return False  # User cancelled
+
+        # rnsd running as correct user (or no sudo context)
+        return True
+
+    def _validate_nomadnet_config(self) -> bool:
+        """Validate and repair NomadNet config if needed.
+
+        NomadNet requires a [textui] section when running in text UI mode.
+        If the config exists but lacks this section (e.g., old config from
+        before [textui] was required), NomadNet will crash with KeyError.
+
+        This function checks for and adds a minimal [textui] section if missing.
+
+        Returns:
+            True to proceed with launch, False if user cancelled.
+        """
+        config_path = self._get_nomadnet_config_path()
+        if not config_path or not config_path.exists():
+            # No config yet - NomadNet will create default on first run
+            return True
+
+        try:
+            content = config_path.read_text()
+        except (OSError, PermissionError) as e:
+            logger.warning(f"Cannot read NomadNet config: {e}")
+            return True  # Let NomadNet handle the error
+
+        # Check if [textui] section exists (case-insensitive)
+        if '[textui]' in content.lower():
+            return True
+
+        # Missing [textui] section - need to add it
+        logger.info(f"NomadNet config missing [textui] section: {config_path}")
+
+        if not self.ctx.dialog.yesno(
+            "Config Repair Needed",
+            f"Your NomadNet config is missing the [textui] section\n"
+            f"required for text UI mode.\n\n"
+            f"Config: {config_path}\n\n"
+            f"Add a default [textui] section now?",
+        ):
+            return self.ctx.dialog.yesno(
+                "Proceed Anyway?",
+                "Without [textui], NomadNet will crash.\n\n"
+                "Continue anyway?",
+            )
+
+        # Add minimal [textui] section
+        textui_section = """
+
+[textui]
+# Text UI configuration added by MeshForge
+intro_time = 1
+theme = dark
+colormode = 256
+glyphs = unicode
+mouse_enabled = yes
+hide_guide = no
+"""
+        try:
+            # Append [textui] section to config
+            with open(config_path, 'a') as f:
+                f.write(textui_section)
+            logger.info(f"Added [textui] section to {config_path}")
+
+            # Fix ownership if running via sudo
+            sudo_user = os.environ.get('SUDO_USER')
+            if sudo_user and sudo_user != 'root':
+                subprocess.run(
+                    ['chown', f'{sudo_user}:{sudo_user}', str(config_path)],
+                    capture_output=True, timeout=10
+                )
+
+            self.ctx.dialog.msgbox(
+                "Config Updated",
+                f"Added [textui] section to config.\n\n"
+                f"NomadNet text UI should now work.",
+            )
+            return True
+        except (OSError, PermissionError) as e:
+            self.ctx.dialog.msgbox(
+                "Config Update Failed",
+                f"Could not update config:\n  {config_path}\n\n"
+                f"Error: {e}\n\n"
+                f"Add [textui] section manually or delete config\n"
+                f"and let NomadNet recreate it.",
+            )
+            return False

--- a/src/launcher_tui/handlers/system_tools.py
+++ b/src/launcher_tui/handlers/system_tools.py
@@ -1,0 +1,1342 @@
+"""
+System Tools Handler — Comprehensive Linux diagnostic tools for NOC operations.
+
+Converted from system_tools_mixin.py as part of the mixin-to-registry migration (Batch 8).
+
+Provides full Linux terminal-like diagnostic capabilities:
+- Interactive monitoring (top, htop, btop)
+- Process management (ps, pstree, lsof, kill)
+- Network diagnostics (netstat, ss, ip, traceroute, nslookup)
+- Hardware info (lsusb, lspci, lscpu, lsblk)
+- Performance tools (vmstat, iostat, free, sar)
+- Storage & disk analysis
+- Service management (systemd)
+- Log analysis (journalctl, dmesg, syslog)
+"""
+
+import subprocess
+import shutil
+from pathlib import Path
+from typing import Optional
+import logging
+
+from backend import clear_screen
+from handler_protocol import BaseHandler
+
+logger = logging.getLogger(__name__)
+
+# Centralized service checker — SINGLE SOURCE OF TRUTH
+from utils.service_check import check_service, check_port, ServiceState, apply_config_and_restart
+
+# Sudo-safe home directory (MF001)
+from utils.paths import get_real_user_home
+
+
+class SystemToolsHandler(BaseHandler):
+    """Comprehensive Linux diagnostic tools for NOC operations."""
+
+    handler_id = "system_tools"
+    menu_section = "system"
+
+    def menu_items(self):
+        return [
+            ("shell", "Linux Shell         Drop to bash", None),
+        ]
+
+    def execute(self, action):
+        if action == "shell":
+            self._drop_to_shell()
+
+    # =========================================================================
+    # Main System Tools Menu
+    # =========================================================================
+
+    def _system_tools_menu(self):
+        """Full Linux diagnostic tools menu - like being on the terminal."""
+        while True:
+            choices = [
+                ("monitor", "Interactive Monitoring (top/htop/btop)"),
+                ("process", "Process Management"),
+                ("network", "Network Diagnostics"),
+                ("hardware", "Hardware Information"),
+                ("performance", "Performance & Memory"),
+                ("storage", "Storage & Disk"),
+                ("services", "Service Management"),
+                ("logs", "Advanced Log Analysis"),
+                ("shell", "Drop to Shell"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "System Tools",
+                "Full Linux diagnostic capabilities:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "monitor": ("Interactive Monitoring", self._interactive_monitoring_menu),
+                "process": ("Process Management", self._process_tools_menu),
+                "network": ("Network Diagnostics", self._network_diagnostics_menu),
+                "hardware": ("Hardware Information", self._hardware_info_menu),
+                "performance": ("Performance Tools", self._performance_tools_menu),
+                "storage": ("Storage Tools", self._storage_tools_menu),
+                "services": ("Service Management", self._service_management_menu),
+                "logs": ("Advanced Log Analysis", self._advanced_logs_menu),
+                "shell": ("Drop to Shell", self._drop_to_shell),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    # =========================================================================
+    # Interactive Monitoring (top, htop, btop)
+    # =========================================================================
+
+    def _interactive_monitoring_menu(self):
+        """Interactive system monitoring tools."""
+        # Detect available tools
+        has_htop = shutil.which('htop') is not None
+        has_btop = shutil.which('btop') is not None
+        has_glances = shutil.which('glances') is not None
+        has_nmon = shutil.which('nmon') is not None
+
+        while True:
+            choices = []
+
+            # Prefer btop > htop > top
+            if has_btop:
+                choices.append(("btop", "btop (Best - Resource Monitor)"))
+            if has_htop:
+                choices.append(("htop", "htop (Interactive Process Viewer)"))
+            choices.append(("top", "top (Classic Process Viewer)"))
+
+            if has_glances:
+                choices.append(("glances", "glances (System Overview)"))
+            if has_nmon:
+                choices.append(("nmon", "nmon (Performance Monitor)"))
+
+            choices.extend([
+                ("watch_ps", "watch ps (Auto-refresh processes)"),
+                ("iotop", "iotop (I/O by Process)"),
+                ("back", "Back"),
+            ])
+
+            choice = self.ctx.dialog.menu(
+                "Interactive Monitoring",
+                "Real-time system monitoring (Ctrl+C to exit):",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Monitor: {choice}", self._run_interactive_tool, choice)
+
+    def _run_interactive_tool(self, tool: str):
+        """Run an interactive monitoring tool."""
+        clear_screen()
+
+        tool_commands = {
+            'btop': ['btop'],
+            'htop': ['htop'],
+            'top': ['top'],
+            'glances': ['glances'],
+            'nmon': ['nmon'],
+            'watch_ps': ['watch', '-n', '2', 'ps', 'aux', '--sort=-%mem'],
+            'iotop': ['sudo', 'iotop', '-o'],
+        }
+
+        cmd = tool_commands.get(tool)
+        if not cmd:
+            return
+
+        # Check if tool exists
+        if not shutil.which(cmd[0] if cmd[0] != 'sudo' else cmd[1]):
+            self.ctx.dialog.msgbox(
+                "Tool Not Found",
+                f"'{tool}' is not installed.\n\n"
+                f"Install with: sudo apt install {tool}\n"
+                f"Or: sudo dnf install {tool}"
+            )
+            return
+
+        print(f"=== Running {tool} (Ctrl+C to exit) ===\n")
+        try:
+            subprocess.run(cmd, timeout=None)
+        except KeyboardInterrupt:
+            print("\n\nStopped.")
+        except FileNotFoundError:
+            print(f"\n{tool} not found. Install it first.")
+        except Exception as e:
+            print(f"\nError: {e}")
+
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Process Management
+    # =========================================================================
+
+    def _process_tools_menu(self):
+        """Process management tools."""
+        while True:
+            choices = [
+                ("ps_all", "ps aux (All Processes)"),
+                ("ps_tree", "pstree (Process Tree)"),
+                ("ps_mem", "ps (Sorted by Memory)"),
+                ("ps_cpu", "ps (Sorted by CPU)"),
+                ("ps_mesh", "Mesh-Related Processes"),
+                ("lsof", "lsof (Open Files)"),
+                ("lsof_net", "lsof -i (Network Connections)"),
+                ("fuser", "fuser (Who's Using a Port)"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Process Management",
+                "View and manage processes:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Process: {choice}", self._run_process_command, choice)
+
+    def _run_process_command(self, cmd_type: str):
+        """Run process-related command."""
+        clear_screen()
+
+        commands = {
+            'ps_all': (['ps', 'aux', '--forest'], "All Processes (ps aux --forest)"),
+            'ps_tree': (['pstree', '-p'], "Process Tree (pstree -p)"),
+            'ps_mem': (['ps', 'aux', '--sort=-%mem'], "Processes by Memory"),
+            'ps_cpu': (['ps', 'aux', '--sort=-%cpu'], "Processes by CPU"),
+            'ps_mesh': None,  # Special handling
+            'lsof': (['lsof', '-n'], "Open Files (lsof)"),
+            'lsof_net': (['lsof', '-i', '-P', '-n'], "Network Connections (lsof -i)"),
+            'fuser': None,  # Special handling - needs port input
+        }
+
+        if cmd_type == 'ps_mesh':
+            self._show_mesh_processes()
+            return
+        elif cmd_type == 'fuser':
+            self._fuser_port_check()
+            return
+
+        cmd_info = commands.get(cmd_type)
+        if not cmd_info:
+            return
+
+        cmd, title = cmd_info
+        print(f"=== {title} ===\n")
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30
+            )
+            # Show first 100 lines
+            lines = result.stdout.strip().split('\n')[:100]
+            print('\n'.join(lines))
+            if len(result.stdout.strip().split('\n')) > 100:
+                print(f"\n... (truncated, {len(result.stdout.strip().split(chr(10)))} total lines)")
+        except FileNotFoundError:
+            print("Command not found. Install required package.")
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _show_mesh_processes(self):
+        """Show mesh-related processes."""
+        clear_screen()
+        print("=== Mesh-Related Processes ===\n")
+
+        patterns = ['meshtastic', 'rnsd', 'lxmf', 'nomadnet', 'meshforge', 'python.*mesh']
+
+        try:
+            result = subprocess.run(
+                ['ps', 'aux'],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+
+            # Header
+            lines = result.stdout.strip().split('\n')
+            if lines and lines[0]:
+                print(lines[0])  # Header
+                print("-" * 80)
+            else:
+                print("No process information available")
+                print("-" * 80)
+
+            found = False
+            for line in lines[1:]:
+                for pattern in patterns:
+                    if pattern.replace('.*', '') in line.lower():
+                        print(line)
+                        found = True
+                        break
+
+            if not found:
+                print("\nNo mesh-related processes found.")
+
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _fuser_port_check(self):
+        """Check what's using a specific port."""
+        port = self.ctx.dialog.inputbox(
+            "Port Check",
+            "Enter port number to check:",
+            "4403"
+        )
+
+        if not port:
+            return
+
+        # Validate port is a valid number
+        try:
+            port_num = int(port.strip())
+            if not (1 <= port_num <= 65535):
+                raise ValueError
+            port = str(port_num)
+        except (ValueError, TypeError):
+            self.ctx.dialog.msgbox("Error", "Port must be a number between 1 and 65535")
+            return
+
+        clear_screen()
+        print(f"=== Who's Using Port {port}? ===\n")
+
+        try:
+            # Try fuser
+            result = subprocess.run(
+                ['fuser', '-v', f'{port}/tcp'],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            if result.stdout or result.stderr:
+                print("fuser output:")
+                print(result.stdout + result.stderr)
+            else:
+                print(f"No process found using port {port}")
+
+            # Also try ss
+            print("\nss output:")
+            result = subprocess.run(
+                ['ss', '-tlnp', f'sport = :{port}'],
+                capture_output=True,
+                text=True,
+                timeout=10
+            )
+            print(result.stdout if result.stdout else f"No listeners on port {port}")
+
+        except Exception as e:
+            print(f"Error: {e}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Network Diagnostics
+    # =========================================================================
+
+    def _network_diagnostics_menu(self):
+        """Comprehensive network diagnostics."""
+        while True:
+            choices = [
+                ("tcp_monitor", "TCP Monitor (Meshtasticd Connections)"),
+                ("network_scan", "Discover Meshtasticd Devices"),
+                ("ss", "ss -tuln (Listening Ports)"),
+                ("ss_all", "ss -tunap (All Connections)"),
+                ("netstat", "netstat -an (Legacy - All)"),
+                ("ip_addr", "ip addr (IP Addresses)"),
+                ("ip_route", "ip route (Routing Table)"),
+                ("ip_link", "ip link (Interface Status)"),
+                ("arp", "arp -a (ARP Table)"),
+                ("dns", "DNS Lookup"),
+                ("traceroute", "Traceroute"),
+                ("ping", "Ping Test"),
+                ("iptables", "iptables -L (Firewall Rules)"),
+                ("nft", "nft list ruleset (nftables)"),
+                ("wifi", "WiFi Status (iwconfig/iw)"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Network Diagnostics",
+                "Network troubleshooting tools:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Network: {choice}", self._run_network_command, choice)
+
+    def _run_network_command(self, cmd_type: str):
+        """Run network diagnostic command."""
+        clear_screen()
+
+        simple_commands = {
+            'ss': (['ss', '-tuln'], "Listening Ports (ss -tuln)"),
+            'ss_all': (['ss', '-tunap'], "All Connections (ss -tunap)"),
+            'netstat': (['netstat', '-an'], "Network Statistics (netstat -an)"),
+            'ip_addr': (['ip', 'addr'], "IP Addresses"),
+            'ip_route': (['ip', 'route'], "Routing Table"),
+            'ip_link': (['ip', '-s', 'link'], "Interface Statistics"),
+            'arp': (['arp', '-a'], "ARP Table"),
+            'iptables': (['sudo', 'iptables', '-L', '-n', '-v'], "Firewall Rules (iptables)"),
+            'nft': (['sudo', 'nft', 'list', 'ruleset'], "nftables Rules"),
+        }
+
+        if cmd_type in simple_commands:
+            cmd, title = simple_commands[cmd_type]
+            print(f"=== {title} ===\n")
+
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                print(result.stdout)
+                if result.stderr:
+                    print(f"stderr: {result.stderr}")
+            except FileNotFoundError:
+                print("Command not found.")
+            except Exception as e:
+                print(f"Error: {e}")
+
+            print("\n" + "=" * 60)
+            self.ctx.wait_for_enter()
+
+        elif cmd_type == 'dns':
+            self._dns_lookup()
+        elif cmd_type == 'traceroute':
+            self._traceroute()
+        elif cmd_type == 'ping':
+            self._ping_test()
+        elif cmd_type == 'wifi':
+            self._wifi_status()
+        elif cmd_type == 'tcp_monitor':
+            self._tcp_monitor_view()
+        elif cmd_type == 'network_scan':
+            self._network_scan_view()
+
+    def _dns_lookup(self):
+        """Perform DNS lookup."""
+        host = self.ctx.dialog.inputbox(
+            "DNS Lookup",
+            "Enter hostname to lookup:",
+            "meshtastic.org"
+        )
+
+        if not host:
+            return
+
+        if not self.ctx.validate_hostname(host):
+            self.ctx.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
+        clear_screen()
+        print(f"=== DNS Lookup: {host} ===\n")
+
+        # Try multiple DNS tools
+        tools = [
+            (['dig', host, '+short'], "dig"),
+            (['nslookup', host], "nslookup"),
+            (['host', host], "host"),
+        ]
+
+        for cmd, name in tools:
+            if shutil.which(cmd[0]):
+                print(f"\n--- {name} ---")
+                try:
+                    result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+                    print(result.stdout)
+                except Exception as e:
+                    print(f"Error: {e}")
+                break
+        else:
+            # Fallback to Python
+            import socket
+            try:
+                ip = socket.gethostbyname(host)
+                print(f"Resolved to: {ip}")
+            except Exception as e:
+                print(f"Resolution failed: {e}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _traceroute(self):
+        """Run traceroute to a host."""
+        host = self.ctx.dialog.inputbox(
+            "Traceroute",
+            "Enter destination host:",
+            "8.8.8.8"
+        )
+
+        if not host:
+            return
+
+        if not self.ctx.validate_hostname(host):
+            self.ctx.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
+        clear_screen()
+        print(f"=== Traceroute to {host} ===\n")
+        print("(Ctrl+C to stop)\n")
+
+        # Try traceroute, then tracepath, then mtr
+        for cmd in [['traceroute', host], ['tracepath', host], ['mtr', '-r', '-c', '3', host]]:
+            if shutil.which(cmd[0]):
+                try:
+                    subprocess.run(cmd, timeout=60)
+                except KeyboardInterrupt:
+                    print("\n\nStopped.")
+                except Exception as e:
+                    print(f"Error: {e}")
+                break
+        else:
+            print("No traceroute tool found. Install: sudo apt install traceroute")
+
+        self.ctx.wait_for_enter()
+
+    def _ping_test(self):
+        """Interactive ping test."""
+        host = self.ctx.dialog.inputbox(
+            "Ping Test",
+            "Enter host to ping:",
+            "8.8.8.8"
+        )
+
+        if not host:
+            return
+
+        if not self.ctx.validate_hostname(host):
+            self.ctx.dialog.msgbox("Error", "Invalid hostname or IP address.")
+            return
+
+        count = self.ctx.dialog.inputbox(
+            "Ping Count",
+            "Number of pings (0 for continuous):",
+            "5"
+        )
+
+        try:
+            count = int(count) if count else 5
+        except ValueError:
+            count = 5
+
+        clear_screen()
+        print(f"=== Ping {host} ===\n")
+
+        cmd = ['ping', host]
+        if count > 0:
+            cmd.extend(['-c', str(count)])
+
+        try:
+            subprocess.run(cmd, timeout=None if count == 0 else count * 5)
+        except KeyboardInterrupt:
+            print("\n\nStopped.")
+        except Exception as e:
+            print(f"Error: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _wifi_status(self):
+        """Show WiFi status."""
+        clear_screen()
+        print("=== WiFi Status ===\n")
+
+        # Try iw first (modern), then iwconfig (legacy)
+        if shutil.which('iw'):
+            print("--- iw dev ---")
+            subprocess.run(['iw', 'dev'], timeout=10)
+            print("\n--- iw dev wlan0 info ---")
+            subprocess.run(['iw', 'dev', 'wlan0', 'info'], capture_output=False, timeout=10)
+            print("\n--- iw dev wlan0 station dump ---")
+            subprocess.run(['iw', 'dev', 'wlan0', 'station', 'dump'], capture_output=False, timeout=10)
+        elif shutil.which('iwconfig'):
+            print("--- iwconfig ---")
+            subprocess.run(['iwconfig'], timeout=10)
+        else:
+            print("No WiFi tools found. Install: sudo apt install iw")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _tcp_monitor_view(self):
+        """Display TCP connections related to Meshtastic."""
+        clear_screen()
+        print("=== TCP Connection Monitor ===\n")
+        print("Monitoring connections to meshtasticd (port 4403) and web interfaces\n")
+
+        try:
+            from monitoring.tcp_monitor import TCPMonitor, TCPState
+        except ImportError:
+            print("TCP Monitor not available.")
+            print("Check that the monitoring module is installed correctly.")
+            self.ctx.wait_for_enter()
+            return
+
+        monitor = TCPMonitor()
+        connections = monitor._get_tcp_connections()
+
+        # Group by type
+        meshtasticd_conns = []
+        web_conns = []
+        other_conns = []
+
+        for conn in connections:
+            if 4403 in (conn["local_port"], conn["remote_port"]):
+                meshtasticd_conns.append(conn)
+            elif any(p in (conn["local_port"], conn["remote_port"]) for p in (80, 443, 8080)):
+                web_conns.append(conn)
+            else:
+                other_conns.append(conn)
+
+        # Display meshtasticd connections
+        print("--- Meshtasticd Connections (port 4403) ---")
+        if meshtasticd_conns:
+            print(f"{'Remote Address':<20} {'Port':<8} {'State':<15} {'Process':<20}")
+            print("-" * 65)
+            for conn in meshtasticd_conns:
+                remote = conn["remote_addr"]
+                port = conn["remote_port"] if conn["remote_port"] != 4403 else conn["local_port"]
+                state = conn["state"].value
+                proc = conn.get("process_name", "unknown") or "unknown"
+                print(f"{remote:<20} {port:<8} {state:<15} {proc:<20}")
+        else:
+            print("  No active meshtasticd connections")
+        print()
+
+        # Display web connections
+        print("--- Web Interface Connections (ports 80, 443, 8080) ---")
+        if web_conns:
+            print(f"{'Remote Address':<20} {'Port':<8} {'State':<15} {'Process':<20}")
+            print("-" * 65)
+            for conn in web_conns[:10]:  # Limit to 10
+                remote = conn["remote_addr"]
+                port = conn["remote_port"]
+                state = conn["state"].value
+                proc = conn.get("process_name", "unknown") or "unknown"
+                print(f"{remote:<20} {port:<8} {state:<15} {proc:<20}")
+            if len(web_conns) > 10:
+                print(f"  ... and {len(web_conns) - 10} more")
+        else:
+            print("  No active web connections")
+        print()
+
+        # Summary
+        print("--- Summary ---")
+        state_counts = {}
+        for conn in connections:
+            state = conn["state"].value
+            state_counts[state] = state_counts.get(state, 0) + 1
+
+        print(f"Total connections: {len(connections)}")
+        print(f"  Meshtasticd: {len(meshtasticd_conns)}")
+        print(f"  Web: {len(web_conns)}")
+        print(f"  Other: {len(other_conns)}")
+        print()
+        print("Connection states:")
+        for state, count in sorted(state_counts.items()):
+            print(f"  {state}: {count}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _network_scan_view(self):
+        """Scan network for meshtasticd devices."""
+        clear_screen()
+        print("=== Network Device Discovery ===\n")
+        print("Scanning for Meshtastic devices on the local network...\n")
+
+        try:
+            from monitoring.tcp_monitor import NetworkScanner
+        except ImportError:
+            print("Network Scanner not available.")
+            print("Check that the monitoring module is installed correctly.")
+            self.ctx.wait_for_enter()
+            return
+
+        # Get subnet to scan
+        subnet = self.ctx.dialog.inputbox(
+            "Network Scan",
+            "Enter subnet to scan (CIDR notation):\n\n"
+            "Examples:\n"
+            "  192.168.1.0/24 (256 hosts)\n"
+            "  10.0.0.0/24 (256 hosts)\n"
+            "  Leave blank for auto-detect",
+            ""
+        )
+
+        clear_screen()
+        print("=== Scanning Network ===\n")
+
+        scanner = NetworkScanner(timeout=1.0, max_threads=50)
+
+        # Progress callback
+        def on_progress(current, total):
+            pct = (current / total) * 100
+            bar_len = 40
+            filled = int(bar_len * current / total)
+            bar = "=" * filled + "-" * (bar_len - filled)
+            print(f"\rProgress: [{bar}] {pct:.0f}% ({current}/{total})", end="", flush=True)
+
+        scanner.on_progress = on_progress
+
+        try:
+            if subnet:
+                devices = scanner.scan_subnet(subnet)
+            else:
+                devices = scanner.scan_local_network()
+        except Exception as e:
+            print(f"\nError scanning network: {e}")
+            self.ctx.wait_for_enter()
+            return
+
+        print("\n\n")
+
+        if not devices:
+            print("No devices with open Meshtastic ports found.")
+            print("\nNote: Devices must have port 4403 (meshtasticd) or web ports open.")
+        else:
+            # Show meshtasticd devices first
+            meshtasticd_devices = [d for d in devices if d.is_meshtasticd]
+            web_devices = [d for d in devices if d.is_web_enabled and not d.is_meshtasticd]
+
+            if meshtasticd_devices:
+                print("--- Meshtasticd Devices (port 4403) ---")
+                print(f"{'IP Address':<18} {'Hostname':<30} {'Response':<12}")
+                print("-" * 60)
+                for dev in meshtasticd_devices:
+                    hostname = dev.hostname or "(no hostname)"
+                    response = f"{dev.response_time_ms:.1f}ms" if dev.response_time_ms else "N/A"
+                    print(f"{dev.ip_address:<18} {hostname:<30} {response:<12}")
+                print()
+
+            if web_devices:
+                print("--- Web-Enabled Devices ---")
+                print(f"{'IP Address':<18} {'Hostname':<30} {'Ports':<20}")
+                print("-" * 70)
+                for dev in web_devices:
+                    hostname = dev.hostname or "(no hostname)"
+                    ports = ", ".join(f"{p}" for p in dev.ports.keys())
+                    print(f"{dev.ip_address:<18} {hostname:<30} {ports:<20}")
+                print()
+
+            print(f"Total devices found: {len(devices)}")
+            print(f"  With meshtasticd: {len(meshtasticd_devices)}")
+            print(f"  With web interface: {len(web_devices)}")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Hardware Information
+    # =========================================================================
+
+    def _hardware_info_menu(self):
+        """Hardware information tools."""
+        while True:
+            choices = [
+                ("lscpu", "lscpu (CPU Info)"),
+                ("lsmem", "lsmem (Memory Layout)"),
+                ("lsusb", "lsusb (USB Devices)"),
+                ("lsusb_v", "lsusb -v (USB Verbose)"),
+                ("lspci", "lspci (PCI Devices)"),
+                ("lsblk", "lsblk (Block Devices)"),
+                ("lshw", "lshw (Full Hardware Summary)"),
+                ("dmidecode", "dmidecode (BIOS/System Info)"),
+                ("sensors", "sensors (Temperature/Voltage)"),
+                ("gpio", "GPIO Status (Pi/SBC)"),
+                ("spi_i2c", "SPI/I2C Status"),
+                ("uname", "uname -a (Kernel Info)"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Hardware Information",
+                "System hardware details:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Hardware: {choice}", self._run_hardware_command, choice)
+
+    def _run_hardware_command(self, cmd_type: str):
+        """Run hardware info command."""
+        clear_screen()
+
+        simple_commands = {
+            'lscpu': (['lscpu'], "CPU Information"),
+            'lsmem': (['lsmem'], "Memory Layout"),
+            'lsusb': (['lsusb'], "USB Devices"),
+            'lsusb_v': (['lsusb', '-v'], "USB Devices (Verbose)"),
+            'lspci': (['lspci', '-v'], "PCI Devices"),
+            'lsblk': (['lsblk', '-f'], "Block Devices"),
+            'lshw': (['sudo', 'lshw', '-short'], "Hardware Summary"),
+            'dmidecode': (['sudo', 'dmidecode', '-t', 'system'], "System Info (BIOS)"),
+            'sensors': (['sensors'], "Sensors"),
+            'uname': (['uname', '-a'], "Kernel Info"),
+        }
+
+        if cmd_type in simple_commands:
+            cmd, title = simple_commands[cmd_type]
+            print(f"=== {title} ===\n")
+
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                print(result.stdout)
+                if result.stderr and 'not found' in result.stderr.lower():
+                    print("\nTool not found. Install required package.")
+            except FileNotFoundError:
+                print("Command not found. Install required package.")
+            except Exception as e:
+                print(f"Error: {e}")
+
+            print("\n" + "=" * 60)
+            self.ctx.wait_for_enter()
+
+        elif cmd_type == 'gpio':
+            self._gpio_status()
+        elif cmd_type == 'spi_i2c':
+            self._spi_i2c_status()
+
+    def _gpio_status(self):
+        """Show GPIO status for Pi/SBC."""
+        clear_screen()
+        print("=== GPIO Status ===\n")
+
+        # Try raspi-gpio first, then gpioinfo
+        if shutil.which('raspi-gpio'):
+            print("--- raspi-gpio get ---")
+            subprocess.run(['raspi-gpio', 'get'], timeout=10)
+        elif shutil.which('gpioinfo'):
+            print("--- gpioinfo ---")
+            subprocess.run(['gpioinfo'], timeout=10)
+        elif Path('/sys/class/gpio').exists():
+            print("--- /sys/class/gpio ---")
+            for gpio_dir in Path('/sys/class/gpio').glob('gpio*'):
+                if gpio_dir.is_dir() and gpio_dir.name.startswith('gpio') and gpio_dir.name[4:].isdigit():
+                    try:
+                        direction = (gpio_dir / 'direction').read_text().strip()
+                        value = (gpio_dir / 'value').read_text().strip()
+                        print(f"{gpio_dir.name}: direction={direction}, value={value}")
+                    except OSError as e:
+                        logger.debug("GPIO %s read failed: %s", gpio_dir.name, e)
+        else:
+            print("No GPIO interface found.")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    def _spi_i2c_status(self):
+        """Show SPI and I2C status."""
+        clear_screen()
+        print("=== SPI/I2C Status ===\n")
+
+        # SPI
+        print("--- SPI Devices ---")
+        spi_devs = list(Path('/dev').glob('spidev*'))
+        if spi_devs:
+            for dev in spi_devs:
+                print(f"  {dev}")
+        else:
+            print("  No SPI devices found (enable with raspi-config or modprobe)")
+
+        # I2C
+        print("\n--- I2C Devices ---")
+        i2c_devs = list(Path('/dev').glob('i2c-*'))
+        if i2c_devs:
+            for dev in i2c_devs:
+                print(f"  {dev}")
+                # Try i2cdetect
+                if shutil.which('i2cdetect'):
+                    bus = dev.name.split('-')[1]
+                    print(f"    Scanning bus {bus}...")
+                    result = subprocess.run(
+                        ['i2cdetect', '-y', bus],
+                        capture_output=True, text=True, timeout=10
+                    )
+                    for line in result.stdout.split('\n'):
+                        if line.strip():
+                            print(f"    {line}")
+        else:
+            print("  No I2C devices found")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Performance Tools
+    # =========================================================================
+
+    def _performance_tools_menu(self):
+        """Performance monitoring tools."""
+        while True:
+            choices = [
+                ("free", "free -h (Memory Usage)"),
+                ("vmstat", "vmstat (Virtual Memory Stats)"),
+                ("vmstat_live", "vmstat 1 (Live - 1s interval)"),
+                ("iostat", "iostat (I/O Statistics)"),
+                ("mpstat", "mpstat (CPU per Core)"),
+                ("uptime", "uptime (Load Average)"),
+                ("sar", "sar (System Activity)"),
+                ("stress", "Stress Test (careful!)"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Performance Tools",
+                "System performance analysis:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Performance: {choice}", self._run_performance_command, choice)
+
+    def _run_performance_command(self, cmd_type: str):
+        """Run performance monitoring command."""
+        clear_screen()
+
+        simple_commands = {
+            'free': (['free', '-h'], "Memory Usage"),
+            'vmstat': (['vmstat', '-w'], "Virtual Memory Stats"),
+            'iostat': (['iostat', '-x', '1', '3'], "I/O Statistics"),
+            'mpstat': (['mpstat', '-P', 'ALL'], "CPU per Core"),
+            'uptime': (['uptime'], "System Uptime & Load"),
+            'sar': (['sar', '-u', '1', '5'], "CPU Activity (5 samples)"),
+        }
+
+        if cmd_type in simple_commands:
+            cmd, title = simple_commands[cmd_type]
+            print(f"=== {title} ===\n")
+
+            try:
+                result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+                print(result.stdout)
+            except FileNotFoundError:
+                print("Command not found. Install: sudo apt install sysstat")
+            except Exception as e:
+                print(f"Error: {e}")
+
+            print("\n" + "=" * 60)
+            self.ctx.wait_for_enter()
+
+        elif cmd_type == 'vmstat_live':
+            print("=== vmstat 1 (Live - Ctrl+C to stop) ===\n")
+            try:
+                subprocess.run(['vmstat', '1'], timeout=None)
+            except KeyboardInterrupt:
+                print("\n\nStopped.")
+            self.ctx.wait_for_enter()
+
+        elif cmd_type == 'stress':
+            self._stress_test_menu()
+
+    def _stress_test_menu(self):
+        """CPU/Memory stress test (careful!)."""
+        confirm = self.ctx.dialog.yesno(
+            "Stress Test",
+            "WARNING: This will stress your system!\n\n"
+            "Only use for testing stability.\n"
+            "System may become unresponsive.\n\n"
+            "Continue?"
+        )
+
+        if not confirm:
+            return
+
+        if not shutil.which('stress'):
+            self.ctx.dialog.msgbox(
+                "Not Installed",
+                "stress tool not found.\n\n"
+                "Install: sudo apt install stress"
+            )
+            return
+
+        duration = self.ctx.dialog.inputbox(
+            "Duration",
+            "Stress test duration in seconds:",
+            "10"
+        )
+
+        try:
+            duration = int(duration) if duration else 10
+        except ValueError:
+            duration = 10
+
+        clear_screen()
+        print(f"=== Stress Test ({duration}s) ===\n")
+        print("Running CPU stress test...\n")
+
+        try:
+            subprocess.run(
+                ['stress', '--cpu', '2', '--timeout', str(duration)],
+                timeout=duration + 10
+            )
+            print("\nStress test completed!")
+        except Exception as e:
+            print(f"Error: {e}")
+
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Storage Tools
+    # =========================================================================
+
+    def _storage_tools_menu(self):
+        """Storage and disk tools."""
+        while True:
+            choices = [
+                ("df", "df -h (Disk Free Space)"),
+                ("du_home", "du (Home Directory Usage)"),
+                ("du_etc", "du /etc/meshtasticd (Config Size)"),
+                ("mount", "mount (Mounted Filesystems)"),
+                ("findmnt", "findmnt (Mount Tree)"),
+                ("fdisk", "fdisk -l (Partition Table)"),
+                ("smartctl", "smartctl (Disk Health)"),
+                ("ncdu", "ncdu (Interactive Disk Usage)"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Storage Tools",
+                "Disk and storage analysis:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Storage: {choice}", self._run_storage_command, choice)
+
+    def _run_storage_command(self, cmd_type: str):
+        """Run storage command."""
+        clear_screen()
+
+        if cmd_type == 'df':
+            print("=== Disk Free Space ===\n")
+            subprocess.run(['df', '-h'], timeout=10)
+
+        elif cmd_type == 'du_home':
+            print("=== Home Directory Usage (top 20) ===\n")
+            try:
+                result = subprocess.run(
+                    ['du', '-h', '--max-depth=1', str(get_real_user_home())],
+                    capture_output=True, text=True, timeout=60
+                )
+                lines = sorted(result.stdout.strip().split('\n'), key=lambda x: x.split()[0] if x else '0')
+                for line in lines[-20:]:
+                    print(line)
+            except Exception as e:
+                print(f"Error: {e}")
+
+        elif cmd_type == 'du_etc':
+            print("=== /etc/meshtasticd Size ===\n")
+            subprocess.run(['du', '-ah', '/etc/meshtasticd'], timeout=30)
+
+        elif cmd_type == 'mount':
+            print("=== Mounted Filesystems ===\n")
+            subprocess.run(['mount'], timeout=10)
+
+        elif cmd_type == 'findmnt':
+            print("=== Mount Tree ===\n")
+            subprocess.run(['findmnt'], timeout=10)
+
+        elif cmd_type == 'fdisk':
+            print("=== Partition Table ===\n")
+            subprocess.run(['sudo', 'fdisk', '-l'], timeout=10)
+
+        elif cmd_type == 'smartctl':
+            print("=== Disk Health (SMART) ===\n")
+            if not shutil.which('smartctl'):
+                print("smartctl not found. Install: sudo apt install smartmontools")
+            else:
+                # Find first disk
+                result = subprocess.run(['lsblk', '-d', '-o', 'NAME'], capture_output=True, text=True, timeout=10)
+                disks = [l.strip() for l in result.stdout.split('\n')[1:] if l.strip() and not l.strip().startswith('loop')]
+                if disks:
+                    subprocess.run(['sudo', 'smartctl', '-H', f'/dev/{disks[0]}'], timeout=30)
+                else:
+                    print("No disks found")
+
+        elif cmd_type == 'ncdu':
+            if shutil.which('ncdu'):
+                print("=== Interactive Disk Usage (q to quit) ===\n")
+                subprocess.run(['ncdu', '/'], timeout=None)
+            else:
+                print("ncdu not found. Install: sudo apt install ncdu")
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Service Management
+    # =========================================================================
+
+    def _service_management_menu(self):
+        """SystemD service management."""
+        while True:
+            choices = [
+                ("status_all", "All Services Status"),
+                ("status_mesh", "Mesh Services Status"),
+                ("failed", "Failed Services"),
+                ("timers", "System Timers"),
+                ("recent", "Recently Changed"),
+                ("analyze", "Boot Time Analysis"),
+                ("logs_unit", "Logs for Specific Unit"),
+                ("restart", "Restart a Service"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Service Management",
+                "SystemD service control:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Service: {choice}", self._run_service_command, choice)
+
+    def _run_service_command(self, cmd_type: str):
+        """Run service management command."""
+        clear_screen()
+
+        if cmd_type == 'status_all':
+            print("=== All Services Status ===\n")
+            subprocess.run(['systemctl', 'list-units', '--type=service', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'status_mesh':
+            print("=== Mesh Services Status ===\n")
+            for svc in ['meshtasticd', 'rnsd', 'lxmf.delivery', 'nomadnetd']:
+                print(f"\n--- {svc} ---")
+                result = subprocess.run(
+                    ['systemctl', 'status', svc, '--no-pager', '-l'],
+                    capture_output=True, text=True, timeout=10
+                )
+                print(result.stdout[:1000] if result.stdout else "Not found")
+
+        elif cmd_type == 'failed':
+            print("=== Failed Services ===\n")
+            subprocess.run(['systemctl', '--failed', '--no-pager'], timeout=10)
+
+        elif cmd_type == 'timers':
+            print("=== System Timers ===\n")
+            subprocess.run(['systemctl', 'list-timers', '--no-pager'], timeout=10)
+
+        elif cmd_type == 'recent':
+            print("=== Recently Changed Services ===\n")
+            subprocess.run(
+                ['systemctl', 'list-units', '--type=service', '--state=activating,deactivating,reloading', '--no-pager'],
+                timeout=10
+            )
+
+        elif cmd_type == 'analyze':
+            print("=== Boot Time Analysis ===\n")
+            subprocess.run(['systemd-analyze'], timeout=10)
+            print("\n--- Blame (slowest units) ---")
+            subprocess.run(['systemd-analyze', 'blame', '--no-pager'], timeout=10)
+
+        elif cmd_type == 'logs_unit':
+            unit = self.ctx.dialog.inputbox(
+                "Service Logs",
+                "Enter service/unit name:",
+                "meshtasticd"
+            )
+            if unit:
+                print(f"\n=== Logs for {unit} ===\n")
+                subprocess.run(['journalctl', '-u', unit, '-n', '100', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'restart':
+            unit = self.ctx.dialog.inputbox(
+                "Restart Service",
+                "Enter service to restart:",
+                "meshtasticd"
+            )
+            if unit:
+                confirm = self.ctx.dialog.yesno(
+                    "Confirm Restart",
+                    f"Restart {unit}?"
+                )
+                if confirm:
+                    print(f"\n=== Restarting {unit} ===\n")
+                    success, msg = apply_config_and_restart(unit)
+                    print(msg)
+                    subprocess.run(['systemctl', 'status', unit, '--no-pager'], timeout=10)
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Advanced Log Analysis
+    # =========================================================================
+
+    def _advanced_logs_menu(self):
+        """Advanced log analysis tools."""
+        while True:
+            choices = [
+                ("journal_size", "Journal Disk Usage"),
+                ("journal_boots", "Previous Boots"),
+                ("priority", "Filter by Priority"),
+                ("since", "Logs Since Time"),
+                ("grep_logs", "Search Logs (grep)"),
+                ("export", "Export Logs to File"),
+                ("rotate", "Rotate Logs Now"),
+                ("clear_journal", "Clear Old Journals"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Advanced Log Analysis",
+                "Deep log inspection:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            self.ctx.safe_call(f"Logs: {choice}", self._run_advanced_log_command, choice)
+
+    def _run_advanced_log_command(self, cmd_type: str):
+        """Run advanced log command."""
+        clear_screen()
+
+        if cmd_type == 'journal_size':
+            print("=== Journal Disk Usage ===\n")
+            subprocess.run(['journalctl', '--disk-usage'], timeout=10)
+
+        elif cmd_type == 'journal_boots':
+            print("=== Previous Boots ===\n")
+            subprocess.run(['journalctl', '--list-boots'], timeout=10)
+            boot = self.ctx.dialog.inputbox(
+                "View Boot",
+                "Enter boot number (0=current, -1=previous):",
+                "0"
+            )
+            if boot:
+                subprocess.run(['journalctl', '-b', boot, '-n', '50', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'priority':
+            choices = [
+                ("0", "emerg - System is unusable"),
+                ("1", "alert - Action must be taken"),
+                ("2", "crit - Critical conditions"),
+                ("3", "err - Error conditions"),
+                ("4", "warning - Warning conditions"),
+                ("5", "notice - Normal but significant"),
+                ("6", "info - Informational"),
+                ("7", "debug - Debug messages"),
+            ]
+            prio = self.ctx.dialog.menu("Log Priority", "Show logs at priority level and above:", choices)
+            if prio:
+                subprocess.run(['journalctl', '-p', prio, '-n', '100', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'since':
+            since = self.ctx.dialog.inputbox(
+                "Logs Since",
+                "Enter time (e.g., '1 hour ago', '2024-01-20', 'today'):",
+                "1 hour ago"
+            )
+            if since:
+                subprocess.run(['journalctl', '--since', since, '-n', '100', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'grep_logs':
+            pattern = self.ctx.dialog.inputbox(
+                "Search Logs",
+                "Enter search pattern:",
+                "error"
+            )
+            if pattern:
+                print(f"=== Searching for: {pattern} ===\n")
+                subprocess.run(['journalctl', '-g', pattern, '-n', '50', '--no-pager'], timeout=30)
+
+        elif cmd_type == 'export':
+            filename = self.ctx.dialog.inputbox(
+                "Export Logs",
+                "Export filename:",
+                "/tmp/meshforge_logs.txt"
+            )
+            if filename:
+                export_path = Path(filename).resolve()
+                safe_dirs = [Path('/tmp'), get_real_user_home(), Path('/var/log')]
+                if not any(str(export_path).startswith(str(d.resolve())) for d in safe_dirs):
+                    self.ctx.dialog.msgbox(
+                        "Error",
+                        "Export path must be under /tmp, home directory, or /var/log"
+                    )
+                    return
+                print(f"=== Exporting to {export_path} ===\n")
+                with open(str(export_path), 'w') as f:
+                    subprocess.run(
+                        ['journalctl', '-u', 'meshtasticd', '-u', 'rnsd', '-n', '1000', '--no-pager'],
+                        stdout=f, timeout=60
+                    )
+                print(f"Logs exported to: {export_path}")
+
+        elif cmd_type == 'rotate':
+            print("=== Rotating Logs ===\n")
+            subprocess.run(['sudo', 'journalctl', '--rotate'], timeout=30)
+            print("Done!")
+
+        elif cmd_type == 'clear_journal':
+            confirm = self.ctx.dialog.yesno(
+                "Clear Journals",
+                "Clear journal logs older than 2 days?\n\n"
+                "This frees disk space but removes history."
+            )
+            if confirm:
+                subprocess.run(['sudo', 'journalctl', '--vacuum-time=2d'], timeout=60)
+
+        print("\n" + "=" * 60)
+        self.ctx.wait_for_enter()
+
+    # =========================================================================
+    # Drop to Shell
+    # =========================================================================
+
+    def _drop_to_shell(self):
+        """Drop to an interactive shell."""
+        self.ctx.dialog.msgbox(
+            "Shell Access",
+            "Dropping to shell...\n\n"
+            "Type 'exit' to return to MeshForge.\n\n"
+            "Useful commands:\n"
+            "  meshtastic --info\n"
+            "  rnstatus\n"
+            "  journalctl -f\n"
+            "  systemctl status meshtasticd"
+        )
+
+        clear_screen()
+        print("=== MeshForge Shell ===")
+        print("Type 'exit' to return to the menu.\n")
+
+        # Try to use user's preferred shell
+        import os
+        shell = os.environ.get('SHELL', '/bin/bash')
+
+        try:
+            subprocess.run([shell], timeout=None)
+        except Exception as e:
+            print(f"Shell error: {e}")
+            self.ctx.wait_for_enter()

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -62,17 +62,12 @@ from conflict_resolver import check_and_resolve_conflicts
 # Import mixins to reduce file size
 from rf_tools_mixin import RFToolsMixin
 from channel_config_mixin import ChannelConfigMixin
-from ai_tools_mixin import AIToolsMixin
 from meshtasticd_config_mixin import MeshtasticdConfigMixin
 from site_planner_mixin import SitePlannerMixin
 from service_discovery_mixin import ServiceDiscoveryMixin
-from first_run_mixin import FirstRunMixin
-from system_tools_mixin import SystemToolsMixin
 from quick_actions_mixin import QuickActionsMixin
 from emergency_mode_mixin import EmergencyModeMixin
 from rns_interfaces_mixin import RNSInterfacesMixin
-from nomadnet_client_mixin import NomadNetClientMixin
-from meshchat_client_mixin import MeshChatClientMixin
 from rf_awareness_mixin import RFAwarenessMixin
 from metrics_mixin import MetricsMixin
 from link_quality_mixin import LinkQualityMixin
@@ -109,17 +104,12 @@ class MeshForgeLauncher(
     PropagationMixin,
     RFToolsMixin,
     ChannelConfigMixin,
-    AIToolsMixin,
     MeshtasticdConfigMixin,
     SitePlannerMixin,
     ServiceDiscoveryMixin,
-    FirstRunMixin,
-    SystemToolsMixin,
     QuickActionsMixin,
     EmergencyModeMixin,
     RNSInterfacesMixin,
-    NomadNetClientMixin,
-    MeshChatClientMixin,
     RFAwarenessMixin,
     MetricsMixin,
     LinkQualityMixin,
@@ -456,9 +446,10 @@ class MeshForgeLauncher(
         if not self._run_startup_checks():
             return  # User aborted due to conflicts
 
-        # Check for first run and offer setup wizard
-        if self._check_first_run():
-            self._run_first_run_wizard()
+        # Check for first run and offer setup wizard (Batch 8: via handler)
+        first_run_handler = self._registry.get_handler("first_run")
+        if first_run_handler:
+            first_run_handler.on_startup()
 
         # Check for service misconfiguration (SPI HAT with USB config)
         self._check_service_misconfig()
@@ -472,8 +463,7 @@ class MeshForgeLauncher(
             # Only auto-start services when daemon ISN'T running.
             # If daemon owns these, starting them here would cause
             # port conflicts (Config API :8081) or singleton clashes.
-            self._maybe_auto_start_map()
-            self._registry.startup_all()  # MQTTHandler.on_startup() etc.
+            self._registry.startup_all()  # AIToolsHandler, MQTTHandler, etc.
             self._maybe_auto_start_config_api()
             self._maybe_auto_lock_port()
             self._start_health_monitor()
@@ -974,9 +964,6 @@ class MeshForgeLauncher(
             legacy.append(("aredn", "AREDN Mesh          AREDN integration"))
             legacy.append(("messaging", "Messaging           Send/receive messages"))
             legacy.append(("favorites", "Favorites           Manage favorite nodes"))
-            if self._feature_enabled("rns"):
-                legacy.append(("nomadnet", "NomadNet Client     RNS messaging"))
-                legacy.append(("meshchat", "MeshChat Client     RNS messaging"))
             choices = self._build_section_menu("mesh_networks", legacy, _ORDERING)
 
             choice = self.dialog.menu(
@@ -998,8 +985,6 @@ class MeshForgeLauncher(
                 "meshcore": ("MeshCore Radio", self._meshcore_menu),
                 "rns": ("RNS / Reticulum", self._rns_menu),
                 "gateway": ("Gateway Bridge", self._gateway_config_menu),
-                "nomadnet": ("NomadNet Client", self._nomadnet_menu),
-                "meshchat": ("MeshChat Client", self._meshchat_menu),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -1039,12 +1024,7 @@ class MeshForgeLauncher(
         while True:
             # Legacy items — removed automatically as handlers take over their tags
             legacy = [
-                ("livemap", "Live NOC Map        Real-time browser view"),
-                ("coverage", "Coverage Map        Generate coverage map"),
-                ("heatmap", "Heatmap             Node density heatmap"),
-                ("tiles", "Offline Tiles       Cache map tiles"),
                 ("quality", "Link Quality        Quality analysis"),
-                ("ai", "AI Diagnostics      Knowledge base, assistant"),
             ]
             choices = self._build_section_menu("maps_viz", legacy, _ORDERING)
 
@@ -1063,11 +1043,6 @@ class MeshForgeLauncher(
 
             # Legacy mixin dispatch (not yet converted)
             dispatch = {
-                "livemap": ("Live NOC Map", self._open_live_map),
-                "coverage": ("Coverage Map", self._generate_coverage_map),
-                "heatmap": ("Heatmap", self._generate_heatmap),
-                "tiles": ("Offline Tile Cache", self._tile_cache_menu),
-                "ai": ("AI Diagnostics", self._ai_tools_menu),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -1090,7 +1065,6 @@ class MeshForgeLauncher(
                 ("webhooks", "Webhooks            External notifications"),
                 ("meshforge", "MeshForge Settings  App preferences"),
                 ("config-api", "Config API Server   REST config endpoint"),
-                ("wizard", "Setup Wizard        First-run wizard"),
             ]
             choices = self._build_section_menu("configuration", legacy, _ORDERING)
 
@@ -1115,7 +1089,6 @@ class MeshForgeLauncher(
                 "updates": ("Software Updates", self._updates_menu),
                 "meshforge": ("MeshForge Settings", self._settings_menu),
                 "config-api": ("Config API Server", self._config_api_menu),
-                "wizard": ("Setup Wizard", self._run_first_run_wizard),
             }
             entry = dispatch.get(choice)
             if entry:
@@ -1135,9 +1108,7 @@ class MeshForgeLauncher(
                 ("network", "Network Tools       Ping, ports, interfaces"),
                 ("diagnose", "Diagnostics         System health check"),
                 ("daemon", "Daemon Mode         Start/stop headless NOC"),
-                ("review", "Code Review         Auto-review codebase"),
                 ("status", "Quick Status        One-shot status display"),
-                ("shell", "Linux Shell         Drop to bash"),
                 ("reboot", "Reboot/Shutdown     Safe system control"),
             ]
             choices = self._build_section_menu("system", legacy, _ORDERING)
@@ -1159,9 +1130,7 @@ class MeshForgeLauncher(
             dispatch = {
                 "diagnose": ("Diagnostics", self._run_diagnostics),
                 "daemon": ("Daemon Mode", self._daemon_menu),
-                "review": ("Code Review", self._auto_review_menu),
                 "status": ("Quick Status", self._run_terminal_status),
-                "shell": ("Linux Shell", self._drop_to_shell),
                 "reboot": ("Reboot/Shutdown", self._reboot_menu),
             }
             entry = dispatch.get(choice)
@@ -1429,7 +1398,7 @@ SUPPORT:
                 "channels": ("Channel Config", self._channel_config_menu),
                 "meshtasticd": ("Advanced Config", self._meshtasticd_menu),
                 "settings": ("MeshForge Settings", self._settings_menu),
-                "wizard": ("Setup Wizard", self._run_first_run_wizard),
+                "wizard": ("Setup Wizard", lambda: self._registry.dispatch("configuration", "wizard")),
             }
             entry = dispatch.get(choice)
             if entry:


### PR DESCRIPTION
## Summary
Completes Batch 8 of the mixin-to-registry migration by converting five large mixin classes into standalone handler modules. This refactoring improves code organization, reduces main.py complexity, and enables independent handler lifecycle management.

## Key Changes

**New Handler Modules:**
- `handlers/ai_tools.py` — Maps, coverage analysis, diagnostics, knowledge base, Claude assistant (1,298 lines)
- `handlers/system_tools.py` — Linux diagnostics: monitoring, processes, network, hardware, performance, storage, services, logs (1,342 lines)
- `handlers/nomadnet.py` — NomadNet LXMF client: install, config, launch, manage (1,610 lines)
- `handlers/meshchat.py` — MeshChat LXMF client: install, manage, monitor (1,048 lines)
- `handlers/first_run.py` — First-run wizard: hardware detection, connection type, initial setup (1,143 lines)
- `handlers/auto_review.py` — Code review and self-audit (127 lines)
- `handlers/_lxmf_utils.py` — Shared LXMF exclusivity utility for MeshChat/NomadNet conflict prevention (121 lines)

**Registry Integration:**
- Updated `handlers/__init__.py` to register all new handlers in `get_all_handlers()`
- Updated `main.py` to remove mixin imports and rely on registry-based handler discovery

## Notable Implementation Details

- **LXMF Exclusivity:** Extracted shared conflict-prevention logic into `_lxmf_utils.py` to prevent MeshChat and NomadNet from running simultaneously on port 37428
- **RNS Config Path Detection:** NomadNet handler implements explicit config path resolution to prevent drift between rnsd and NomadNet (always uses `/etc/reticulum` when available, fixes permissions if needed)
- **Ownership Fixes:** NomadNet handler detects and fixes user directory ownership issues when applications were previously run as root
- **Lifecycle Hooks:** AIToolsHandler and FirstRunHandler implement `on_startup()` for auto-start map server and first-run wizard detection
- **Service Delegation:** NomadNet and MeshChat handlers delegate to RNSDiagnosticsHandler when available for cross-handler coordination
- **Safe Imports:** All optional dependencies (diagnostics, knowledge base, Claude, coverage maps, tile cache) use `safe_import()` for graceful degradation

## Testing Notes
- All handlers follow the `BaseHandler` protocol with `handler_id`, `menu_section`, `menu_items()`, and `execute()` methods
- Handlers are registered in menu sections: `mesh_networks`, `maps_viz`, `system`, `configuration`
- LXMF exclusivity tested via shared utility with fallback pgrep checks
- RNS config path resolution tested with permission fixes for `/etc/reticulum/storage`

https://claude.ai/code/session_014Tr4WzoxTrYNM7EiqD8b4W