### PR TITLE
feat(meshchatx): promote rollout to remaining fleet boxes

### DIFF
--- a/src/utils/deployment_profiles.py
+++ b/src/utils/deployment_profiles.py
@@ -190,7 +190,7 @@ PROFILES: Dict[ProfileName, ProfileDefinition] = {
             "mqtt": True,
             "maps": True,
             "tactical": True,
-            "meshchatx": False,
+            "meshchatx": True,
         },
     ),
 }


### PR DESCRIPTION
## What

Flip the `meshchatx` feature flag from `False` to `True` on the **FULL** deployment profile, leaving GATEWAY at `False` (per `project_gateway_fleet_state` — moc3 is the canonical Meshtastic↔RNS gateway and shouldn't carry a second LXMF client yet).

## Why

MeshChatX integration shipped 2026-05-02 as opt-in (parity install of the NomadNet pattern, Issue #45/#46). After 14 days of optional adoption, this PR promotes it to the default-on state for FULL-profile boxes so the friendly web UI is available on every box that runs the full stack.

## Diff

Exactly one line changed — `"meshchatx": False` → `"meshchatx": True` under `ProfileName.FULL` in `src/utils/deployment_profiles.py`. GATEWAY profile untouched.

## Soak checklist — operator must complete before marking ready

Before converting this PR from draft to ready, run these on each FULL-profile box and tick the boxes:

```bash
# Run on each box where you've already enabled meshchatx + run the installer:
systemctl --user is-active meshchatx                 # expect: active
systemctl --user show meshchatx -p NRestarts --value  # expect: 0 (or very low)
journalctl --user -u meshchatx --since '14 days ago' \
  | grep -iE 'AuthenticationError|exit-code|Failed|rpc_key' | tail -20
# expect: empty (or only benign systemd lifecycle entries)
```

- [ ] **moc1** (test bed) — clean for full 14d window
- [ ] **volcanoai** (operator-monitor) — clean for full 14d window
- [ ] **moc** — clean OR not yet enabled (note in PR comment which)
- [ ] **moc2** — clean OR not yet enabled (note in PR comment which)
- [ ] **moc3 stays GATEWAY profile** — not in scope for this flip

If any box shows `AuthenticationError` or `rpc_key` mismatch in the journal, do NOT merge — run `sudo python3 scripts/rns_alignment.py normalize && sudo systemctl restart rnsd` first, restart meshchatx, and re-run the soak window. (This is the Issue #41 path the wrapper is supposed to refuse-loud on; if it leaked through to runtime, that's a regression worth investigating before promoting.)

If NO boxes have been enabled yet, this PR is premature — close it and re-arm the schedule for another 2 weeks.

## Baseline

- Integration commit: `8de5ecf` (2026-05-02)
- Operator runbook: `docs/MESHCHATX_DEPLOYMENT.md`
- The schedule that opened this PR: one-shot agent fired 2026-05-16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017fiFJX74uuG21V1FsRdCAQ)_