### PR TITLE
fix(lab): add ssh -n inside fleet_hosts loop (silently truncated rollup)

### DIFF
--- a/scripts/lab_traffic_rollup.sh
+++ b/scripts/lab_traffic_rollup.sh
@@ -95,7 +95,15 @@ while IFS= read -r raw; do
 
     # journalctl emits "<ts> <host> <id>[<pid>]: <message>". We only
     # want the message body. -o cat strips everything but the body.
-    result=$(ssh -o BatchMode=yes -o ConnectTimeout=8 "$host" \
+    # NB: `-n` is load-bearing here. The header docstring of this file
+    # already warns about the gotcha (ssh inside a `while read` loop
+    # eats the host list via stdin), and the sibling
+    # soak_check_fleet_2026_05_14.sh follows the rule. This call site
+    # missed it pre-2026-05-14, which silently truncated the rollup to
+    # only the first peer (caught when moc/moc1/moc2/moc3 tracer data
+    # never appeared in /lab/rollup even though each host's tracer was
+    # firing cleanly).
+    result=$(ssh -n -o BatchMode=yes -o ConnectTimeout=8 "$host" \
         "journalctl --user-unit=meshforge-tracer --since '${LOOKBACK_HOURS} hours ago' \
          --no-pager -o cat 2>/dev/null | grep -E 'tracer: rtt seq='" \
         2>/dev/null || true)


### PR DESCRIPTION
## Summary

The header docstring of `lab_traffic_rollup.sh` explicitly warns about exactly this gotcha:

```
SSH gotcha (committed for future readers): bare `ssh \"\$host\" ...` inside
a `while IFS= read -r host` loop eats the host list via stdin. Use `ssh -n`
anywhere SSH is called inside a read loop.
```

The sibling `soak_check_fleet_2026_05_14.sh` follows the rule. This call site missed it.

## Symptom (caught 2026-05-14)

After PR #1164 + the fleet deploy of `meshforge-tracer.timer` on moc + moc3, each fleet host's tracer was firing cleanly (verified via `journalctl --user-unit meshforge-tracer`) but the rollup output (and therefore the new `/lab/rollup` + MA `/fleet/lab-rollup` dashboard panel) still showed only VolcanoAI + moc rows.

`bash -x` trace confirmed the `while read host` loop processed exactly one iteration and exited — classic ssh-eats-stdin pattern.

## After this fix

Local rollup shows 18 rows:

```
| VolcanoAI -> meshforge-moc3 | 144 | 1030 | 1030 | 99.3 | no-route=143 |
| ... 5 more VolcanoAI rows ...
| moc -> ... | 3 | ... |  (6 rows)
| moc3 -> ... | 1 | ... | (6 rows)
_window: last 24 h    hosts queried: 5    hosts with data: 3_
```

vs pre-fix:

```
_window: last 24 h    hosts queried: 2    hosts with data: 1_
```

## Test plan
- [x] `bash -x scripts/lab_traffic_rollup.sh` — confirms loop now iterates all hosts
- [x] Inspect rollup output before/after — 12 rows → 18 rows
- [x] Pre-commit hook (regression guards) — green