### PR TITLE
docs(fleet): document meshforge-gateway bridge unit in role catalog

### DIFF
--- a/docs/fleet_manifest.md
+++ b/docs/fleet_manifest.md
@@ -49,14 +49,14 @@ fleet degrades in a way that's expensive to debug.
 
 ## Role catalog
 
-| Role | Board tier | meshtasticd | rnsd | mosquitto | map server | tile server | cloud-push | watchdog | Notes |
-|------|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|-------|
-| `primary` | Pi 4 / Pi 5 (≥4 GB) | ✓ | ✓ | ✓ | ✓ | — | — | ✓ | Canonical memory/repo writer. Drives the cloud-push *source* API. |
-| `full-gateway` | Pi 4 (≥4 GB) | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | Full NOC node: radio + bridge + map + tiles. |
-| `cloud-publisher` | Pi 4 / Pi 5 (≥4 GB) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | `full-gateway` **+** the cloud-push timer. Exactly one in the fleet. |
-| `gateway-only` | Pi 3B+ (~1 GB ok) | ✓ | ✓ | ✓ | **disabled** | — | — | ✓ | Constrained board: bridge + radio, **map server off** (too heavy for ~1 GB). |
-| `meshanchor-noc` | Pi 4 (≥4 GB) | — | ✓ | ✓ | (meshanchor map) | — | — | (meshanchor wd) | Sister app ([MeshAnchor](https://github.com/Nursedude/meshanchor)), MeshCore-primary. No MeshForge stack. Radio-less egress to a peer meshtasticd. Provisioned by the MeshAnchor repo, not the MeshForge provisioner. |
-| `bot` *(optional, non-fleet)* | Zero-class (Zero 2 W rec.) | — | — | — | — | — | — | — | A dedicated [meshing-around](https://github.com/SpudGunMan/meshing-around) bot. Not a MeshForge node; reaches the mesh via a companion radio. |
+| Role | Board tier | meshtasticd | rnsd | mosquitto | bridge | map server | tile server | cloud-push | watchdog | Notes |
+|------|-----------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|-------|
+| `primary` | Pi 4 / Pi 5 (≥4 GB) | ✓ | ✓ | ✓ | — | ✓ | — | — | ✓ | Canonical memory/repo writer. Drives the cloud-push *source* API. Does not host the bridge. |
+| `full-gateway` | Pi 4 (≥4 GB) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | ✓ | Full NOC node: radio + bridge + map + tiles. |
+| `cloud-publisher` | Pi 4 / Pi 5 (≥4 GB) | ✓ | ✓ | ✓ | **disabled** | ✓ | ✓ | ✓ | ✓ | `full-gateway` **+** the cloud-push timer, **−** the bridge (publishes snapshots, does not bridge RF). Exactly one in the fleet. |
+| `gateway-only` | Pi 3B+ (~1 GB ok) | ✓ | ✓ | ✓ | ✓ | **disabled** | — | — | ✓ | Constrained board: bridge + radio, **map server off** (too heavy for ~1 GB). |
+| `meshanchor-noc` | Pi 4 (≥4 GB) | — | ✓ | ✓ | — | (meshanchor map) | — | — | (meshanchor wd) | Sister app ([MeshAnchor](https://github.com/Nursedude/meshanchor)), MeshCore-primary. No MeshForge stack. Radio-less egress to a peer meshtasticd. Provisioned by the MeshAnchor repo, not the MeshForge provisioner. |
+| `bot` *(optional, non-fleet)* | Zero-class (Zero 2 W rec.) | — | — | — | — | — | — | — | — | A dedicated [meshing-around](https://github.com/SpudGunMan/meshing-around) bot. Not a MeshForge node; reaches the mesh via a companion radio. |
 
 > Machine-readable companion: **[`fleet_roles.yaml`](fleet_roles.yaml)** — the same
 > catalog + deltas in structured form, intended to drive a role-aware provisioner.

--- a/docs/fleet_roles.yaml
+++ b/docs/fleet_roles.yaml
@@ -8,7 +8,7 @@
 #   disabled = unit installed but deliberately enabled=false/inactive (not a fault)
 #   absent   = unit not installed for this role
 version: 0
-updated: "2026-05-24"
+updated: "2026-05-27"
 
 # Role ownership: the MeshForge provisioner converges only roles WITHOUT a
 # `provisioned_by` key. A role with `provisioned_by: <repo>` is documented here
@@ -51,6 +51,8 @@ roles:
       meshtasticd: enabled
       rnsd: enabled
       mosquitto: enabled
+      meshforge-gateway: absent       # primary authors memory + serves the map; it does
+                                      # not host the Meshtastic<->RNS/LXMF bridge
       meshforge-map: enabled
       meshforge-maps: disabled        # tiles served by full-gateway nodes
       meshforge-watchdog: enabled
@@ -67,6 +69,8 @@ roles:
       meshtasticd: enabled
       rnsd: enabled
       mosquitto: enabled
+      meshforge-gateway: enabled      # the Meshtastic<->RNS/LXMF bridge daemon — the
+                                      # unit that makes this node an actual gateway
       meshforge-map: enabled
       meshforge-maps: enabled
       meshforge-watchdog: enabled
@@ -77,6 +81,9 @@ roles:
     inherits: full-gateway
     board_tier: pi4_or_pi5_min_4gb
     services:
+      meshforge-gateway: disabled     # OVERRIDE full-gateway: this node publishes the
+                                      # cloud snapshot, it does not bridge RF — unit
+                                      # installed but deliberately off (not a fault)
       meshforge-cloud-push.timer: enabled
     flags:
       cloud_push_publisher: true
@@ -89,6 +96,8 @@ roles:
       meshtasticd: enabled
       rnsd: enabled
       mosquitto: enabled
+      meshforge-gateway: enabled      # the bridge daemon — a gateway-only node's whole
+                                      # job; lighter than the map, fits the ~1GB board
       meshforge-map: disabled         # DELIBERATE: map server too heavy for ~1GB
       meshforge-maps: absent
       meshforge-watchdog: enabled


### PR DESCRIPTION
## Why

The role catalog (`docs/fleet_roles.yaml` + `docs/fleet_manifest.md`) never listed **`meshforge-gateway.service`** — the Meshtastic↔RNS/LXMF bridge daemon — even though it's the unit that actually makes a node a gateway. moc and moc3 run it; the spec was silent on it.

That gap surfaced while checking moc2: it's declared `full-gateway` and runs the *documented* full-gateway manifest (meshtasticd, rnsd, mosquitto, map, maps, watchdog — all active), yet it does **not** run the bridge. By the spec moc2 looked conformant; in reality it's missing the unit that defines its role.

## Change

Add `meshforge-gateway` to every role's service map, matching live fleet state:

| Role (box) | bridge | rationale |
|---|---|---|
| primary (VolcanoAI) | `absent` | authors memory + serves the map; doesn't host the bridge |
| full-gateway (moc) | `enabled` | active — the unit that makes a gateway |
| cloud-publisher (moc1) | `disabled` | **override** inherited full-gateway: publishes cloud snapshot, doesn't bridge RF (installed but deliberately off) |
| gateway-only (moc3) | `enabled` | active — the box's whole job |

Mirrored as a new `bridge` column in the `fleet_manifest.md` role table. Bumped `updated:` to 2026-05-27.

Now moc2's missing bridge is **well-defined drift** an operator/provisioner can act on, instead of an invisible inconsistency.

## Scope
Docs only. No code change. moc2's `deployment.json` left untouched (`role: full-gateway` is correct). YAML re-validates; `lint.py --all` clean; regression guards green (pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)