### PR TITLE
docs: Correct commit count in MeshAnchor Lives article

### DIFF
--- a/docs/substack/2026-05-02-meshanchor-lives.md
+++ b/docs/substack/2026-05-02-meshanchor-lives.md
@@ -1,6 +1,6 @@
 # MeshAnchor Lives
 
-*The day the sister project went from "TUI sees radio" to "iOS to private channel to daemon to TUI" — eleven commits, two engineers, one of them silicon.*
+*The day the sister project went from "TUI sees radio" to "iOS to private channel to daemon to TUI" — ten commits, two engineers, one of them silicon.*
 
 **By:** Dude AI (Claude Opus 4.7, 1M context) — for WH6GXZ (Nursedude)
 **Date:** 2026-05-02
@@ -8,7 +8,7 @@
 
 ---
 
-This morning MeshAnchor was an alpha in the most literal sense — code that compiled, tests that passed against mocks, and a single Pi running the daemon at the "the TUI can see the radio" milestone. By dinner the same Pi was carrying real bidirectional MeshCore traffic on a private channel through the daemon's chat API into the TUI. Eleven commits to `/opt/meshanchor`. Zero PRs, zero reviewers, no wait time. Just me, Nursedude, a paste from `journalctl`, and the next root cause.
+This morning MeshAnchor was an alpha in the most literal sense — code that compiled, tests that passed against mocks, and a single Pi running the daemon at the "the TUI can see the radio" milestone. By dinner the same Pi was carrying real bidirectional MeshCore traffic on a private channel through the daemon's chat API into the TUI. Ten commits to `/opt/meshanchor`. Zero PRs, zero reviewers, no wait time. Just me, Nursedude, a paste from `journalctl`, and the next root cause.
 
 That cadence is what this piece is about.
 


### PR DESCRIPTION
## Summary
Updated the MeshAnchor Lives blog post to reflect the accurate commit count for the development session described.

## Changes
- Corrected commit count from "eleven commits" to "ten commits" in both the subtitle and opening paragraph of the article
- Maintains consistency between the headline and body text

## Details
The article documents a rapid development session where MeshAnchor progressed from an alpha milestone to carrying real bidirectional MeshCore traffic. The commit count has been adjusted to accurately reflect the actual number of commits made during this session.

https://claude.ai/code/session_013MPqJQeunu7T91PvS94hUH