### PR TITLE
diag(observability): backport boundary timing helper + Phases A-C wraps

### DIFF
--- a/src/commands/rns.py
+++ b/src/commands/rns.py
@@ -18,6 +18,7 @@ from typing import Optional, Dict, Any, List, Tuple
 from dataclasses import dataclass, field
 
 from .base import CommandResult
+from utils.boundary_timing import call_boundary
 from utils.safe_import import safe_import
 from utils.service_check import check_service, start_service, stop_service
 
@@ -910,9 +911,12 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
 
     try:
         dest_bytes = bytes.fromhex(destination_hash)
+        hash_short = destination_hash[:8]
 
         # Check if path exists
-        has_path = RNS.Transport.has_path(dest_bytes)
+        has_path = call_boundary("rnsd.has_path",
+                                 RNS.Transport.has_path, dest_bytes,
+                                 target=hash_short)
 
         if has_path:
             return CommandResult.ok(
@@ -924,7 +928,9 @@ def test_path(destination_hash: str, timeout: int = 10) -> CommandResult:
             )
 
         # Request path
-        RNS.Transport.request_path(dest_bytes)
+        call_boundary("rnsd.request_path",
+                      RNS.Transport.request_path, dest_bytes,
+                      target=hash_short)
 
         # Wait for path
         import time

--- a/src/gateway/meshtastic_handler.py
+++ b/src/gateway/meshtastic_handler.py
@@ -32,6 +32,7 @@ try:
 except ImportError:
     def broadcast_message(*args, **kwargs):
         pass
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 from utils.service_check import check_service
 
@@ -285,11 +286,12 @@ class MeshtasticHandler(BaseMessageHandler):
                 # For broadcasts, use ^all instead of None
                 dest = destination if destination else "^all"
                 logger.debug(f"Sending to Meshtastic: dest={dest}, ch={channel}, msg={message[:50]}")
-                result = self._interface.sendText(
-                    message,
-                    destinationId=dest,
-                    channelIndex=channel
-                )
+                with timed_boundary("meshtasticd.send_text", target=str(dest)):
+                    result = self._interface.sendText(
+                        message,
+                        destinationId=dest,
+                        channelIndex=channel
+                    )
                 if result is None or result is False:
                     logger.warning(f"sendText returned {result} — TX may have failed "
                                    f"(dest={dest}, ch={channel})")
@@ -325,7 +327,8 @@ class MeshtasticHandler(BaseMessageHandler):
         try:
             if self._interface:
                 dest = destination if destination else "^all"
-                result = self._interface.sendText(message, destinationId=dest, channelIndex=channel)
+                with timed_boundary("meshtasticd.send_text", target=str(dest)):
+                    result = self._interface.sendText(message, destinationId=dest, channelIndex=channel)
                 if result is None or result is False:
                     logger.warning(f"Queue sendText returned {result} — TX may have failed")
                     return False
@@ -345,12 +348,13 @@ class MeshtasticHandler(BaseMessageHandler):
         sock = None
         try:
             import socket
+            host = self.config.meshtastic.host
+            port = self.config.meshtastic.port
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.settimeout(5)
-            result = sock.connect_ex((
-                self.config.meshtastic.host,
-                self.config.meshtastic.port
-            ))
+            with timed_boundary("meshtasticd.tcp_probe",
+                                target=f"{host}:{port}"):
+                result = sock.connect_ex((host, port))
             return result == 0
         except (OSError, Exception) as e:
             logger.debug(f"Meshtastic connection test failed: {e}")
@@ -596,11 +600,13 @@ class MeshtasticHandler(BaseMessageHandler):
                 logger.debug("Meshtastic CLI not found")
                 return False
 
-            result = subprocess.run(
-                [cli_path, '--info'],
-                capture_output=True,
-                timeout=10
-            )
+            # CLI shells out to meshtasticd; subprocess timeout is 10s
+            with timed_boundary("meshtasticd.cli_info", threshold_s=10.0):
+                result = subprocess.run(
+                    [cli_path, '--info'],
+                    capture_output=True,
+                    timeout=10
+                )
             return result.returncode == 0
         except (subprocess.TimeoutExpired, subprocess.SubprocessError, FileNotFoundError) as e:
             logger.debug(f"Meshtastic CLI test failed: {e}")
@@ -617,7 +623,11 @@ class MeshtasticHandler(BaseMessageHandler):
             if channel > 0:
                 cmd.extend(['--ch-index', str(channel)])
 
-            result = subprocess.run(cmd, capture_output=True, timeout=30)
+            # CLI fallback shells out to meshtasticd; subprocess timeout is 30s
+            with timed_boundary("meshtasticd.cli_send",
+                                target=destination or "broadcast",
+                                threshold_s=30.0):
+                result = subprocess.run(cmd, capture_output=True, timeout=30)
             return result.returncode == 0
         except Exception as e:
             logger.error(f"CLI send failed: {e}")

--- a/src/gateway/meshtastic_protobuf_client.py
+++ b/src/gateway/meshtastic_protobuf_client.py
@@ -31,6 +31,7 @@ import urllib.error
 import urllib.request
 from typing import Any, Callable, Dict, List, Optional
 
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 
 from .meshtastic_protobuf_ops import (
@@ -178,18 +179,22 @@ def send_text_direct(
             headers={'Content-Type': 'application/x-protobuf'},
         )
         ctx = _stateless_ssl_ctx if tls else None
-        with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
-            if resp.status in (200, 204):
-                logger.info(
-                    f"Sent text via stateless HTTP protobuf "
-                    f"(id={packet_id}, dest={'broadcast' if dest == 0xFFFFFFFF else f'!{dest:08x}'})"
-                )
-                logger.debug(f"Message content: {text[:50]}")
-                _protobuf_circuit.record_success(cb_dest)
-                return True
-            logger.warning(f"send_text_direct: unexpected status {resp.status}")
-            _protobuf_circuit.record_failure(cb_dest, f"HTTP {resp.status}")
-            return False
+        # threshold matches caller-supplied HTTP timeout (default 5s)
+        with timed_boundary("meshtasticd.toradio_put",
+                            target=f"{packet_id:08x}",
+                            threshold_s=max(timeout, 2.0)):
+            with urllib.request.urlopen(req, timeout=timeout, context=ctx) as resp:
+                if resp.status in (200, 204):
+                    logger.info(
+                        f"Sent text via stateless HTTP protobuf "
+                        f"(id={packet_id}, dest={'broadcast' if dest == 0xFFFFFFFF else f'!{dest:08x}'})"
+                    )
+                    logger.debug(f"Message content: {text[:50]}")
+                    _protobuf_circuit.record_success(cb_dest)
+                    return True
+                logger.warning(f"send_text_direct: unexpected status {resp.status}")
+                _protobuf_circuit.record_failure(cb_dest, f"HTTP {resp.status}")
+                return False
     except urllib.error.HTTPError as e:
         logger.warning(f"send_text_direct: HTTP {e.code}: {e.reason}")
         _protobuf_circuit.record_failure(cb_dest, f"HTTP {e.code}")
@@ -337,10 +342,14 @@ class MeshtasticProtobufClient(ProtobufAdminMixin):
                 },
             )
             ctx = self._ssl_ctx if self._config.tls else None
-            with urllib.request.urlopen(
-                req, timeout=self._config.connect_timeout, context=ctx
-            ) as resp:
-                return resp.status in (200, 204)
+            with timed_boundary(
+                "meshtasticd.toradio_put",
+                threshold_s=max(self._config.connect_timeout, 2.0),
+            ):
+                with urllib.request.urlopen(
+                    req, timeout=self._config.connect_timeout, context=ctx
+                ) as resp:
+                    return resp.status in (200, 204)
         except urllib.error.HTTPError as e:
             logger.warning(f"POST /api/v1/toradio HTTP {e.code}: {e.reason}")
             return False
@@ -364,13 +373,19 @@ class MeshtasticProtobufClient(ProtobufAdminMixin):
                 },
             )
             ctx = self._ssl_ctx if self._config.tls else None
-            with urllib.request.urlopen(
-                req, timeout=self._config.read_timeout, context=ctx
-            ) as resp:
-                data = resp.read()
-                if data and len(data) > 0:
-                    return data
-                return None
+            # threshold matches read_timeout — fromradio polls legitimately
+            # wait the full read_timeout before returning empty.
+            with timed_boundary(
+                "meshtasticd.fromradio_get",
+                threshold_s=max(self._config.read_timeout, 2.0),
+            ):
+                with urllib.request.urlopen(
+                    req, timeout=self._config.read_timeout, context=ctx
+                ) as resp:
+                    data = resp.read()
+                    if data and len(data) > 0:
+                        return data
+                    return None
         except urllib.error.HTTPError as e:
             logger.warning(f"GET /api/v1/fromradio HTTP {e.code}: {e.reason}")
             return None

--- a/src/gateway/network_topology.py
+++ b/src/gateway/network_topology.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from enum import Enum, auto
 from typing import Dict, List, Optional, Set, Tuple, Callable, Any
 
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
@@ -229,13 +230,19 @@ class PathTableMonitor:
         try:
             RNS = _RNS
 
-            if not hasattr(RNS.Transport, 'path_table') or not RNS.Transport.path_table:
-                return
+            # Snapshot path_table inside one timed_boundary block. On a
+            # shared-instance client this is a mostly-local read, but
+            # slowness here flags sync pressure on rnsd or a very large
+            # table — exactly what the wedge investigation needs visible.
+            with timed_boundary("rnsd.path_table_read"):
+                if not hasattr(RNS.Transport, 'path_table') or not RNS.Transport.path_table:
+                    return
+                path_table_items = list(RNS.Transport.path_table.items())
 
             current_snapshot: Dict[bytes, PathTableEntry] = {}
 
             # Build current snapshot
-            for dest_hash, path_data in RNS.Transport.path_table.items():
+            for dest_hash, path_data in path_table_items:
                 if not isinstance(dest_hash, bytes) or len(dest_hash) != 16:
                     continue
 

--- a/src/gateway/node_tracker.py
+++ b/src/gateway/node_tracker.py
@@ -27,6 +27,7 @@ from .node_models import (
     NODE_STATE_AVAILABLE, RNS_SERVICES_AVAILABLE
 )
 
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 
 # Import RNS service registry and topology (optional - graceful fallback)
@@ -208,8 +209,11 @@ class UnifiedNodeTracker:
                 except ImportError:
                     pass  # service_check not available, proceed anyway
 
-                # Connect using client-only config
-                self._reticulum = RNS.Reticulum(configdir=str(client_config_dir))
+                # Connect using client-only config. Cold-start RNS attach is
+                # genuinely slow (identity load + shared-instance socket open
+                # + state sync), so the threshold is higher than the default.
+                with timed_boundary("rnsd.attach", threshold_s=10.0):
+                    self._reticulum = RNS.Reticulum(configdir=str(client_config_dir))
                 self._rns_connected = True
                 logger.info("Connected to existing rnsd instance")
 

--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -21,6 +21,7 @@ from .bridge_health import (
     BridgeHealthMonitor, DeliveryTracker,
     BridgeStatus, SubsystemState, MessageOrigin
 )
+from utils.boundary_timing import call_boundary
 from utils.safe_import import safe_import
 
 # MQTT bridge handler (zero-interference, recommended)
@@ -793,8 +794,13 @@ class RNSMeshtasticBridge(
 
             if destination_hash:
                 # Direct message
-                if not RNS.Transport.has_path(destination_hash):
-                    RNS.Transport.request_path(destination_hash)
+                hash_short = destination_hash.hex()[:8]
+                if not call_boundary("rnsd.has_path",
+                                     RNS.Transport.has_path, destination_hash,
+                                     target=hash_short):
+                    call_boundary("rnsd.request_path",
+                                  RNS.Transport.request_path, destination_hash,
+                                  target=hash_short)
                     # Wait briefly for path (interruptible on shutdown)
                     for _ in range(50):
                         if RNS.Transport.has_path(destination_hash):
@@ -806,7 +812,9 @@ class RNSMeshtasticBridge(
                     logger.warning("No path to destination")
                     return False
 
-                dest_identity = RNS.Identity.recall(destination_hash)
+                dest_identity = call_boundary("rnsd.identity_recall",
+                                              RNS.Identity.recall, destination_hash,
+                                              target=hash_short)
                 destination = RNS.Destination(
                     dest_identity,
                     RNS.Destination.OUT,
@@ -854,7 +862,9 @@ class RNSMeshtasticBridge(
                 # LXMF version may not support callbacks
                 logger.debug("LXMF callbacks not available, skipping delivery tracking")
 
-            self._lxmf_router.handle_outbound(lxm)
+            call_boundary("rnsd.handle_outbound",
+                          self._lxmf_router.handle_outbound, lxm,
+                          target=hash_short)
             return True
 
         except Exception as e:
@@ -882,9 +892,14 @@ class RNSMeshtasticBridge(
 
             if isinstance(destination_hash, str):
                 destination_hash = bytes.fromhex(destination_hash)
+            hash_short = destination_hash.hex()[:8]
 
-            if not RNS.Transport.has_path(destination_hash):
-                RNS.Transport.request_path(destination_hash)
+            if not call_boundary("rnsd.has_path",
+                                 RNS.Transport.has_path, destination_hash,
+                                 target=hash_short):
+                call_boundary("rnsd.request_path",
+                              RNS.Transport.request_path, destination_hash,
+                              target=hash_short)
                 for _ in range(30):
                     if RNS.Transport.has_path(destination_hash):
                         break
@@ -894,14 +909,18 @@ class RNSMeshtasticBridge(
             if not RNS.Transport.has_path(destination_hash):
                 return False
 
-            dest_identity = RNS.Identity.recall(destination_hash)
+            dest_identity = call_boundary("rnsd.identity_recall",
+                                          RNS.Identity.recall, destination_hash,
+                                          target=hash_short)
             destination = RNS.Destination(
                 dest_identity, RNS.Destination.OUT,
                 RNS.Destination.SINGLE, "lxmf", "delivery"
             )
 
             lxm = LXMF.LXMessage(destination, self._lxmf_source, message, "MeshForge Gateway")
-            self._lxmf_router.handle_outbound(lxm)
+            call_boundary("rnsd.handle_outbound",
+                          self._lxmf_router.handle_outbound, lxm,
+                          target=hash_short)
             return True
 
         except Exception as e:

--- a/src/monitoring/rns_sniffer.py
+++ b/src/monitoring/rns_sniffer.py
@@ -29,6 +29,7 @@ from monitoring.traffic_inspector import (
     MeshPacket, PacketProtocol, PacketDirection, PacketTree,
     PacketField, FieldType, get_traffic_inspector
 )
+from utils.boundary_timing import call_boundary
 from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
@@ -744,7 +745,9 @@ class RNSSniffer:
             dest_hash = bytes.fromhex(dest_hash_hex)
 
             # Request path
-            RNS.Transport.request_path(dest_hash)
+            call_boundary("rnsd.request_path",
+                          RNS.Transport.request_path, dest_hash,
+                          target=dest_hash_hex[:8])
 
             # Capture as outbound packet
             packet = RNSPacketInfo(

--- a/src/utils/_port_detection.py
+++ b/src/utils/_port_detection.py
@@ -16,6 +16,8 @@ import subprocess
 from pathlib import Path
 from typing import Optional, Tuple
 
+from utils.boundary_timing import timed_boundary
+
 logger = logging.getLogger(__name__)
 
 
@@ -327,6 +329,16 @@ def get_rns_shared_instance_info(instance_name: str = 'default',
         instance_name: RNS instance name (default: ``'default'``).
         port: Shared instance port for TCP/UDP fallback (default: 37428).
     """
+    # Wrap the entire probe path so a stalled rnsd-availability check
+    # (most often caused by the unix-socket scan or fallback TCP connect)
+    # produces a forensic. Per-tier timing (proc/net/unix scan vs.
+    # TCP connect) is rarely worth knowing — what matters for diagnosis
+    # is "the rnsd availability check stalled".
+    with timed_boundary("rnsd.shared_instance_probe"):
+        return _shared_instance_info_inner(instance_name, port)
+
+
+def _shared_instance_info_inner(instance_name: str, port: int) -> dict:
     # 1. Passive check: scan /proc/net/unix for the abstract domain socket.
     # RNS creates @rns/{instance_name} (LocalInterface data transport).
     # This mirrors how check_udp_port() reads /proc/net/udp — no connection

--- a/src/utils/boundary_timing.py
+++ b/src/utils/boundary_timing.py
@@ -1,0 +1,198 @@
+"""Boundary timing helper — observability for cross-process calls.
+
+A "boundary" is anywhere MeshAnchor talks to something *outside* its own
+Python process: rnsd shared-instance RPC, meshtasticd TCP/HTTP, MeshCore
+TCP, MQTT publish/subscribe, systemctl shell-outs, etc.
+
+When one of those calls stalls, the symptom upstream is "the daemon
+hung." Without per-boundary timings, we waste hours bisecting which
+external system actually went sideways. This module is the shared floor:
+every boundary call is wrapped, every slow call logs a forensic, every
+boundary's p50/p95/p99 is queryable for status surfaces.
+
+Usage:
+
+    # Context manager — best when wrapping a block
+    from utils.boundary_timing import timed_boundary
+    with timed_boundary("rnsd.has_path", target=hash_short):
+        has = RNS.Transport.has_path(dest_hash)
+
+    # Call wrapper — best for a single call
+    from utils.boundary_timing import call_boundary
+    result = call_boundary(
+        "rnsd.handle_outbound",
+        router.handle_outbound, lxm,
+        target=hash_short,
+    )
+
+    # Status / diagnostics
+    from utils.boundary_timing import get_boundary_stats
+    stats = get_boundary_stats()  # all boundaries
+    stats = get_boundary_stats("rnsd.has_path")  # one boundary
+
+Behavior:
+- Sub-threshold calls log at DEBUG.
+- Slow calls (>= threshold_s) log at WARNING with the full label.
+- Exceptions log at WARNING with elapsed time, then re-raise.
+- Counters and a ring buffer of recent samples are kept per label;
+  ``get_boundary_stats`` exposes count / slow_count / error_count and
+  p50/p95/p99 over the ring buffer.
+
+Design rules (see ``.claude/plans/boundary_observability_charter.md``):
+- Logger only — no Prometheus / OTel deps.
+- Don't suppress exceptions — they propagate untouched.
+- Default threshold 2.0s, override per call site only when documented.
+- Don't wrap in-process functions; only daemon/socket/RPC boundaries.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections import defaultdict, deque
+from contextlib import contextmanager
+from typing import Any, Callable, Deque, Dict, Iterator, Optional
+
+
+DEFAULT_THRESHOLD_S: float = 2.0
+"""Default WARN threshold for any boundary call. See charter for tuning rules."""
+
+_RING_SIZE: int = 1000
+"""Per-label ring buffer of recent sample durations for percentile reporting."""
+
+logger = logging.getLogger("boundary")
+
+
+_lock = threading.Lock()
+_counters: Dict[str, Dict[str, int]] = defaultdict(
+    lambda: {"count": 0, "slow_count": 0, "error_count": 0}
+)
+_samples: Dict[str, Deque[float]] = defaultdict(lambda: deque(maxlen=_RING_SIZE))
+
+
+def _format_label(label: str, target: Optional[str]) -> str:
+    if target:
+        return f"{label}[{target}]"
+    return label
+
+
+@contextmanager
+def timed_boundary(
+    label: str,
+    *,
+    target: Optional[str] = None,
+    threshold_s: float = DEFAULT_THRESHOLD_S,
+) -> Iterator[None]:
+    """Time a boundary call.
+
+    ``label`` should be ``<system>.<operation>`` (e.g. ``rnsd.has_path``,
+    ``meshtasticd.send_text_direct``). ``target`` adds a hash/id suffix
+    for fan-out correlation, e.g. the destination hash prefix when several
+    calls fire in quick succession against different targets.
+
+    Exceptions inside the body propagate untouched. The duration up to
+    the exception is still recorded as an error sample.
+    """
+    full_label = _format_label(label, target)
+    t0 = time.monotonic()
+    completed = False
+    try:
+        yield
+        completed = True
+    finally:
+        elapsed = time.monotonic() - t0
+        with _lock:
+            counters = _counters[full_label]
+            counters["count"] += 1
+            if not completed:
+                counters["error_count"] += 1
+            elif elapsed >= threshold_s:
+                counters["slow_count"] += 1
+            _samples[full_label].append(elapsed)
+        if not completed:
+            logger.warning("rpc[%s] raised after %.3fs", full_label, elapsed)
+        elif elapsed >= threshold_s:
+            logger.warning(
+                "rpc[%s] slow: %.3fs (>=%.1fs threshold)",
+                full_label, elapsed, threshold_s,
+            )
+        else:
+            logger.debug("rpc[%s] ok %.3fs", full_label, elapsed)
+
+
+def call_boundary(
+    label: str,
+    fn: Callable[..., Any],
+    *args: Any,
+    target: Optional[str] = None,
+    threshold_s: float = DEFAULT_THRESHOLD_S,
+    **kwargs: Any,
+) -> Any:
+    """Call wrapper variant of :func:`timed_boundary`.
+
+    Equivalent to::
+
+        with timed_boundary(label, target=target, threshold_s=threshold_s):
+            return fn(*args, **kwargs)
+
+    Convenient when you only need to time one call and don't want a
+    nested ``with`` block. Returns whatever ``fn`` returns.
+    """
+    with timed_boundary(label, target=target, threshold_s=threshold_s):
+        return fn(*args, **kwargs)
+
+
+def _percentile(sorted_samples: list, fraction: float) -> float:
+    if not sorted_samples:
+        return 0.0
+    # Nearest-rank: index = ceil(fraction * n) - 1, clamped to [0, n-1]
+    n = len(sorted_samples)
+    idx = max(0, min(n - 1, int(fraction * n)))
+    return sorted_samples[idx]
+
+
+def _stats_dict(counters: Dict[str, int], samples_snapshot: list) -> Dict[str, Any]:
+    sorted_samples = sorted(samples_snapshot)
+    return {
+        "count": counters["count"],
+        "slow_count": counters["slow_count"],
+        "error_count": counters["error_count"],
+        "p50_s": _percentile(sorted_samples, 0.50),
+        "p95_s": _percentile(sorted_samples, 0.95),
+        "p99_s": _percentile(sorted_samples, 0.99),
+        "samples": len(sorted_samples),
+    }
+
+
+def get_boundary_stats(label: Optional[str] = None) -> Dict[str, Any]:
+    """Return per-boundary stats.
+
+    With no argument, returns ``{label: stats_dict}`` for every boundary
+    that has been observed in this process. With a ``label``, returns
+    just that boundary's stats. Returns an empty dict / zero-stats dict
+    when nothing has been recorded yet.
+    """
+    with _lock:
+        if label is not None:
+            counters = dict(_counters.get(label, {"count": 0, "slow_count": 0, "error_count": 0}))
+            samples_snapshot = list(_samples.get(label, ()))
+            return _stats_dict(counters, samples_snapshot)
+        return {
+            k: _stats_dict(dict(_counters[k]), list(_samples[k]))
+            for k in _counters
+        }
+
+
+def reset_boundary_stats(label: Optional[str] = None) -> None:
+    """Clear recorded counters and samples.
+
+    With no argument, clears everything (use only for tests). With a
+    ``label``, clears only that boundary.
+    """
+    with _lock:
+        if label is None:
+            _counters.clear()
+            _samples.clear()
+        else:
+            _counters.pop(label, None)
+            _samples.pop(label, None)

--- a/src/utils/connection_manager.py
+++ b/src/utils/connection_manager.py
@@ -35,6 +35,7 @@ import time
 from pathlib import Path
 from typing import Optional, Dict, Any, List, Union
 
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 
 logger = logging.getLogger(__name__)
@@ -196,10 +197,14 @@ class _ConnectionManager:
         last_error = None
         for attempt in range(max_retries):
             try:
-                self._connection = _tcp_interface_mod.TCPInterface(
-                    hostname=self._host,
-                    portNumber=self._port
-                )
+                # cold-start TCPInterface drains initial config burst — give it 5s
+                with timed_boundary("meshtasticd.tcp_connect",
+                                    target=f"{self._host}:{self._port}",
+                                    threshold_s=5.0):
+                    self._connection = _tcp_interface_mod.TCPInterface(
+                        hostname=self._host,
+                        portNumber=self._port
+                    )
                 return self._connection
             except (ConnectionResetError, BrokenPipeError, OSError) as e:
                 last_error = e
@@ -235,7 +240,9 @@ class _ConnectionManager:
         if interface is None:
             return
         try:
-            interface.close()
+            with timed_boundary("meshtasticd.close",
+                                target=f"{self._host}:{self._port}"):
+                interface.close()
         except (BrokenPipeError, ConnectionResetError, OSError) as e:
             # Connection already closed by server - this is fine
             logger.debug(f"Connection already closed during cleanup: {e}")
@@ -253,10 +260,12 @@ class _ConnectionManager:
     def is_available(self, timeout: float = 2.0) -> bool:
         """Check if meshtasticd port is reachable."""
         try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(timeout)
-                sock.connect((self._host, self._port))
-                return True
+            with timed_boundary("meshtasticd.tcp_probe",
+                                target=f"{self._host}:{self._port}"):
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    sock.settimeout(timeout)
+                    sock.connect((self._host, self._port))
+                    return True
         except (socket.error, socket.timeout, OSError):
             return False
 

--- a/src/utils/meshtastic_connection.py
+++ b/src/utils/meshtastic_connection.py
@@ -24,6 +24,7 @@ from contextlib import contextmanager
 from enum import Enum
 from typing import Optional, List, Dict, Any
 
+from utils.boundary_timing import timed_boundary
 from utils.safe_import import safe_import
 from utils.service_check import restart_service
 
@@ -228,7 +229,8 @@ def safe_close_interface(interface) -> None:
 
     try:
         # Try to close normally
-        interface.close()
+        with timed_boundary("meshtasticd.close"):
+            interface.close()
     except (BrokenPipeError, ConnectionResetError, OSError) as e:
         # Connection already closed by server - this is fine
         logger.debug(f"Connection already closed during cleanup: {e}")
@@ -324,10 +326,12 @@ class MeshtasticConnectionManager:
             True if port is reachable, False otherwise
         """
         try:
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
-                sock.settimeout(timeout)
-                sock.connect((self.host, self.port))
-                return True
+            with timed_boundary("meshtasticd.tcp_probe",
+                                target=f"{self.host}:{self.port}"):
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    sock.settimeout(timeout)
+                    sock.connect((self.host, self.port))
+                    return True
         except (socket.error, socket.timeout, OSError):
             return False
 
@@ -341,7 +345,11 @@ class MeshtasticConnectionManager:
         Returns:
             True if lock acquired, False if timeout
         """
-        return self._lock.acquire(timeout=timeout)
+        # Per charter: lock already times itself; emit elapsed as a boundary
+        # metric. Default 2.0s threshold — any wait that long signals real
+        # contention regardless of the caller's wider timeout budget.
+        with timed_boundary("meshtasticd.connection_lock_acquire"):
+            return self._lock.acquire(timeout=timeout)
 
     def release_lock(self):
         """Release the connection lock"""
@@ -493,7 +501,11 @@ class MeshtasticConnectionManager:
             raise ConnectionError("meshtastic library not installed")
         try:
             logger.debug(f"Creating TCP interface to {self.host}:{self.port}")
-            return _meshtastic_tcp.TCPInterface(hostname=self.host)
+            # cold-start TCPInterface drains initial config burst — give it 5s
+            with timed_boundary("meshtasticd.tcp_connect",
+                                target=f"{self.host}:{self.port}",
+                                threshold_s=5.0):
+                return _meshtastic_tcp.TCPInterface(hostname=self.host)
         except Exception as e:
             raise ConnectionError(f"TCP connection failed: {e}")
 
@@ -508,7 +520,11 @@ class MeshtasticConnectionManager:
                     "No USB device found. Connect a Meshtastic radio or specify serial_port."
                 )
             logger.debug(f"Creating Serial interface to {device}")
-            return _meshtastic_serial.SerialInterface(devPath=device)
+            # SerialInterface also drains initial config burst on connect
+            with timed_boundary("meshtasticd.serial_connect",
+                                target=device,
+                                threshold_s=5.0):
+                return _meshtastic_serial.SerialInterface(devPath=device)
         except Exception as e:
             raise ConnectionError(f"Serial connection failed: {e}")
 

--- a/tests/test_boundary_timing.py
+++ b/tests/test_boundary_timing.py
@@ -1,0 +1,284 @@
+"""Tests for utils.boundary_timing.
+
+The helper is the shared floor for every cross-process call site in
+MeshAnchor (see .claude/plans/boundary_observability_charter.md).
+A regression here would silently degrade the diagnostic floor across
+the whole codebase, so the test surface is intentionally generous:
+happy path, slow path, exception path, threshold logic, counter
+accuracy, percentile correctness, label formatting, and concurrency.
+
+Run: python3 -m pytest tests/test_boundary_timing.py -v
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+from utils.boundary_timing import (
+    DEFAULT_THRESHOLD_S,
+    call_boundary,
+    get_boundary_stats,
+    reset_boundary_stats,
+    timed_boundary,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_stats():
+    """Each test starts with empty counters/samples."""
+    reset_boundary_stats()
+    yield
+    reset_boundary_stats()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+class TestHappyPath:
+
+    def test_fast_call_records_count(self):
+        with timed_boundary("test.fast"):
+            pass
+        stats = get_boundary_stats("test.fast")
+        assert stats["count"] == 1
+        assert stats["slow_count"] == 0
+        assert stats["error_count"] == 0
+
+    def test_fast_call_logs_at_debug(self, caplog):
+        with caplog.at_level(logging.DEBUG, logger="boundary"):
+            with timed_boundary("test.fast"):
+                pass
+        # No WARN-level records
+        assert not any(r.levelno >= logging.WARNING for r in caplog.records)
+        # At least one DEBUG record mentions our label
+        debug_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.DEBUG]
+        assert any("test.fast" in m and "ok" in m for m in debug_msgs)
+
+    def test_call_boundary_returns_fn_result(self):
+        result = call_boundary("test.call", lambda x, y: x + y, 2, 3)
+        assert result == 5
+
+    def test_call_boundary_passes_kwargs(self):
+        def fn(a, b, c=0):
+            return a + b + c
+        result = call_boundary("test.kwargs", fn, 1, 2, c=10)
+        assert result == 13
+
+
+# ---------------------------------------------------------------------------
+# Slow path
+# ---------------------------------------------------------------------------
+
+class TestSlowPath:
+
+    def test_slow_call_increments_slow_count(self):
+        # Use threshold near zero so any real elapsed time trips it.
+        with timed_boundary("test.slow", threshold_s=0.0):
+            time.sleep(0.001)
+        stats = get_boundary_stats("test.slow")
+        assert stats["count"] == 1
+        assert stats["slow_count"] == 1
+        assert stats["error_count"] == 0
+
+    def test_slow_call_logs_at_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="boundary"):
+            with timed_boundary("test.slow_warn", threshold_s=0.0):
+                time.sleep(0.001)
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("test.slow_warn" in m and "slow" in m for m in warn_msgs)
+
+    def test_threshold_above_elapsed_does_not_count_as_slow(self):
+        with timed_boundary("test.fast_under_threshold", threshold_s=10.0):
+            pass  # ~microseconds
+        stats = get_boundary_stats("test.fast_under_threshold")
+        assert stats["slow_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Exception path
+# ---------------------------------------------------------------------------
+
+class TestExceptionPath:
+
+    def test_exception_propagates(self):
+        class Boom(Exception):
+            pass
+
+        with pytest.raises(Boom):
+            with timed_boundary("test.boom"):
+                raise Boom("kaboom")
+
+    def test_exception_increments_error_count(self):
+        with pytest.raises(ValueError):
+            with timed_boundary("test.err"):
+                raise ValueError("bad")
+        stats = get_boundary_stats("test.err")
+        assert stats["count"] == 1
+        assert stats["error_count"] == 1
+        # Errors do not also count as slow even if they were over threshold.
+        assert stats["slow_count"] == 0
+
+    def test_exception_logs_at_warning(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="boundary"):
+            with pytest.raises(RuntimeError):
+                with timed_boundary("test.err_log"):
+                    raise RuntimeError("nope")
+        warn_msgs = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("test.err_log" in m and "raised" in m for m in warn_msgs)
+
+    def test_call_boundary_propagates_exception(self):
+        def boom():
+            raise KeyError("missing")
+
+        with pytest.raises(KeyError):
+            call_boundary("test.call_err", boom)
+        stats = get_boundary_stats("test.call_err")
+        assert stats["error_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Label formatting
+# ---------------------------------------------------------------------------
+
+class TestLabelFormatting:
+
+    def test_target_appended_to_label(self):
+        with timed_boundary("rnsd.has_path", target="abc12345"):
+            pass
+        stats = get_boundary_stats()
+        assert "rnsd.has_path[abc12345]" in stats
+
+    def test_no_target_uses_bare_label(self):
+        with timed_boundary("rnsd.has_path"):
+            pass
+        stats = get_boundary_stats()
+        assert "rnsd.has_path" in stats
+        assert "rnsd.has_path[]" not in stats
+
+    def test_different_targets_record_separately(self):
+        with timed_boundary("rnsd.send", target="aa"):
+            pass
+        with timed_boundary("rnsd.send", target="bb"):
+            pass
+        stats = get_boundary_stats()
+        assert stats["rnsd.send[aa]"]["count"] == 1
+        assert stats["rnsd.send[bb]"]["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Counters and percentiles
+# ---------------------------------------------------------------------------
+
+class TestCountersAndPercentiles:
+
+    def test_counts_accumulate(self):
+        for _ in range(5):
+            with timed_boundary("test.repeat"):
+                pass
+        stats = get_boundary_stats("test.repeat")
+        assert stats["count"] == 5
+
+    def test_percentiles_with_known_samples(self):
+        # Drive deterministic samples by patching time.monotonic.
+        # Sequence: each enter/exit pair reads monotonic twice.
+        # We provide pairs (t0, t1) so elapsed = 0.0, 0.1, 0.2, ..., 0.9
+        # → samples = [0.0, 0.1, 0.2, ..., 0.9]
+        ticks = []
+        for i in range(10):
+            ticks.append(0.0)         # enter
+            ticks.append(i * 0.1)     # exit
+        with patch("utils.boundary_timing.time.monotonic", side_effect=ticks):
+            for _ in range(10):
+                with timed_boundary("test.pctl", threshold_s=10.0):
+                    pass
+        stats = get_boundary_stats("test.pctl")
+        assert stats["count"] == 10
+        # Sorted samples are [0.0, 0.1, ..., 0.9]
+        # Nearest-rank: p50 → idx 5 → 0.5, p95 → idx 9 → 0.9, p99 → idx 9 → 0.9
+        assert stats["p50_s"] == pytest.approx(0.5, abs=1e-9)
+        assert stats["p95_s"] == pytest.approx(0.9, abs=1e-9)
+        assert stats["p99_s"] == pytest.approx(0.9, abs=1e-9)
+
+    def test_empty_stats_zero_percentiles(self):
+        # Querying a label with no samples returns zeros, not crash.
+        stats = get_boundary_stats("never.observed")
+        assert stats["count"] == 0
+        assert stats["p50_s"] == 0.0
+        assert stats["p95_s"] == 0.0
+        assert stats["p99_s"] == 0.0
+        assert stats["samples"] == 0
+
+    def test_get_all_returns_every_label(self):
+        with timed_boundary("a.x"):
+            pass
+        with timed_boundary("b.y"):
+            pass
+        stats = get_boundary_stats()
+        assert set(stats.keys()) >= {"a.x", "b.y"}
+
+
+# ---------------------------------------------------------------------------
+# Reset
+# ---------------------------------------------------------------------------
+
+class TestReset:
+
+    def test_reset_clears_all(self):
+        with timed_boundary("reset.a"):
+            pass
+        with timed_boundary("reset.b"):
+            pass
+        reset_boundary_stats()
+        stats = get_boundary_stats()
+        assert stats == {}
+
+    def test_reset_single_label(self):
+        with timed_boundary("keep.me"):
+            pass
+        with timed_boundary("drop.me"):
+            pass
+        reset_boundary_stats("drop.me")
+        stats = get_boundary_stats()
+        assert "keep.me" in stats
+        assert "drop.me" not in stats
+
+
+# ---------------------------------------------------------------------------
+# Defaults and concurrency
+# ---------------------------------------------------------------------------
+
+class TestDefaults:
+
+    def test_default_threshold_constant(self):
+        # The charter calls out 2.0s as the project-wide default.
+        # If this changes, every boundary inherits a new floor.
+        assert DEFAULT_THRESHOLD_S == 2.0
+
+
+class TestConcurrency:
+
+    def test_threadsafe_count(self):
+        # Many threads incrementing the same boundary should produce an
+        # exact count — the lock around counters/samples prevents lost
+        # increments. 8 threads × 200 calls = 1600 expected.
+        n_threads = 8
+        per_thread = 200
+
+        def worker():
+            for _ in range(per_thread):
+                with timed_boundary("concurrent.x"):
+                    pass
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        stats = get_boundary_stats("concurrent.x")
+        assert stats["count"] == n_threads * per_thread


### PR DESCRIPTION
## Summary
Mirror-image port from MeshAnchor's boundary observability charter (Phases A-C). Every cross-process call to rnsd or meshtasticd now produces a forensic when it stalls, same shape as the sister project.

| Component | New | Wrapped sites |
|---|---|---|
| `utils/boundary_timing.py` | new file (verbatim from MA) | helper |
| `tests/test_boundary_timing.py` | new file (verbatim from MA) | 22 tests |
| `gateway/rns_bridge.py` | edit | 8 (has_path/request_path/identity_recall/handle_outbound × 2 send paths) |
| `gateway/network_topology.py` | edit | 1 (rnsd.path_table_read) |
| `gateway/node_tracker.py` | edit | 1 (rnsd.attach, 10s) |
| `utils/_port_detection.py` | edit | 1 (rnsd.shared_instance_probe via inner-fn extraction) |
| `commands/rns.py` | edit | 2 (manual TUI ping) |
| `monitoring/rns_sniffer.py` | edit | 1 (manual probe) |
| `utils/connection_manager.py` | edit | 3 (tcp_connect, close, tcp_probe) |
| `utils/meshtastic_connection.py` | edit | 5 (close, lock, tcp_connect, serial_connect, tcp_probe) |
| `gateway/meshtastic_handler.py` | edit | 5 (sendText × 2, tcp_probe, cli_info, cli_send) |
| `gateway/meshtastic_protobuf_client.py` | edit | 3 (toradio_put × 2, fromradio_get) |

Same labels as MeshAnchor (`rnsd.<op>`, `meshtasticd.<op>`) so a future fleet aggregator can roll up across both projects identically.

## Why
Phase F of MeshAnchor's boundary observability charter — sister-project parity. After this lands, any wedge in either codebase produces the same shape of forensic.

## NOT in this PR (deliberate)
- MeshAnchor's Phase D (MeshCore + MQTT + systemd shell-outs). Those exist in MeshForge too but are larger surface and deserve their own focused follow-up.
- MeshForge-only files (`mqtt_bridge_handler.py`, `mesh_bridge.py`, `rns_transport.py`, `rns_status_parser.py`). Same — focused follow-up.

## Test plan
- [x] `pytest tests/test_boundary_timing.py` — 22 pass (helper portable, no MA-specific deps)
- [x] `pytest tests/test_rns_bridge.py` — 180 pass
- [x] `pytest tests/test_regression_guards.py` — 19 pass
- [x] `python3 scripts/lint.py --all` clean
- [ ] post-merge: confirm no `rpc[*] slow` lines appear during normal operation (silence = healthy, by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)