### PR TITLE
feat(provisioner): per-node service_overrides — loud, reasoned waivers

### DIFF
--- a/scripts/provision_role.py
+++ b/scripts/provision_role.py
@@ -126,13 +126,39 @@ def _unit_current(name: str) -> str:
     return f"{'active' if running else 'inactive'}/{'enabled' if enabled else 'disabled'}"
 
 
-def plan(role_def: dict) -> List[Action]:
+def plan(role_def: dict, overrides: Optional[Dict[str, dict]] = None) -> List[Action]:
     """Build the ordered action list to converge to `role_def`. Pure w.r.t.
-    the SSOT observe functions (which read the live system)."""
+    the SSOT observe functions (which read the live system).
+
+    `overrides` is the box's instance-local `service_overrides` (from
+    deployment.json): per-unit intentional exceptions to the role's service
+    map. A waived unit is reported as a NON-blocking advisory carrying the
+    reason — visible and auditable, never silently dropped — and is skipped by
+    convergence (left as the operator set it). A waiver WITHOUT a `reason` is
+    NOT honored (it stays a blocking warning) — an unexplained exception is
+    just hidden drift.
+    """
     actions: List[Action] = []
     services: Dict[str, str] = role_def.get("services", {})
+    overrides = overrides or {}
 
     for unit, desired in services.items():
+        ov = overrides.get(unit)
+        if ov is not None:
+            reason = (ov.get("reason") or "").strip() if isinstance(ov, dict) else ""
+            waived = ov.get("state", "?") if isinstance(ov, dict) else str(ov)
+            cur = _unit_current(unit)
+            if reason:
+                actions.append(Action(unit, cur, f"waived:{waived}", "warn",
+                                      required=False,
+                                      detail=f"intentional per-node exception: {reason}"))
+            else:
+                actions.append(Action(unit, cur, f"waived:{waived}", "warn",
+                                      required=True,
+                                      detail="service_override missing required 'reason' "
+                                             "— NOT honored (an unexplained waiver is "
+                                             "hidden drift)"))
+            continue
         if desired not in VALID_UNIT_STATES:
             actions.append(Action(unit, "?", str(desired), "warn", required=False,
                                   detail=f"unknown desired state '{desired}'"))
@@ -218,6 +244,23 @@ def read_role() -> Optional[str]:
         return json.loads(DEPLOYMENT_JSON.read_text()).get("role")
     except (json.JSONDecodeError, OSError):
         return None
+
+
+def read_overrides() -> Dict[str, dict]:
+    """Instance-local per-unit exceptions from deployment.json `service_overrides`.
+
+    Shape: ``{"<unit>": {"state": "disabled"|"absent"|..., "reason": "<why>"}}``.
+    Instance specifics (which box, why) live HERE, never in the committed roles
+    file (MF014/MF015). Honored by ``plan()``; a waiver without a ``reason`` is
+    rejected there.
+    """
+    if not DEPLOYMENT_JSON.exists():
+        return {}
+    try:
+        ov = json.loads(DEPLOYMENT_JSON.read_text()).get("service_overrides") or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return ov if isinstance(ov, dict) else {}
 
 
 def write_role(role: str) -> None:
@@ -378,8 +421,11 @@ def main(argv: Optional[List[str]] = None) -> int:
               f"— the MeshForge provisioner does not converge it.", file=sys.stderr)
         return 2
 
+    overrides = read_overrides()
     print(f"# role: {role}  (mode: {'APPLY' if args.apply else 'dry-run'})")
-    actions = plan(role_def)
+    if overrides:
+        print(f"# service_overrides active: {', '.join(sorted(overrides))}")
+    actions = plan(role_def, overrides)
     render(actions, args.apply)
 
     changes = [a for a in actions if a.verb in ("enable", "disable", "mask")]

--- a/tests/test_provision_role.py
+++ b/tests/test_provision_role.py
@@ -135,6 +135,70 @@ class TestPlanUnitStates:
         assert a.verb == "noop"
 
 
+class TestPlanServiceOverrides:
+    """Per-node service_overrides (instance-local deployment.json) waivers."""
+
+    def _plan_with_override(self, override, running, enabled, installed):
+        # full-gateway expects meshforge-gateway enabled; the override waives it.
+        role_def = {"services": {"meshforge-gateway": "enabled"}}
+        m1, m2, m3 = _mock_observe(running, enabled, installed)
+        with m1, m2, m3:
+            return pr.plan(role_def, {"meshforge-gateway": override})
+
+    def test_waiver_with_reason_is_nonblocking_advisory(self):
+        """moc2 case: unit absent, role wants enabled, but a reasoned waiver
+        downgrades the would-be blocking warn to a non-blocking advisory — so
+        the box stops failing the drift check."""
+        a = [x for x in self._plan_with_override(
+                {"state": "disabled", "reason": "RF-sparse site, bridge intentionally off"},
+                running=False, enabled=False, installed=False)
+             if x.item == "meshforge-gateway"][0]
+        assert a.verb == "warn"
+        assert a.required is False                      # non-blocking → dry-run exit 0
+        assert "RF-sparse" in a.detail                  # reason is surfaced (loud)
+        assert a.desired == "waived:disabled"
+
+    def test_waiver_without_reason_stays_blocking(self):
+        """An unexplained waiver is hidden drift — NOT honored."""
+        a = [x for x in self._plan_with_override(
+                {"state": "disabled"}, running=False, enabled=False, installed=False)
+             if x.item == "meshforge-gateway"][0]
+        assert a.verb == "warn"
+        assert a.required is True                       # still blocks
+        assert "NOT honored" in a.detail
+
+    def test_waived_unit_is_not_converged(self):
+        """A waived unit produces no enable/disable action even when it diverges
+        from the role (left as the operator set it)."""
+        actions = self._plan_with_override(
+            {"state": "disabled", "reason": "x"},
+            running=False, enabled=False, installed=True)
+        verbs = {x.verb for x in actions if x.item == "meshforge-gateway"}
+        assert verbs == {"warn"}                         # never enable/disable
+
+    def test_no_override_unchanged_behavior(self):
+        """Without an override, the unit converges normally (regression guard)."""
+        a = [x for x in _plan_one("meshforge-gateway", "enabled", False, False, True)
+             if x.item == "meshforge-gateway"][0]
+        assert a.verb == "enable"
+
+    def test_read_overrides_parses_deployment_json(self, tmp_path, monkeypatch):
+        dj = tmp_path / "deployment.json"
+        dj.write_text(json.dumps({
+            "role": "full-gateway",
+            "service_overrides": {"meshforge-gateway": {"state": "disabled", "reason": "y"}},
+        }))
+        monkeypatch.setattr(pr, "DEPLOYMENT_JSON", dj)
+        ov = pr.read_overrides()
+        assert ov["meshforge-gateway"]["reason"] == "y"
+
+    def test_read_overrides_absent_key_is_empty(self, tmp_path, monkeypatch):
+        dj = tmp_path / "deployment.json"
+        dj.write_text(json.dumps({"role": "full-gateway"}))
+        monkeypatch.setattr(pr, "DEPLOYMENT_JSON", dj)
+        assert pr.read_overrides() == {}
+
+
 class TestPlanMaskingInvariant:
     def _plan_with_rival(self, rnsd_enabled, rival_installed, rival_masked):
         role_def = {"services": {"rnsd": "enabled" if rnsd_enabled else "disabled"}}


### PR DESCRIPTION
## Why

PR #1170 documented `meshforge-gateway: enabled` for the `full-gateway` role. That correctly turned **moc2** into *defined drift*: it's full-gateway hardware but the bridge is deliberately off (RF-sparse site — hears 4 mesh nodes vs moc's 126, MQTT unconfigured). `provision_role.py` now flags the absent bridge as a **blocking** warn (exit 1) — a false positive, since the omission is intentional.

## What

A generic **instance-local exception primitive**, not a moc2 special-case:

- `deployment.json` gains optional `service_overrides`:
  ```json
  "service_overrides": {
    "meshforge-gateway": {"state": "disabled", "reason": "RF-sparse site; bridge intentionally off"}
  }
  ```
  Instance specifics (which box, why) stay here — **never** in the committed `fleet_roles.yaml` (MF014: that file is generic + duplicable).
- `read_overrides()` loads them; `plan(role_def, overrides)` honors them.

### Loud, not silent (the design point)
The failure mode we keep fighting this session is *hidden drift*, so a waiver does **not** make the unit disappear from the report:

| Waiver | Result |
|---|---|
| with `reason` | non-blocking **advisory** showing `waived:<state>  (intentional per-node exception: <reason>)`. Box stops failing the drift check (exit 0); operator still sees the bridge is intentionally off + why. Unit skipped by convergence (left as set). |
| **without** `reason` | **NOT honored** — stays a blocking warning. An unexplained exception is just hidden drift. |

This is the substrate v3's self-healing loop needs to tell real drift from acknowledged exceptions.

## Tests
+6 in `test_provision_role.py`: reasoned waiver → non-blocking advisory w/ reason surfaced; reason-less → still blocking; waived unit not converged; no-override regression; `read_overrides` parse + absent-key. **38 pass; `lint --all` clean.**

## Scope
Code only. No instance values committed — moc2's `deployment.json` override is written out-of-band on the box after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)