### PR TITLE
feat(lab): scheduled rollup writer + /lab/rollup endpoint

### DIFF
--- a/scripts/lab_traffic_rollup.sh
+++ b/scripts/lab_traffic_rollup.sh
@@ -13,9 +13,14 @@
 # ~/lab_rollup_$(date +%Y%m%d).md` or pastes into substack writeups.
 #
 # Usage:
-#   bash scripts/lab_traffic_rollup.sh                # last 24h, default fleet
+#   bash scripts/lab_traffic_rollup.sh                  # last 24h, alphabetical
 #   LOOKBACK_HOURS=6 bash scripts/lab_traffic_rollup.sh
 #   FLEET_HOSTS=~/.config/meshforge/fleet_hosts bash scripts/lab_traffic_rollup.sh
+#   SORT_BY=fail bash scripts/lab_traffic_rollup.sh     # leaderboard: worst-fail-first
+#   SORT_BY=rtt  bash scripts/lab_traffic_rollup.sh     # leaderboard: slowest-RTT-first
+#
+# SORT_BY values: pair (default), fail (desc), rtt (desc), samples (desc).
+# Leaderboard ordering (fail/rtt) makes outliers pop in dashboards.
 #
 # Exit codes:
 #   0 — rollup emitted (even if some hosts unreachable; those become "?"s)
@@ -27,6 +32,12 @@ set -o pipefail
 
 LOOKBACK_HOURS="${LOOKBACK_HOURS:-24}"
 FLEET_HOSTS="${FLEET_HOSTS:-}"
+SORT_BY="${SORT_BY:-pair}"
+
+case "$SORT_BY" in
+    pair|fail|rtt|samples) ;;
+    *) echo "error: SORT_BY must be pair|fail|rtt|samples (got: $SORT_BY)" >&2; exit 2 ;;
+esac
 
 if [[ -z "$FLEET_HOSTS" ]]; then
     if [[ -r "$HOME/.config/meshforge/fleet_hosts" ]]; then
@@ -161,14 +172,48 @@ END {
     print "| pair | samples | mean ms | p95 ms | fail % | breakdown |"
     print "|---|---:|---:|---:|---:|---|"
 
-    # Stable order: sort the pair keys.
+    # Compute per-pair stats first (mean/p95/fail_pct), then sort keys
+    # by SORT_BY before printing. Two-pass so the sort comparator has
+    # the stats it needs.
     n = 0
     for (k in samples) { keys[++n] = k }
-    # Simple insertion sort — fleet is small.
+
+    # First pass: compute mean / p95 / fail_pct per key.
+    for (i = 1; i <= n; i++) {
+        p = keys[i]
+        s = samples[p]
+        o = ok[p] + 0
+        fail_pct_arr[p] = (s == 0) ? 0 : 100 * (s - o) / s
+
+        cnt = rtt_count[p] + 0
+        if (cnt == 0) {
+            mean_arr[p] = -1   # sentinel — formatted as "-" later
+            p95_arr[p]  = -1
+        } else {
+            sum = 0
+            for (j = 1; j <= cnt; j++) {
+                v[j] = rtts[p "/" j]
+                sum += v[j]
+            }
+            for (a = 2; a <= cnt; a++) {
+                x = v[a]; b = a - 1
+                while (b >= 1 && v[b] > x) { v[b+1] = v[b]; b-- }
+                v[b+1] = x
+            }
+            mean_arr[p] = sum / cnt
+            p95_idx = int(0.95 * cnt + 0.999999)
+            if (p95_idx < 1) p95_idx = 1
+            if (p95_idx > cnt) p95_idx = cnt
+            p95_arr[p] = v[p95_idx]
+        }
+    }
+
+    # Sort comparator key per SORT_BY. Insertion sort — fleet is small.
+    sort_by = "'"$SORT_BY"'"
     for (i = 2; i <= n; i++) {
         x = keys[i]
         j = i - 1
-        while (j >= 1 && keys[j] > x) {
+        while (j >= 1 && _greater(keys[j], x, sort_by, fail_pct_arr, mean_arr, samples)) {
             keys[j+1] = keys[j]
             j--
         }
@@ -178,36 +223,14 @@ END {
     for (i = 1; i <= n; i++) {
         p = keys[i]
         s = samples[p]
-        o = ok[p] + 0
-        fail_pct = (s == 0) ? 0 : 100 * (s - o) / s
 
-        # Collect this pair'\''s RTTs into a sorted list for p95.
-        cnt = rtt_count[p] + 0
-        if (cnt == 0) {
-            mean = "-"
-            p95 = "-"
+        if (mean_arr[p] < 0) {
+            mean = "-"; p95 = "-"
         } else {
-            sum = 0
-            for (j = 1; j <= cnt; j++) {
-                v[j] = rtts[p "/" j]
-                sum += v[j]
-            }
-            # Sort v[1..cnt].
-            for (a = 2; a <= cnt; a++) {
-                x = v[a]
-                b = a - 1
-                while (b >= 1 && v[b] > x) {
-                    v[b+1] = v[b]; b--
-                }
-                v[b+1] = x
-            }
-            mean = sprintf("%.0f", sum / cnt)
-            # p95 index (1-based): ceil(0.95 * cnt)
-            p95_idx = int(0.95 * cnt + 0.999999)
-            if (p95_idx < 1) p95_idx = 1
-            if (p95_idx > cnt) p95_idx = cnt
-            p95 = sprintf("%.0f", v[p95_idx])
+            mean = sprintf("%.0f", mean_arr[p])
+            p95  = sprintf("%.0f", p95_arr[p])
         }
+        fail_pct = fail_pct_arr[p]
 
         # Breakdown of failure kinds for this pair.
         breakdown = ""
@@ -224,7 +247,38 @@ END {
         printf("| %s | %d | %s | %s | %.1f | %s |\n",
             p, s, mean, p95, fail_pct, breakdown)
     }
+}
 
+# Returns 1 if a sorts after b under the chosen sort key (= "a is greater").
+# For pair: alphabetical asc (a > b means a comes after b). For fail/rtt/samples:
+# desc order (a > b means a has a SMALLER value, so it should be moved later).
+function _greater(a, b, kind, fail, mean, samples_,    av, bv) {
+    if (kind == "pair") return a > b
+    if (kind == "fail") {
+        av = fail[a]; bv = fail[b]
+        if (av == bv) return a > b   # stable tiebreak by name
+        return av < bv               # desc: smaller fail sorts later
+    }
+    if (kind == "rtt") {
+        # Treat missing RTT (-1) as "highest" — pure-fail pairs lead the leaderboard.
+        av = mean[a]; bv = mean[b]
+        if (av < 0 && bv >= 0) return 0   # a is "infinity" — a stays earlier
+        if (bv < 0 && av >= 0) return 1   # b is "infinity" — a moves later
+        if (av == bv) return a > b
+        return av < bv               # desc
+    }
+    if (kind == "samples") {
+        av = samples_[a]; bv = samples_[b]
+        if (av == bv) return a > b
+        return av < bv               # desc
+    }
+    return a > b   # fallback
+}
+
+# Awk concatenates multiple END blocks in source order. The window
+# footer is split into a second END so the comparator function can sit
+# at top level (awk forbids function defs inside blocks).
+END {
     print ""
     printf("_window: last %d h    hosts queried: %d    hosts with data: %d_\n",
         '"$LOOKBACK_HOURS"', '"$hosts_seen"', '"$hosts_with_data"')

--- a/src/utils/map_http_handler.py
+++ b/src/utils/map_http_handler.py
@@ -412,6 +412,12 @@ class MapRequestHandler(
             self._serve_weather()
         elif path_only == '/fleet/slo':
             self._serve_fleet_slo()
+        elif path_only == '/lab/rollup' or path_only == '/lab/rollup/':
+            self._serve_lab_rollup(variant='leaderboard')
+        elif path_only == '/lab/rollup/alphabetical':
+            self._serve_lab_rollup(variant='alphabetical')
+        elif path_only == '/lab/synth-rollup' or path_only == '/lab/synth-rollup/':
+            self._serve_lab_rollup(variant='synth')
         # ─────────────────────────────────────────────────────────────
         # Meshtastic API Proxy - MeshForge owns the web client API
         # ─────────────────────────────────────────────────────────────
@@ -1188,6 +1194,91 @@ class MapRequestHandler(
         """
         from utils.fleet_snapshot import build_slo_snapshot
         self._serve_json(build_slo_snapshot(collector=self.collector))
+
+    # Lab rollup state files written every 10min by
+    # meshforge-lab-rollup.service. Variants:
+    #   leaderboard   — traffic rollup sorted worst-fail-first (default)
+    #   alphabetical  — traffic rollup sorted by pair (historical)
+    #   synth         — multi-user synth-soak rollup (only on synth boxes)
+    _LAB_ROLLUP_FILES = {
+        'leaderboard':  'lab-traffic-rollup-leaderboard.md',
+        'alphabetical': 'lab-traffic-rollup.md',
+        'synth':        'lab-synth-soak-rollup.md',
+    }
+
+    def _serve_lab_rollup(self, variant: str):
+        """Serve the lab rollup markdown produced by meshforge-lab-rollup.
+
+        State file lives under $XDG_STATE_HOME/meshforge/ (default
+        ~/.local/state/meshforge). 404s with a fix-hint when the file
+        doesn't exist — typical cause is the rollup timer never having
+        been installed on this host.
+        """
+        filename = self._LAB_ROLLUP_FILES.get(variant)
+        if filename is None:
+            self._serve_text(f"unknown rollup variant: {variant}\n",
+                             status=404, content_type='text/plain')
+            return
+
+        # XDG_STATE_HOME with the standard ~/.local/state fallback.
+        state_home = os.environ.get('XDG_STATE_HOME') or \
+            os.path.join(os.path.expanduser('~'), '.local', 'state')
+        path = os.path.join(state_home, 'meshforge', filename)
+
+        try:
+            with open(path, 'rb') as f:
+                data = f.read()
+        except FileNotFoundError:
+            hint = (
+                f"# lab rollup not found\n\n"
+                f"`{path}` does not exist on this host.\n\n"
+                f"Fix: install and enable the rollup timer on this box:\n"
+                f"```\n"
+                f"cp /opt/meshforge/templates/systemd/meshforge-lab-rollup-user.service \\\n"
+                f"   ~/.config/systemd/user/meshforge-lab-rollup.service\n"
+                f"cp /opt/meshforge/templates/systemd/meshforge-lab-rollup-user.timer \\\n"
+                f"   ~/.config/systemd/user/meshforge-lab-rollup.timer\n"
+                f"systemctl --user daemon-reload\n"
+                f"systemctl --user enable --now meshforge-lab-rollup.timer\n"
+                f"```\n"
+            )
+            self._serve_text(hint, status=404, content_type='text/markdown')
+            return
+        except OSError as e:
+            self._serve_text(f"# error reading rollup\n\n{e}\n",
+                             status=500, content_type='text/markdown')
+            return
+
+        self._serve_text(data, status=200, content_type='text/markdown')
+
+    def _serve_text(self, body, status: int = 200,
+                    content_type: str = 'text/plain'):
+        """Send a text/markdown response with the gzip + CORS pattern.
+
+        Accepts bytes or str. Uses the same gzip threshold as _serve_json
+        so small responses skip compression overhead.
+        """
+        if isinstance(body, str):
+            data = body.encode('utf-8')
+        else:
+            data = body
+        encoding: Optional[str] = None
+        if len(data) >= self._GZIP_MIN_BYTES and self._client_accepts_gzip():
+            data = gzip.compress(data, compresslevel=6)
+            encoding = 'gzip'
+        self.send_response(status)
+        self.send_header('Content-Type', f'{content_type}; charset=utf-8')
+        self.send_header('Content-Length', str(len(data)))
+        if encoding:
+            self.send_header('Content-Encoding', encoding)
+        self.send_header('Vary', 'Accept-Encoding')
+        self._send_cors_header()
+        self.send_header('Cache-Control', 'no-cache')
+        self.end_headers()
+        try:
+            self.wfile.write(data)
+        except (BrokenPipeError, ConnectionResetError, ConnectionAbortedError) as e:
+            logger.debug(f"Client disconnected during _serve_text: {e}")
 
     def _serve_coverage(self, parts: List[str]):
         """Serve terrain-aware coverage prediction for a location.

--- a/templates/systemd/meshforge-lab-rollup-user.service
+++ b/templates/systemd/meshforge-lab-rollup-user.service
@@ -1,0 +1,59 @@
+# MeshForge — lab rollup writer (systemd-user, one-shot, fired by the timer)
+# ==========================================================================
+#
+# Runs scripts/lab_traffic_rollup.sh (and lab_synth_soak_rollup.sh if data
+# is present) every 10 min and writes the output to fixed state files that
+# the NOC dashboard reads. Without this on a schedule, the rollup scripts
+# exist but produce no surface — they have to be run by hand.
+#
+# Output paths:
+#   ~/.local/state/meshforge/lab-traffic-rollup.md    (alphabetical)
+#   ~/.local/state/meshforge/lab-traffic-rollup-leaderboard.md  (SORT_BY=fail)
+#   ~/.local/state/meshforge/lab-synth-soak-rollup.md (only on the synth box)
+#
+# Atomicity: each rollup is written to a .tmp sibling and renamed in place,
+# so dashboard reads never see a half-written file.
+#
+# Install (on the "tester box" — the host whose ssh keys reach the rest of
+# the fleet AND whose own tracer fires; typically the NOC control box):
+#   cp /opt/meshforge/templates/systemd/meshforge-lab-rollup-user.service \
+#      ~/.config/systemd/user/meshforge-lab-rollup.service
+#   cp /opt/meshforge/templates/systemd/meshforge-lab-rollup-user.timer \
+#      ~/.config/systemd/user/meshforge-lab-rollup.timer
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now meshforge-lab-rollup.timer
+#
+# Memory: feedback_bundle_full_stack_not_light_version — this unit IS the
+# surfacing layer; deploying tracer without this is the silent-script
+# anti-pattern.
+
+[Unit]
+Description=MeshForge lab rollup writer (markdown for NOC dashboard)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/meshforge
+# State dir is created idempotently each fire — no separate ExecStartPre needed.
+# Bash handles tmp+rename atomicity. Synth rollup is skipped silently when
+# the data dir is absent (most hosts).
+ExecStart=/usr/bin/bash -c ' \
+    set -u; \
+    out_dir="${XDG_STATE_HOME:-$HOME/.local/state}/meshforge"; \
+    mkdir -p "$out_dir"; \
+    LOOKBACK_HOURS=24 SORT_BY=pair bash /opt/meshforge/scripts/lab_traffic_rollup.sh \
+        > "$out_dir/lab-traffic-rollup.md.tmp" 2>/dev/null \
+        && mv "$out_dir/lab-traffic-rollup.md.tmp" "$out_dir/lab-traffic-rollup.md"; \
+    LOOKBACK_HOURS=24 SORT_BY=fail bash /opt/meshforge/scripts/lab_traffic_rollup.sh \
+        > "$out_dir/lab-traffic-rollup-leaderboard.md.tmp" 2>/dev/null \
+        && mv "$out_dir/lab-traffic-rollup-leaderboard.md.tmp" "$out_dir/lab-traffic-rollup-leaderboard.md"; \
+    if [ -d "$out_dir/synth_soak" ] && ls "$out_dir/synth_soak/"synth-*.json >/dev/null 2>&1; then \
+        bash /opt/meshforge/scripts/lab_synth_soak_rollup.sh \
+            > "$out_dir/lab-synth-soak-rollup.md.tmp" 2>/dev/null \
+            && mv "$out_dir/lab-synth-soak-rollup.md.tmp" "$out_dir/lab-synth-soak-rollup.md"; \
+    fi; \
+    exit 0'
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=meshforge-lab-rollup

--- a/templates/systemd/meshforge-lab-rollup-user.timer
+++ b/templates/systemd/meshforge-lab-rollup-user.timer
@@ -1,0 +1,27 @@
+# MeshForge — lab rollup timer (every 10 min, matches tracer cadence)
+# ===================================================================
+#
+# Fires meshforge-lab-rollup.service on a 10-minute cadence so the
+# dashboard's view of federation round-trip health stays at most 10 min
+# stale. Matches the tracer cadence — every tracer fire produces fresh
+# journal lines, then the next rollup picks them up.
+#
+# Persistent=true so a missed firing (e.g. box rebooted) catches up
+# after boot. Without persistence, a Pi power-cycle leaves the dashboard
+# rendering stale rollup data forever.
+
+[Unit]
+Description=Fire meshforge-lab-rollup every 10 minutes
+Requires=meshforge-lab-rollup.service
+
+[Timer]
+# *:05/10 = 05, 15, 25, 35, 45, 55 — offset 5min from the tracer's
+# *:00/10 so the rollup runs AFTER the tracer journal lines have landed,
+# not before. Without this offset the rollup races the tracer and
+# regularly captures one-cycle-old data.
+OnCalendar=*-*-* *:05/10:00
+Persistent=true
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target

--- a/tests/test_map_http_handler.py
+++ b/tests/test_map_http_handler.py
@@ -326,3 +326,103 @@ class TestApplyViewPresetToPositionLess:
         )
         assert len(out) == 1
         assert out[0]["id"] == "a"
+
+
+# ---------------------------------------------------------------------------
+# /lab/rollup endpoint — serves rollup markdown produced by
+# meshforge-lab-rollup.service. See feedback_bundle_full_stack_not_light_version.
+# ---------------------------------------------------------------------------
+
+class TestServeLabRollup:
+    """The /lab/* endpoints surface the rollup state files."""
+
+    def _make_handler_with_state(self, tmp_path, monkeypatch,
+                                  filename: str | None = None,
+                                  content: bytes | str = b""):
+        """Point XDG_STATE_HOME at tmp_path and optionally seed a file."""
+        state_dir = tmp_path / "meshforge"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        if filename is not None:
+            data = content.encode() if isinstance(content, str) else content
+            (state_dir / filename).write_bytes(data)
+        monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+
+        h = _make_handler("gzip")
+        return h
+
+    def test_leaderboard_variant_serves_file(self, tmp_path, monkeypatch):
+        h = self._make_handler_with_state(
+            tmp_path, monkeypatch,
+            filename="lab-traffic-rollup-leaderboard.md",
+            content="| pair | fail % |\n|---|---:|\n| foo->bar | 100.0 |\n",
+        )
+        h._serve_lab_rollup(variant="leaderboard")
+        body = h.wfile.getvalue()
+        # Small payload — not gzipped, raw markdown comes through.
+        assert b"foo->bar" in body
+        h.send_response.assert_called_once_with(200)
+        content_types = [v for k, v in h._sent_headers if k == "Content-Type"]
+        assert any("text/markdown" in v for v in content_types)
+
+    def test_alphabetical_variant_routes_to_different_file(self, tmp_path, monkeypatch):
+        h = self._make_handler_with_state(
+            tmp_path, monkeypatch,
+            filename="lab-traffic-rollup.md",
+            content="alphabetical-marker\n",
+        )
+        h._serve_lab_rollup(variant="alphabetical")
+        assert b"alphabetical-marker" in h.wfile.getvalue()
+        h.send_response.assert_called_once_with(200)
+
+    def test_synth_variant_routes_to_synth_file(self, tmp_path, monkeypatch):
+        h = self._make_handler_with_state(
+            tmp_path, monkeypatch,
+            filename="lab-synth-soak-rollup.md",
+            content="synth-marker\n",
+        )
+        h._serve_lab_rollup(variant="synth")
+        assert b"synth-marker" in h.wfile.getvalue()
+
+    def test_missing_file_returns_404_with_install_hint(self, tmp_path, monkeypatch):
+        # No file seeded — must 404 and emit a fix-hint pointing at the
+        # systemd template. Per feedback_visual_dashboard_as_human_claude_collab,
+        # a silent-empty response is the failure mode we're explicitly avoiding.
+        h = self._make_handler_with_state(tmp_path, monkeypatch)
+        h._serve_lab_rollup(variant="leaderboard")
+        h.send_response.assert_called_once_with(404)
+        body = h.wfile.getvalue()
+        assert b"meshforge-lab-rollup" in body
+        assert b"systemctl --user enable --now" in body
+
+    def test_unknown_variant_returns_404(self, tmp_path, monkeypatch):
+        h = self._make_handler_with_state(tmp_path, monkeypatch)
+        h._serve_lab_rollup(variant="garbage")
+        h.send_response.assert_called_once_with(404)
+        assert b"unknown rollup variant" in h.wfile.getvalue()
+
+
+class TestServeText:
+    """_serve_text is the helper used by /lab/* and any future markdown-y
+    endpoints. Mirrors _serve_json gzip + CORS behavior."""
+
+    def test_str_input_encoded_as_utf8(self):
+        h = _make_handler("")
+        h._serve_text("hello-Ω")
+        assert h.wfile.getvalue() == "hello-Ω".encode("utf-8")
+
+    def test_bytes_input_passed_through(self):
+        h = _make_handler("")
+        h._serve_text(b"\x01\x02\x03")
+        assert h.wfile.getvalue() == b"\x01\x02\x03"
+
+    def test_large_payload_gzipped_when_client_accepts(self):
+        h = _make_handler("gzip")
+        h._serve_text("x" * 50000, content_type="text/markdown")
+        body = h.wfile.getvalue()
+        assert body.startswith(b"\x1f\x8b"), "expected gzip magic bytes"
+        assert gzip.decompress(body) == ("x" * 50000).encode("utf-8")
+
+    def test_custom_status_code(self):
+        h = _make_handler("")
+        h._serve_text("oops", status=503)
+        h.send_response.assert_called_once_with(503)


### PR DESCRIPTION
## Summary

Closes the "build a script and never deploy it" gap on the federation lab probes. The bash rollup scripts (`lab_traffic_rollup.sh`, `lab_synth_soak_rollup.sh`) have existed for ~3 days but had no schedule and no HTTP surface — 24 h of perfectly good tracer data was sitting silently in journalctl.

- `SORT_BY={pair,fail,rtt,samples}` flag added to `lab_traffic_rollup.sh`. Default unchanged; `SORT_BY=fail` produces leaderboard ordering (worst fail %% first).
- `meshforge-lab-rollup-user.{service,timer}` fires every 10 min (offset `*:05/10`), writes three atomic state files under `~/.local/state/meshforge/`.
- `/lab/rollup`, `/lab/rollup/alphabetical`, `/lab/synth-rollup` endpoints added to the map HTTP handler. Serves `text/markdown` with gzip + CORS. 404 case emits a fix-hint markdown body pointing at the install command — silent-empty response is the failure mode we're explicitly avoiding.

## Pairs with (next PR)

MeshAnchor PR: `/fleet/lab-rollup` endpoint + "Federation Round-Trip" panel on `fleet.html` that polls this side's `/lab/rollup`.

## Field deploy (post-merge ops step, not in PR)

- moc3: install `meshforge-echo-user.service` — closes the 100% no-route hole visible in 24h rollup
- moc + moc3: install `meshforge-tracer-user.{service,timer}` — extends RTT coverage beyond VolcanoAI-only
- VolcanoAI: install `meshforge-lab-rollup-user.{service,timer}` — turns the existing 24h of tracer data into a live dashboard surface

## Test plan
- [x] `python3 -m pytest tests/test_map_http_handler.py -v` — 48/48 (9 new for `TestServeLabRollup` + `TestServeText`, 39 existing)
- [x] `python3 -m pytest tests/test_regression_guards.py` — 19/19
- [x] `python3 scripts/lint.py` — clean
- [x] Pre-commit hook (linter + regression guards + permission grammar) — green
- [x] Smoke: `SORT_BY=fail bash scripts/lab_traffic_rollup.sh` — moc3 leaderboards at top (100% no-route), other 5 pairs sorted alphabetically as stable tiebreak

## Memory linkage

This PR is the first concrete application of the 2026-05-14 philosophy memories:
- [feedback_bundle_full_stack_not_light_version](https://github.com/Nursedude/claude-memory-meshanchor/blob/main/feedback_bundle_full_stack_not_light_version.md) — the rollup-on-cron + HTTP endpoint ship in the SAME change as the SORT_BY flag, not "we'll wire it up next time".
- [feedback_visual_dashboard_as_human_claude_collab](https://github.com/Nursedude/claude-memory-meshanchor/blob/main/feedback_visual_dashboard_as_human_claude_collab.md) — leaderboard ordering and the 404 fix-hint exist specifically to make the surface non-silent.