### PR TITLE
Migrate meshtasticd config from mixin to handler registry (Batch 9)

### DIFF
--- a/src/launcher_tui/handlers/__init__.py
+++ b/src/launcher_tui/handlers/__init__.py
@@ -155,4 +155,16 @@ def get_all_handlers() -> List[Type]:
         FirstRunHandler,
     ])
 
+    # Batch 9 — meshtasticd config (split) + inheritance cleanup
+    from handlers.meshtasticd_config import MeshtasticdConfigHandler
+    from handlers.meshtasticd_lora import MeshtasticdLoRaHandler
+    from handlers.meshtasticd_mqtt import MeshtasticdDeviceMQTTHandler
+    from handlers.meshtasticd_nodedb import MeshtasticdNodeDBHandler
+    handlers.extend([
+        MeshtasticdConfigHandler,
+        MeshtasticdLoRaHandler,
+        MeshtasticdDeviceMQTTHandler,
+        MeshtasticdNodeDBHandler,
+    ])
+
     return handlers

--- a/src/launcher_tui/handlers/meshtasticd_config.py
+++ b/src/launcher_tui/handlers/meshtasticd_config.py
@@ -1,0 +1,1052 @@
+"""
+Meshtasticd Config Handler — Thin dispatcher for meshtasticd configuration.
+
+Converted from meshtasticd_config_mixin.py and _config_menu in main.py as part
+of the mixin-to-registry migration (Batch 9).
+
+Routes to sub-handlers (meshtasticd_lora, meshtasticd_mqtt, meshtasticd_nodedb)
+via the handler registry, and handles its own inline items (view, overlays,
+presets, hardware, status, owner, web client, edit, restart).
+"""
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import yaml
+from pathlib import Path
+
+from handler_protocol import BaseHandler
+from backend import clear_screen
+from utils.service_check import (
+    check_service, check_systemd_service,
+    apply_config_and_restart,
+)
+logger = logging.getLogger(__name__)
+
+# Direct imports for first-party modules (MF006: no safe_import for first-party)
+from core.meshtastic_cli import get_cli as _get_cli
+from utils.meshtastic_http import get_http_client as _get_http_client
+from utils.broker_profiles import get_active_profile as _get_active_profile
+
+# --- Shared overlay utilities (imported by sub-handlers) ---
+
+OVERLAY_PATH = Path('/etc/meshtasticd/config.d/meshforge-overrides.yaml')
+OVERLAY_HEADER = (
+    "# MeshForge configuration overrides\n"
+    "# These settings override /etc/meshtasticd/config.yaml\n"
+    "# To reset: sudo rm this file and restart meshtasticd\n"
+)
+
+
+def read_overlay() -> dict:
+    """Load meshforge-overrides.yaml from config.d/ (or empty dict)."""
+    if OVERLAY_PATH.exists():
+        try:
+            data = yaml.safe_load(OVERLAY_PATH.read_text())
+            return data if isinstance(data, dict) else {}
+        except Exception as e:
+            logger.debug("Failed to read overlay: %s", e)
+    return {}
+
+
+def write_overlay(data: dict, dialog=None) -> bool:
+    """Write meshforge-overrides.yaml to config.d/. Never touches config.yaml.
+
+    Uses atomic write (tempfile + rename) to prevent corruption on
+    power loss or interruption.
+    """
+    try:
+        OVERLAY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        content = OVERLAY_HEADER + "\n" + yaml.dump(
+            data, default_flow_style=False, sort_keys=False
+        )
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            dir=str(OVERLAY_PATH.parent), suffix='.tmp'
+        )
+        try:
+            with os.fdopen(tmp_fd, 'w') as f:
+                f.write(content)
+            os.rename(tmp_path, str(OVERLAY_PATH))
+        except BaseException:
+            os.unlink(tmp_path)
+            raise
+        return True
+    except PermissionError:
+        if dialog:
+            dialog.msgbox("Error", "Permission denied. Run with sudo.")
+        return False
+    except Exception as e:
+        if dialog:
+            dialog.msgbox("Error", f"Failed to write overlay:\n{e}")
+        return False
+
+
+def ensure_meshtasticd_config():
+    """Auto-create /etc/meshtasticd structure and templates if missing."""
+    try:
+        from core.meshtasticd_config import MeshtasticdConfig
+        MeshtasticdConfig().ensure_structure()
+    except PermissionError:
+        logger.debug("Cannot auto-create meshtasticd config (no root)")
+    except Exception as e:
+        logger.debug("meshtasticd config auto-create failed: %s", e)
+
+
+# Desired menu order for the meshtasticd submenu.
+_MESHTASTICD_ORDERING = [
+    "web", "status", "owner", "lora", "presets", "hardware",
+    "channels", "mqtt", "gateway", "cleanup", "edit", "restart",
+]
+
+
+class MeshtasticdConfigHandler(BaseHandler):
+    """TUI handler for meshtasticd configuration (thin dispatcher + core)."""
+
+    handler_id = "meshtasticd_config"
+    menu_section = "configuration"
+
+    def menu_items(self):
+        return [
+            ("radio", "Radio Config        meshtasticd settings", "meshtastic"),
+        ]
+
+    def execute(self, action):
+        if action == "radio":
+            self._config_menu()
+
+    # ------------------------------------------------------------------
+    # Top-level config menu (moved from main.py)
+    # ------------------------------------------------------------------
+
+    def _config_menu(self):
+        """Configuration management for meshtasticd."""
+        ensure_meshtasticd_config()
+
+        while True:
+            choices = [
+                ("view", "View Active Config"),
+                ("overlays", "View config.d/ Overlays"),
+                ("available", "Available Hardware Configs"),
+                ("presets", "LoRa Presets"),
+                ("channels", "Channel Configuration"),
+                ("meshtasticd", "Advanced meshtasticd Config"),
+                ("settings", "MeshForge Settings"),
+                ("wizard", "Run Setup Wizard"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Configuration",
+                "meshtasticd & MeshForge configuration:",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "view": ("View Active Config", self._view_active_config),
+                "overlays": ("Config Overlays", self._view_config_overlays),
+                "available": ("Available Hardware Configs", self._view_available_configs),
+                "presets": ("LoRa Presets", self._radio_presets_menu),
+                "meshtasticd": ("Advanced Config", self._meshtasticd_menu),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+                continue
+
+            # Cross-handler dispatch via registry
+            if choice == "channels":
+                if self.ctx.registry:
+                    self.ctx.registry.dispatch("configuration", "channels")
+                continue
+            if choice == "settings":
+                if self.ctx.registry:
+                    self.ctx.registry.dispatch("configuration", "meshforge")
+                continue
+            if choice == "wizard":
+                if self.ctx.registry:
+                    self.ctx.registry.dispatch("configuration", "wizard")
+                continue
+
+    # ------------------------------------------------------------------
+    # View methods (moved from main.py)
+    # ------------------------------------------------------------------
+
+    def _view_active_config(self):
+        """Show the active meshtasticd config.yaml."""
+        clear_screen()
+        print("=== meshtasticd config.yaml ===\n")
+
+        config_path = Path('/etc/meshtasticd/config.yaml')
+
+        if not config_path.exists():
+            ensure_meshtasticd_config()
+
+        if config_path.exists():
+            print(f"File: {config_path}\n")
+            try:
+                print(config_path.read_text())
+            except PermissionError:
+                print("Permission denied. Try: sudo cat /etc/meshtasticd/config.yaml")
+        else:
+            print("config.yaml not found!\n")
+            print("Run MeshForge with sudo to auto-create:")
+            print("  sudo python3 src/launcher_tui/main.py")
+            print("\nOr create manually:")
+            print("  sudo mkdir -p /etc/meshtasticd/{available.d,config.d}")
+            print("  sudo cp templates/config.yaml /etc/meshtasticd/")
+            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
+
+        self.ctx.wait_for_enter()
+
+    def _view_config_overlays(self):
+        """Show config.d/ overlay files (active hardware configs)."""
+        clear_screen()
+        print("=== config.d/ Active Hardware Configs ===\n")
+
+        config_d = Path('/etc/meshtasticd/config.d')
+
+        if not config_d.exists():
+            ensure_meshtasticd_config()
+
+        if not config_d.exists():
+            print("config.d/ directory not found.")
+            print("\nRun with sudo to auto-create, or:")
+            print("  sudo mkdir -p /etc/meshtasticd/config.d")
+            self.ctx.wait_for_enter()
+            return
+
+        overlays = sorted(config_d.glob('*.yaml'))
+        if not overlays:
+            print("No active hardware configs in config.d/\n")
+            print("Select your hardware from:")
+            print("  Configuration > Available Hardware Configs")
+            print("  Configuration > Advanced meshtasticd Config > Hardware Config")
+        else:
+            print(f"Found {len(overlays)} active config(s):\n")
+            for f in overlays:
+                size = f.stat().st_size
+                print(f"  {f.name} ({size} bytes)")
+
+            print("\n" + "=" * 50)
+            for f in overlays:
+                print(f"\n--- {f.name} ---")
+                try:
+                    print(f.read_text())
+                except PermissionError:
+                    print("  (permission denied)")
+
+        self.ctx.wait_for_enter()
+
+    def _view_available_configs(self):
+        """Show available hardware configs (USB + SPI HATs)."""
+        clear_screen()
+        print("=== Available Hardware Configs ===\n")
+
+        available_d = Path('/etc/meshtasticd/available.d')
+
+        if not available_d.exists():
+            ensure_meshtasticd_config()
+
+        if not available_d.exists():
+            print("available.d/ not found.\n")
+            print("Run with sudo to auto-create, or:")
+            print("  sudo mkdir -p /etc/meshtasticd/available.d")
+            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
+            self.ctx.wait_for_enter()
+            return
+
+        configs = sorted(available_d.glob('*.yaml'))
+        if not configs:
+            print("No hardware configs available.")
+        else:
+            usb_configs = [f for f in configs if '-usb' in f.stem or f.stem.startswith('usb-')]
+            spi_configs = [f for f in configs if f not in usb_configs]
+
+            if usb_configs:
+                print(f"USB Radios ({len(usb_configs)}):")
+                for i, f in enumerate(usb_configs, 1):
+                    print(f"  {i:2d}. {f.stem}")
+
+            if spi_configs:
+                if usb_configs:
+                    print()
+                print(f"SPI HATs ({len(spi_configs)}):")
+                for i, f in enumerate(spi_configs, 1):
+                    print(f"  {i:2d}. {f.stem}")
+
+            config_d = Path('/etc/meshtasticd/config.d')
+            if config_d.exists():
+                active = list(config_d.glob('*.yaml'))
+                if active:
+                    print(f"\nActive: {', '.join(f.stem for f in active)}")
+
+            print(f"\nTotal: {len(configs)} templates")
+            print("\nActivate via: Configuration > Advanced meshtasticd Config > Hardware Config")
+
+        self.ctx.wait_for_enter()
+
+    # ------------------------------------------------------------------
+    # Meshtasticd submenu (thin dispatcher)
+    # ------------------------------------------------------------------
+
+    def _meshtasticd_menu(self):
+        """Meshtasticd configuration menu (thin dispatcher)."""
+        ensure_meshtasticd_config()
+
+        while True:
+            # Own inline items
+            own_items = [
+                ("web", "Web Client (Full Config)"),
+                ("status", "Service Status"),
+                ("owner", "Set Owner/Node Name"),
+                ("presets", "Radio Presets (LoRa)"),
+                ("hardware", "Hardware Config"),
+                ("channels", "Channel Config"),
+                ("edit", "Edit Config Files"),
+                ("restart", "Restart Service"),
+            ]
+
+            # Merge with registry sub-handler items (lora, mqtt, cleanup)
+            registry_items = []
+            if self.ctx.registry:
+                registry_items = self.ctx.registry.get_menu_items("meshtasticd")
+
+            registry_tags = {tag for tag, _ in registry_items}
+            own_map = {tag: desc for tag, desc in own_items}
+            reg_map = {tag: desc for tag, desc in registry_items}
+            all_map = {**own_map, **reg_map}
+
+            # Apply ordering
+            result = []
+            for tag in _MESHTASTICD_ORDERING:
+                if tag in all_map:
+                    result.append((tag, all_map[tag]))
+            # Append any unordered items
+            ordered_set = set(_MESHTASTICD_ORDERING)
+            for tag, desc in list(own_items) + list(registry_items):
+                if tag not in ordered_set and (tag, desc) not in result:
+                    result.append((tag, desc))
+
+            result.append(("back", "Back"))
+
+            choice = self.ctx.dialog.menu(
+                "Meshtasticd Config",
+                "Configure meshtasticd radio daemon:",
+                result
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            # Try registry sub-handlers first (lora, mqtt, cleanup)
+            if choice in registry_tags:
+                if self.ctx.registry:
+                    self.ctx.registry.dispatch("meshtasticd", choice)
+                continue
+
+            # Own inline dispatch
+            own_dispatch = {
+                "web": ("Web Client", self._show_web_client_info),
+                "status": ("Service Status", self._meshtasticd_status),
+                "owner": ("Set Owner Name", self._set_owner_name),
+                "presets": ("Radio Presets", self._radio_presets_menu),
+                "hardware": ("Hardware Config", self._hardware_config_menu),
+                "edit": ("Edit Config Files", self._edit_config_menu),
+                "restart": ("Restart Service", self._restart_meshtasticd),
+            }
+            entry = own_dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+                continue
+
+            # Cross-handler dispatch
+            if choice == "channels":
+                if self.ctx.registry:
+                    self.ctx.registry.dispatch("configuration", "channels")
+            elif choice == "gateway":
+                # Gateway template is in ChannelConfigHandler
+                handler = self.ctx.registry.get_handler("channel_config") if self.ctx.registry else None
+                if handler and hasattr(handler, '_gateway_template_menu'):
+                    self.ctx.safe_call("Gateway Template", handler._gateway_template_menu)
+
+    # ------------------------------------------------------------------
+    # General operations
+    # ------------------------------------------------------------------
+
+    def _show_web_client_info(self):
+        """Show meshtasticd web client info with URL."""
+        # Try WebClientHandler first
+        if self.ctx.registry:
+            handler = self.ctx.registry.get_handler("web_client")
+            if handler:
+                handler.execute("web")
+                return
+
+        # Fallback: show URL info
+        import socket
+        try:
+            local_ip = socket.gethostbyname(socket.gethostname())
+            if local_ip.startswith('127.'):
+                s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+                s.settimeout(2)
+                s.connect(("8.8.8.8", 80))
+                local_ip = s.getsockname()[0]
+                s.close()
+        except OSError as e:
+            logger.debug("Local IP detection failed: %s", e)
+            local_ip = "YOUR_PI_IP"
+
+        self.ctx.dialog.msgbox(
+            "Meshtastic Web Client",
+            f"Full radio configuration via browser:\n\n"
+            f"  URL: https://{local_ip}:9443\n\n"
+            f"Set these to join your mesh network:\n"
+            f"  Config > LoRa > Region  (US, EU_868, etc.)\n"
+            f"  Config > LoRa > Preset  (LONG_FAST, etc.)\n"
+            f"  Config > Channels       (PSK, name)\n\n"
+            f"The web client gives full access to all\n"
+            f"meshtasticd settings, maps, and messaging."
+        )
+
+    def _meshtasticd_status(self):
+        """Show meshtasticd service status."""
+        self.ctx.dialog.infobox("Status", "Checking meshtasticd status...")
+
+        try:
+            status = check_service('meshtasticd')
+            is_running = status.available
+            _, is_enabled = check_systemd_service('meshtasticd')
+
+            preset_display = "Unknown (select via Radio Presets)"
+            region_display = ""
+            detection_method = ""
+            if is_running:
+                try:
+                    from utils.lora_presets import detect_meshtastic_settings
+                    detection = detect_meshtastic_settings()
+                    if detection and detection.get('preset'):
+                        preset_display = detection['preset']
+                        detection_method = detection.get('detection_method', '')
+                        if detection.get('region'):
+                            region_display = detection['region']
+                except Exception as e:
+                    logger.debug("Preset detection failed (service still running): %s", e)
+
+            config_path = Path('/etc/meshtasticd/config.yaml')
+            config_exists = config_path.exists()
+
+            if not config_exists:
+                ensure_meshtasticd_config()
+                config_exists = config_path.exists()
+
+            config_d = Path('/etc/meshtasticd/config.d')
+            active_configs = list(config_d.glob('*.yaml')) if config_d.exists() else []
+
+            available_d = Path('/etc/meshtasticd/available.d')
+            available_count = len(list(available_d.glob('*.yaml'))) if available_d.exists() else 0
+
+            text = "Meshtasticd Service Status:\n"
+            if is_running:
+                text += "\nService: RUNNING"
+            else:
+                text += "\nService: STOPPED"
+                if status.fix_hint:
+                    text += f"\n  Hint: {status.fix_hint}"
+            text += f"\nBoot:    {'enabled' if is_enabled else 'not enabled (will not start on reboot)'}"
+            text += f"\n\nPreset:  {preset_display}"
+            if region_display:
+                text += f"\nRegion:  {region_display}"
+            if detection_method:
+                text += f"\n  (detected via {detection_method})"
+            elif is_running and preset_display.startswith("Unknown"):
+                text += "\n  (CLI detection unavailable — select preset manually)"
+            text += f"\n\nConfig File: {config_path}"
+            text += f"\nConfig Exists: {'Yes' if config_exists else 'No — run with sudo to create'}"
+            text += f"\nAvailable Templates: {available_count}"
+            text += f"\n\nActive Hardware Configs: {len(active_configs)}"
+
+            for cfg in active_configs[:5]:
+                text += f"\n  - {cfg.name}"
+
+            if len(active_configs) > 5:
+                text += f"\n  ... and {len(active_configs) - 5} more"
+
+            if not active_configs and available_count > 0:
+                text += "\n  (none — select hardware from Hardware Config)"
+
+            self.ctx.dialog.msgbox("Meshtasticd Status", text)
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to get status:\n{e}")
+
+    def _set_owner_name(self):
+        """Set node owner name (long name and short name)."""
+        self.ctx.dialog.infobox("Owner", "Getting current owner info...")
+
+        try:
+            sys.path.insert(0, str(self.ctx.src_dir))
+            from commands import meshtastic as mesh_cmd
+
+            result = mesh_cmd.get_node_info()
+            current_long = ""
+            current_short = ""
+
+            if result.success and result.raw:
+                for line in result.raw.split('\n'):
+                    if 'longName' in line or 'long_name' in line:
+                        parts = line.split(':')
+                        if len(parts) > 1:
+                            current_long = parts[1].strip().strip('"')
+                    elif 'shortName' in line or 'short_name' in line:
+                        parts = line.split(':')
+                        if len(parts) > 1:
+                            current_short = parts[1].strip().strip('"')
+
+            long_name = self.ctx.dialog.inputbox(
+                "Set Long Name",
+                f"Enter node name (current: {current_long or 'none'}):",
+                current_long or ""
+            )
+
+            if long_name is None:
+                return
+
+            short_name = self.ctx.dialog.inputbox(
+                "Set Short Name",
+                f"Enter 4-char short name (current: {current_short or 'none'}):",
+                current_short or ""
+            )
+
+            if short_name is None:
+                return
+
+            if long_name:
+                long_name = long_name[:40]
+            if short_name:
+                short_name = short_name[:4].upper()
+
+            changes_made = []
+
+            if long_name:
+                self.ctx.dialog.infobox("Setting", f"Setting long name to: {long_name}")
+                result = mesh_cmd.set_owner(long_name)
+                if result.success:
+                    changes_made.append(f"Long name: {long_name}")
+                else:
+                    self.ctx.dialog.msgbox("Error", f"Failed to set long name:\n{result.message}")
+                    return
+
+            if short_name:
+                self.ctx.dialog.infobox("Setting", f"Setting short name to: {short_name}")
+                result = mesh_cmd.set_owner_short(short_name)
+                if result.success:
+                    changes_made.append(f"Short name: {short_name}")
+                else:
+                    self.ctx.dialog.msgbox("Error", f"Failed to set short name:\n{result.message}")
+                    return
+
+            if changes_made:
+                from utils.device_config_store import save_device_settings
+                owner_data = {}
+                if long_name:
+                    owner_data['long_name'] = long_name
+                if short_name:
+                    owner_data['short_name'] = short_name
+                save_device_settings({'owner': owner_data})
+
+                self.ctx.dialog.msgbox("Success",
+                    f"Owner settings updated:\n\n"
+                    + "\n".join(changes_made)
+                    + "\n\nSaved for restart persistence.")
+            else:
+                self.ctx.dialog.msgbox("Info", "No changes made.")
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to set owner name:\n{e}")
+
+    # ------------------------------------------------------------------
+    # Radio presets
+    # ------------------------------------------------------------------
+
+    def _radio_presets_menu(self):
+        """Radio/LoRa preset selection via meshtastic CLI."""
+        current_preset = None
+        try:
+            from utils.lora_presets import detect_meshtastic_settings
+            detection = detect_meshtastic_settings()
+            if detection and detection.get('preset'):
+                current_preset = detection['preset']
+        except Exception:
+            pass
+
+        presets = [
+            ("SHORT_TURBO", "500kHz SF7  - Max speed, <1km"),
+            ("SHORT_FAST", "250kHz SF7  - Urban, 1-5km"),
+            ("SHORT_SLOW", "125kHz SF7  - Reliable short"),
+            ("MEDIUM_FAST", "250kHz SF10 - MtnMesh std, 5-20km"),
+            ("MEDIUM_SLOW", "125kHz SF10 - Alt medium"),
+            ("LONG_FAST", "250kHz SF11 - Default, 10-30km"),
+            ("LONG_MODERATE", "125kHz SF11 - Extended, 15-40km"),
+            ("LONG_SLOW", "125kHz SF12 - Max range, 20-50km"),
+            ("back", "Back"),
+        ]
+
+        if current_preset:
+            presets = [
+                (tag, f"{desc} [ACTIVE]" if tag == current_preset else desc)
+                for tag, desc in presets
+            ]
+
+        current_info = f"\nCurrent: {current_preset}" if current_preset else "\nCurrent: Unknown"
+
+        choice = self.ctx.dialog.menu(
+            "Radio Presets",
+            f"Select LoRa modem preset:{current_info}\n\n"
+            "Higher speed = shorter range\n"
+            "Lower speed = longer range",
+            presets
+        )
+
+        if choice and choice != "back":
+            self._apply_radio_preset(choice)
+
+    def _apply_radio_preset(self, preset: str):
+        """Apply a radio preset via meshtastic CLI."""
+        preset_info = {
+            "SHORT_TURBO": {"bw": 500, "sf": 7, "cr": 8},
+            "SHORT_FAST": {"bw": 250, "sf": 7, "cr": 8},
+            "SHORT_SLOW": {"bw": 125, "sf": 7, "cr": 8},
+            "MEDIUM_FAST": {"bw": 250, "sf": 10, "cr": 8},
+            "MEDIUM_SLOW": {"bw": 125, "sf": 10, "cr": 8},
+            "LONG_FAST": {"bw": 250, "sf": 11, "cr": 8},
+            "LONG_MODERATE": {"bw": 125, "sf": 11, "cr": 8},
+            "LONG_SLOW": {"bw": 125, "sf": 12, "cr": 8},
+        }
+
+        info = preset_info.get(preset, {})
+        if not info:
+            return
+
+        slot_input = self.ctx.dialog.inputbox(
+            "Frequency Slot",
+            f"Set frequency slot (channel_num) for {preset}:\n\n"
+            "Slot determines the center frequency.\n"
+            "US: 0=903.875 MHz (default), 12=903.625 (HawaiiNet)\n"
+            "Must match your mesh network's slot.\n\n"
+            "Leave empty or 0 for default:",
+            "0"
+        )
+
+        if slot_input is None:
+            return
+
+        try:
+            freq_slot = int(slot_input) if slot_input.strip() else 0
+        except ValueError:
+            freq_slot = 0
+
+        confirm_text = (
+            f"Apply {preset} preset?\n\n"
+            f"Bandwidth: {info['bw']} kHz\n"
+            f"Spreading Factor: SF{info['sf']}\n"
+            f"Coding Rate: 4/{info['cr']}\n"
+            f"Frequency Slot: {freq_slot}\n\n"
+            "Applied via meshtastic CLI (--set lora.modem_preset).\n"
+            "Region must already be set (use Web Client)."
+        )
+
+        confirm = self.ctx.dialog.yesno(
+            "Apply Preset",
+            confirm_text,
+            default_no=True
+        )
+
+        if not confirm:
+            return
+
+        self.ctx.dialog.infobox("Applying", f"Applying {preset} preset...")
+
+        try:
+            cli = _get_cli()
+
+            result = cli.set_lora_preset(preset)
+            if not result.success:
+                self.ctx.dialog.msgbox("Error",
+                    f"Failed to set modem preset:\n{result.error}\n\n"
+                    "Ensure meshtastic CLI is installed and\n"
+                    "meshtasticd is running with region set.")
+                return
+
+            verified = '[verified]' in (result.output or '')
+
+            slot_result = cli.set_channel_num(freq_slot)
+            slot_msg = ""
+            if not slot_result.success:
+                slot_msg = f"\nFrequency slot: FAILED ({slot_result.error})"
+            else:
+                slot_msg = f"\nFrequency slot: {freq_slot}"
+
+            from utils.device_config_store import save_device_settings
+            save_device_settings({
+                'lora': {
+                    'modem_preset': preset,
+                    'channel_num': freq_slot,
+                }
+            })
+
+            verify_note = " (verified)" if verified else ""
+            self.ctx.dialog.msgbox("Success",
+                f"{preset} preset applied!{verify_note}\n\n"
+                f"Modem preset: {preset}{slot_msg}\n\n"
+                "Settings saved for restart persistence.\n"
+                "Will be re-applied if meshtasticd restarts.")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Failed to apply preset:\n{e}")
+
+    # ------------------------------------------------------------------
+    # Hardware config
+    # ------------------------------------------------------------------
+
+    def _classify_hardware_config(self, config_path: Path) -> str:
+        """Classify a hardware config as 'usb' or 'spi'."""
+        try:
+            from core.meshtasticd_config import RADIO_TEMPLATES, RadioType
+            template = RADIO_TEMPLATES.get(config_path.stem, {})
+            if template:
+                rtype = template.get("radio_type")
+                if rtype == RadioType.USB_SERIAL:
+                    return "usb"
+                return "spi"
+        except ImportError:
+            pass
+
+        try:
+            content = config_path.read_text(errors='replace')[:500]
+            if 'Serial:' in content and 'spidev' not in content.lower():
+                return "usb"
+        except Exception:
+            pass
+        return "spi"
+
+    def _hardware_config_menu(self):
+        """Hardware configuration selection with USB/SPI categorization."""
+        try:
+            from core.meshtasticd_config import MeshtasticdConfig
+            config_mgr = MeshtasticdConfig()
+            config_mgr.ensure_structure()
+        except PermissionError:
+            logger.debug("Cannot auto-create templates (no root), using existing")
+        except Exception as e:
+            logger.debug("Template auto-creation failed: %s", e)
+
+        available_dir = Path('/etc/meshtasticd/available.d')
+        config_d = Path('/etc/meshtasticd/config.d')
+
+        if not available_dir.exists():
+            self.ctx.dialog.msgbox("Error",
+                "Hardware templates not found.\n\n"
+                f"Expected: {available_dir}\n\n"
+                "Run with sudo to auto-create, or run the installer.")
+            return
+
+        available = list(available_dir.glob('*.yaml'))
+        if not available:
+            self.ctx.dialog.msgbox("Error",
+                "No hardware templates found.\n\n"
+                "Run with sudo to auto-create, or run the installer.")
+            return
+
+        active = set()
+        if config_d.exists():
+            active = {f.name for f in config_d.glob('*.yaml')}
+
+        usb_configs = []
+        spi_configs = []
+        for cfg in sorted(available):
+            if self._classify_hardware_config(cfg) == "usb":
+                usb_configs.append(cfg)
+            else:
+                spi_configs.append(cfg)
+
+        choices = []
+        choices.append(("--usb--", f"--- USB Radios ({len(usb_configs)}) ---"))
+        for cfg in usb_configs:
+            status = " [ACTIVE]" if cfg.name in active else ""
+            choices.append((cfg.name, f"  {cfg.stem}{status}"))
+
+        choices.append(("--spi--", f"--- SPI HATs ({len(spi_configs)}) ---"))
+        for cfg in spi_configs:
+            status = " [ACTIVE]" if cfg.name in active else ""
+            choices.append((cfg.name, f"  {cfg.stem}{status}"))
+
+        choices.append(("view", "View Config Details"))
+        choices.append(("back", "Back"))
+
+        active_names = [n.replace('.yaml', '') for n in active
+                        if n != 'meshforge-overrides.yaml']
+        active_display = ', '.join(active_names) if active_names else 'none'
+
+        choice = self.ctx.dialog.menu(
+            "Hardware Config",
+            f"Total: {len(available)} templates | "
+            f"Active: {active_display}\n\n"
+            "Select hardware configuration to activate:",
+            choices
+        )
+
+        if choice is None or choice == "back":
+            return
+        elif choice in ("--usb--", "--spi--"):
+            self._hardware_config_menu()
+        elif choice == "view":
+            self._view_hardware_config(available)
+        else:
+            self._activate_hardware_config(choice, available_dir, config_d)
+
+    def _activate_hardware_config(self, config_name: str, available_dir: Path, config_d: Path):
+        """Activate a hardware configuration."""
+        src = available_dir / config_name
+
+        if not src.exists():
+            self.ctx.dialog.msgbox("Error", f"Config not found: {src}")
+            return
+
+        confirm = self.ctx.dialog.yesno(
+            "Activate Config",
+            f"Activate hardware config?\n\n"
+            f"Template: {config_name}\n\n"
+            "This will:\n"
+            f"1. Copy to {config_d}/\n"
+            "2. Restart meshtasticd service",
+            default_no=True
+        )
+
+        if not confirm:
+            return
+
+        try:
+            self.ctx.dialog.infobox("Activating", f"Activating {config_name}...")
+            config_d.mkdir(parents=True, exist_ok=True)
+            dst = config_d / config_name
+            shutil.copy(src, dst)
+            apply_config_and_restart('meshtasticd')
+            self.ctx.dialog.msgbox("Success",
+                f"Hardware config activated!\n\n"
+                f"Config: {dst}\n\n"
+                "Service restarted.")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Activation failed:\n{e}")
+
+    def _view_hardware_config(self, configs: list):
+        """View details of a hardware config."""
+        choices = [(cfg.name, cfg.stem[:30]) for cfg in sorted(configs)]
+        choices.append(("back", "Back"))
+
+        choice = self.ctx.dialog.menu(
+            "View Config",
+            "Select config to view:",
+            choices
+        )
+
+        if choice and choice != "back":
+            config_path = Path('/etc/meshtasticd/available.d') / choice
+            if config_path.exists():
+                try:
+                    content = config_path.read_text()[:1500]
+                    self.ctx.dialog.msgbox(f"Config: {choice}", content)
+                except Exception as e:
+                    self.ctx.dialog.msgbox("Error", str(e))
+
+    # ------------------------------------------------------------------
+    # Edit / restart
+    # ------------------------------------------------------------------
+
+    def _offer_restart(self, message: str):
+        """Offer to restart meshtasticd after a config change."""
+        if self.ctx.dialog.yesno(
+            "Restart Service?",
+            f"{message}\n\n"
+            f"Saved to: {OVERLAY_PATH}\n"
+            "(config.yaml unchanged)\n\n"
+            "Restart meshtasticd to apply?",
+            default_no=False
+        ):
+            self._restart_meshtasticd()
+
+    def _edit_config_menu(self):
+        """Edit config files directly."""
+        choices = [
+            ("main", "Main Config (/etc/meshtasticd/config.yaml)"),
+            ("active", "Active Hardware Configs"),
+            ("templates", "Hardware Templates"),
+            ("back", "Back"),
+        ]
+
+        choice = self.ctx.dialog.menu(
+            "Edit Config Files",
+            "Edit meshtasticd configuration files:\n\n"
+            "Opens in nano editor.\n"
+            "Save: Ctrl+O, Exit: Ctrl+X",
+            choices
+        )
+
+        if choice is None or choice == "back":
+            return
+
+        if choice == "main":
+            self._edit_file('/etc/meshtasticd/config.yaml')
+        elif choice == "active":
+            self._edit_config_d()
+        elif choice == "templates":
+            self._edit_available_d()
+
+    def _edit_file(self, path: str):
+        """Edit a file with nano."""
+        if not Path(path).exists():
+            if '/etc/meshtasticd/' in path:
+                try:
+                    from core.meshtasticd_config import MeshtasticdConfig
+                    config_mgr = MeshtasticdConfig()
+                    config_mgr.ensure_structure()
+                except Exception as e:
+                    logger.debug("Auto-create config failed: %s", e)
+            if not Path(path).exists():
+                self.ctx.dialog.msgbox("Error", f"File not found:\n{path}")
+                return
+
+        clear_screen()
+        subprocess.run(['nano', path])  # Interactive editor - no timeout
+
+        if self.ctx.dialog.yesno(
+            "Restart Service?",
+            "Config file modified.\n\n"
+            "Restart meshtasticd to apply changes?",
+            default_no=False
+        ):
+            self._restart_meshtasticd()
+
+    def _edit_config_d(self):
+        """Edit files in config.d."""
+        config_d = Path('/etc/meshtasticd/config.d')
+        if not config_d.exists():
+            self.ctx.dialog.msgbox("Error", f"Directory not found:\n{config_d}")
+            return
+
+        configs = list(config_d.glob('*.yaml'))
+        if not configs:
+            self.ctx.dialog.msgbox("Info", "No active configs in config.d/")
+            return
+
+        choices = [(str(cfg), cfg.name) for cfg in sorted(configs)]
+
+        choice = self.ctx.dialog.menu(
+            "Active Configs",
+            "Select config to edit (Cancel to go back):",
+            choices
+        )
+
+        if choice:
+            self._edit_file(choice)
+
+    def _edit_available_d(self):
+        """Edit files in available.d."""
+        available_d = Path('/etc/meshtasticd/available.d')
+        if not available_d.exists():
+            self.ctx.dialog.msgbox("Error", f"Directory not found:\n{available_d}")
+            return
+
+        configs = list(available_d.glob('*.yaml'))
+        if not configs:
+            self.ctx.dialog.msgbox("Info", "No templates in available.d/")
+            return
+
+        choices = [(str(cfg), cfg.name) for cfg in sorted(configs)]
+
+        choice = self.ctx.dialog.menu(
+            "Hardware Templates",
+            "Select template to view (Cancel to go back):",
+            choices
+        )
+
+        if choice:
+            self._edit_file(choice)
+
+    def _restart_meshtasticd(self):
+        """Restart meshtasticd service and re-apply saved device settings."""
+        confirm = self.ctx.dialog.yesno(
+            "Restart Service",
+            "Restart meshtasticd?\n\n"
+            "This will:\n"
+            "1. Reload systemd daemon\n"
+            "2. Restart meshtasticd service\n"
+            "3. Wait for TCP readiness\n"
+            "4. Re-apply saved device settings",
+            default_no=True
+        )
+
+        if not confirm:
+            return
+
+        try:
+            self.ctx.dialog.infobox("Restarting", "Restarting meshtasticd...")
+
+            success, msg = apply_config_and_restart('meshtasticd')
+            if not success:
+                self.ctx.dialog.msgbox("Error", f"Restart failed:\n{msg}")
+                return
+
+            from utils.device_config_store import load_device_config, apply_saved_config
+            saved = load_device_config()
+
+            if not saved:
+                self.ctx.dialog.msgbox("Success", f"meshtasticd restarted.\n\n{msg}")
+                return
+
+            sections = []
+            for section, values in saved.items():
+                items = [f"  {k}: {v}" for k, v in values.items()]
+                sections.append(f"{section}:\n" + "\n".join(items))
+            summary = "\n".join(sections)
+
+            reapply = self.ctx.dialog.yesno(
+                "Re-apply Settings?",
+                f"meshtasticd restarted.\n\n"
+                f"Saved device settings found:\n{summary}\n\n"
+                "Re-apply these settings now?\n"
+                "(Device config may have reverted to defaults)",
+                default_no=False
+            )
+
+            if not reapply:
+                self.ctx.dialog.msgbox("Info",
+                    "Settings NOT re-applied.\n\n"
+                    "You can re-apply manually via the\n"
+                    "Radio Presets or Owner Name menus.")
+                return
+
+            self.ctx.dialog.infobox("Applying", "Re-applying saved device settings...")
+
+            cli = _get_cli()
+            all_ok, results = apply_saved_config(cli)
+
+            if all_ok:
+                self.ctx.dialog.msgbox("Success",
+                    "meshtasticd restarted and settings restored!\n\n"
+                    f"{results}")
+            else:
+                self.ctx.dialog.msgbox("Partial Success",
+                    "Some settings could not be restored:\n\n"
+                    f"{results}\n\n"
+                    "Check the web UI at :9443 to verify.")
+
+        except subprocess.TimeoutExpired:
+            self.ctx.dialog.msgbox("Error", "Restart timed out")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Restart failed:\n{e}")

--- a/src/launcher_tui/handlers/meshtasticd_lora.py
+++ b/src/launcher_tui/handlers/meshtasticd_lora.py
@@ -1,0 +1,484 @@
+"""
+Meshtasticd LoRa Module Handler — SPI/GPIO configuration for LoRa radios.
+
+Converted from meshtasticd_config_mixin.py (lines 1047-1491) as part of
+the mixin-to-registry migration (Batch 9).
+
+Sub-handler registered in section "meshtasticd", dispatched from
+MeshtasticdConfigHandler's thin dispatcher menu.
+"""
+
+import logging
+import re
+import yaml
+from pathlib import Path
+
+from handler_protocol import BaseHandler
+from handlers.meshtasticd_config import (
+    OVERLAY_PATH, read_overlay, write_overlay,
+)
+
+logger = logging.getLogger(__name__)
+
+# LoRa module types supported by meshtasticd
+LORA_MODULES = {
+    "sx1262": "SX1262 (Waveshare, Ebyte E22-900M, MeshAdv, etc.)",
+    "sx1268": "SX1268 (Ebyte E22-400M, etc.)",
+    "sx1280": "SX1280 (2.4 GHz)",
+    "RF95": "RF95/RFM95 (Elecrow, Adafruit RFM9x)",
+    "sim": "Simulation mode (no radio)",
+}
+
+
+class MeshtasticdLoRaHandler(BaseHandler):
+    """TUI handler for LoRa module SPI/GPIO configuration."""
+
+    handler_id = "meshtasticd_lora"
+    menu_section = "meshtasticd"
+
+    def menu_items(self):
+        return [
+            ("lora", "LoRa Module Config", None),
+        ]
+
+    def execute(self, action):
+        if action == "lora":
+            self._lora_module_menu()
+
+    def _offer_restart(self, message: str):
+        """Offer to restart meshtasticd after a config change."""
+        handler = self.ctx.registry.get_handler("meshtasticd_config") if self.ctx.registry else None
+        if handler and hasattr(handler, '_offer_restart'):
+            handler._offer_restart(message)
+
+    def _lora_module_menu(self):
+        """Configure LoRa module type and SPI/GPIO settings."""
+        while True:
+            overlay = read_overlay()
+            lora_overlay = overlay.get('Lora', {})
+
+            config_yaml = Path('/etc/meshtasticd/config.yaml')
+            base_lora = {}
+            if config_yaml.exists():
+                try:
+                    base = yaml.safe_load(config_yaml.read_text()) or {}
+                    base_lora = base.get('Lora', {})
+                except Exception as e:
+                    logger.debug("Failed to read config.yaml for display: %s", e)
+
+            effective = {**base_lora, **lora_overlay}
+            current_module = effective.get('Module', 'auto')
+
+            status_lines = (
+                f"Current Module: {current_module}\n"
+                f"CS: {effective.get('CS', '-')}  "
+                f"IRQ: {effective.get('IRQ', '-')}  "
+                f"Busy: {effective.get('Busy', '-')}  "
+                f"Reset: {effective.get('Reset', '-')}\n"
+                f"DIO2 RF Switch: {effective.get('DIO2_AS_RF_SWITCH', '-')}  "
+                f"DIO3 TCXO: {effective.get('DIO3_TCXO_VOLTAGE', '-')}\n"
+            )
+
+            choices = [
+                ("module", "Set Module Type"),
+                ("pins", "Set GPIO Pins (CS, IRQ, Busy, Reset)"),
+                ("dio", "DIO2/DIO3 Settings"),
+                ("spi", "SPI Device & Speed"),
+                ("txrx", "TX/RX Enable Pins (PA/LNA)"),
+                ("gpiochip", "GPIO Chip (Pi 5)"),
+                ("preset", "Apply Hardware Preset"),
+                ("view", "View Current Overlay"),
+                ("clear", "Clear LoRa Overlay"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "LoRa Module Config",
+                f"{status_lines}\n"
+                "Settings saved to config.d/ overlay.\n"
+                "config.yaml is never modified.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "module": ("Set Module", self._lora_set_module),
+                "pins": ("Set GPIO Pins", self._lora_set_pins),
+                "dio": ("DIO Settings", self._lora_set_dio),
+                "spi": ("SPI Settings", self._lora_set_spi),
+                "txrx": ("TX/RX Pins", self._lora_set_txrx),
+                "gpiochip": ("GPIO Chip", self._lora_set_gpiochip),
+                "preset": ("Hardware Preset", self._lora_apply_preset),
+                "view": ("View Overlay", self._lora_view_overlay),
+                "clear": ("Clear Overlay", self._lora_clear_overlay),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _lora_set_module(self):
+        """Select LoRa module type."""
+        choices = [(mod, desc) for mod, desc in LORA_MODULES.items()]
+
+        choice = self.ctx.dialog.menu(
+            "LoRa Module Type",
+            "Select the LoRa radio chip type.\n\n"
+            "Match your hardware — SPI radios require\n"
+            "the correct module type to bind.",
+            choices
+        )
+
+        if choice is None:
+            return
+
+        overlay = read_overlay()
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+        overlay['Lora']['Module'] = choice
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart(f"Module set to: {choice}")
+
+    def _lora_set_pins(self):
+        """Configure GPIO pins for SPI LoRa radio."""
+        overlay = read_overlay()
+        lora = overlay.get('Lora', {})
+
+        cs = self.ctx.dialog.inputbox(
+            "Chip Select (CS)", "GPIO pin for Chip Select:",
+            str(lora.get('CS', '21'))
+        )
+        if cs is None:
+            return
+
+        irq = self.ctx.dialog.inputbox(
+            "IRQ (DIO1)", "GPIO pin for Interrupt Request:",
+            str(lora.get('IRQ', '16'))
+        )
+        if irq is None:
+            return
+
+        busy = self.ctx.dialog.inputbox(
+            "Busy", "GPIO pin for Busy signal\n(leave empty for RF95):",
+            str(lora.get('Busy', '20'))
+        )
+        if busy is None:
+            return
+
+        reset = self.ctx.dialog.inputbox(
+            "Reset", "GPIO pin for Reset:",
+            str(lora.get('Reset', '18'))
+        )
+        if reset is None:
+            return
+
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+
+        try:
+            overlay['Lora']['CS'] = int(cs)
+            overlay['Lora']['IRQ'] = int(irq)
+            if busy and busy.strip():
+                overlay['Lora']['Busy'] = int(busy)
+            overlay['Lora']['Reset'] = int(reset)
+        except ValueError:
+            self.ctx.dialog.msgbox("Error", "GPIO pins must be integers.")
+            return
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart("GPIO pins updated")
+
+    def _lora_set_dio(self):
+        """Configure DIO2 RF switch and DIO3 TCXO voltage."""
+        overlay = read_overlay()
+        lora = overlay.get('Lora', {})
+
+        dio2 = self.ctx.dialog.yesno(
+            "DIO2 as RF Switch",
+            "Enable DIO2 as RF switch?\n\n"
+            "Required for Ebyte E22 and some SX1262 modules.",
+            default_no=not lora.get('DIO2_AS_RF_SWITCH', False)
+        )
+
+        choices = [
+            ("false", "Disabled"),
+            ("true", "Enabled (auto voltage)"),
+            ("1.6", "1.6V"),
+            ("1.7", "1.7V"),
+            ("1.8", "1.8V (common)"),
+            ("2.2", "2.2V"),
+            ("2.4", "2.4V"),
+            ("2.7", "2.7V"),
+            ("3.0", "3.0V"),
+            ("3.3", "3.3V"),
+        ]
+
+        tcxo = self.ctx.dialog.menu(
+            "DIO3 TCXO Voltage",
+            "Set DIO3 TCXO voltage.\n\n"
+            "Required for Waveshare SX1262 and\n"
+            "modules with a TCXO oscillator.",
+            choices
+        )
+
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+
+        overlay['Lora']['DIO2_AS_RF_SWITCH'] = bool(dio2)
+
+        if tcxo and tcxo != "false":
+            if tcxo == "true":
+                overlay['Lora']['DIO3_TCXO_VOLTAGE'] = True
+            else:
+                try:
+                    overlay['Lora']['DIO3_TCXO_VOLTAGE'] = float(tcxo)
+                except ValueError:
+                    overlay['Lora']['DIO3_TCXO_VOLTAGE'] = True
+        else:
+            overlay['Lora'].pop('DIO3_TCXO_VOLTAGE', None)
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart("DIO settings updated")
+
+    def _lora_set_spi(self):
+        """Configure SPI device and speed."""
+        overlay = read_overlay()
+        lora = overlay.get('Lora', {})
+
+        spidev = self.ctx.dialog.inputbox(
+            "SPI Device",
+            "SPI device path:\n\n"
+            "  spidev0.0 — Raspberry Pi native SPI\n"
+            "  ch341     — CH341 USB-to-SPI bridge",
+            str(lora.get('spidev', 'spidev0.0'))
+        )
+        if spidev is None:
+            return
+
+        if not re.match(r'^(spidev\d+\.\d+|ch341)$', spidev):
+            self.ctx.dialog.msgbox(
+                "Invalid",
+                f"Invalid SPI device: {spidev}\n\n"
+                "Expected: spidev0.0, spidev0.1, ch341"
+            )
+            return
+
+        speed = self.ctx.dialog.inputbox(
+            "SPI Speed",
+            "SPI bus speed in Hz (default: 2000000):",
+            str(lora.get('spiSpeed', '2000000'))
+        )
+
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+        overlay['Lora']['spidev'] = spidev
+
+        if speed and speed.strip():
+            try:
+                overlay['Lora']['spiSpeed'] = int(speed)
+            except ValueError:
+                self.ctx.dialog.msgbox("Warning", f"Invalid SPI speed '{speed}' — using default.")
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart("SPI settings updated")
+
+    def _lora_set_txrx(self):
+        """Configure TX/RX enable pins for external PA/LNA."""
+        overlay = read_overlay()
+        lora = overlay.get('Lora', {})
+
+        txen = self.ctx.dialog.inputbox(
+            "TX Enable Pin",
+            "GPIO pin for TX enable (PA control).\n"
+            "Leave empty if not used:",
+            str(lora.get('TXen', ''))
+        )
+
+        rxen = self.ctx.dialog.inputbox(
+            "RX Enable Pin",
+            "GPIO pin for RX enable (LNA control).\n"
+            "Leave empty if not used:",
+            str(lora.get('RXen', ''))
+        )
+
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+
+        if txen and txen.strip():
+            try:
+                overlay['Lora']['TXen'] = int(txen)
+            except ValueError:
+                pass
+        else:
+            overlay['Lora'].pop('TXen', None)
+
+        if rxen and rxen.strip():
+            try:
+                overlay['Lora']['RXen'] = int(rxen)
+            except ValueError:
+                pass
+        else:
+            overlay['Lora'].pop('RXen', None)
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart("TX/RX pins updated")
+
+    def _lora_set_gpiochip(self):
+        """Set GPIO chip number (Raspberry Pi 5 uses gpiochip4)."""
+        overlay = read_overlay()
+        lora = overlay.get('Lora', {})
+
+        chip = self.ctx.dialog.inputbox(
+            "GPIO Chip",
+            "GPIO chip number:\n\n"
+            "  0 — Raspberry Pi 4 and earlier\n"
+            "  4 — Raspberry Pi 5 (GPIO header)",
+            str(lora.get('gpiochip', '0'))
+        )
+
+        if chip is None:
+            return
+
+        if 'Lora' not in overlay:
+            overlay['Lora'] = {}
+
+        try:
+            overlay['Lora']['gpiochip'] = int(chip)
+        except ValueError:
+            self.ctx.dialog.msgbox("Error", "GPIO chip must be an integer.")
+            return
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart("GPIO chip updated")
+
+    def _lora_apply_preset(self):
+        """Apply a known hardware preset for common LoRa boards."""
+        presets = {
+            "meshadv-mini": {
+                "desc": "MeshAdv-Mini (SX1262, 22dBm)",
+                "config": {
+                    "Module": "sx1262", "CS": 8, "IRQ": 16,
+                    "Busy": 20, "Reset": 24,
+                    "DIO2_AS_RF_SWITCH": True,
+                    "DIO3_TCXO_VOLTAGE": True,
+                },
+            },
+            "meshadv-pi-hat": {
+                "desc": "MeshAdv-Pi HAT (SX1262, 1W, PA/LNA)",
+                "config": {
+                    "Module": "sx1262", "CS": 21, "IRQ": 16,
+                    "Busy": 20, "Reset": 18, "RXen": 12, "TXen": 13,
+                    "DIO2_AS_RF_SWITCH": True,
+                    "DIO3_TCXO_VOLTAGE": True,
+                },
+            },
+            "waveshare-sx1262": {
+                "desc": "Waveshare SX1262 HAT",
+                "config": {
+                    "Module": "sx1262", "CS": 21, "IRQ": 16,
+                    "Busy": 20, "Reset": 18,
+                    "DIO3_TCXO_VOLTAGE": 1.8,
+                },
+            },
+            "elecrow-rfm95": {
+                "desc": "Elecrow RFM95 (SX1276, no Busy pin)",
+                "config": {
+                    "Module": "RF95", "CS": 7, "IRQ": 25, "Reset": 22,
+                },
+            },
+            "ebyte-e22-900m30s": {
+                "desc": "Ebyte E22-900M30S (SX1262, 1W, 915MHz)",
+                "config": {
+                    "Module": "sx1262", "CS": 21, "IRQ": 16,
+                    "Busy": 20, "Reset": 18,
+                    "DIO2_AS_RF_SWITCH": True,
+                    "DIO3_TCXO_VOLTAGE": 1.8,
+                },
+            },
+            "meshtoad-spi": {
+                "desc": "MeshToad SPI (CH341 USB-SPI bridge)",
+                "config": {
+                    "Module": "sx1262", "spidev": "ch341",
+                    "CS": 0, "IRQ": 6, "Busy": 4, "Reset": 2,
+                    "DIO2_AS_RF_SWITCH": True,
+                    "DIO3_TCXO_VOLTAGE": True,
+                },
+            },
+        }
+
+        choices = [(key, p["desc"]) for key, p in presets.items()]
+
+        choice = self.ctx.dialog.menu(
+            "Hardware Preset",
+            "Select a hardware preset.\n\n"
+            "This sets Module, GPIO pins, and DIO\n"
+            "options for known hardware configurations.",
+            choices
+        )
+
+        if choice is None or choice not in presets:
+            return
+
+        preset = presets[choice]
+        detail = "\n".join(
+            f"  {k}: {v}" for k, v in preset["config"].items()
+        )
+
+        if not self.ctx.dialog.yesno(
+            "Apply Preset",
+            f"Apply preset: {preset['desc']}\n\n{detail}\n\n"
+            f"This writes to:\n  {OVERLAY_PATH}\n"
+            "(config.yaml is not modified)",
+            default_no=True
+        ):
+            return
+
+        overlay = read_overlay()
+        overlay['Lora'] = preset["config"]
+
+        if write_overlay(overlay, self.ctx.dialog):
+            self._offer_restart(f"Preset applied: {choice}")
+
+    def _lora_view_overlay(self):
+        """Show current meshforge-overrides.yaml content."""
+        if OVERLAY_PATH.exists():
+            try:
+                content = OVERLAY_PATH.read_text()
+            except Exception as e:
+                content = f"Error reading overlay: {e}"
+        else:
+            content = "(No overlay file — using defaults from config.yaml)"
+
+        self.ctx.dialog.msgbox(f"Overlay: {OVERLAY_PATH}", content)
+
+    def _lora_clear_overlay(self):
+        """Remove LoRa section from the overlay file."""
+        overlay = read_overlay()
+        if 'Lora' not in overlay:
+            self.ctx.dialog.msgbox("Info", "No LoRa overrides to clear.")
+            return
+
+        if not self.ctx.dialog.yesno(
+            "Clear LoRa Overlay",
+            "Remove all LoRa overrides?\n\n"
+            "meshtasticd will use config.yaml defaults\n"
+            "and any active hardware template in config.d/.",
+            default_no=True
+        ):
+            return
+
+        del overlay['Lora']
+
+        if overlay:
+            if not write_overlay(overlay, self.ctx.dialog):
+                return
+        else:
+            try:
+                OVERLAY_PATH.unlink()
+            except Exception as e:
+                self.ctx.dialog.msgbox("Error", f"Failed to remove overlay:\n{e}")
+                return
+
+        self._offer_restart("LoRa overlay cleared")

--- a/src/launcher_tui/handlers/meshtasticd_mqtt.py
+++ b/src/launcher_tui/handlers/meshtasticd_mqtt.py
@@ -1,0 +1,366 @@
+"""
+Meshtasticd MQTT Device Handler — Configure radio MQTT uplink/downlink.
+
+Converted from meshtasticd_config_mixin.py (lines 1681-2016) as part of
+the mixin-to-registry migration (Batch 9).
+
+Sub-handler registered in section "meshtasticd", dispatched from
+MeshtasticdConfigHandler's thin dispatcher menu.
+"""
+
+import logging
+import subprocess
+
+from handler_protocol import BaseHandler
+from backend import clear_screen
+logger = logging.getLogger(__name__)
+
+from utils.broker_profiles import get_active_profile as _get_active_profile
+
+
+class MeshtasticdDeviceMQTTHandler(BaseHandler):
+    """TUI handler for Meshtastic radio MQTT uplink/downlink configuration."""
+
+    handler_id = "meshtasticd_device_mqtt"
+    menu_section = "meshtasticd"
+
+    def menu_items(self):
+        return [
+            ("mqtt", "MQTT Uplink/Downlink", None),
+        ]
+
+    def execute(self, action):
+        if action == "mqtt":
+            self._mqtt_device_config()
+
+    def _mqtt_device_config(self):
+        """Configure MQTT uplink/downlink for the Meshtastic radio."""
+        while True:
+            choices = [
+                ("view", "View Current Settings"),
+                ("enable", "Enable MQTT Uplink"),
+                ("disable", "Disable MQTT"),
+                ("broker", "Set Broker Address"),
+                ("credentials", "Set Username/Password"),
+                ("topic", "Set Root Topic"),
+                ("encryption", "Encryption Key (PKC)"),
+                ("uplink", "Configure Uplink Channels"),
+                ("downlink", "Configure Downlink Channels"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "MQTT Device Config",
+                "Configure radio MQTT uplink/downlink:\n\n"
+                "This sends mesh traffic to an MQTT broker.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "view": ("MQTT View Settings", self._mqtt_view_settings),
+                "enable": ("Enable MQTT", lambda: self._mqtt_set_enabled(True)),
+                "disable": ("Disable MQTT", lambda: self._mqtt_set_enabled(False)),
+                "broker": ("Set MQTT Broker", self._mqtt_set_broker),
+                "credentials": ("Set MQTT Credentials", self._mqtt_set_credentials),
+                "topic": ("Set MQTT Topic", self._mqtt_set_topic),
+                "encryption": ("Set MQTT Encryption", self._mqtt_set_encryption),
+                "uplink": ("Configure Uplink", self._mqtt_configure_uplink),
+                "downlink": ("Configure Downlink", self._mqtt_configure_downlink),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _mqtt_view_settings(self):
+        """View current MQTT settings."""
+        clear_screen()
+        print("=== MQTT Settings ===\n")
+        cli = self.ctx.get_meshtastic_cli()
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--get', 'mqtt'],
+                timeout=15
+            )
+            if result.returncode != 0:
+                print("\nFailed to get MQTT settings.")
+                print("Is meshtasticd running?")
+        except FileNotFoundError:
+            print("meshtastic CLI not found. Install via Radio Tools menu.")
+        except subprocess.TimeoutExpired:
+            print("\nCommand timed out.")
+        except KeyboardInterrupt:
+            print("\nAborted.")
+        self.ctx.wait_for_enter()
+
+    def _mqtt_set_enabled(self, enabled: bool):
+        """Enable or disable MQTT."""
+        if not self.ctx.dialog.yesno(
+            f"{'Enable' if enabled else 'Disable'} MQTT",
+            f"{'Enable' if enabled else 'Disable'} MQTT uplink/downlink?\n\n"
+            f"{'This will start sending mesh traffic to the MQTT broker.' if enabled else 'This will stop MQTT traffic.'}"
+        ):
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        clear_screen()
+        print(f"=== {'Enabling' if enabled else 'Disabling'} MQTT ===\n")
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.enabled', str(enabled).lower()],
+                timeout=15
+            )
+            if result.returncode == 0:
+                print(f"\nMQTT {'enabled' if enabled else 'disabled'} successfully.")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'enabled', enabled)
+            else:
+                print("\nCommand failed.")
+        except Exception as e:
+            print(f"\nError: {e}")
+        self.ctx.wait_for_enter()
+
+    def _mqtt_set_broker(self):
+        """Set MQTT broker address."""
+        default_broker = "mqtt.meshtastic.org"
+        try:
+            active = _get_active_profile()
+            if active:
+                default_broker = active.host
+        except Exception:
+            pass
+
+        broker = self.ctx.dialog.inputbox(
+            "MQTT Broker",
+            "Enter MQTT broker address:\n\n"
+            "Examples:\n"
+            "  localhost (private broker on this machine)\n"
+            "  192.168.1.100 (private broker on LAN)\n"
+            "  mqtt.meshtastic.org (public)",
+            init=default_broker
+        )
+
+        if not broker:
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        clear_screen()
+        print("=== Setting MQTT Broker ===\n")
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.address', broker.strip()],
+                timeout=15
+            )
+            if result.returncode == 0:
+                print(f"\nMQTT broker set to: {broker}")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'address', broker.strip())
+            else:
+                print("\nCommand failed.")
+        except Exception as e:
+            print(f"\nError: {e}")
+        self.ctx.wait_for_enter()
+
+    def _mqtt_set_credentials(self):
+        """Set MQTT username and password."""
+        username = self.ctx.dialog.inputbox(
+            "MQTT Username",
+            "Enter MQTT username (blank for anonymous):",
+            init=""
+        )
+
+        if username is None:
+            return
+
+        password = self.ctx.dialog.inputbox(
+            "MQTT Password",
+            "Enter MQTT password (blank for none):",
+            init=""
+        )
+
+        if password is None:
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        clear_screen()
+        print("=== Setting MQTT Credentials ===\n")
+        try:
+            cmd = [cli, '--host', 'localhost']
+            if username:
+                cmd.extend(['--set', 'mqtt.username', username])
+            if password:
+                cmd.extend(['--set', 'mqtt.password', password])
+
+            if len(cmd) > 3:
+                result = subprocess.run(cmd, timeout=15)
+                if result.returncode == 0:
+                    print("\nMQTT credentials updated.")
+                    from utils.device_config_store import save_device_settings
+                    cred_data = {}
+                    if username:
+                        cred_data['username'] = username
+                    if password:
+                        cred_data['password'] = password
+                    if cred_data:
+                        save_device_settings({'mqtt': cred_data})
+                else:
+                    print("\nCommand failed.")
+            else:
+                print("No credentials to set.")
+        except Exception as e:
+            print(f"\nError: {e}")
+        self.ctx.wait_for_enter()
+
+    def _mqtt_set_topic(self):
+        """Set MQTT root topic."""
+        topic = self.ctx.dialog.inputbox(
+            "MQTT Root Topic",
+            "Enter MQTT root topic:\n\n"
+            "Default: msh\n"
+            "Full topic pattern: {root}/{region}/2/e/{channel}/...",
+            init="msh"
+        )
+
+        if not topic:
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        clear_screen()
+        print("=== Setting MQTT Topic ===\n")
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost', '--set', 'mqtt.root', topic.strip()],
+                timeout=15
+            )
+            if result.returncode == 0:
+                print(f"\nMQTT root topic set to: {topic}")
+                from utils.device_config_store import save_device_setting
+                save_device_setting('mqtt', 'root_topic', topic.strip())
+            else:
+                print("\nCommand failed.")
+        except Exception as e:
+            print(f"\nError: {e}")
+        self.ctx.wait_for_enter()
+
+    def _mqtt_set_encryption(self):
+        """Configure MQTT encryption key (Public Key Cryptography)."""
+        self.ctx.dialog.msgbox(
+            "MQTT Encryption",
+            "MQTT Encryption Options:\n\n"
+            "1. JSON mode (default): Messages sent as plaintext JSON\n"
+            "2. PKC mode: Messages encrypted with channel key\n\n"
+            "PKC mode requires:\n"
+            "  - encryption_enabled = true\n"
+            "  - A valid channel PSK\n\n"
+            "Configure encryption via:\n"
+            "  --set mqtt.encryption_enabled true\n"
+            "  --set mqtt.json_enabled false"
+        )
+
+        choices = [
+            ("json", "JSON Mode (plaintext, human-readable)"),
+            ("encrypted", "Encrypted Mode (PKC, secure)"),
+            ("back", "Back"),
+        ]
+
+        choice = self.ctx.dialog.menu(
+            "MQTT Encryption Mode",
+            "Select MQTT message format:",
+            choices
+        )
+
+        if choice is None or choice == "back":
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        clear_screen()
+
+        if choice == "json":
+            print("=== Setting JSON Mode ===\n")
+            try:
+                subprocess.run(
+                    [cli, '--host', 'localhost',
+                     '--set', 'mqtt.json_enabled', 'true',
+                     '--set', 'mqtt.encryption_enabled', 'false'],
+                    timeout=15
+                )
+                print("\nMQTT set to JSON mode (plaintext).")
+            except Exception as e:
+                print(f"\nError: {e}")
+        else:
+            print("=== Setting Encrypted Mode ===\n")
+            try:
+                subprocess.run(
+                    [cli, '--host', 'localhost',
+                     '--set', 'mqtt.json_enabled', 'false',
+                     '--set', 'mqtt.encryption_enabled', 'true'],
+                    timeout=15
+                )
+                print("\nMQTT set to encrypted mode (PKC).")
+                print("Messages will be encrypted with channel PSK.")
+            except Exception as e:
+                print(f"\nError: {e}")
+
+        self.ctx.wait_for_enter()
+
+    def _mqtt_configure_uplink(self):
+        """Configure which channels uplink to MQTT."""
+        self.ctx.dialog.msgbox(
+            "MQTT Uplink",
+            "MQTT Uplink sends local mesh messages to the broker.\n\n"
+            "Per-channel uplink is configured via:\n"
+            "  Channel Config > Edit Channel > Uplink Enabled\n\n"
+            "Or via CLI:\n"
+            "  meshtastic --ch-index 0 --ch-set uplink_enabled true"
+        )
+
+        if self.ctx.dialog.yesno(
+            "Enable Primary Uplink",
+            "Enable MQTT uplink on primary channel (index 0)?",
+            default_no=True
+        ):
+            cli = self.ctx.get_meshtastic_cli()
+            clear_screen()
+            print("=== Enabling Uplink ===\n")
+            try:
+                subprocess.run(
+                    [cli, '--host', 'localhost',
+                     '--ch-index', '0', '--ch-set', 'uplink_enabled', 'true'],
+                    timeout=15
+                )
+                print("\nUplink enabled on primary channel.")
+            except Exception as e:
+                print(f"\nError: {e}")
+            self.ctx.wait_for_enter()
+
+    def _mqtt_configure_downlink(self):
+        """Configure which channels downlink from MQTT."""
+        self.ctx.dialog.msgbox(
+            "MQTT Downlink",
+            "MQTT Downlink receives broker messages to local mesh.\n\n"
+            "Per-channel downlink is configured via:\n"
+            "  Channel Config > Edit Channel > Downlink Enabled\n\n"
+            "Or via CLI:\n"
+            "  meshtastic --ch-index 0 --ch-set downlink_enabled true"
+        )
+
+        if self.ctx.dialog.yesno(
+            "Enable Primary Downlink",
+            "Enable MQTT downlink on primary channel (index 0)?",
+            default_no=True
+        ):
+            cli = self.ctx.get_meshtastic_cli()
+            clear_screen()
+            print("=== Enabling Downlink ===\n")
+            try:
+                subprocess.run(
+                    [cli, '--host', 'localhost',
+                     '--ch-index', '0', '--ch-set', 'downlink_enabled', 'true'],
+                    timeout=15
+                )
+                print("\nDownlink enabled on primary channel.")
+            except Exception as e:
+                print(f"\nError: {e}")
+            self.ctx.wait_for_enter()

--- a/src/launcher_tui/handlers/meshtasticd_nodedb.py
+++ b/src/launcher_tui/handlers/meshtasticd_nodedb.py
@@ -1,0 +1,375 @@
+"""
+Meshtasticd Node DB Cleanup Handler — Phantom node detection and removal.
+
+Converted from meshtasticd_config_mixin.py (lines 697-1045) as part of
+the mixin-to-registry migration (Batch 9).
+
+Sub-handler registered in section "meshtasticd", dispatched from
+MeshtasticdConfigHandler's thin dispatcher menu.
+"""
+
+import logging
+import re
+import subprocess
+
+from handler_protocol import BaseHandler
+from handlers.meshtasticd_config import (
+    OVERLAY_PATH, read_overlay, write_overlay,
+)
+logger = logging.getLogger(__name__)
+
+from utils.meshtastic_http import get_http_client as _get_http_client
+
+
+class MeshtasticdNodeDBHandler(BaseHandler):
+    """TUI handler for node database cleanup operations."""
+
+    handler_id = "meshtasticd_nodedb"
+    menu_section = "meshtasticd"
+
+    def menu_items(self):
+        return [
+            ("cleanup", "Node DB Cleanup", None),
+        ]
+
+    def execute(self, action):
+        if action == "cleanup":
+            self._node_db_cleanup_menu()
+
+    def _node_db_cleanup_menu(self):
+        """Node database cleanup — identify and remove phantom/incomplete nodes."""
+        while True:
+            choices = [
+                ("scan", "Scan for Phantom Nodes"),
+                ("reset", "Reset Node Database (removes ALL nodes)"),
+                ("maxnodes", "Check MaxNodes Setting"),
+                ("back", "Back"),
+            ]
+
+            choice = self.ctx.dialog.menu(
+                "Node DB Cleanup",
+                "Clean up the meshtasticd node database.\n\n"
+                "Phantom nodes (incomplete data from MQTT) can\n"
+                "crash the web client when clicked.\n\n"
+                "Scan identifies nodes with missing info.",
+                choices
+            )
+
+            if choice is None or choice == "back":
+                break
+
+            dispatch = {
+                "scan": ("Scan Phantom Nodes", self._scan_phantom_nodes),
+                "reset": ("Reset Node DB", self._reset_node_database),
+                "maxnodes": ("Check MaxNodes", self._check_maxnodes),
+            }
+            entry = dispatch.get(choice)
+            if entry:
+                self.ctx.safe_call(*entry)
+
+    def _scan_phantom_nodes(self):
+        """Scan for phantom/incomplete nodes via HTTP API."""
+        self.ctx.dialog.infobox("Scanning", "Fetching node list from meshtasticd...")
+
+        try:
+            client = _get_http_client()
+
+            if not client.is_available:
+                self.ctx.dialog.msgbox(
+                    "Not Available",
+                    "meshtasticd HTTP API not reachable.\n\n"
+                    "Ensure meshtasticd is running:\n"
+                    "  sudo systemctl start meshtasticd"
+                )
+                return
+
+            nodes = client.get_nodes()
+
+            if not nodes:
+                self.ctx.dialog.msgbox("No Nodes", "No nodes found in the device database.")
+                return
+
+            phantom = []
+            healthy = []
+            for node in nodes:
+                has_name = bool(node.long_name.strip()) or bool(node.short_name.strip())
+                if not has_name:
+                    phantom.append(node)
+                else:
+                    healthy.append(node)
+
+            if not phantom:
+                self.ctx.dialog.msgbox(
+                    "All Clear",
+                    f"All {len(nodes)} nodes have valid names.\n\n"
+                    "No phantom nodes detected.\n\n"
+                    "If the web client still crashes on search,\n"
+                    "this may be an upstream Meshtastic bug.\n"
+                    "See: github.com/meshtastic/web/issues/862"
+                )
+                return
+
+            lines = [
+                f"Found {len(phantom)} phantom node(s) "
+                f"(of {len(nodes)} total)\n",
+                "Phantom nodes have no name data and can crash",
+                "the web client when clicked in search results.\n",
+            ]
+
+            for node in phantom[:20]:
+                node_id = node.node_id
+                hw = node.hw_model or "unknown hw"
+                heard = ""
+                if node.last_heard > 0:
+                    import time
+                    age = time.time() - node.last_heard
+                    if age < 3600:
+                        heard = f"{age / 60:.0f}m ago"
+                    elif age < 86400:
+                        heard = f"{age / 3600:.0f}h ago"
+                    else:
+                        heard = f"{age / 86400:.0f}d ago"
+                mqtt_tag = " [MQTT]" if node.via_mqtt else ""
+                lines.append(f"  {node_id} ({hw}) {heard}{mqtt_tag}")
+
+            if len(phantom) > 20:
+                lines.append(f"  ... and {len(phantom) - 20} more")
+
+            lines.append("")
+            lines.append("Options:")
+            lines.append("  - Remove individually (if CLI supports it)")
+            lines.append("  - Reset entire node DB (re-discovers all)")
+            lines.append("  - Reduce MaxNodes to limit MQTT phantoms")
+
+            self.ctx.dialog.msgbox("Phantom Nodes Found", "\n".join(lines))
+
+            if self.ctx.dialog.yesno(
+                "Remove Phantom Nodes?",
+                f"Try to remove {len(phantom)} phantom node(s)?\n\n"
+                "Uses 'meshtastic --remove-node' for each.\n"
+                "If that command isn't available, will offer\n"
+                "to reset the full node database instead.",
+                default_no=True
+            ):
+                self._remove_phantom_nodes(phantom)
+
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Scan failed:\n{e}")
+
+    def _remove_phantom_nodes(self, phantom_nodes):
+        """Try to remove phantom nodes individually via CLI."""
+        cli = self.ctx.get_meshtastic_cli()
+        removed = 0
+        failed = 0
+        cli_unsupported = False
+
+        self.ctx.dialog.infobox(
+            "Removing",
+            f"Removing {len(phantom_nodes)} phantom node(s)..."
+        )
+
+        for node in phantom_nodes:
+            node_id = node.node_id
+            try:
+                if node_id.startswith('!'):
+                    node_num = str(int(node_id[1:], 16))
+                else:
+                    node_num = node_id
+            except ValueError:
+                node_num = node_id
+
+            try:
+                result = subprocess.run(
+                    [cli, '--host', 'localhost:4403',
+                     '--remove-node', node_num],
+                    capture_output=True, text=True, timeout=15
+                )
+                if result.returncode == 0:
+                    removed += 1
+                else:
+                    stderr = result.stderr or ""
+                    if "unrecognized" in stderr.lower() or "unknown" in stderr.lower():
+                        cli_unsupported = True
+                        break
+                    failed += 1
+            except FileNotFoundError:
+                self.ctx.dialog.msgbox(
+                    "CLI Not Found",
+                    "meshtastic CLI not installed.\n\n"
+                    "Install: pip install meshtastic"
+                )
+                return
+            except subprocess.TimeoutExpired:
+                failed += 1
+
+        if cli_unsupported:
+            if self.ctx.dialog.yesno(
+                "CLI Too Old",
+                "'meshtastic --remove-node' not available.\n\n"
+                "Your meshtastic CLI version doesn't support\n"
+                "individual node removal.\n\n"
+                "Options:\n"
+                "  - Upgrade: pip install --upgrade meshtastic\n"
+                "  - Reset entire node DB (re-discovers all)\n\n"
+                "Reset entire node database now?",
+                default_no=True
+            ):
+                self._reset_node_database()
+        elif removed > 0 or failed > 0:
+            self.ctx.dialog.msgbox(
+                "Cleanup Complete",
+                f"Removed: {removed} phantom node(s)\n"
+                f"Failed:  {failed}\n\n"
+                "The device will re-discover legitimate nodes\n"
+                "through normal mesh traffic."
+            )
+        else:
+            self.ctx.dialog.msgbox("No Changes", "No nodes were removed.")
+
+    def _reset_node_database(self):
+        """Reset the entire node database (nuclear option)."""
+        confirm = self.ctx.dialog.yesno(
+            "Reset Node Database",
+            "This will CLEAR ALL known nodes from the device.\n\n"
+            "The device will re-discover nodes through\n"
+            "normal mesh traffic (may take minutes to hours).\n\n"
+            "This fixes web client crashes caused by phantom\n"
+            "nodes with incomplete data.\n\n"
+            "Proceed?",
+            default_no=True
+        )
+
+        if not confirm:
+            return
+
+        cli = self.ctx.get_meshtastic_cli()
+        try:
+            result = subprocess.run(
+                [cli, '--host', 'localhost:4403', '--reset-nodedb'],
+                capture_output=True, text=True, timeout=30
+            )
+            if result.returncode == 0:
+                self.ctx.dialog.msgbox(
+                    "Database Reset",
+                    "Node database cleared.\n\n"
+                    "Nodes will re-appear as they are heard\n"
+                    "over the mesh (a few minutes for nearby nodes)."
+                )
+            else:
+                self.ctx.dialog.msgbox(
+                    "Reset Failed",
+                    f"Command failed:\n{result.stderr or result.stdout}"
+                )
+        except FileNotFoundError:
+            self.ctx.dialog.msgbox("Error", "meshtastic CLI not found.")
+        except subprocess.TimeoutExpired:
+            self.ctx.dialog.msgbox("Error", "Command timed out.")
+        except Exception as e:
+            self.ctx.dialog.msgbox("Error", f"Reset failed:\n{e}")
+
+    def _check_maxnodes(self):
+        """Check and optionally reduce MaxNodes in config.yaml."""
+        from pathlib import Path
+
+        config_path = Path('/etc/meshtasticd/config.yaml')
+
+        if not config_path.exists():
+            self.ctx.dialog.msgbox(
+                "Config Not Found",
+                f"{config_path} not found.\n\n"
+                "meshtasticd may not be installed."
+            )
+            return
+
+        try:
+            content = config_path.read_text()
+        except OSError as e:
+            self.ctx.dialog.msgbox("Error", f"Cannot read config:\n{e}")
+            return
+
+        overlay = read_overlay()
+        overlay_maxnodes = overlay.get('General', {}).get('MaxNodes')
+
+        match = re.search(r'MaxNodes:\s*(\d+)', content)
+        base_value = int(match.group(1)) if match else None
+        current = overlay_maxnodes if overlay_maxnodes is not None else base_value
+
+        if current is None:
+            self.ctx.dialog.msgbox(
+                "MaxNodes Not Set",
+                "MaxNodes is not configured in config.yaml.\n\n"
+                "Default is typically 200 (device dependent).\n\n"
+                "Add to General section:\n"
+                "  General:\n"
+                "    MaxNodes: 100"
+            )
+            return
+
+        source = "overlay" if overlay_maxnodes is not None else "config.yaml"
+        text = (
+            f"Current MaxNodes: {current} (from {source})\n\n"
+            "MaxNodes limits how many nodes the device tracks.\n"
+            "High values accumulate phantom MQTT nodes that\n"
+            "can crash the web client.\n\n"
+            "Recommended values:\n"
+            "  50  — Small local mesh\n"
+            "  100 — Medium mesh with MQTT\n"
+            "  200 — Large mesh (default)\n\n"
+        )
+
+        if current > 100:
+            text += (
+                f"Your value ({current}) is high. Reducing to 100\n"
+                "limits phantom node accumulation."
+            )
+
+        new_val = self.ctx.dialog.inputbox(
+            "MaxNodes Setting",
+            text + "\n\nEnter new MaxNodes value (or Cancel to keep):",
+            str(current)
+        )
+
+        if new_val is None:
+            return
+
+        try:
+            new_int = int(new_val)
+            if new_int < 10 or new_int > 500:
+                self.ctx.dialog.msgbox("Invalid", "MaxNodes must be between 10 and 500.")
+                return
+        except ValueError:
+            self.ctx.dialog.msgbox("Invalid", "Enter a number between 10 and 500.")
+            return
+
+        if new_int == current:
+            self.ctx.dialog.msgbox("No Change", f"MaxNodes remains at {current}.")
+            return
+
+        overlay = read_overlay()
+        if 'General' not in overlay:
+            overlay['General'] = {}
+        overlay['General']['MaxNodes'] = new_int
+
+        if not write_overlay(overlay, self.ctx.dialog):
+            return
+
+        if self.ctx.dialog.yesno(
+            "Restart Service?",
+            f"MaxNodes override: {current} -> {new_int}\n\n"
+            f"Saved to: {OVERLAY_PATH}\n"
+            "(config.yaml unchanged)\n\n"
+            "Restart meshtasticd to apply?",
+            default_no=False
+        ):
+            handler = self.ctx.registry.get_handler("meshtasticd_config") if self.ctx.registry else None
+            if handler and hasattr(handler, '_restart_meshtasticd'):
+                handler._restart_meshtasticd()
+        else:
+            self.ctx.dialog.msgbox(
+                "Config Updated",
+                f"MaxNodes set to {new_int}.\n\n"
+                f"Overlay: {OVERLAY_PATH}\n"
+                "(config.yaml unchanged)\n\n"
+                "Restart meshtasticd to apply:\n"
+                "  sudo systemctl restart meshtasticd"
+            )

--- a/src/launcher_tui/main.py
+++ b/src/launcher_tui/main.py
@@ -59,40 +59,7 @@ from backend import DialogBackend, clear_screen
 from startup_checks import StartupChecker, EnvironmentState, ServiceRunState
 from conflict_resolver import check_and_resolve_conflicts
 
-# Import mixins to reduce file size
-from rf_tools_mixin import RFToolsMixin
-from channel_config_mixin import ChannelConfigMixin
-from meshtasticd_config_mixin import MeshtasticdConfigMixin
-from site_planner_mixin import SitePlannerMixin
-from service_discovery_mixin import ServiceDiscoveryMixin
-from quick_actions_mixin import QuickActionsMixin
-from emergency_mode_mixin import EmergencyModeMixin
-from rns_interfaces_mixin import RNSInterfacesMixin
-from rf_awareness_mixin import RFAwarenessMixin
-from metrics_mixin import MetricsMixin
-from link_quality_mixin import LinkQualityMixin
-from rns_menu_mixin import RNSMenuMixin
-from aredn_mixin import AREDNMixin
-from radio_menu_mixin import RadioMenuMixin
-from hardware_menu_mixin import HardwareMenuMixin
-from settings_menu_mixin import SettingsMenuMixin
-from logs_menu_mixin import LogsMenuMixin
-from device_backup_mixin import DeviceBackupMixin
-from updates_mixin import UpdatesMixin
-from gateway_config_mixin import GatewayConfigMixin
-from favorites_mixin import FavoritesMixin
-from network_tools_mixin import NetworkToolsMixin
-from node_health_mixin import NodeHealthMixin
-from amateur_radio_mixin import AmateurRadioMixin
-from analytics_mixin import AnalyticsMixin
-from webhooks_mixin import WebhooksMixin
-from messaging_mixin import MessagingMixin
-from classifier_mixin import ClassifierMixin
-from rnode_mixin import RNodeMixin
-from latency_mixin import LatencyMixin
-from dashboard_mixin import DashboardMixin
-from meshcore_mixin import MeshCoreMixin
-from propagation_mixin import PropagationMixin
+# Mixins removed — all functionality now in handler registry (Batch 9)
 
 # Handler registry infrastructure (Phase 1 of mixin-to-registry migration)
 from handler_protocol import TUIContext
@@ -100,41 +67,7 @@ from handler_registry import HandlerRegistry
 from handlers import get_all_handlers
 
 
-class MeshForgeLauncher(
-    PropagationMixin,
-    RFToolsMixin,
-    ChannelConfigMixin,
-    MeshtasticdConfigMixin,
-    SitePlannerMixin,
-    ServiceDiscoveryMixin,
-    QuickActionsMixin,
-    EmergencyModeMixin,
-    RNSInterfacesMixin,
-    RFAwarenessMixin,
-    MetricsMixin,
-    LinkQualityMixin,
-    RNSMenuMixin,
-    AREDNMixin,
-    RadioMenuMixin,
-    HardwareMenuMixin,
-    SettingsMenuMixin,
-    LogsMenuMixin,
-    DeviceBackupMixin,
-    UpdatesMixin,
-    GatewayConfigMixin,
-    FavoritesMixin,
-    NetworkToolsMixin,
-    NodeHealthMixin,
-    AmateurRadioMixin,
-    AnalyticsMixin,
-    WebhooksMixin,
-    MessagingMixin,
-    ClassifierMixin,
-    RNodeMixin,
-    LatencyMixin,
-    DashboardMixin,
-    MeshCoreMixin,
-):
+class MeshForgeLauncher:
     """MeshForge launcher with raspi-config style interface."""
 
     def __init__(self, profile=None):
@@ -935,13 +868,9 @@ class MeshForgeLauncher(
             if self._registry.dispatch("dashboard", choice):
                 continue
 
-            # Legacy mixin dispatch (network still routes via mixin)
-            dispatch = {
-                "network": ("Network Status", self._network_menu),
-            }
-            entry = dispatch.get(choice)
-            if entry:
-                self._safe_call(*entry)
+            # Cross-section dispatch (network handler is in "system" section)
+            if choice == "network":
+                self._registry.dispatch("system", "network")
 
     # --- Submenu: Mesh Networks (2) ---
 
@@ -979,16 +908,7 @@ class MeshForgeLauncher(
             if self._registry.dispatch("mesh_networks", choice):
                 continue
 
-            # Legacy mixin dispatch (not yet converted)
-            dispatch = {
-                "meshtastic": ("Meshtastic Radio", self._radio_menu),
-                "meshcore": ("MeshCore Radio", self._meshcore_menu),
-                "rns": ("RNS / Reticulum", self._rns_menu),
-                "gateway": ("Gateway Bridge", self._gateway_config_menu),
-            }
-            entry = dispatch.get(choice)
-            if entry:
-                self._safe_call(*entry)
+            # All mesh_networks items handled by registry (Batch 3-9)
 
     # --- NEW Submenu: RF & SDR (3) ---
 
@@ -1041,12 +961,7 @@ class MeshForgeLauncher(
             if self._registry.dispatch("maps_viz", choice):
                 continue
 
-            # Legacy mixin dispatch (not yet converted)
-            dispatch = {
-            }
-            entry = dispatch.get(choice)
-            if entry:
-                self._safe_call(*entry)
+            # All maps_viz items handled by registry
 
     # --- NEW Submenu: Configuration (5) ---
 
@@ -1081,18 +996,11 @@ class MeshForgeLauncher(
             if self._registry.dispatch("configuration", choice):
                 continue
 
-            # Legacy mixin dispatch (not yet converted)
-            dispatch = {
-                "radio": ("Radio Config", self._config_menu),
-                "channels": ("Channel Config", self._channel_config_menu),
-                "rns-config": ("RNS Config", self._edit_rns_config),
-                "updates": ("Software Updates", self._updates_menu),
-                "meshforge": ("MeshForge Settings", self._settings_menu),
-                "config-api": ("Config API Server", self._config_api_menu),
-            }
-            entry = dispatch.get(choice)
-            if entry:
-                self._safe_call(*entry)
+            # Remaining items not in configuration registry section
+            if choice == "rns-config":
+                self._registry.dispatch("rns", "edit")
+            elif choice == "config-api":
+                self._safe_call("Config API Server", self._config_api_menu)
 
     # --- NEW Submenu: System (6) ---
 
@@ -1351,178 +1259,7 @@ SUPPORT:
         print(help_text)
         self._wait_for_enter()
 
-    # --- Config Menu - meshtasticd config.d/ management ---
-
-    def _ensure_meshtasticd_config(self):
-        """Auto-create /etc/meshtasticd structure and templates if missing."""
-        try:
-            from core.meshtasticd_config import MeshtasticdConfig
-            MeshtasticdConfig().ensure_structure()
-        except PermissionError:
-            logger.debug("Cannot auto-create meshtasticd config (no root)")
-        except Exception as e:
-            logger.debug("meshtasticd config auto-create failed: %s", e)
-
-    def _config_menu(self):
-        """Configuration management for meshtasticd."""
-        # Auto-create /etc/meshtasticd structure if missing
-        self._ensure_meshtasticd_config()
-
-        while True:
-            choices = [
-                ("view", "View Active Config"),
-                ("overlays", "View config.d/ Overlays"),
-                ("available", "Available Hardware Configs"),
-                ("presets", "LoRa Presets"),
-                ("channels", "Channel Configuration"),
-                ("meshtasticd", "Advanced meshtasticd Config"),
-                ("settings", "MeshForge Settings"),
-                ("wizard", "Run Setup Wizard"),
-                ("back", "Back"),
-            ]
-
-            choice = self.dialog.menu(
-                "Configuration",
-                "meshtasticd & MeshForge configuration:",
-                choices
-            )
-
-            if choice is None or choice == "back":
-                break
-
-            dispatch = {
-                "view": ("View Active Config", self._view_active_config),
-                "overlays": ("Config Overlays", self._view_config_overlays),
-                "available": ("Available Hardware Configs", self._view_available_configs),
-                "presets": ("LoRa Presets", self._radio_presets_menu),
-                "channels": ("Channel Config", self._channel_config_menu),
-                "meshtasticd": ("Advanced Config", self._meshtasticd_menu),
-                "settings": ("MeshForge Settings", self._settings_menu),
-                "wizard": ("Setup Wizard", lambda: self._registry.dispatch("configuration", "wizard")),
-            }
-            entry = dispatch.get(choice)
-            if entry:
-                self._safe_call(*entry)
-
-    def _view_active_config(self):
-        """Show the active meshtasticd config.yaml."""
-        clear_screen()
-        print("=== meshtasticd config.yaml ===\n")
-
-        config_path = Path('/etc/meshtasticd/config.yaml')
-
-        # Auto-create if missing
-        if not config_path.exists():
-            self._ensure_meshtasticd_config()
-
-        if config_path.exists():
-            print(f"File: {config_path}\n")
-            try:
-                print(config_path.read_text())
-            except PermissionError:
-                print("Permission denied. Try: sudo cat /etc/meshtasticd/config.yaml")
-        else:
-            print("config.yaml not found!\n")
-            print("Run MeshForge with sudo to auto-create:")
-            print("  sudo python3 src/launcher_tui/main.py")
-            print("\nOr create manually:")
-            print("  sudo mkdir -p /etc/meshtasticd/{available.d,config.d}")
-            print("  sudo cp templates/config.yaml /etc/meshtasticd/")
-            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
-
-        self._wait_for_enter()
-
-    def _view_config_overlays(self):
-        """Show config.d/ overlay files (active hardware configs)."""
-        clear_screen()
-        print("=== config.d/ Active Hardware Configs ===\n")
-
-        config_d = Path('/etc/meshtasticd/config.d')
-
-        # Auto-create if missing
-        if not config_d.exists():
-            self._ensure_meshtasticd_config()
-
-        if not config_d.exists():
-            print("config.d/ directory not found.")
-            print("\nRun with sudo to auto-create, or:")
-            print("  sudo mkdir -p /etc/meshtasticd/config.d")
-            self._wait_for_enter()
-            return
-
-        overlays = sorted(config_d.glob('*.yaml'))
-        if not overlays:
-            print("No active hardware configs in config.d/\n")
-            print("Select your hardware from:")
-            print("  Configuration > Available Hardware Configs")
-            print("  Configuration > Advanced meshtasticd Config > Hardware Config")
-        else:
-            print(f"Found {len(overlays)} active config(s):\n")
-            for f in overlays:
-                size = f.stat().st_size
-                print(f"  {f.name} ({size} bytes)")
-
-            # Show contents of each
-            print("\n" + "=" * 50)
-            for f in overlays:
-                print(f"\n--- {f.name} ---")
-                try:
-                    print(f.read_text())
-                except PermissionError:
-                    print("  (permission denied)")
-
-        self._wait_for_enter()
-
-    def _view_available_configs(self):
-        """Show available hardware configs (USB + SPI HATs)."""
-        clear_screen()
-        print("=== Available Hardware Configs ===\n")
-
-        available_d = Path('/etc/meshtasticd/available.d')
-
-        # Auto-create if missing
-        if not available_d.exists():
-            self._ensure_meshtasticd_config()
-
-        if not available_d.exists():
-            print("available.d/ not found.\n")
-            print("Run with sudo to auto-create, or:")
-            print("  sudo mkdir -p /etc/meshtasticd/available.d")
-            print("  sudo cp templates/available.d/*.yaml /etc/meshtasticd/available.d/")
-            self._wait_for_enter()
-            return
-
-        configs = sorted(available_d.glob('*.yaml'))
-        if not configs:
-            print("No hardware configs available.")
-        else:
-            # Categorize USB vs SPI
-            usb_configs = [f for f in configs if '-usb' in f.stem or f.stem.startswith('usb-')]
-            spi_configs = [f for f in configs if f not in usb_configs]
-
-            if usb_configs:
-                print(f"USB Radios ({len(usb_configs)}):")
-                for i, f in enumerate(usb_configs, 1):
-                    print(f"  {i:2d}. {f.stem}")
-
-            if spi_configs:
-                if usb_configs:
-                    print()
-                print(f"SPI HATs ({len(spi_configs)}):")
-                for i, f in enumerate(spi_configs, 1):
-                    print(f"  {i:2d}. {f.stem}")
-
-            # Show active
-            config_d = Path('/etc/meshtasticd/config.d')
-            if config_d.exists():
-                active = list(config_d.glob('*.yaml'))
-                if active:
-                    print(f"\nActive: {', '.join(f.stem for f in active)}")
-
-            print(f"\nTotal: {len(configs)} templates")
-            print("\nActivate via: Configuration > Advanced meshtasticd Config > Hardware Config")
-
-        self._wait_for_enter()
+    # Config menu and view methods moved to MeshtasticdConfigHandler (Batch 9)
 
     # --- Terminal-native utilities ---
 


### PR DESCRIPTION
## Summary

Complete migration of meshtasticd configuration functionality from the monolithic `MeshtasticdConfigMixin` to a modular handler registry architecture. This is part of the ongoing mixin-to-registry refactoring (Batch 9) that reduces main.py complexity and improves code organization.

## Key Changes

- **New handler modules created:**
  - `meshtasticd_config.py` — Main dispatcher handling view, overlays, presets, hardware, status, owner, web client, edit, and restart operations
  - `meshtasticd_lora.py` — LoRa module SPI/GPIO configuration (Module type, pins, DIO2/DIO3, SPI device, TX/RX, GPIO chip)
  - `meshtasticd_mqtt.py` — MQTT uplink/downlink configuration for radio
  - `meshtasticd_nodedb.py` — Node database cleanup with phantom node detection and removal

- **Shared utilities extracted:**
  - `read_overlay()` / `write_overlay()` functions for atomic config.d/ overlay management
  - `ensure_meshtasticd_config()` for auto-creating /etc/meshtasticd structure
  - `OVERLAY_PATH` and `OVERLAY_HEADER` constants for consistent overlay handling

- **Handler registration:**
  - All four handlers registered in `handlers/__init__.py`
  - `meshtasticd_config` in "configuration" section (top-level menu item)
  - `meshtasticd_lora`, `meshtasticd_mqtt`, `meshtasticd_nodedb` in "meshtasticd" section (sub-handlers)

- **Main.py cleanup:**
  - Removed `MeshtasticdConfigMixin` import and inheritance
  - Removed legacy `_config_menu()`, `_meshtasticd_menu()`, and related methods
  - Updated `_configuration_menu()` to dispatch "radio" action via registry
  - Simplified class definition (no longer inherits from 30+ mixins)

## Implementation Details

- **Thin dispatcher pattern:** `MeshtasticdConfigHandler` acts as a thin dispatcher that routes to sub-handlers via the registry while handling its own inline operations
- **Overlay-based configuration:** All changes written to `/etc/meshtasticd/config.d/meshforge-overrides.yaml` using atomic writes (tempfile + rename) to prevent corruption
- **Menu ordering:** Implemented `_MESHTASTICD_ORDERING` list to maintain consistent menu item order across registry and inline items
- **Cross-handler dispatch:** Supports routing to other handlers (channels, meshforge, wizard) via registry
- **Backward compatibility:** Preserves all original functionality including service status checks, preset detection, and hardware config management

## Testing Notes

- All meshtasticd configuration operations now route through handler registry
- Overlay read/write operations use atomic file operations for safety
- Sub-handlers can be independently tested and extended
- Menu structure preserved from original mixin implementation

https://claude.ai/code/session_01Mqkrcw3eS2Ma4Ka4nDvmeL