### PR TITLE
fix(gateway): handle bytes-content LXMF in sniffer capture

### DIFF
--- a/src/gateway/rns_bridge.py
+++ b/src/gateway/rns_bridge.py
@@ -1296,8 +1296,16 @@ class RNSMeshtasticBridge(
                 try:
                     sniffer = get_rns_sniffer()
                     if sniffer and sniffer._running:
-                        # Encode message content as payload
-                        content_bytes = message.content.encode('utf-8') if message.content else b''
+                        # LXMessage.content can be either bytes (binary LXMF
+                        # payload) or str — encode only when we got text.
+                        # (Issue #1162: 'bytes'.encode() raised, dropping the
+                        # capture; delivery itself was unaffected.)
+                        raw_content = message.content or b''
+                        content_bytes = (
+                            raw_content.encode('utf-8')
+                            if isinstance(raw_content, str)
+                            else raw_content
+                        )
                         packet_info = RNSPacketInfo(
                             packet_type=RNSPacketType.DATA,
                             source_hash=source_hash,

--- a/tests/test_rns_bridge.py
+++ b/tests/test_rns_bridge.py
@@ -2330,3 +2330,57 @@ class TestBridgeStartRefuses:
         # Operator-visible error with fix-hint hook
         assert any("Refusing to start bridge" in rec.message for rec in caplog.records)
         assert any("meshforge" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# _on_lxmf_receive — sniffer-capture branch (Issue #1162)
+# ---------------------------------------------------------------------------
+
+class TestLXMFReceiveSnifferCapture:
+    """The traffic-inspection sniffer hook in _on_lxmf_receive must accept
+    both bytes and str content. LXMessage.content arrives as bytes for
+    binary LXMF payloads; pre-fix the .encode('utf-8') call raised
+    AttributeError, dropping the capture (delivery itself was unaffected
+    but observability missed the message)."""
+
+    @staticmethod
+    def _make_message(content):
+        msg = MagicMock()
+        msg.source_hash = b"\x3d\xfb\xdb\x5d" + b"\x00" * 12
+        msg.content = content
+        msg.title = None
+        msg.stamp = None
+        msg.fields = None
+        return msg
+
+    def _run_with_sniffer(self, bridge, message):
+        sniffer = MagicMock()
+        sniffer._running = True
+        with patch("gateway.rns_bridge.HAS_RNS_SNIFFER", True), \
+             patch("gateway.rns_bridge.get_rns_sniffer", return_value=sniffer), \
+             patch("gateway.rns_bridge.UnifiedNode"), \
+             patch("commands.messaging.store_incoming"):
+            bridge._on_lxmf_receive(message)
+        return sniffer
+
+    def test_bytes_content_does_not_raise(self, bridge):
+        """Regression for #1162: bytes content must pass through unchanged."""
+        sniffer = self._run_with_sniffer(bridge, self._make_message(b"hello-bytes"))
+        sniffer._store_packet.assert_called_once()
+        captured = sniffer._store_packet.call_args[0][0]
+        assert captured.payload == b"hello-bytes"
+        assert captured.payload_size == len(b"hello-bytes")
+
+    def test_str_content_is_utf8_encoded(self, bridge):
+        sniffer = self._run_with_sniffer(bridge, self._make_message("hello-str-Ω"))
+        sniffer._store_packet.assert_called_once()
+        captured = sniffer._store_packet.call_args[0][0]
+        assert captured.payload == "hello-str-Ω".encode("utf-8")
+        assert captured.payload_size == len("hello-str-Ω".encode("utf-8"))
+
+    def test_none_content_yields_empty_payload(self, bridge):
+        sniffer = self._run_with_sniffer(bridge, self._make_message(None))
+        sniffer._store_packet.assert_called_once()
+        captured = sniffer._store_packet.call_args[0][0]
+        assert captured.payload == b""
+        assert captured.payload_size == 0


### PR DESCRIPTION
## Summary

- `_on_lxmf_receive` sniffer-capture branch in `src/gateway/rns_bridge.py:1300` unconditionally called `message.content.encode('utf-8')`, but `LXMessage.content` is `bytes` for binary LXMF payloads. The `AttributeError` was caught at DEBUG so message delivery was unaffected — but the traffic-inspection sniffer silently dropped the packet (~2-3 captures/wk per active gateway on the Hawaii federation).
- Branch on `isinstance(raw_content, str)` before encoding; pass bytes through unchanged.
- Adds `TestLXMFReceiveSnifferCapture` (3 cases: bytes / str / None content).

## Test plan
- [x] `python3 -m pytest tests/test_rns_bridge.py` — 183/183 passed (3 new + 180 existing)
- [x] `python3 -m pytest tests/test_regression_guards.py` — 19/19 passed
- [x] `python3 scripts/lint.py` — clean
- [x] Pre-commit hook (linter + regression guards + permission grammar) — green
- [ ] After merge: pull on `moc` + `moc3`, restart `meshforge-gateway.service`, confirm `RNS sniffer LXMF capture error` stops firing within a couple of hours of inbound LXMF traffic.

## Repro evidence (pre-fix, live fleet)

```
moc3, last 7d: 2 hits
  May 13 22:46:50  gateway.rns_bridge | DEBUG | RNS sniffer LXMF capture error: 'bytes' object has no attribute 'encode'
  May 14 06:26:10  gateway.rns_bridge | DEBUG | RNS sniffer LXMF capture error: 'bytes' object has no attribute 'encode'
moc,  last 7d: 3 hits
```

Each hit is immediately followed by `commands.messaging | INFO | Stored message NNNN from <hash>` — the receive path itself worked; only the sniffer-store branch failed.

## Sister-project note

The same line exists in `meshanchor` at `src/gateway/rns_bridge.py:1235`. Sibling PR to follow once this lands so the two trees stay aligned.

Closes #1162