### PR TITLE
Add architecture diagram for pair debugging mesh bot article

### DIFF
--- a/docs/substack/2026-04-10-pair-debugging-mesh-bot.mmd
+++ b/docs/substack/2026-04-10-pair-debugging-mesh-bot.mmd
@@ -1,6 +1,8 @@
-%% Source of truth for the architecture diagram in 2026-04-10-pair-debugging-mesh-bot.md
-%% Rendered SVG: 2026-04-10-pair-debugging-mesh-bot.svg
-%% Render with: mmdc -i 2026-04-10-pair-debugging-mesh-bot.mmd -o out.svg -t neutral
+%% Architecture diagram for 2026-04-10-pair-debugging-mesh-bot.md
+%% The published Substack article uses a narrative bullet list in-body for
+%% mobile readability — this Mermaid source is the diff-friendly diagram of
+%% record, kept for future re-use (repo README, follow-up posts, etc.).
+%% Render locally with: mmdc -i <this file> -o out.svg -t neutral
 
 flowchart TB
     G2["<b>G2 'Borg Server'</b><br/>Solar · WiFi · LoRa TX/RX<br/><i>meshtasticd</i>"]

--- a/docs/substack/2026-04-10-pair-debugging-mesh-bot.mmd
+++ b/docs/substack/2026-04-10-pair-debugging-mesh-bot.mmd
@@ -1,0 +1,21 @@
+%% Source of truth for the architecture diagram in 2026-04-10-pair-debugging-mesh-bot.md
+%% Rendered SVG: 2026-04-10-pair-debugging-mesh-bot.svg
+%% Render with: mmdc -i 2026-04-10-pair-debugging-mesh-bot.mmd -o out.svg -t neutral
+
+flowchart TB
+    G2["<b>G2 'Borg Server'</b><br/>Solar · WiFi · LoRa TX/RX<br/><i>meshtasticd</i>"]
+    MESH(("LoRa mesh<br/>meshforge channel"))
+    PI["<b>Pi Zero 2W</b><br/>No USB · power-only<br/><i>mosquitto broker</i>"]
+    TUI["<b>mesh_client</b><br/>terminal UI<br/>(subscribes)"]
+    BOT["<b>meshing-around bot</b><br/>auto-replies over LoRa"]
+
+    G2 -- "LoRa ))" --> MESH
+    G2 -- "native MQTT uplink" --> PI
+    PI --> TUI
+    PI --> BOT
+    BOT -. "TCP → G2 → LoRa TX" .-> G2
+
+    classDef device fill:#fff,stroke:#2b2b2b,stroke-width:2px,color:#2b2b2b
+    classDef cloud fill:#fef3e0,stroke:#c97b3e,stroke-width:2px,color:#c97b3e
+    class G2,PI,TUI,BOT device
+    class MESH cloud


### PR DESCRIPTION
## Summary
Added a Mermaid flowchart diagram documenting the system architecture described in the Substack article about pair debugging with a LoRa mesh bot.

## Changes
- Created `docs/substack/2026-04-10-pair-debugging-mesh-bot.mmd` with a flowchart showing the relationships between:
  - G2 'Borg Server' (LoRa transceiver running meshtasticd)
  - Pi Zero 2W (MQTT broker via mosquitto)
  - mesh_client terminal UI
  - meshing-around bot (auto-reply service)
  - LoRa mesh network

## Details
- Diagram illustrates both LoRa mesh connectivity and native MQTT uplink architecture
- Includes rendering instructions for local generation using Mermaid CLI
- Styled with device and cloud node classifications for visual clarity
- Serves as a diff-friendly source record for reuse in README and follow-up documentation

https://claude.ai/code/session_01CdyoxAnMMKzCV1RQTddXd6