### PR TITLE
fix(ci): pr_overdue_check fetches base via FETCH_HEAD, not --prune

### DIFF
--- a/.github/workflows/pr_overdue_check.yml
+++ b/.github/workflows/pr_overdue_check.yml
@@ -44,8 +44,16 @@ jobs:
           # Fetch latest base in case origin/<base> moved between
           # PR-event and runner pickup. Important: we want behind vs
           # the CURRENT base tip, not the snapshot in the event payload.
-          git fetch --no-tags --prune origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
-          BASE_TIP="$(git rev-parse "origin/$BASE_REF")"
+          #
+          # Use FETCH_HEAD instead of an explicit refspec. The previous
+          # form (`--prune origin "main:refs/remotes/origin/main"`)
+          # interacted with actions/checkout@v4's narrow
+          # `remote.origin.fetch` config and DELETED `origin/main`
+          # instead of updating it, breaking `git rev-parse origin/main`.
+          # Caught downstream in MeshAnchor PR #13 (CI run 25297110388,
+          # fixed in MeshAnchor commit 72ff06fc).
+          git fetch --no-tags origin "$BASE_REF"
+          BASE_TIP="$(git rev-parse FETCH_HEAD)"
 
           BEHIND=$(git rev-list --count "$HEAD_SHA..$BASE_TIP")
           AHEAD=$(git rev-list --count "$BASE_TIP..$HEAD_SHA" || echo "?")


### PR DESCRIPTION
## Summary

Latent bug in this workflow since its introduction (commit 95d36b2 — Insight 2 of the 2026-05-03 diagnostic-insights plan). The fetch line is wrong against `actions/checkout@v4`'s narrow `remote.origin.fetch` config:

\`\`\`bash
# WRONG — --prune + explicit refspec deletes origin/main
git fetch --no-tags --prune origin "$BASE_REF":"refs/remotes/origin/$BASE_REF"
BASE_TIP="\$(git rev-parse "origin/$BASE_REF")"
\`\`\`

The `--prune` flag interprets the configured `remote.origin.fetch` (set by actions/checkout to only the PR head) as the canonical "what should exist" list. Result: `origin/main` is deleted before `git rev-parse` can read it. The job dies with:

\`\`\`
- [deleted]         (none)     -> origin/main
fatal: ambiguous argument 'origin/main': unknown revision
\`\`\`

The bug was latent in MeshForge — no PR had triggered this workflow against the bad fetch path yet. **Caught downstream** in MeshAnchor PR #13 (the mirror), CI run [25297110388](https://github.com/Nursedude/meshanchor/actions/runs/25297110388/job/74157670568). Fixed there in commit [72ff06fc](https://github.com/Nursedude/meshanchor/commit/72ff06fc); MeshAnchor CI run [25297243769](https://github.com/Nursedude/meshanchor/actions/runs/25297243769) confirms the fix.

This PR backports the same fix to MeshForge so it doesn't surface as a "this PR mysteriously broke CI" event on a future PR here.

## Fix

Use `FETCH_HEAD` instead of an explicit refspec — works regardless of how actions/checkout configures the remote:

\`\`\`bash
git fetch --no-tags origin "$BASE_REF"
BASE_TIP="\$(git rev-parse FETCH_HEAD)"
\`\`\`

## Test plan

- [x] Pre-commit + pre-push hooks green
- [ ] **Verification on this PR's CI**: the very workflow being fixed is the one that runs on this PR. If `PR Overdue Check` succeeds here, the fix is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)