### PR TITLE
fix(tests): PEP-604 union → Optional for Python 3.9 CI

### DIFF
--- a/tests/test_map_http_handler.py
+++ b/tests/test_map_http_handler.py
@@ -337,9 +337,13 @@ class TestServeLabRollup:
     """The /lab/* endpoints surface the rollup state files."""
 
     def _make_handler_with_state(self, tmp_path, monkeypatch,
-                                  filename: str | None = None,
-                                  content: bytes | str = b""):
-        """Point XDG_STATE_HOME at tmp_path and optionally seed a file."""
+                                  filename=None, content=b""):
+        """Point XDG_STATE_HOME at tmp_path and optionally seed a file.
+
+        ``filename`` is str|None and ``content`` is bytes|str — annotations
+        omitted because this file currently has to import-compile under
+        Python 3.9 in CI (PEP-604 union syntax landed in 3.10).
+        """
         state_dir = tmp_path / "meshforge"
         state_dir.mkdir(parents=True, exist_ok=True)
         if filename is not None:


### PR DESCRIPTION
## Summary

Follow-up to #1164 — Test Suite (3.9) failed on collection with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`. PEP-604 union syntax (`str | None`) is 3.10+; MeshForge CI matrix is 3.9 + 3.11. Auto-merge fired despite the 3.9 failure because branch protection doesn't gate on it.

Replaces:
```python
filename: str | None = None,
content: bytes | str = b"",
```

with un-annotated parameters (helper is internal; types are obvious from call sites).

## Test plan
- [x] `python3 -m pytest tests/test_map_http_handler.py` — 48/48 (local 3.13)
- [x] Will be validated on CI 3.9 + 3.11

## Lesson

The "CI errors pile up" pattern the operator called out today. Auto-merge + non-blocking-but-failing checks = main goes red. Worth a follow-up on branch protection to make Test Suite (3.9) required (separate change).